### PR TITLE
fix(ci): add default bump value for mobile workflow_dispatch

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -7,6 +7,7 @@ on:
         description: Version bump type
         required: true
         type: choice
+        default: patch
         options:
           - patch
           - minor


### PR DESCRIPTION
## Summary

The `workflow_dispatch` UI in the GitHub mobile app keeps the **Run Workflow** button disabled until every required input has an explicit value. Choice inputs without a `default:` don't count — the placeholder shows the first option but no value is actually selected, so the button stays greyed out (see screenshot in the conversation thread).

Adds `default: patch` so the field arrives pre-selected and the button is immediately clickable.

## Test plan

- [ ] Open the Actions tab in the mobile app → Manual Release → Run workflow → confirm the Run button is enabled without any extra taps.
- [ ] Web UI: dispatch with each of `patch`/`minor`/`major` to confirm all three options still work.

https://claude.ai/code/session_015g4xhKW97kcwXfcoS9rDYL

---
_Generated by [Claude Code](https://claude.ai/code/session_015g4xhKW97kcwXfcoS9rDYL)_