### PR TITLE
feat(oauth): 60-day sliding refresh + Luxon, JWT tests, doc sweep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -287,28 +287,51 @@ Three services run in order via `depends_on`:
    matching obsidian-sync's `PUID` so both containers can read/write the
    shared `/vault` volume.
 
+### Durability
+
+Four layers cover different failure classes:
+
+| Layer                                 | What it does                                                                                                                | Where                         |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| App-level `removal: "retain"`         | Blocks `sst remove` from destroying the stack                                                                               | `sst.config.ts` `app()`       |
+| Resource-level `protect: true`        | Refuses any Pulumi op that would destroy or replace the Instance                                                            | `sst.config.ts` instance opts |
+| Resource-level `retainOnDelete: true` | If SST does decide to delete (stage rename), orphan the AWS resource instead of destroying                                  | `sst.config.ts` instance opts |
+| Lightsail auto-snapshot (`addOn`)     | Daily disk image at 03:00 UTC, 7-day rolling retention. Captures the full boot disk including ad-hoc SSH-installed packages | `addOn` on the Instance       |
+
+The auto-snapshot is the only one that protects against AWS-side events
+(hardware failure, AZ outage) and against in-VM mistakes (fat-finger
+`rm -rf`, container compromise). The IaC seatbelts only protect against
+Pulumi-driven replacement.
+
+Restore procedures, the intentional-replace flow (unprotect → deploy →
+re-protect, e.g. for a Phase 2 bundle upgrade), SST state reconciliation,
+and auth implications post-restore live in [`RECOVERY.md`](./RECOVERY.md).
+
 ## Cost
 
-| Component                    | Phase 1       | Phase 2       |
-| ---------------------------- | ------------- | ------------- |
-| Lightsail                    | $12/mo (2 GB) | $24/mo (4 GB) |
-| API Gateway                  | ~$0           | ~$0           |
-| Obsidian Sync                | existing      | same          |
-| LightRAG (OpenAI embeddings) | —             | ~$1–2/mo      |
-| **Total**                    | **~$12/mo**   | **~$26/mo**   |
+| Component                    | Phase 1                                    | Phase 2       |
+| ---------------------------- | ------------------------------------------ | ------------- |
+| Lightsail                    | $12/mo (2 GB)                              | $24/mo (4 GB) |
+| Lightsail auto-snapshots     | ~$0.50–1.50/mo (used disk × 7d × $0.05/GB) | same          |
+| API Gateway                  | ~$0                                        | ~$0           |
+| Obsidian Sync                | existing                                   | same          |
+| LightRAG (OpenAI embeddings) | —                                          | ~$1–2/mo      |
+| **Total**                    | **~$13/mo**                                | **~$27/mo**   |
 
 ## Key Decisions
 
-| Decision                 | Rationale                                                                     |
-| ------------------------ | ----------------------------------------------------------------------------- |
-| Lightsail over ECS       | $12 vs ~$50+. Single-user server.                                             |
-| API Gateway over Caddy   | Free HTTPS URL, no domain needed, SST native.                                 |
-| OAuth 2.0 + static token | OAuth for all clients. Static bearer token as CLI alternative.                |
-| JWT over opaque tokens   | Verifiable at Lambda edge without shared state. HS256 with MCP_AUTH_TOKEN.    |
-| 60-day sliding refresh   | Active clients never re-auth; leaked tokens bounded. Standard OAuth practice. |
-| SQLite FTS5              | Zero services, embedded, personal scale.                                      |
-| chokidar                 | Node-native, same process as SQLite. Phase 2: adds LightRAG hook.             |
-| Streamable HTTP          | Current MCP spec (2025-11-25). SSE is deprecated.                             |
-| GHCR over ECR            | GITHUB_TOKEN auth, no AWS IAM for images.                                     |
-| Factory over class       | Functional style. Closure holds db ref, no `this`.                            |
-| `type` over `interface`  | Preferred unless `interface` specifically required.                           |
+| Decision                            | Rationale                                                                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Lightsail over ECS                  | $12 vs ~$50+. Single-user server.                                                                                                     |
+| API Gateway over Caddy              | Free HTTPS URL, no domain needed, SST native.                                                                                         |
+| OAuth 2.0 + static token            | OAuth for all clients. Static bearer token as CLI alternative.                                                                        |
+| JWT over opaque tokens              | Verifiable at Lambda edge without shared state. HS256 with MCP_AUTH_TOKEN.                                                            |
+| 60-day sliding refresh              | Active clients never re-auth; leaked tokens bounded. Standard OAuth practice.                                                         |
+| Auto-snapshot (`addOn`)             | Native Lightsail primitive over hand-rolled cron + S3. Daily, 7-day retention, captures full boot disk including SSH-installed state. |
+| Pulumi `protect` + `retainOnDelete` | IaC seatbelt over `replaceOnChanges` gymnastics. Intentional replaces require explicit unprotect — the friction is the feature.       |
+| SQLite FTS5                         | Zero services, embedded, personal scale.                                                                                              |
+| chokidar                            | Node-native, same process as SQLite. Phase 2: adds LightRAG hook.                                                                     |
+| Streamable HTTP                     | Current MCP spec (2025-11-25). SSE is deprecated.                                                                                     |
+| GHCR over ECR                       | GITHUB_TOKEN auth, no AWS IAM for images.                                                                                             |
+| Factory over class                  | Functional style. Closure holds db ref, no `this`.                                                                                    |
+| `type` over `interface`             | Preferred unless `interface` specifically required.                                                                                   |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,10 +207,10 @@ See `sst.config.ts` for full IaC.
 
 Two authentication methods, both validated at two layers:
 
-| Method                                | Used by                                                      | Token format                | Lifetime                               |
-| ------------------------------------- | ------------------------------------------------------------ | --------------------------- | -------------------------------------- |
-| OAuth 2.0 (Authorization Code + PKCE) | Claude Desktop, Claude Code, Claude Mobile, any OAuth client | JWT (HS256)                 | 24h access, no-expiry refresh (SQLite) |
-| Static bearer token                   | Claude Code, MCP Inspector, curl                             | Raw string (MCP_AUTH_TOKEN) | No expiry                              |
+| Method                                | Used by                                                      | Token format                | Lifetime                                    |
+| ------------------------------------- | ------------------------------------------------------------ | --------------------------- | ------------------------------------------- |
+| OAuth 2.0 (Authorization Code + PKCE) | Claude Desktop, Claude Code, Claude Mobile, any OAuth client | JWT (HS256)                 | 24h access, 60-day sliding refresh (SQLite) |
+| Static bearer token                   | Claude Code, MCP Inspector, curl                             | Raw string (MCP_AUTH_TOKEN) | No expiry                                   |
 
 **Layer 1 — API Gateway Lambda authorizer** (`src/functions/authorizer.ts`):
 Path-aware. OAuth discovery paths (`/.well-known/*`, `/authorize`, `/token`,
@@ -245,9 +245,17 @@ authorizer and Express can verify independently — no shared state needed.
 
 **Token storage:** Refresh tokens and registered clients are persisted in
 SQLite (`/data/oauth.db`) — survives container restarts, no re-authentication
-needed after deploys. Auth codes are in-memory (short-lived, 10 minutes).
-Access tokens are JWTs (stateless, no storage needed). Revoked tokens are
-tracked in SQLite.
+needed after deploys for active clients. Auth codes are in-memory (short-lived,
+10 minutes). Access tokens are JWTs (stateless, no storage needed). Revoked
+tokens are tracked in SQLite.
+
+**Refresh token expiry:** 60-day sliding (inactivity) window. Each successful
+use rotates the token AND extends the window by another 60 days, so a daily
+client never sees expiry. A client dormant for >60 days is forced through the
+full OAuth flow on its next attempt. The schema column is `expires_at INTEGER
+NOT NULL`; rows past `expires_at` are deleted on read so the table self-cleans.
+This bounds the blast radius of a leaked refresh token without inconveniencing
+active sessions.
 
 **Rate limiting:** OAuth endpoints (`/token`, `/register`, `/authorize`,
 `/revoke`) are rate-limited at 5 req/min per client IP. A custom key
@@ -291,15 +299,16 @@ Three services run in order via `depends_on`:
 
 ## Key Decisions
 
-| Decision                 | Rationale                                                                  |
-| ------------------------ | -------------------------------------------------------------------------- |
-| Lightsail over ECS       | $12 vs ~$50+. Single-user server.                                          |
-| API Gateway over Caddy   | Free HTTPS URL, no domain needed, SST native.                              |
-| OAuth 2.0 + static token | OAuth for all clients. Static bearer token as CLI alternative.             |
-| JWT over opaque tokens   | Verifiable at Lambda edge without shared state. HS256 with MCP_AUTH_TOKEN. |
-| SQLite FTS5              | Zero services, embedded, personal scale.                                   |
-| chokidar                 | Node-native, same process as SQLite. Phase 2: adds LightRAG hook.          |
-| Streamable HTTP          | Current MCP spec (2025-11-25). SSE is deprecated.                          |
-| GHCR over ECR            | GITHUB_TOKEN auth, no AWS IAM for images.                                  |
-| Factory over class       | Functional style. Closure holds db ref, no `this`.                         |
-| `type` over `interface`  | Preferred unless `interface` specifically required.                        |
+| Decision                 | Rationale                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| Lightsail over ECS       | $12 vs ~$50+. Single-user server.                                             |
+| API Gateway over Caddy   | Free HTTPS URL, no domain needed, SST native.                                 |
+| OAuth 2.0 + static token | OAuth for all clients. Static bearer token as CLI alternative.                |
+| JWT over opaque tokens   | Verifiable at Lambda edge without shared state. HS256 with MCP_AUTH_TOKEN.    |
+| 60-day sliding refresh   | Active clients never re-auth; leaked tokens bounded. Standard OAuth practice. |
+| SQLite FTS5              | Zero services, embedded, personal scale.                                      |
+| chokidar                 | Node-native, same process as SQLite. Phase 2: adds LightRAG hook.             |
+| Streamable HTTP          | Current MCP spec (2025-11-25). SSE is deprecated.                             |
+| GHCR over ECR            | GITHUB_TOKEN auth, no AWS IAM for images.                                     |
+| Factory over class       | Functional style. Closure holds db ref, no `this`.                            |
+| `type` over `interface`  | Preferred unless `interface` specifically required.                           |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- **oauth:** 60-day sliding (inactivity) expiry on refresh tokens. Active clients never re-auth; dormant clients re-auth after 60 days. Schema migration adds `expires_at INTEGER NOT NULL` to `refresh_tokens` (#8).
+- **sst:** Lightsail durability — daily auto-snapshot (`addOn` AutoSnapshot, 7-day retention) plus Pulumi `protect: true` + `retainOnDelete: true` on the Instance. Captures the full boot disk including ad-hoc SSH-installed packages. New `RECOVERY.md` documents three restore scenarios + intentional-replace flow (#7).
+
+### Refactor
+
+- **oauth:** Migrated date logic to Luxon. Dropped `nowSec()` closure; in-memory state stores `DateTime` objects directly; DB / wire-format integers go through `DateTime.now().plus({...}).toUnixInteger()`. `AUTH_CODE_TTL_MS` → `AUTH_CODE_TTL_S` for unit consistency (#8).
+
+### Tests
+
+- **jwt:** New test suite for `signJwt` / `verifyJwt` — 13 tests covering determinism, header format, payload encoding, signature verification, expiry, tampering, and constant-time mismatch (#8).
+
 ## [0.1.2] — 2026-05-11
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ OAuth is the primary auth method. All MCP clients that support OAuth 2.0 — Cla
 2. Leave OAuth Client ID and Secret empty (dynamic registration handles it)
 3. The client auto-discovers endpoints via `/.well-known/oauth-protected-resource`
 4. A consent page opens in your browser — enter your `MCP_AUTH_TOKEN` to approve
-5. The client receives a JWT access token (24h) + refresh token (no expiry, persisted in SQLite)
-6. Token refresh is automatic — no re-authentication unless the server's data volume is wiped
+5. The client receives a JWT access token (24h) + refresh token (60-day sliding expiry, persisted in SQLite)
+6. Token refresh is automatic — no re-authentication unless the data volume is wiped or the client is dormant for >60 days. Each refresh resets the 60-day countdown.
 
 ### Connecting with a static bearer token
 

--- a/src/__tests__/jwt.test.ts
+++ b/src/__tests__/jwt.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest"
+import { createHmac } from "node:crypto"
+import { DateTime } from "luxon"
+import { signJwt, verifyJwt } from "../jwt.js"
+import type { JwtPayload } from "../jwt.js"
+
+const SECRET = "test-secret"
+const OTHER_SECRET = "other-secret"
+
+const buildPayload = (overrides: Partial<JwtPayload> = {}): JwtPayload => ({
+  sub: "test-client",
+  scope: "vault",
+  exp: DateTime.now().plus({ hours: 1 }).toUnixInteger(),
+  iss: "vault-cortex",
+  ...overrides,
+})
+
+describe("signJwt", () => {
+  it("produces a 3-part dot-separated token", () => {
+    const token = signJwt(buildPayload(), SECRET)
+    expect(token.split(".")).toHaveLength(3)
+  })
+
+  it("is deterministic — same payload + secret yields same token", () => {
+    const payload = buildPayload()
+    expect(signJwt(payload, SECRET)).toBe(signJwt(payload, SECRET))
+  })
+
+  it("uses the HS256 + JWT header", () => {
+    const token = signJwt(buildPayload(), SECRET)
+    const [header] = token.split(".") as [string]
+    const decoded = JSON.parse(Buffer.from(header, "base64url").toString()) as {
+      alg: string
+      typ: string
+    }
+    expect(decoded).toEqual({ alg: "HS256", typ: "JWT" })
+  })
+
+  it("encodes the payload as base64url JSON", () => {
+    const payload = buildPayload({ sub: "alice", scope: "vault read" })
+    const token = signJwt(payload, SECRET)
+    const [, body] = token.split(".") as [string, string]
+    const decoded = JSON.parse(
+      Buffer.from(body, "base64url").toString(),
+    ) as JwtPayload
+    expect(decoded).toEqual(payload)
+  })
+})
+
+describe("verifyJwt", () => {
+  it("round-trips a valid payload", () => {
+    const payload = buildPayload()
+    const decoded = verifyJwt(signJwt(payload, SECRET), SECRET)
+    expect(decoded).toEqual(payload)
+  })
+
+  it("returns null for a token signed with a different secret", () => {
+    const token = signJwt(buildPayload(), SECRET)
+    expect(verifyJwt(token, OTHER_SECRET)).toBeNull()
+  })
+
+  it("returns null for malformed tokens (wrong number of parts)", () => {
+    expect(verifyJwt("only-one-part", SECRET)).toBeNull()
+    expect(verifyJwt("two.parts", SECRET)).toBeNull()
+    expect(verifyJwt("four.parts.in.token", SECRET)).toBeNull()
+    expect(verifyJwt("", SECRET)).toBeNull()
+  })
+
+  it("returns null when the payload has been tampered with", () => {
+    const token = signJwt(buildPayload(), SECRET)
+    const [header, , sig] = token.split(".") as [string, string, string]
+    const tamperedBody = Buffer.from(
+      JSON.stringify(buildPayload({ scope: "admin" })),
+    ).toString("base64url")
+    expect(verifyJwt(`${header}.${tamperedBody}.${sig}`, SECRET)).toBeNull()
+  })
+
+  it("returns null for an expired token (exp in the past)", () => {
+    const expired = buildPayload({
+      exp: DateTime.now().minus({ minutes: 1 }).toUnixInteger(),
+    })
+    expect(verifyJwt(signJwt(expired, SECRET), SECRET)).toBeNull()
+  })
+
+  it("accepts a token whose exp is comfortably in the future", () => {
+    const future = buildPayload({
+      exp: DateTime.now().plus({ days: 1 }).toUnixInteger(),
+    })
+    expect(verifyJwt(signJwt(future, SECRET), SECRET)).toEqual(future)
+  })
+
+  it("returns null when the payload body is not valid JSON", () => {
+    const header = Buffer.from(
+      JSON.stringify({ alg: "HS256", typ: "JWT" }),
+    ).toString("base64url")
+    const garbageBody = Buffer.from("not-json").toString("base64url")
+    const sig = createHmac("sha256", SECRET)
+      .update(`${header}.${garbageBody}`)
+      .digest()
+      .toString("base64url")
+    expect(verifyJwt(`${header}.${garbageBody}.${sig}`, SECRET)).toBeNull()
+  })
+
+  it("returns null for a token whose signature differs in length", () => {
+    const token = signJwt(buildPayload(), SECRET)
+    const [header, body] = token.split(".") as [string, string]
+    expect(verifyJwt(`${header}.${body}.short`, SECRET)).toBeNull()
+  })
+
+  it("returns null for a signature of correct length but wrong bytes", () => {
+    const token = signJwt(buildPayload(), SECRET)
+    const [header, body, sig] = token.split(".") as [string, string, string]
+    const flipped = Buffer.from(sig, "base64url")
+    flipped[0] = flipped[0]! ^ 0xff
+    expect(
+      verifyJwt(`${header}.${body}.${flipped.toString("base64url")}`, SECRET),
+    ).toBeNull()
+  })
+})

--- a/src/vault-mcp/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/__tests__/oauth-provider.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import Database from "better-sqlite3"
+import { createOAuthProvider } from "../oauth-provider.js"
+import type { OAuthProvider } from "../oauth-provider.js"
+import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js"
+
+const AUTH_TOKEN = "test-static-token"
+const SIXTY_DAYS_S = 60 * 24 * 3600
+
+const seedClient = (db: Database.Database): OAuthClientInformationFull => {
+  const client = {
+    client_id: "test-client",
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+    client_secret: "test-secret",
+    client_secret_expires_at: 0,
+    redirect_uris: ["https://example.com/cb"],
+    token_endpoint_auth_method: "none",
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+  } as OAuthClientInformationFull
+  db.prepare("INSERT INTO clients (client_id, data) VALUES (?, ?)").run(
+    client.client_id,
+    JSON.stringify(client),
+  )
+  return client
+}
+
+const seedRefreshToken = (
+  db: Database.Database,
+  token: string,
+  clientId: string,
+  scopes: string[],
+  expiresAt: number,
+): void => {
+  db.prepare(
+    "INSERT INTO refresh_tokens (token, client_id, scopes, expires_at) VALUES (?, ?, ?, ?)",
+  ).run(token, clientId, scopes.join(" "), expiresAt)
+}
+
+describe("OAuth refresh token sliding expiry", () => {
+  let dir: string
+  let dbPath: string
+  let oauth: OAuthProvider
+  let db: Database.Database
+  let client: OAuthClientInformationFull
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "oauth-test-"))
+    dbPath = join(dir, "oauth.db")
+    oauth = createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      serverUrl: new URL("https://example.com"),
+      dbPath,
+    })
+    db = new Database(dbPath)
+    client = seedClient(db)
+  })
+
+  afterEach(async () => {
+    db.close()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it("accepts a refresh token used within the 60-day window", async () => {
+    const now = Math.floor(Date.now() / 1000)
+    seedRefreshToken(
+      db,
+      "fresh-token",
+      client.client_id,
+      ["vault"],
+      now + SIXTY_DAYS_S,
+    )
+
+    const tokens = await oauth.provider.exchangeRefreshToken!(
+      client,
+      "fresh-token",
+    )
+
+    expect(tokens.refresh_token).toBeDefined()
+    expect(tokens.refresh_token).not.toBe("fresh-token")
+    expect(tokens.scope).toBe("vault")
+  })
+
+  it("rejects a refresh token past its expires_at", async () => {
+    const now = Math.floor(Date.now() / 1000)
+    seedRefreshToken(db, "expired-token", client.client_id, ["vault"], now - 1)
+
+    await expect(
+      oauth.provider.exchangeRefreshToken!(client, "expired-token"),
+    ).rejects.toThrow("Refresh token expired or invalid")
+  })
+
+  it("removes an expired token from the DB on read", async () => {
+    const now = Math.floor(Date.now() / 1000)
+    seedRefreshToken(db, "expired-token", client.client_id, ["vault"], now - 1)
+
+    await expect(
+      oauth.provider.exchangeRefreshToken!(client, "expired-token"),
+    ).rejects.toThrow()
+
+    const row = db
+      .prepare("SELECT * FROM refresh_tokens WHERE token = ?")
+      .get("expired-token")
+    expect(row).toBeUndefined()
+  })
+
+  it("rotates to a new token with a fresh 60-day window on use", async () => {
+    const now = Math.floor(Date.now() / 1000)
+    seedRefreshToken(
+      db,
+      "first-token",
+      client.client_id,
+      ["vault"],
+      now + SIXTY_DAYS_S,
+    )
+
+    const tokens = await oauth.provider.exchangeRefreshToken!(
+      client,
+      "first-token",
+    )
+    const newToken = tokens.refresh_token
+    expect(newToken).toBeDefined()
+
+    const row = db
+      .prepare("SELECT expires_at FROM refresh_tokens WHERE token = ?")
+      .get(newToken!) as { expires_at: number } | undefined
+    expect(row).toBeDefined()
+
+    // The new token's expires_at should be ~60 days from "now" — i.e.
+    // a fresh window, not inherited from the old token's expires_at.
+    const expected = Math.floor(Date.now() / 1000) + SIXTY_DAYS_S
+    expect(row!.expires_at).toBeGreaterThanOrEqual(expected - 5)
+    expect(row!.expires_at).toBeLessThanOrEqual(expected + 5)
+  })
+
+  it("invalidates the old token after rotation (single-use)", async () => {
+    const now = Math.floor(Date.now() / 1000)
+    seedRefreshToken(
+      db,
+      "first-token",
+      client.client_id,
+      ["vault"],
+      now + SIXTY_DAYS_S,
+    )
+
+    await oauth.provider.exchangeRefreshToken!(client, "first-token")
+
+    await expect(
+      oauth.provider.exchangeRefreshToken!(client, "first-token"),
+    ).rejects.toThrow("Refresh token expired or invalid")
+  })
+
+  it("treats a row with expires_at=0 as expired (migration default)", async () => {
+    seedRefreshToken(db, "pre-migration-token", client.client_id, ["vault"], 0)
+
+    await expect(
+      oauth.provider.exchangeRefreshToken!(client, "pre-migration-token"),
+    ).rejects.toThrow("Refresh token expired or invalid")
+  })
+
+  it("rejects a non-existent refresh token", async () => {
+    await expect(
+      oauth.provider.exchangeRefreshToken!(client, "never-existed"),
+    ).rejects.toThrow("Refresh token expired or invalid")
+  })
+})
+
+describe("OAuth refresh token schema migration", () => {
+  let dir: string
+  let dbPath: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "oauth-migration-test-"))
+    dbPath = join(dir, "oauth.db")
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it("adds expires_at to a pre-sliding-expiry refresh_tokens table", () => {
+    const oldDb = new Database(dbPath)
+    oldDb.exec(`
+      CREATE TABLE refresh_tokens (
+        token TEXT PRIMARY KEY,
+        client_id TEXT NOT NULL,
+        scopes TEXT NOT NULL
+      );
+      INSERT INTO refresh_tokens (token, client_id, scopes)
+      VALUES ('legacy-token', 'legacy-client', 'vault');
+    `)
+    oldDb.close()
+
+    createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      serverUrl: new URL("https://example.com"),
+      dbPath,
+    })
+
+    const db = new Database(dbPath)
+    try {
+      const columns = db
+        .prepare("SELECT name FROM pragma_table_info('refresh_tokens')")
+        .all() as { name: string }[]
+      expect(columns.map((c) => c.name)).toContain("expires_at")
+
+      const row = db
+        .prepare("SELECT expires_at FROM refresh_tokens WHERE token = ?")
+        .get("legacy-token") as { expires_at: number } | undefined
+      expect(row).toBeDefined()
+      expect(row!.expires_at).toBe(0) // DEFAULT 0 — treated as expired
+    } finally {
+      db.close()
+    }
+  })
+
+  it("is idempotent — re-running on a migrated DB doesn't error", () => {
+    createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      serverUrl: new URL("https://example.com"),
+      dbPath,
+    })
+
+    expect(() =>
+      createOAuthProvider({
+        authToken: AUTH_TOKEN,
+        serverUrl: new URL("https://example.com"),
+        dbPath,
+      }),
+    ).not.toThrow()
+  })
+})

--- a/src/vault-mcp/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/__tests__/oauth-provider.test.ts
@@ -3,17 +3,17 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import Database from "better-sqlite3"
+import { DateTime } from "luxon"
 import { createOAuthProvider } from "../oauth-provider.js"
 import type { OAuthProvider } from "../oauth-provider.js"
 import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js"
 
 const AUTH_TOKEN = "test-static-token"
-const SIXTY_DAYS_S = 60 * 24 * 3600
 
 const seedClient = (db: Database.Database): OAuthClientInformationFull => {
   const client = {
     client_id: "test-client",
-    client_id_issued_at: Math.floor(Date.now() / 1000),
+    client_id_issued_at: DateTime.now().toUnixInteger(),
     client_secret: "test-secret",
     client_secret_expires_at: 0,
     redirect_uris: ["https://example.com/cb"],
@@ -65,13 +65,12 @@ describe("OAuth refresh token sliding expiry", () => {
   })
 
   it("accepts a refresh token used within the 60-day window", async () => {
-    const now = Math.floor(Date.now() / 1000)
     seedRefreshToken(
       db,
       "fresh-token",
       client.client_id,
       ["vault"],
-      now + SIXTY_DAYS_S,
+      DateTime.now().plus({ days: 60 }).toUnixInteger(),
     )
 
     const tokens = await oauth.provider.exchangeRefreshToken!(
@@ -85,8 +84,13 @@ describe("OAuth refresh token sliding expiry", () => {
   })
 
   it("rejects a refresh token past its expires_at", async () => {
-    const now = Math.floor(Date.now() / 1000)
-    seedRefreshToken(db, "expired-token", client.client_id, ["vault"], now - 1)
+    seedRefreshToken(
+      db,
+      "expired-token",
+      client.client_id,
+      ["vault"],
+      DateTime.now().minus({ seconds: 1 }).toUnixInteger(),
+    )
 
     await expect(
       oauth.provider.exchangeRefreshToken!(client, "expired-token"),
@@ -94,8 +98,13 @@ describe("OAuth refresh token sliding expiry", () => {
   })
 
   it("removes an expired token from the DB on read", async () => {
-    const now = Math.floor(Date.now() / 1000)
-    seedRefreshToken(db, "expired-token", client.client_id, ["vault"], now - 1)
+    seedRefreshToken(
+      db,
+      "expired-token",
+      client.client_id,
+      ["vault"],
+      DateTime.now().minus({ seconds: 1 }).toUnixInteger(),
+    )
 
     await expect(
       oauth.provider.exchangeRefreshToken!(client, "expired-token"),
@@ -108,13 +117,12 @@ describe("OAuth refresh token sliding expiry", () => {
   })
 
   it("rotates to a new token with a fresh 60-day window on use", async () => {
-    const now = Math.floor(Date.now() / 1000)
     seedRefreshToken(
       db,
       "first-token",
       client.client_id,
       ["vault"],
-      now + SIXTY_DAYS_S,
+      DateTime.now().plus({ days: 60 }).toUnixInteger(),
     )
 
     const tokens = await oauth.provider.exchangeRefreshToken!(
@@ -131,19 +139,18 @@ describe("OAuth refresh token sliding expiry", () => {
 
     // The new token's expires_at should be ~60 days from "now" — i.e.
     // a fresh window, not inherited from the old token's expires_at.
-    const expected = Math.floor(Date.now() / 1000) + SIXTY_DAYS_S
+    const expected = DateTime.now().plus({ days: 60 }).toUnixInteger()
     expect(row!.expires_at).toBeGreaterThanOrEqual(expected - 5)
     expect(row!.expires_at).toBeLessThanOrEqual(expected + 5)
   })
 
   it("invalidates the old token after rotation (single-use)", async () => {
-    const now = Math.floor(Date.now() / 1000)
     seedRefreshToken(
       db,
       "first-token",
       client.client_id,
       ["vault"],
-      now + SIXTY_DAYS_S,
+      DateTime.now().plus({ days: 60 }).toUnixInteger(),
     )
 
     await oauth.provider.exchangeRefreshToken!(client, "first-token")

--- a/src/vault-mcp/oauth-provider.ts
+++ b/src/vault-mcp/oauth-provider.ts
@@ -29,12 +29,14 @@ import { safeEqual } from "../auth.js"
 import { signJwt, verifyJwt } from "../jwt.js"
 import { renderConsentPage } from "./consent-page.js"
 
+// 24 hours
 const ACCESS_TOKEN_TTL_S = 24 * 60 * 60
-// Sliding (inactivity) expiry on refresh tokens. Each use rotates the
-// token AND resets the 60-day countdown — a daily user never sees it,
-// a dormant client re-auths after 60 days. Bounds the blast radius of a
-// leaked refresh token without inconveniencing active sessions.
+// 60 days. Sliding (inactivity) expiry — each use rotates the token
+// AND resets the countdown, so a daily user never sees it and a
+// dormant client re-auths after 60 days. Bounds the blast radius of
+// a leaked refresh token without inconveniencing active sessions.
 const REFRESH_TOKEN_TTL_S = 60 * 24 * 60 * 60
+// 10 minutes — OAuth spec recommends short auth code lifetimes.
 const AUTH_CODE_TTL_S = 10 * 60
 
 export type PendingAuthRequest = {

--- a/src/vault-mcp/oauth-provider.ts
+++ b/src/vault-mcp/oauth-provider.ts
@@ -29,6 +29,11 @@ import { signJwt, verifyJwt } from "../jwt.js"
 import { renderConsentPage } from "./consent-page.js"
 
 const ACCESS_TOKEN_TTL_S = 24 * 3600
+// Sliding (inactivity) expiry on refresh tokens. Each use rotates the
+// token AND resets the 60-day countdown — a daily user never sees it,
+// a dormant client re-auths after 60 days. Bounds the blast radius of a
+// leaked refresh token without inconveniencing active sessions.
+const REFRESH_TOKEN_TTL_S = 60 * 24 * 3600
 const AUTH_CODE_TTL_MS = 10 * 60 * 1000
 
 export type PendingAuthRequest = {
@@ -61,13 +66,29 @@ const initDb = (dbPath: string): Database.Database => {
     CREATE TABLE IF NOT EXISTS refresh_tokens (
       token TEXT PRIMARY KEY,
       client_id TEXT NOT NULL,
-      scopes TEXT NOT NULL
+      scopes TEXT NOT NULL,
+      expires_at INTEGER NOT NULL
     );
     CREATE TABLE IF NOT EXISTS revoked_tokens (
       token TEXT PRIMARY KEY,
       revoked_at INTEGER NOT NULL
     );
   `)
+  // Migration for DBs created before sliding expiry: add expires_at
+  // with DEFAULT 0 so any pre-migration row is treated as expired on
+  // first read. Accepted trade-off — a one-time forced re-auth for any
+  // currently-active session — and it keeps the new column NOT NULL
+  // without an arbitrary backfill timestamp.
+  const hasExpiresAt = db
+    .prepare(
+      "SELECT 1 FROM pragma_table_info('refresh_tokens') WHERE name = 'expires_at'",
+    )
+    .get()
+  if (!hasExpiresAt) {
+    db.exec(
+      "ALTER TABLE refresh_tokens ADD COLUMN expires_at INTEGER NOT NULL DEFAULT 0",
+    )
+  }
   return db
 }
 
@@ -138,20 +159,29 @@ export const createOAuthProvider = ({
     scopes: string[],
   ): void => {
     db.prepare(
-      "INSERT INTO refresh_tokens (token, client_id, scopes) VALUES (?, ?, ?)",
-    ).run(token, clientId, scopes.join(" "))
+      "INSERT INTO refresh_tokens (token, client_id, scopes, expires_at) VALUES (?, ?, ?, ?)",
+    ).run(token, clientId, scopes.join(" "), nowSec() + REFRESH_TOKEN_TTL_S)
   }
 
-  /** Refresh token rotation: consume (delete) on use, caller issues a new one.
-   *  Single-use tokens prevent replay attacks — a stolen token can only be used once. */
+  /** Refresh token rotation with sliding expiry. Tokens are single-use
+   *  (consumed on read to prevent replay) AND time-bounded (rejected
+   *  past expires_at). A successful refresh issues a new token whose
+   *  expires_at is REFRESH_TOKEN_TTL_S from now — every use resets the
+   *  countdown, so active clients never expire. Expired rows are still
+   *  deleted on read so the table self-cleans. */
   const consumeRefreshToken = (
     token: string,
   ): { clientId: string; scopes: string[] } | null => {
     const row = db
-      .prepare("SELECT client_id, scopes FROM refresh_tokens WHERE token = ?")
-      .get(token) as { client_id: string; scopes: string } | undefined
+      .prepare(
+        "SELECT client_id, scopes, expires_at FROM refresh_tokens WHERE token = ?",
+      )
+      .get(token) as
+      | { client_id: string; scopes: string; expires_at: number }
+      | undefined
     if (!row) return null
     db.prepare("DELETE FROM refresh_tokens WHERE token = ?").run(token)
+    if (row.expires_at < nowSec()) return null
     return { clientId: row.client_id, scopes: row.scopes.split(" ") }
   }
 

--- a/src/vault-mcp/oauth-provider.ts
+++ b/src/vault-mcp/oauth-provider.ts
@@ -11,6 +11,7 @@
 
 import Database from "better-sqlite3"
 import { randomUUID, randomBytes } from "node:crypto"
+import { DateTime } from "luxon"
 import type { Response } from "express"
 import type {
   OAuthServerProvider,
@@ -28,25 +29,25 @@ import { safeEqual } from "../auth.js"
 import { signJwt, verifyJwt } from "../jwt.js"
 import { renderConsentPage } from "./consent-page.js"
 
-const ACCESS_TOKEN_TTL_S = 24 * 3600
+const ACCESS_TOKEN_TTL_S = 24 * 60 * 60
 // Sliding (inactivity) expiry on refresh tokens. Each use rotates the
 // token AND resets the 60-day countdown — a daily user never sees it,
 // a dormant client re-auths after 60 days. Bounds the blast radius of a
 // leaked refresh token without inconveniencing active sessions.
-const REFRESH_TOKEN_TTL_S = 60 * 24 * 3600
-const AUTH_CODE_TTL_MS = 10 * 60 * 1000
+const REFRESH_TOKEN_TTL_S = 60 * 24 * 60 * 60
+const AUTH_CODE_TTL_S = 10 * 60
 
 export type PendingAuthRequest = {
   client: OAuthClientInformationFull
   params: AuthorizationParams
-  createdAt: number
+  createdAt: DateTime
 }
 
 type StoredAuthCode = {
   clientId: string
   codeChallenge: string
   params: AuthorizationParams
-  expiresAt: number
+  expiresAt: DateTime
 }
 
 export type OAuthProviderOptions = {
@@ -113,7 +114,7 @@ class SqliteClientsStore implements OAuthRegisteredClientsStore {
     const full: OAuthClientInformationFull = {
       ...client,
       client_id: randomUUID(),
-      client_id_issued_at: Math.floor(Date.now() / 1000),
+      client_id_issued_at: DateTime.now().toUnixInteger(),
       client_secret: randomBytes(32).toString("hex"),
       client_secret_expires_at: 0,
     }
@@ -140,14 +141,14 @@ export const createOAuthProvider = ({
   const pendingRequests = new Map<string, PendingAuthRequest>()
   const authCodes = new Map<string, StoredAuthCode>()
 
-  const nowSec = (): number => Math.floor(Date.now() / 1000)
-
   const issueAccessToken = (clientId: string, scopes: string[]): string =>
     signJwt(
       {
         sub: clientId,
         scope: scopes.join(" "),
-        exp: nowSec() + ACCESS_TOKEN_TTL_S,
+        exp: DateTime.now()
+          .plus({ seconds: ACCESS_TOKEN_TTL_S })
+          .toUnixInteger(),
         iss: "vault-cortex",
       },
       authToken,
@@ -160,7 +161,12 @@ export const createOAuthProvider = ({
   ): void => {
     db.prepare(
       "INSERT INTO refresh_tokens (token, client_id, scopes, expires_at) VALUES (?, ?, ?, ?)",
-    ).run(token, clientId, scopes.join(" "), nowSec() + REFRESH_TOKEN_TTL_S)
+    ).run(
+      token,
+      clientId,
+      scopes.join(" "),
+      DateTime.now().plus({ seconds: REFRESH_TOKEN_TTL_S }).toUnixInteger(),
+    )
   }
 
   /** Refresh token rotation with sliding expiry. Tokens are single-use
@@ -181,7 +187,7 @@ export const createOAuthProvider = ({
       | undefined
     if (!row) return null
     db.prepare("DELETE FROM refresh_tokens WHERE token = ?").run(token)
-    if (row.expires_at < nowSec()) return null
+    if (row.expires_at < DateTime.now().toUnixInteger()) return null
     return { clientId: row.client_id, scopes: row.scopes.split(" ") }
   }
 
@@ -205,7 +211,7 @@ export const createOAuthProvider = ({
       pendingRequests.set(requestId, {
         client,
         params,
-        createdAt: Date.now(),
+        createdAt: DateTime.now(),
       })
 
       res.type("html").send(
@@ -223,7 +229,7 @@ export const createOAuthProvider = ({
       authorizationCode: string,
     ): Promise<string> {
       const stored = authCodes.get(authorizationCode)
-      if (!stored || stored.expiresAt < nowSec()) {
+      if (!stored || stored.expiresAt < DateTime.now()) {
         throw new InvalidGrantError("Authorization code expired or invalid")
       }
       return stored.codeChallenge
@@ -237,7 +243,7 @@ export const createOAuthProvider = ({
       _resource?: URL,
     ): Promise<OAuthTokens> {
       const stored = authCodes.get(authorizationCode)
-      if (!stored || stored.expiresAt < nowSec()) {
+      if (!stored || stored.expiresAt < DateTime.now()) {
         throw new InvalidGrantError("Authorization code expired or invalid")
       }
       authCodes.delete(authorizationCode)
@@ -314,7 +320,7 @@ export const createOAuthProvider = ({
     ): Promise<void> {
       db.prepare(
         "INSERT OR IGNORE INTO revoked_tokens (token, revoked_at) VALUES (?, ?)",
-      ).run(request.token, nowSec())
+      ).run(request.token, DateTime.now().toUnixInteger())
       db.prepare("DELETE FROM refresh_tokens WHERE token = ?").run(
         request.token,
       )
@@ -324,7 +330,7 @@ export const createOAuthProvider = ({
   const getPendingRequest = (id: string): PendingAuthRequest | undefined => {
     const req = pendingRequests.get(id)
     if (!req) return undefined
-    if (Date.now() - req.createdAt > AUTH_CODE_TTL_MS) {
+    if (req.createdAt.plus({ seconds: AUTH_CODE_TTL_S }) < DateTime.now()) {
       pendingRequests.delete(id)
       return undefined
     }
@@ -341,7 +347,7 @@ export const createOAuthProvider = ({
       clientId: pending.client.client_id,
       codeChallenge: pending.params.codeChallenge,
       params: pending.params,
-      expiresAt: nowSec() + 600,
+      expiresAt: DateTime.now().plus({ seconds: AUTH_CODE_TTL_S }),
     })
     return code
   }


### PR DESCRIPTION
## Summary

Refresh tokens now have a 60-day inactivity expiry that resets on every use. Daily clients never see it — each refresh rotates the token AND extends the window. Dormant clients force re-auth after 60 days, bounding the blast radius of a leaked refresh token without inconveniencing active sessions.

Previously refresh tokens had no expiry — a leaked token worked forever until manually revoked or `MCP_AUTH_TOKEN` rotated. The "no expiry" choice was atypical for OAuth implementations (Auth0/Okta/Google all impose 30–90 day caps).

## Schema change

`refresh_tokens` gains an `expires_at INTEGER NOT NULL` column.

- New DBs: column is created at table creation time.
- Existing DBs: migrated with `ALTER TABLE ... ADD COLUMN ... DEFAULT 0`. Any pre-migration row is treated as already-expired on first read — accepted trade-off (a one-time forced re-auth for any currently-active session). After yesterday's instance nuke the table is empty, so in practice nothing carries over.

## Behavior

- `saveRefreshToken` writes `expires_at = now + REFRESH_TOKEN_TTL_S` (60 days).
- `consumeRefreshToken` rejects tokens whose `expires_at < now`, and deletes the row either way so the table self-cleans.
- Refresh-token rotation already existed; sliding expiry composes naturally — every rotation issues a new row with a fresh window.

## Luxon refactor (commit `a97266f`)

While in this file: dropped the `nowSec()` closure and every `Math.floor(Date.now() / 1000)` in `oauth-provider.ts` in favor of Luxon (already a project dep + stated preference).

- In-memory state (`pendingRequests.createdAt`, `authCodes[].expiresAt`) now stores `DateTime` objects directly. Comparisons read as `req.createdAt.plus({ seconds: AUTH_CODE_TTL_S }) < DateTime.now()` instead of subtracting milliseconds.
- DB / wire-format integers (`refresh_tokens.expires_at`, `revoked_tokens.revoked_at`, JWT `exp`, `client_id_issued_at`, OAuth `expires_in`) stay as Unix seconds (the spec requires them) but are produced via `DateTime.now().plus({...}).toUnixInteger()`.
- `AUTH_CODE_TTL_MS` → `AUTH_CODE_TTL_S` for unit consistency with the other TTL constants.
- TTL constants now have a one-line unit comment above them (commit `6ce8e84`).
- Test refactor mirrors the same pattern: `DateTime.now().plus({ days: 60 }).toUnixInteger()` in place of `Math.floor(Date.now() / 1000) + SIXTY_DAYS_S`.

**Out of scope:** the `Date.now() / 1000` in `src/jwt.ts:56` itself — that's library code, not the oauth provider being refactored. Filed as a follow-up.

## JWT test gap fixed (commit `a97266f`)

New `src/__tests__/jwt.test.ts` — 13 tests for the previously-untested `signJwt` / `verifyJwt` pair:

- `signJwt`: 3-part output, deterministic, HS256 + JWT header, base64url JSON payload encoding
- `verifyJwt`: round-trip, wrong-secret rejection, malformed input (wrong part count, empty), payload tampering, expired tokens, unparseable JSON body, short-signature rejection, byte-flipped (correct length, wrong bytes) signature mismatch

## Doc freshness sweep (commits `741f810` + `3642ae7`)

Audit caught stale claims and gaps:

- `ARCHITECTURE.md` auth table: "no-expiry refresh" → "60-day sliding refresh"; new "Refresh token expiry" paragraph in the Token storage section.
- `README.md` "Connecting via OAuth" steps 5/6: refresh token is no longer "no expiry"; re-auth happens after a wipe OR >60 days dormant.
- `CHANGELOG.md` `[Unreleased]` section added — entries for both this PR and #7.
- `ARCHITECTURE.md` backfilled durability section after #7 merged: four-layer table (removal:retain / protect / retainOnDelete / auto-snapshot), points at `RECOVERY.md` for restore steps. Cost table gains snapshot row. Key Decisions table gains rows for auto-snapshot and protect+retainOnDelete choices.

## Test plan

- [x] **22 new tests** total: 9 in `__tests__/oauth-provider.test.ts` (sliding expiry + migration), 13 in `__tests__/jwt.test.ts` (sign/verify pair)
- [x] Full suite: **173/173 tests pass** (151 existing + 22 new)
- [x] `prettier --check .` clean
- [x] `eslint .` clean
- [x] `tsc` compiles

## Followup PR — independent of [#7](https://github.com/aliasunder/vault-cortex/pull/7)

The OAuth and Luxon work was the second of two changes from the durability planning session. PR #7 covered Lightsail durability code; this PR covers the OAuth side AND backfills the missing ARCHITECTURE.md durability docs.

## Commits

1. `e13a026` `feat(oauth): 60-day sliding expiry on refresh tokens`
2. `a97266f` `refactor(oauth): use Luxon for date logic; add jwt tests`
3. `6ce8e84` `docs(oauth): annotate TTL constants with their human-readable units`
4. `741f810` `docs: refresh OAuth lifetime claims for sliding expiry; add CHANGELOG entries`
5. `3642ae7` `docs(architecture): backfill durability section after PR #7 merged`

https://claude.ai/code/session_012VFVHWsKEQLJFE3SNguq9C