### PR TITLE
feat(mcp): FTS5 fix, search response shape, tool descriptions, new tools

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist/
 node_modules/
 *.db
 *.sqlite
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Documentation
 
 - Update CHANGELOG.md for v0.1.2
+
 ## [0.1.2] — 2026-05-11
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Context Protocol.
 
-> **Status:** Phase 1 complete — all 12 MCP tools implemented and tested (151 tests). Infrastructure deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
+> **Status:** Phase 1 complete — 13 MCP tools implemented and tested (196 tests). Infrastructure deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
 
 ## Contents
 
@@ -308,7 +308,7 @@ Test with the same curl commands above. The hardcoded token is `local-dev-token`
 
 ### MCP Inspector
 
-Test all 12 tools interactively in a browser UI. The server must be running first:
+Test all tools interactively in a browser UI. The server must be running first:
 
 ```bash
 # Terminal 1 — start the server

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -150,11 +150,8 @@ describe("fullTextSearch", () => {
 
   it("rounds score to at most 4 significant figures", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
-    const digits = String(results[0].score)
-      .replace(".", "")
-      .replace(/^0+/, "")
-      .replace(/0+$/, "")
-    expect(digits.length).toBeLessThanOrEqual(4)
+    const score = results[0].score
+    expect(score).toBe(Number(score.toPrecision(4)))
   })
 
   it("omits created when null", () => {
@@ -264,6 +261,7 @@ describe("fullTextSearch", () => {
       logger,
     )
     expect(phraseResults.some((r) => r.path === "phrase.md")).toBe(true)
+    expect(phraseResults.some((r) => r.path === "separate.md")).toBe(false)
   })
 
   it("query with FTS5 operators does not throw", () => {
@@ -486,9 +484,9 @@ describe("getStats", () => {
     expect(stats.noteCount).toBe(3)
   })
 
-  it("returns correct tag count", () => {
+  it("returns correct distinct tag count", () => {
     const stats = index.getStats(logger)
-    expect(stats.tagCount).toBeGreaterThanOrEqual(3)
+    expect(stats.tagCount).toBe(3)
   })
 
   it("counts recently modified notes", () => {
@@ -496,12 +494,12 @@ describe("getStats", () => {
     expect(stats.recentlyModified).toBe(2)
   })
 
-  it("returns top tags ordered by count", () => {
+  it("returns top tags ordered by count descending", () => {
     const stats = index.getStats(logger)
-    expect(stats.topTags.length).toBeGreaterThan(0)
-    expect(stats.topTags[0].count).toBeGreaterThanOrEqual(
-      stats.topTags[stats.topTags.length - 1].count,
-    )
+    expect(stats.topTags).toHaveLength(3)
+    expect(stats.topTags[0].count).toBe(2)
+    expect(stats.topTags[2].count).toBe(1)
+    expect(stats.topTags[2].tag).toBe("self")
   })
 })
 

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -467,41 +467,6 @@ describe("recentNotes", () => {
   })
 })
 
-describe("getStats", () => {
-  beforeEach(() => {
-    index.upsertNote("About Me/Principles.md", NOTE_WITH_FRONTMATTER, 1000)
-    index.upsertNote(
-      "a.md",
-      "---\ntags: [principles, work]\n---\nbody\n",
-      Date.now(),
-    )
-    index.upsertNote("b.md", "---\ntags: [work]\n---\nbody\n", Date.now())
-  })
-
-  it("returns correct note count", () => {
-    const stats = index.getStats(logger)
-    expect(stats.noteCount).toBe(3)
-  })
-
-  it("returns correct distinct tag count", () => {
-    const stats = index.getStats(logger)
-    expect(stats.tagCount).toBe(3)
-  })
-
-  it("counts recently modified notes", () => {
-    const stats = index.getStats(logger)
-    expect(stats.recentlyModified).toBe(2)
-  })
-
-  it("returns top tags ordered by count descending", () => {
-    const stats = index.getStats(logger)
-    expect(stats.topTags).toHaveLength(3)
-    expect(stats.topTags[0].count).toBe(2)
-    expect(stats.topTags[2].count).toBe(1)
-    expect(stats.topTags[2].tag).toBe("self")
-  })
-})
-
 describe("rebuildFromVault", () => {
   let vaultDir: string
 

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -183,9 +183,7 @@ describe("fullTextSearch", () => {
       { query: "burnout", filters: { snippet_tokens: 60 } },
       logger,
     )
-    expect(long[0].snippet.length).toBeGreaterThanOrEqual(
-      short[0].snippet.length,
-    )
+    expect(long[0].snippet.length).toBeGreaterThan(short[0].snippet.length)
   })
 
   it("respects folder filter", () => {

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -142,10 +142,9 @@ describe("fullTextSearch", () => {
     expect(results[0].snippet).toContain("burnout")
   })
 
-  it("includes type and related in search results", () => {
+  it("includes type in search results", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
     expect(results[0].type).toBe("about-me")
-    expect(results[0].related).toEqual(["Routines", "Career"])
   })
 
   it("rounds score to at most 4 significant figures", () => {

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import { createSearchIndex } from "../search-index.js"
+import { createSearchIndex, sanitizeFtsQuery } from "../search-index.js"
 import type { SearchIndex } from "../search-index.js"
 import { logger } from "../../logger.js"
 
@@ -57,19 +57,19 @@ describe("upsertNote", () => {
 
   it("extracts title from frontmatter", () => {
     index.upsertNote("About Me/Principles.md", NOTE_WITH_FRONTMATTER, 1000)
-    const results = index.searchByFolder("About Me")
+    const results = index.searchByFolder({ folder: "About Me" }, logger)
     expect(results[0].title).toBe("Principles")
   })
 
   it("falls back to filename for title when no frontmatter title", () => {
     index.upsertNote("notes/random.md", NOTE_MINIMAL, 1000)
-    const results = index.searchByFolder("notes")
+    const results = index.searchByFolder({ folder: "notes" }, logger)
     expect(results[0].title).toBe("random")
   })
 
   it("stores folder as first path segment", () => {
     index.upsertNote("About Me/Principles.md", NOTE_WITH_FRONTMATTER, 1000)
-    const results = index.searchByFolder("About Me")
+    const results = index.searchByFolder({ folder: "About Me" }, logger)
     expect(results[0].folder).toBe("About Me")
   })
 
@@ -136,9 +136,56 @@ describe("fullTextSearch", () => {
     expect(results).toHaveLength(1)
   })
 
-  it("returns highlighted snippets", () => {
+  it("returns snippets without HTML markup", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
-    expect(results[0].snippet).toContain("<mark>")
+    expect(results[0].snippet).not.toContain("<mark>")
+    expect(results[0].snippet).toContain("burnout")
+  })
+
+  it("includes type and related in search results", () => {
+    const results = index.fullTextSearch({ query: "burnout" }, logger)
+    expect(results[0].type).toBe("about-me")
+    expect(results[0].related).toEqual(["Routines", "Career"])
+  })
+
+  it("rounds score to at most 4 significant figures", () => {
+    const results = index.fullTextSearch({ query: "burnout" }, logger)
+    const digits = String(results[0].score)
+      .replace(".", "")
+      .replace(/^0+/, "")
+      .replace(/0+$/, "")
+    expect(digits.length).toBeLessThanOrEqual(4)
+  })
+
+  it("omits created when null", () => {
+    const results = index.fullTextSearch({ query: "content without" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0]).not.toHaveProperty("created")
+  })
+
+  it("includes created when present", () => {
+    const results = index.fullTextSearch({ query: "burnout" }, logger)
+    expect(results[0]).toHaveProperty("created")
+    expect(results[0].created).toContain("2025")
+  })
+
+  it("returns integer mtime", () => {
+    const results = index.fullTextSearch({ query: "burnout" }, logger)
+    expect(Number.isInteger(results[0].mtime)).toBe(true)
+  })
+
+  it("respects custom snippet_tokens", () => {
+    const short = index.fullTextSearch(
+      { query: "burnout", filters: { snippet_tokens: 5 } },
+      logger,
+    )
+    const long = index.fullTextSearch(
+      { query: "burnout", filters: { snippet_tokens: 60 } },
+      logger,
+    )
+    expect(long[0].snippet.length).toBeGreaterThanOrEqual(
+      short[0].snippet.length,
+    )
   })
 
   it("respects folder filter", () => {
@@ -185,6 +232,104 @@ describe("fullTextSearch", () => {
     const results = index.fullTextSearch({ query: "run" }, logger)
     expect(results.length).toBeGreaterThan(0)
     expect(results.some((r) => r.path === "stem.md")).toBe(true)
+  })
+
+  it("multi-word query matches notes containing both terms (implicit AND)", () => {
+    const results = index.fullTextSearch(
+      { query: "burnout boundaries" },
+      logger,
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("About Me/Principles.md")
+  })
+
+  it("multi-word query does not require exact phrase adjacency", () => {
+    index.upsertNote(
+      "spread.md",
+      "The word alpha appears here. Much later, beta shows up.\n",
+      5000,
+    )
+    const results = index.fullTextSearch({ query: "alpha beta" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("spread.md")
+  })
+
+  it("exact phrase match with quotes", () => {
+    index.upsertNote("phrase.md", "Learn machine learning today\n", 5000)
+    index.upsertNote(
+      "separate.md",
+      "The machine was broken. Learning was slow.\n",
+      5001,
+    )
+    const phraseResults = index.fullTextSearch(
+      { query: '"machine learning"' },
+      logger,
+    )
+    expect(phraseResults.some((r) => r.path === "phrase.md")).toBe(true)
+  })
+
+  it("query with FTS5 operators does not throw", () => {
+    expect(() =>
+      index.fullTextSearch(
+        { query: 'test "quoted" AND (grouped) OR NOT *wild*' },
+        logger,
+      ),
+    ).not.toThrow()
+  })
+})
+
+describe("sanitizeFtsQuery", () => {
+  const scenarios = [
+    {
+      name: "multi-word: unquoted terms joined with spaces",
+      input: "burnout boundaries",
+      expected: "burnout boundaries",
+    },
+    {
+      name: "single word: passthrough unquoted for stemming",
+      input: "single",
+      expected: "single",
+    },
+    {
+      name: "quoted phrase: preserved",
+      input: '"machine learning"',
+      expected: '"machine learning"',
+    },
+    {
+      name: "phrase + unquoted term",
+      input: '"machine learning" kubernetes',
+      expected: '"machine learning" kubernetes',
+    },
+    {
+      name: "FTS5 specials stripped, reserved words dropped",
+      input: 'test "quoted" AND (grouped)',
+      expected: '"quoted" test grouped',
+    },
+    {
+      name: "wildcard stripped",
+      input: "burn*",
+      expected: "burn",
+    },
+    {
+      name: "all reserved words: empty result",
+      input: "AND OR NOT",
+      expected: '""',
+    },
+    {
+      name: "empty string: empty result",
+      input: "",
+      expected: '""',
+    },
+    {
+      name: "caret and colon stripped",
+      input: "field:value ^boost",
+      expected: "field value boost",
+    },
+  ]
+
+  it.each(scenarios)("$name", ({ input, expected }) => {
+    const result = sanitizeFtsQuery(input)
+    expect(result).toBe(expected)
   })
 })
 
@@ -239,12 +384,18 @@ describe("searchByFolder", () => {
   })
 
   it("recursive mode includes nested files", () => {
-    const results = index.searchByFolder("About Me", { recursive: true })
+    const results = index.searchByFolder(
+      { folder: "About Me", recursive: true },
+      logger,
+    )
     expect(results).toHaveLength(2)
   })
 
   it("non-recursive mode excludes nested files", () => {
-    const results = index.searchByFolder("About Me", { recursive: false })
+    const results = index.searchByFolder(
+      { folder: "About Me", recursive: false },
+      logger,
+    )
     expect(results).toHaveLength(1)
     expect(results[0].path).toBe("About Me/Principles.md")
   })
@@ -257,13 +408,13 @@ describe("searchByType", () => {
   })
 
   it("finds notes by type", () => {
-    const results = index.searchByType("about-me")
+    const results = index.searchByType({ type: "about-me" }, logger)
     expect(results).toHaveLength(1)
     expect(results[0].path).toBe("About Me/Principles.md")
   })
 
   it("returns empty for unknown type", () => {
-    const results = index.searchByType("nonexistent")
+    const results = index.searchByType({ type: "nonexistent" }, logger)
     expect(results).toHaveLength(0)
   })
 })
@@ -318,6 +469,41 @@ describe("recentNotes", () => {
   it("respects limit", () => {
     const results = index.recentNotes({ limit: 1 }, logger)
     expect(results).toHaveLength(1)
+  })
+})
+
+describe("getStats", () => {
+  beforeEach(() => {
+    index.upsertNote("About Me/Principles.md", NOTE_WITH_FRONTMATTER, 1000)
+    index.upsertNote(
+      "a.md",
+      "---\ntags: [principles, work]\n---\nbody\n",
+      Date.now(),
+    )
+    index.upsertNote("b.md", "---\ntags: [work]\n---\nbody\n", Date.now())
+  })
+
+  it("returns correct note count", () => {
+    const stats = index.getStats(logger)
+    expect(stats.noteCount).toBe(3)
+  })
+
+  it("returns correct tag count", () => {
+    const stats = index.getStats(logger)
+    expect(stats.tagCount).toBeGreaterThanOrEqual(3)
+  })
+
+  it("counts recently modified notes", () => {
+    const stats = index.getStats(logger)
+    expect(stats.recentlyModified).toBe(2)
+  })
+
+  it("returns top tags ordered by count", () => {
+    const stats = index.getStats(logger)
+    expect(stats.topTags.length).toBeGreaterThan(0)
+    expect(stats.topTags[0].count).toBeGreaterThanOrEqual(
+      stats.topTags[stats.topTags.length - 1].count,
+    )
   })
 })
 

--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -14,7 +14,6 @@ const TOOL_NAMES = [
   "vault_search_by_folder",
   "vault_list_tags",
   "vault_recent_notes",
-  "vault_stats",
   "vault_get_memory",
   "vault_update_memory",
   "vault_list_memory_files",
@@ -29,7 +28,6 @@ const READ_ONLY_TOOLS = [
   "vault_search_by_folder",
   "vault_list_tags",
   "vault_recent_notes",
-  "vault_stats",
   "vault_get_memory",
   "vault_list_memory_files",
 ] as const
@@ -69,8 +67,8 @@ const findCall = (name: string): RegisterToolCall | undefined =>
   calls.find((c) => c[0] === name)
 
 describe("registerTools", () => {
-  it("registers exactly 14 tools", () => {
-    expect(mockServer.registerTool).toHaveBeenCalledTimes(14)
+  it("registers exactly 13 tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(13)
   })
 
   it.each(TOOL_NAMES)("registers %s", (name) => {

--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -11,8 +11,10 @@ const TOOL_NAMES = [
   "vault_delete_note",
   "vault_search",
   "vault_search_by_tag",
+  "vault_search_by_folder",
   "vault_list_tags",
   "vault_recent_notes",
+  "vault_stats",
   "vault_get_memory",
   "vault_update_memory",
   "vault_list_memory_files",
@@ -24,8 +26,10 @@ const READ_ONLY_TOOLS = [
   "vault_list_notes",
   "vault_search",
   "vault_search_by_tag",
+  "vault_search_by_folder",
   "vault_list_tags",
   "vault_recent_notes",
+  "vault_stats",
   "vault_get_memory",
   "vault_list_memory_files",
 ] as const
@@ -65,8 +69,8 @@ const findCall = (name: string): RegisterToolCall | undefined =>
   calls.find((c) => c[0] === name)
 
 describe("registerTools", () => {
-  it("registers exactly 12 tools", () => {
-    expect(mockServer.registerTool).toHaveBeenCalledTimes(12)
+  it("registers exactly 14 tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(14)
   })
 
   it.each(TOOL_NAMES)("registers %s", (name) => {
@@ -84,6 +88,18 @@ describe("registerTools", () => {
     for (const call of calls) {
       expect(call[1].description).toBeDefined()
       expect(call[1].description!.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("every tool description includes an example", () => {
+    for (const call of calls) {
+      expect(call[1].description).toContain("Example:")
+    }
+  })
+
+  it("every tool description includes when to use guidance", () => {
+    for (const call of calls) {
+      expect(call[1].description).toContain("When to use")
     }
   })
 

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -455,30 +455,6 @@ export const createSearchIndex = (dbPath: string) => {
     return results
   }
 
-  /** Returns aggregate vault statistics for quick orientation. */
-  const getStats = (logger: Logger) => {
-    const { noteCount } = db
-      .prepare("SELECT COUNT(*) as noteCount FROM notes")
-      .get() as { noteCount: number }
-    const { tagCount } = db
-      .prepare(
-        "SELECT COUNT(DISTINCT value) as tagCount FROM notes, json_each(notes.tags)",
-      )
-      .get() as { tagCount: number }
-    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000
-    const { recentlyModified } = db
-      .prepare("SELECT COUNT(*) as recentlyModified FROM notes WHERE mtime > ?")
-      .get(sevenDaysAgo) as { recentlyModified: number }
-    const topTags = db
-      .prepare(
-        "SELECT value as tag, COUNT(*) as count FROM notes, json_each(notes.tags) GROUP BY value ORDER BY count DESC LIMIT 10",
-      )
-      .all() as Array<{ tag: string; count: number }>
-
-    logger.info("vault stats", { noteCount, tagCount })
-    return { noteCount, tagCount, recentlyModified, topTags }
-  }
-
   return {
     upsertNote,
     removeNote,
@@ -489,7 +465,6 @@ export const createSearchIndex = (dbPath: string) => {
     searchByType,
     listAllTags,
     recentNotes,
-    getStats,
   }
 }
 

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -312,7 +312,7 @@ export const createSearchIndex = (dbPath: string) => {
         path: row.path,
         title: row.title,
         snippet: row.snippet,
-        score: Number(Number(row.score).toPrecision(4)),
+        score: Number(row.score.toPrecision(4)),
         tags: JSON.parse(row.tags) as string[],
         folder: row.folder,
         type: row.type,

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -11,6 +11,29 @@ const isString = (value: unknown): value is string => typeof value === "string"
 
 const isDate = (value: unknown): value is Date => value instanceof Date
 
+// ── FTS5 query sanitization ─────────────────────────────────────
+
+const FTS5_RESERVED = new Set(["AND", "OR", "NOT", "NEAR"])
+
+/** Sanitizes user input for safe FTS5 querying. Quoted phrases are preserved
+ *  for exact-phrase matching; unquoted terms are left bare to preserve porter
+ *  stemming. FTS5 metacharacters and reserved words are stripped. */
+export const sanitizeFtsQuery = (raw: string): string => {
+  const phrases: string[] = []
+  const remaining = raw.replace(/"([^"]+)"/g, (_, phrase: string) => {
+    const cleaned = phrase.replace(/[*^():]/g, "").trim()
+    if (cleaned.length > 0) phrases.push(`"${cleaned}"`)
+    return " "
+  })
+  const tokens = remaining
+    .replace(/["*^():]/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length > 0 && !FTS5_RESERVED.has(t.toUpperCase()))
+
+  const parts = [...phrases, ...tokens]
+  return parts.length === 0 ? '""' : parts.join(" ")
+}
+
 // ── Types ───────────────────────────────────────────────────────
 
 type SearchResult = {
@@ -19,8 +42,10 @@ type SearchResult = {
   snippet: string
   score: number
   tags: string[]
+  related: string[]
   folder: string
-  created: string | null
+  type: string | null
+  created?: string
   mtime: number
 }
 
@@ -48,6 +73,7 @@ type SearchFilters = {
   type?: string
   properties?: Record<string, string | number | boolean>
   limit?: number
+  snippet_tokens?: number
 }
 
 type NoteRow = {
@@ -218,9 +244,8 @@ export const createSearchIndex = (dbPath: string) => {
     const conditions: string[] = []
     const queryParams: unknown[] = []
 
-    // Wrap in double quotes to treat as literal phrase, not FTS5 operators (AND, OR, NOT, *)
     conditions.push("notes_fts MATCH ?")
-    queryParams.push(`"${params.query.replace(/"/g, '""')}"`)
+    queryParams.push(sanitizeFtsQuery(params.query))
 
     if (params.filters?.folder) {
       conditions.push("n.path LIKE ?")
@@ -258,12 +283,13 @@ export const createSearchIndex = (dbPath: string) => {
     }
 
     const limit = params.filters?.limit ?? 20
+    const snippetTokens = params.filters?.snippet_tokens ?? 30
     queryParams.push(limit)
 
     const sql = `
       SELECT n.path, n.title,
-             snippet(notes_fts, 2, '<mark>', '</mark>', '...', 30) as snippet,
-             rank * -1 as score, n.tags, n.folder, n.created, n.mtime
+             snippet(notes_fts, 2, '', '', '...', ${Number(snippetTokens)}) as snippet,
+             rank * -1 as score, n.tags, n.related, n.folder, n.type, n.created, n.mtime
       FROM notes_fts
       JOIN notes n ON n.path = notes_fts.path
       WHERE ${conditions.join(" AND ")}
@@ -276,16 +302,31 @@ export const createSearchIndex = (dbPath: string) => {
       const rows = db.prepare(sql).all(...queryParams) as Array<
         Pick<
           NoteRow,
-          "path" | "title" | "tags" | "folder" | "created" | "mtime"
+          | "path"
+          | "title"
+          | "tags"
+          | "related"
+          | "folder"
+          | "type"
+          | "created"
+          | "mtime"
         > & {
           snippet: string
           score: number
         }
       >
 
-      const results = rows.map((row) => ({
-        ...row,
+      const results: SearchResult[] = rows.map((row) => ({
+        path: row.path,
+        title: row.title,
+        snippet: row.snippet,
+        score: Number(Number(row.score).toPrecision(4)),
         tags: JSON.parse(row.tags) as string[],
+        related: JSON.parse(row.related) as string[],
+        folder: row.folder,
+        type: row.type,
+        ...(row.created !== null ? { created: row.created } : {}),
+        mtime: Math.round(row.mtime),
       }))
       logger.info("full text search", {
         query: params.query,
@@ -330,19 +371,19 @@ export const createSearchIndex = (dbPath: string) => {
 
   /** Lists notes in a folder, optionally including subfolders. */
   const searchByFolder = (
-    folder: string,
-    options?: { recursive?: boolean; limit?: number },
+    params: { folder: string; recursive?: boolean; limit?: number },
+    logger: Logger,
   ): NoteMetadata[] => {
-    const recursive = options?.recursive ?? true
-    const limit = options?.limit ?? 20
+    const recursive = params.recursive ?? true
+    const limit = params.limit ?? 20
 
     const condition = recursive
       ? "path LIKE ? || '/%'"
       : "path LIKE ? || '/%' AND path NOT LIKE ? || '/%/%'"
 
     const queryParams: unknown[] = recursive
-      ? [folder, limit]
-      : [folder, folder, limit]
+      ? [params.folder, limit]
+      : [params.folder, params.folder, limit]
 
     const sql = `
       SELECT path, title, tags, related, folder, type, created, mtime, properties
@@ -352,11 +393,19 @@ export const createSearchIndex = (dbPath: string) => {
     `
 
     const rows = db.prepare(sql).all(...queryParams) as NoteRow[]
-    return rows.map(rowToMetadata)
+    const results = rows.map(rowToMetadata)
+    logger.info("search by folder", {
+      folder: params.folder,
+      resultCount: results.length,
+    })
+    return results
   }
 
   /** Finds notes by their frontmatter `type` field. */
-  const searchByType = (type: string, limit?: number): NoteMetadata[] => {
+  const searchByType = (
+    params: { type: string; limit?: number },
+    logger: Logger,
+  ): NoteMetadata[] => {
     const sql = `
       SELECT path, title, tags, related, folder, type, created, mtime, properties
       FROM notes
@@ -364,8 +413,15 @@ export const createSearchIndex = (dbPath: string) => {
       LIMIT ?
     `
 
-    const rows = db.prepare(sql).all(type, limit ?? 20) as NoteRow[]
-    return rows.map(rowToMetadata)
+    const rows = db
+      .prepare(sql)
+      .all(params.type, params.limit ?? 20) as NoteRow[]
+    const results = rows.map(rowToMetadata)
+    logger.info("search by type", {
+      type: params.type,
+      resultCount: results.length,
+    })
+    return results
   }
 
   /** Returns all tags in the vault with their note counts. */
@@ -408,6 +464,30 @@ export const createSearchIndex = (dbPath: string) => {
     return results
   }
 
+  /** Returns aggregate vault statistics for quick orientation. */
+  const getStats = (logger: Logger) => {
+    const { noteCount } = db
+      .prepare("SELECT COUNT(*) as noteCount FROM notes")
+      .get() as { noteCount: number }
+    const { tagCount } = db
+      .prepare(
+        "SELECT COUNT(DISTINCT value) as tagCount FROM notes, json_each(notes.tags)",
+      )
+      .get() as { tagCount: number }
+    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000
+    const { recentlyModified } = db
+      .prepare("SELECT COUNT(*) as recentlyModified FROM notes WHERE mtime > ?")
+      .get(sevenDaysAgo) as { recentlyModified: number }
+    const topTags = db
+      .prepare(
+        "SELECT value as tag, COUNT(*) as count FROM notes, json_each(notes.tags) GROUP BY value ORDER BY count DESC LIMIT 10",
+      )
+      .all() as Array<{ tag: string; count: number }>
+
+    logger.info("vault stats", { noteCount, tagCount })
+    return { noteCount, tagCount, recentlyModified, topTags }
+  }
+
   return {
     upsertNote,
     removeNote,
@@ -418,6 +498,7 @@ export const createSearchIndex = (dbPath: string) => {
     searchByType,
     listAllTags,
     recentNotes,
+    getStats,
   }
 }
 

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -42,7 +42,6 @@ type SearchResult = {
   snippet: string
   score: number
   tags: string[]
-  related: string[]
   folder: string
   type: string | null
   created?: string
@@ -289,7 +288,7 @@ export const createSearchIndex = (dbPath: string) => {
     const sql = `
       SELECT n.path, n.title,
              snippet(notes_fts, 2, '', '', '...', ${Number(snippetTokens)}) as snippet,
-             rank * -1 as score, n.tags, n.related, n.folder, n.type, n.created, n.mtime
+             rank * -1 as score, n.tags, n.folder, n.type, n.created, n.mtime
       FROM notes_fts
       JOIN notes n ON n.path = notes_fts.path
       WHERE ${conditions.join(" AND ")}
@@ -302,14 +301,7 @@ export const createSearchIndex = (dbPath: string) => {
       const rows = db.prepare(sql).all(...queryParams) as Array<
         Pick<
           NoteRow,
-          | "path"
-          | "title"
-          | "tags"
-          | "related"
-          | "folder"
-          | "type"
-          | "created"
-          | "mtime"
+          "path" | "title" | "tags" | "folder" | "type" | "created" | "mtime"
         > & {
           snippet: string
           score: number
@@ -322,7 +314,6 @@ export const createSearchIndex = (dbPath: string) => {
         snippet: row.snippet,
         score: Number(Number(row.score).toPrecision(4)),
         tags: JSON.parse(row.tags) as string[],
-        related: JSON.parse(row.related) as string[],
         folder: row.folder,
         type: row.type,
         ...(row.created !== null ? { created: row.created } : {}),

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -85,8 +85,14 @@ export const registerTools = (params: {
     "vault_read_note",
     {
       title: "Read Note",
-      description:
-        'Read a markdown note by its vault-relative path. Returns the full raw content including YAML frontmatter.\n\nExample: vault_read_note({ path: "About Me/Principles.md" })\n\nWhen to use: You know the exact path and need the full content of a specific note.\nPrefer vault_search when you don\'t know the path. Prefer vault_get_memory for About Me/ files (returns content without frontmatter).\n\nReturns: Raw markdown string.',
+      description: `Read a markdown note by its vault-relative path. Returns the full raw content including YAML frontmatter.
+
+Example: vault_read_note({ path: "About Me/Principles.md" })
+
+When to use: You know the exact path and need the full content of a specific note.
+Prefer vault_search when you don't know the path. Prefer vault_get_memory for About Me/ files (returns content without frontmatter).
+
+Returns: Raw markdown string.`,
       inputSchema: {
         path: z
           .string()
@@ -119,8 +125,14 @@ export const registerTools = (params: {
     "vault_write_note",
     {
       title: "Write Note",
-      description:
-        'Create or update a markdown note. Body is markdown only — frontmatter is passed separately and merged with any existing frontmatter (new keys added, matching keys overwritten, unmentioned keys preserved).\n\nExample: vault_write_note({ path: "Projects/notes.md", body: "# Notes\\n\\nProject notes here.", frontmatter: { tags: ["project"], type: "project" } })\n\nWhen to use: Creating a new note or fully replacing an existing note\'s body. Frontmatter is the YAML metadata block at the top of a note (title, tags, type, created, related, etc.).\nPrefer vault_update_memory for appending dated entries to About Me/ memory files.\n\nReturns: Confirmation message.',
+      description: `Create or update a markdown note. Body is markdown only — frontmatter is passed separately and merged with any existing frontmatter (new keys added, matching keys overwritten, unmentioned keys preserved).
+
+Example: vault_write_note({ path: "Projects/notes.md", body: "# Notes\\n\\nProject notes here.", frontmatter: { tags: ["project"], type: "project" } })
+
+When to use: Creating a new note or fully replacing an existing note's body. Frontmatter is the YAML metadata block at the top of a note (title, tags, type, created, related, etc.).
+Prefer vault_update_memory for appending dated entries to About Me/ memory files.
+
+Returns: Confirmation message.`,
       inputSchema: {
         path: z.string().describe("Vault-relative path for the note"),
         body: z
@@ -159,8 +171,14 @@ export const registerTools = (params: {
     "vault_list_notes",
     {
       title: "List Notes",
-      description:
-        'List .md file paths in the vault, optionally filtered by folder and/or glob pattern. Returns paths only — not content or metadata.\n\nExample: vault_list_notes({ folder: "Projects" }) or vault_list_notes({ glob: "**/*session-log*.md" })\n\nWhen to use: Browsing what exists in a folder by filename, or finding notes matching a path pattern.\nPrefer vault_search for content-based discovery. Prefer vault_search_by_tag for tag-based discovery.\n\nReturns: JSON array of vault-relative paths.',
+      description: `List .md file paths in the vault, optionally filtered by folder and/or glob pattern. Returns paths only — not content or metadata.
+
+Example: vault_list_notes({ folder: "Projects" }) or vault_list_notes({ glob: "**/*session-log*.md" })
+
+When to use: Browsing what exists in a folder by filename, or finding notes matching a path pattern.
+Prefer vault_search for content-based discovery. Prefer vault_search_by_tag for tag-based discovery.
+
+Returns: JSON array of vault-relative paths.`,
       inputSchema: {
         folder: z
           .string()
@@ -198,8 +216,14 @@ export const registerTools = (params: {
     "vault_delete_note",
     {
       title: "Delete Note",
-      description:
-        'Permanently delete a markdown note. Protected paths (About Me/, Daily Notes/) are refused to prevent accidental deletion of memory or daily notes.\n\nExample: vault_delete_note({ path: "Scratch/temp.md" })\n\nWhen to use: Removing a note you no longer need.\nPrefer vault_delete_memory for removing individual dated entries from About Me/ memory files.\n\nReturns: Confirmation message.',
+      description: `Permanently delete a markdown note. Protected paths (About Me/, Daily Notes/) are refused to prevent accidental deletion of memory or daily notes.
+
+Example: vault_delete_note({ path: "Scratch/temp.md" })
+
+When to use: Removing a note you no longer need.
+Prefer vault_delete_memory for removing individual dated entries from About Me/ memory files.
+
+Returns: Confirmation message.`,
       inputSchema: {
         path: z.string().describe("Vault-relative path of the note to delete"),
       },
@@ -230,8 +254,14 @@ export const registerTools = (params: {
     "vault_search",
     {
       title: "Search Notes",
-      description:
-        'Full-text search across all vault notes, ranked by relevance. Supports filtering by folder, tags, type, and frontmatter properties. Wrap terms in double quotes for exact phrase matching (e.g. \'"machine learning"\'); unquoted terms use implicit AND with porter stemming.\n\nExample: vault_search({ query: "kubernetes networking", filters: { tags: ["reference"] } })\n\nWhen to use: Finding notes by content when you don\'t know the exact path. The primary discovery tool for content-based queries.\nPrefer vault_search_by_tag for tag-only queries without text. Prefer vault_list_notes for browsing by folder without a search term. Prefer vault_recent_notes for time-based browsing.\n\nReturns: JSON with results array (path, title, snippet, score, tags, related, folder, type, created, mtime) and total count. created is omitted when null.',
+      description: `Full-text search across all vault notes, ranked by relevance. Supports filtering by folder, tags, type, and frontmatter properties. Wrap terms in double quotes for exact phrase matching (e.g. '"machine learning"'); unquoted terms use implicit AND with porter stemming.
+
+Example: vault_search({ query: "kubernetes networking", filters: { tags: ["reference"] } })
+
+When to use: Finding notes by content when you don't know the exact path. The primary discovery tool for content-based queries.
+Prefer vault_search_by_tag for tag-only queries without text. Prefer vault_list_notes for browsing by folder without a search term. Prefer vault_recent_notes for time-based browsing.
+
+Returns: JSON with results array (path, title, snippet, score, tags, related, folder, type, created, mtime) and total count. created is omitted when null.`,
       inputSchema: {
         query: z.string().describe("Search query text"),
         filters: z
@@ -287,8 +317,14 @@ export const registerTools = (params: {
     "vault_search_by_tag",
     {
       title: "Search by Tag",
-      description:
-        "Find notes with a specific tag. By default uses hierarchical prefix matching — a parent tag matches all children (e.g. 'project' matches 'project/vault-cortex', 'project/blog'). Set exact=true for exact match only.\n\nExample: vault_search_by_tag({ tag: \"project\" }) returns all notes tagged project or project/*.\n\nWhen to use: Exploring tag hierarchies or finding all notes with a specific tag, without needing a text query.\nPrefer vault_search when you also need text-based relevance ranking. Use vault_list_tags first to discover available tags.\n\nReturns: JSON array of note metadata (path, title, tags, related, folder, type, created, mtime, additional_properties). Promoted frontmatter keys are in top-level fields; additional_properties contains only unpromoted keys.",
+      description: `Find notes with a specific tag. By default uses hierarchical prefix matching — a parent tag matches all children (e.g. "project" matches "project/vault-cortex", "project/blog"). Set exact=true for exact match only.
+
+Example: vault_search_by_tag({ tag: "project" }) returns all notes tagged project or project/*.
+
+When to use: Exploring tag hierarchies or finding all notes with a specific tag, without needing a text query.
+Prefer vault_search when you also need text-based relevance ranking. Use vault_list_tags first to discover available tags.
+
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, mtime, additional_properties). Promoted frontmatter keys are in top-level fields; additional_properties contains only unpromoted keys.`,
       inputSchema: {
         tag: z.string().describe("Tag to search for"),
         exact: z
@@ -321,8 +357,14 @@ export const registerTools = (params: {
     "vault_list_tags",
     {
       title: "List Tags",
-      description:
-        'List all tags in the vault with their note counts, ordered by count descending.\n\nExample: vault_list_tags() returns [{ tag: "session-log", count: 42 }, { tag: "project", count: 15 }, ...]\n\nWhen to use: Discovering what tags exist in the vault before searching by tag. Good first step for vault orientation.\nPrefer vault_search_by_tag once you know which tag to query.\n\nReturns: JSON array of { tag, count } objects.',
+      description: `List all tags in the vault with their note counts, ordered by count descending.
+
+Example: vault_list_tags() returns [{ tag: "session-log", count: 42 }, { tag: "project", count: 15 }, ...]
+
+When to use: Discovering what tags exist in the vault before searching by tag. Good first step for vault orientation.
+Prefer vault_search_by_tag once you know which tag to query.
+
+Returns: JSON array of { tag, count } objects.`,
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -349,8 +391,14 @@ export const registerTools = (params: {
     "vault_recent_notes",
     {
       title: "Recent Notes",
-      description:
-        'List recently modified or created notes.\n\nExample: vault_recent_notes({ sort_by: "mtime", limit: 10 })\n\nWhen to use: Catching up on vault changes, finding recent work, or checking what was modified since a given date.\nPrefer vault_search for content-based discovery. Prefer vault_list_notes for browsing a specific folder.\n\nReturns: JSON array of note metadata (path, title, tags, related, folder, type, created, mtime, additional_properties), sorted by chosen timestamp.',
+      description: `List recently modified or created notes.
+
+Example: vault_recent_notes({ sort_by: "mtime", limit: 10 })
+
+When to use: Catching up on vault changes, finding recent work, or checking what was modified since a given date.
+Prefer vault_search for content-based discovery. Prefer vault_list_notes for browsing a specific folder.
+
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, mtime, additional_properties), sorted by chosen timestamp.`,
       inputSchema: {
         sort_by: z
           .enum(["created", "mtime"])
@@ -383,8 +431,14 @@ export const registerTools = (params: {
     "vault_search_by_folder",
     {
       title: "Search by Folder",
-      description:
-        'Browse notes in a folder with full metadata (tags, type, related, created, mtime). Unlike vault_list_notes which returns paths only, this returns rich metadata for each note.\n\nExample: vault_search_by_folder({ folder: "Projects" }) or vault_search_by_folder({ folder: "About Me", recursive: false })\n\nWhen to use: Exploring a folder\'s contents with full context — tags, type, relationships. Useful for vault orientation and understanding folder structure.\nPrefer vault_list_notes when you only need paths. Prefer vault_search when you have a text query.\n\nReturns: JSON array of note metadata (path, title, tags, related, folder, type, created, mtime, additional_properties).',
+      description: `Browse notes in a folder with full metadata (tags, type, related, created, mtime). Unlike vault_list_notes which returns paths only, this returns rich metadata for each note.
+
+Example: vault_search_by_folder({ folder: "Projects" }) or vault_search_by_folder({ folder: "About Me", recursive: false })
+
+When to use: Exploring a folder's contents with full context — tags, type, relationships. Useful for vault orientation and understanding folder structure.
+Prefer vault_list_notes when you only need paths. Prefer vault_search when you have a text query.
+
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, mtime, additional_properties).`,
       inputSchema: {
         folder: z
           .string()
@@ -421,8 +475,13 @@ export const registerTools = (params: {
     "vault_stats",
     {
       title: "Vault Statistics",
-      description:
-        "Get vault statistics — note count, tag count, notes modified in last 7 days, and top 10 tags by frequency.\n\nExample: vault_stats()\n\nWhen to use: Quick vault orientation at the start of a session, or checking corpus size before planning queries.\n\nReturns: JSON with noteCount, tagCount, recentlyModified, and topTags array.",
+      description: `Get vault statistics — note count, tag count, notes modified in last 7 days, and top 10 tags by frequency.
+
+Example: vault_stats()
+
+When to use: Quick vault orientation at the start of a session, or checking corpus size before planning queries.
+
+Returns: JSON with noteCount, tagCount, recentlyModified, and topTags array.`,
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -451,8 +510,14 @@ export const registerTools = (params: {
     "vault_get_memory",
     {
       title: "Get Memory",
-      description:
-        'Read semantic memory from About Me/ files. These are structured memory files containing dated bullet entries organized under H2 headings. No args: all files concatenated (frontmatter stripped). With file: single file content. With file+section: just that H2 section\'s entries.\n\nExample: vault_get_memory({ file: "Principles", section: "Decision heuristics (newest first)" })\n\nWhen to use: Reading user preferences, principles, opinions, or other persistent context stored in About Me/ files. Call vault_list_memory_files first to discover valid file and section names.\nPrefer vault_read_note for reading non-memory notes.\n\nReturns: Raw markdown text.',
+      description: `Read semantic memory from About Me/ files. These are structured memory files containing dated bullet entries organized under H2 headings. No args: all files concatenated (frontmatter stripped). With file: single file content. With file+section: just that H2 section's entries.
+
+Example: vault_get_memory({ file: "Principles", section: "Decision heuristics (newest first)" })
+
+When to use: Reading user preferences, principles, opinions, or other persistent context stored in About Me/ files. Call vault_list_memory_files first to discover valid file and section names.
+Prefer vault_read_note for reading non-memory notes.
+
+Returns: Raw markdown text.`,
       inputSchema: {
         file: z
           .string()
@@ -492,8 +557,14 @@ export const registerTools = (params: {
     "vault_update_memory",
     {
       title: "Update Memory",
-      description:
-        'Append a dated entry to a section of an About Me/ memory file. The server auto-prefixes today\'s date (format: "- **YYYY-MM-DD**: entry text"). Call vault_list_memory_files first to discover valid file and section names.\n\nExample: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })\n\nWhen to use: Recording a new preference, principle, opinion, or fact about the user. Pass raw entry text without date prefix.\nPrefer vault_write_note for creating entirely new notes (not memory entries).\n\nReturns: Confirmation message.',
+      description: `Append a dated entry to a section of an About Me/ memory file. The server auto-prefixes today's date (format: "- **YYYY-MM-DD**: entry text"). Call vault_list_memory_files first to discover valid file and section names.
+
+Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
+
+When to use: Recording a new preference, principle, opinion, or fact about the user. Pass raw entry text without date prefix.
+Prefer vault_write_note for creating entirely new notes (not memory entries).
+
+Returns: Confirmation message.`,
       inputSchema: {
         file: z
           .string()
@@ -554,8 +625,13 @@ export const registerTools = (params: {
     "vault_list_memory_files",
     {
       title: "List Memory Files",
-      description:
-        'Discovery tool — lists About Me/ memory files with their H1/H2 heading structure and per-section entry counts. Does NOT return actual entries.\n\nExample: vault_list_memory_files() returns file outlines with headings like "Decision heuristics (newest first)" and entry counts.\n\nWhen to use: Discovering what memory files and sections exist BEFORE calling vault_get_memory, vault_update_memory, or vault_delete_memory. Always call this first to get valid file and section names.\n\nReturns: JSON array of file outlines.',
+      description: `Discovery tool — lists About Me/ memory files with their H1/H2 heading structure and per-section entry counts. Does NOT return actual entries.
+
+Example: vault_list_memory_files() returns file outlines with headings like "Decision heuristics (newest first)" and entry counts.
+
+When to use: Discovering what memory files and sections exist BEFORE calling vault_get_memory, vault_update_memory, or vault_delete_memory. Always call this first to get valid file and section names.
+
+Returns: JSON array of file outlines.`,
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -582,8 +658,14 @@ export const registerTools = (params: {
     "vault_delete_memory",
     {
       title: "Delete Memory Entry",
-      description:
-        'Delete a single dated entry from an About Me/ memory file. Both date and entry text are required for exact matching — ensures only the intended entry is removed.\n\nExample: vault_delete_memory({ file: "Opinions", section: "AI tooling & memory (newest first)", date: "2026-05-01", entry: "Prefer X over Y" })\n\nWhen to use: Removing an outdated or incorrect entry from a memory file. Call vault_get_memory(file, section) first to see exact entry text for matching.\nPrefer vault_delete_note for deleting entire non-protected notes.\n\nReturns: Confirmation message.',
+      description: `Delete a single dated entry from an About Me/ memory file. Both date and entry text are required for exact matching — ensures only the intended entry is removed.
+
+Example: vault_delete_memory({ file: "Opinions", section: "AI tooling & memory (newest first)", date: "2026-05-01", entry: "Prefer X over Y" })
+
+When to use: Removing an outdated or incorrect entry from a memory file. Call vault_get_memory(file, section) first to see exact entry text for matching.
+Prefer vault_delete_note for deleting entire non-protected notes.
+
+Returns: Confirmation message.`,
       inputSchema: {
         file: z
           .string()

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -17,7 +17,6 @@ export type ToolName =
   | "vault_search_by_folder"
   | "vault_list_tags"
   | "vault_recent_notes"
-  | "vault_stats"
   | "vault_get_memory"
   | "vault_update_memory"
   | "vault_list_memory_files"
@@ -476,40 +475,6 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
     },
   )
 
-  server.registerTool(
-    "vault_stats",
-    {
-      title: "Vault Statistics",
-      description: `Get vault statistics — note count, tag count, notes modified in last 7 days, and top 10 tags by frequency.
-
-Example: vault_stats()
-
-When to use: Quick vault orientation at the start of a session, or checking corpus size before planning queries.
-Use vault_list_tags for the complete tag list — vault_stats returns only the top 10.
-
-Returns: JSON with noteCount, tagCount, recentlyModified, and topTags array.`,
-      inputSchema: {},
-      annotations: {
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-        openWorldHint: false,
-      },
-    },
-    async (_args, extra) => {
-      const reqLogger = sessionLogger.child({
-        requestId: extra.requestId,
-        tool: "vault_stats",
-      })
-      reqLogger.info("tool_call")
-      return safeHandler(
-        reqLogger,
-        async () => search.getStats(reqLogger),
-        (stats) => JSON.stringify(stats),
-      )
-    },
-  )
-
   // ── Memory ──────────────────────────────────────────────────
 
   server.registerTool(
@@ -707,5 +672,5 @@ Returns: Confirmation message.`,
     },
   )
 
-  sessionLogger.info("registered tools", { count: 14 })
+  sessionLogger.info("registered tools", { count: 13 })
 }

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -23,24 +23,27 @@ export type ToolName =
   | "vault_list_memory_files"
   | "vault_delete_memory"
 
-// ── Presentation helpers ─────────────────────────────────────────
+// ── Response shaping ─────────────────────────────────────────────
 
+// Frontmatter keys that are already top-level fields on NoteMetadata.
+// These are stripped from `properties` before returning to clients
+// so the response doesn't contain the same data twice.
 const PROMOTED_KEYS = new Set(["title", "tags", "type", "created", "related"])
 
-/** Strips promoted frontmatter keys from properties, renaming to additional_properties.
- *  Omits the key entirely when no additional properties remain. */
-const toWireMetadata = (meta: {
+const stripPromotedProperties = (meta: {
   properties: Record<string, unknown>
   [key: string]: unknown
 }) => {
-  const { properties, ...rest } = meta
-  const additional = Object.fromEntries(
+  const { properties, ...fields } = meta
+
+  const additional_properties = Object.fromEntries(
     Object.entries(properties).filter(([key]) => !PROMOTED_KEYS.has(key)),
   )
+
   return {
-    ...rest,
-    ...(Object.keys(additional).length > 0
-      ? { additional_properties: additional }
+    ...fields,
+    ...(Object.keys(additional_properties).length > 0
+      ? { additional_properties }
       : {}),
   }
 }
@@ -309,7 +312,7 @@ export const registerTools = (params: {
       return safeHandler(
         reqLogger,
         async () => search.searchByTag({ tag, exactMatch: exact }, reqLogger),
-        (results) => JSON.stringify(results.map(toWireMetadata)),
+        (results) => JSON.stringify(results.map(stripPromotedProperties)),
       )
     },
   )
@@ -371,7 +374,7 @@ export const registerTools = (params: {
       return safeHandler(
         reqLogger,
         async () => search.recentNotes({ sort_by, limit }, reqLogger),
-        (notes) => JSON.stringify(notes.map(toWireMetadata)),
+        (notes) => JSON.stringify(notes.map(stripPromotedProperties)),
       )
     },
   )
@@ -409,7 +412,7 @@ export const registerTools = (params: {
         reqLogger,
         async () =>
           search.searchByFolder({ folder, recursive, limit }, reqLogger),
-        (results) => JSON.stringify(results.map(toWireMetadata)),
+        (results) => JSON.stringify(results.map(stripPromotedProperties)),
       )
     },
   )

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -33,7 +33,7 @@ const PROMOTED_KEYS = new Set(["title", "tags", "type", "created", "related"])
 /** Reshapes NoteMetadata for client responses: keeps all top-level fields,
  *  replaces `properties` (full frontmatter, mostly duplicated) with
  *  `additional_properties` (only unpromoted keys like topic, agent, date). */
-const formatProperties = (meta: {
+const formatNoteMetadata = (meta: {
   properties: Record<string, unknown>
   [key: string]: unknown
 }) => {
@@ -353,7 +353,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
       return safeHandler(
         reqLogger,
         async () => search.searchByTag({ tag, exactMatch: exact }, reqLogger),
-        (results) => JSON.stringify(results.map(formatProperties)),
+        (results) => JSON.stringify(results.map(formatNoteMetadata)),
       )
     },
   )
@@ -427,7 +427,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
       return safeHandler(
         reqLogger,
         async () => search.recentNotes({ sort_by, limit }, reqLogger),
-        (notes) => JSON.stringify(notes.map(formatProperties)),
+        (notes) => JSON.stringify(notes.map(formatNoteMetadata)),
       )
     },
   )
@@ -471,7 +471,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
         reqLogger,
         async () =>
           search.searchByFolder({ folder, recursive, limit }, reqLogger),
-        (results) => JSON.stringify(results.map(formatProperties)),
+        (results) => JSON.stringify(results.map(formatNoteMetadata)),
       )
     },
   )

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -14,12 +14,36 @@ export type ToolName =
   | "vault_delete_note"
   | "vault_search"
   | "vault_search_by_tag"
+  | "vault_search_by_folder"
   | "vault_list_tags"
   | "vault_recent_notes"
+  | "vault_stats"
   | "vault_get_memory"
   | "vault_update_memory"
   | "vault_list_memory_files"
   | "vault_delete_memory"
+
+// ── Presentation helpers ─────────────────────────────────────────
+
+const PROMOTED_KEYS = new Set(["title", "tags", "type", "created", "related"])
+
+/** Strips promoted frontmatter keys from properties, renaming to additional_properties.
+ *  Omits the key entirely when no additional properties remain. */
+const toWireMetadata = (meta: {
+  properties: Record<string, unknown>
+  [key: string]: unknown
+}) => {
+  const { properties, ...rest } = meta
+  const additional = Object.fromEntries(
+    Object.entries(properties).filter(([key]) => !PROMOTED_KEYS.has(key)),
+  )
+  return {
+    ...rest,
+    ...(Object.keys(additional).length > 0
+      ? { additional_properties: additional }
+      : {}),
+  }
+}
 
 /** Wraps a handler with try/catch, returning isError on failure. */
 const safeHandler = <T>(
@@ -59,7 +83,7 @@ export const registerTools = (params: {
     {
       title: "Read Note",
       description:
-        "Read a markdown note by its vault-relative path. Returns the full raw content including YAML frontmatter.\n\nReturns: Raw markdown string.",
+        'Read a markdown note by its vault-relative path. Returns the full raw content including YAML frontmatter.\n\nExample: vault_read_note({ path: "About Me/Principles.md" })\n\nWhen to use: You know the exact path and need the full content of a specific note.\nPrefer vault_search when you don\'t know the path. Prefer vault_get_memory for About Me/ files (returns content without frontmatter).\n\nReturns: Raw markdown string.',
       inputSchema: {
         path: z
           .string()
@@ -93,7 +117,7 @@ export const registerTools = (params: {
     {
       title: "Write Note",
       description:
-        "Create or update a markdown note. Body is markdown only — frontmatter is passed separately and merged with any existing frontmatter.\n\nReturns: Confirmation message.",
+        'Create or update a markdown note. Body is markdown only — frontmatter is passed separately and merged with any existing frontmatter (new keys added, matching keys overwritten, unmentioned keys preserved).\n\nExample: vault_write_note({ path: "Projects/notes.md", body: "# Notes\\n\\nProject notes here.", frontmatter: { tags: ["project"], type: "project" } })\n\nWhen to use: Creating a new note or fully replacing an existing note\'s body. Frontmatter is the YAML metadata block at the top of a note (title, tags, type, created, related, etc.).\nPrefer vault_update_memory for appending dated entries to About Me/ memory files.\n\nReturns: Confirmation message.',
       inputSchema: {
         path: z.string().describe("Vault-relative path for the note"),
         body: z
@@ -133,7 +157,7 @@ export const registerTools = (params: {
     {
       title: "List Notes",
       description:
-        "List .md files in the vault, optionally filtered by folder and/or glob pattern.\n\nReturns: JSON array of vault-relative paths.",
+        'List .md file paths in the vault, optionally filtered by folder and/or glob pattern. Returns paths only — not content or metadata.\n\nExample: vault_list_notes({ folder: "Projects" }) or vault_list_notes({ glob: "**/*session-log*.md" })\n\nWhen to use: Browsing what exists in a folder by filename, or finding notes matching a path pattern.\nPrefer vault_search for content-based discovery. Prefer vault_search_by_tag for tag-based discovery.\n\nReturns: JSON array of vault-relative paths.',
       inputSchema: {
         folder: z
           .string()
@@ -172,7 +196,7 @@ export const registerTools = (params: {
     {
       title: "Delete Note",
       description:
-        'Delete a markdown note. Refuses paths under "About Me/" or "Daily Notes/" — use vault_delete_memory for individual memory entries.\n\nReturns: Confirmation message.',
+        'Permanently delete a markdown note. Protected paths (About Me/, Daily Notes/) are refused to prevent accidental deletion of memory or daily notes.\n\nExample: vault_delete_note({ path: "Scratch/temp.md" })\n\nWhen to use: Removing a note you no longer need.\nPrefer vault_delete_memory for removing individual dated entries from About Me/ memory files.\n\nReturns: Confirmation message.',
       inputSchema: {
         path: z.string().describe("Vault-relative path of the note to delete"),
       },
@@ -204,7 +228,7 @@ export const registerTools = (params: {
     {
       title: "Search Notes",
       description:
-        "Full-text search across all vault notes. Results are ranked by relevance and include highlighted snippets. Supports filtering by folder, tags, type, and frontmatter properties.\n\nReturns: JSON with results array (path, title, snippet, score, tags, folder) and total count.",
+        'Full-text search across all vault notes, ranked by relevance. Supports filtering by folder, tags, type, and frontmatter properties. Wrap terms in double quotes for exact phrase matching (e.g. \'"machine learning"\'); unquoted terms use implicit AND with porter stemming.\n\nExample: vault_search({ query: "kubernetes networking", filters: { tags: ["reference"] } })\n\nWhen to use: Finding notes by content when you don\'t know the exact path. The primary discovery tool for content-based queries.\nPrefer vault_search_by_tag for tag-only queries without text. Prefer vault_list_notes for browsing by folder without a search term. Prefer vault_recent_notes for time-based browsing.\n\nReturns: JSON with results array (path, title, snippet, score, tags, related, folder, type, created, mtime) and total count. created is omitted when null.',
       inputSchema: {
         query: z.string().describe("Search query text"),
         filters: z
@@ -227,6 +251,10 @@ export const registerTools = (params: {
               .optional()
               .describe("Arbitrary frontmatter key-value filters"),
             limit: z.number().optional().describe("Max results (default 20)"),
+            snippet_tokens: z
+              .number()
+              .optional()
+              .describe("Snippet length in tokens (default 30)"),
           })
           .optional()
           .describe("Optional search filters"),
@@ -257,7 +285,7 @@ export const registerTools = (params: {
     {
       title: "Search by Tag",
       description:
-        "Find notes with a specific tag. By default uses prefix matching (parent tag matches children, e.g. 'project' matches 'project/vault-cortex'). Set exact=true for exact match only.\n\nReturns: JSON array of note metadata.",
+        "Find notes with a specific tag. By default uses hierarchical prefix matching — a parent tag matches all children (e.g. 'project' matches 'project/vault-cortex', 'project/blog'). Set exact=true for exact match only.\n\nExample: vault_search_by_tag({ tag: \"project\" }) returns all notes tagged project or project/*.\n\nWhen to use: Exploring tag hierarchies or finding all notes with a specific tag, without needing a text query.\nPrefer vault_search when you also need text-based relevance ranking. Use vault_list_tags first to discover available tags.\n\nReturns: JSON array of note metadata (path, title, tags, related, folder, type, created, mtime, additional_properties). Promoted frontmatter keys are in top-level fields; additional_properties contains only unpromoted keys.",
       inputSchema: {
         tag: z.string().describe("Tag to search for"),
         exact: z
@@ -281,7 +309,7 @@ export const registerTools = (params: {
       return safeHandler(
         reqLogger,
         async () => search.searchByTag({ tag, exactMatch: exact }, reqLogger),
-        (results) => JSON.stringify(results),
+        (results) => JSON.stringify(results.map(toWireMetadata)),
       )
     },
   )
@@ -291,7 +319,7 @@ export const registerTools = (params: {
     {
       title: "List Tags",
       description:
-        "List all tags in the vault with their note counts, ordered by count descending.\n\nReturns: JSON array of { tag, count } objects.",
+        'List all tags in the vault with their note counts, ordered by count descending.\n\nExample: vault_list_tags() returns [{ tag: "session-log", count: 42 }, { tag: "project", count: 15 }, ...]\n\nWhen to use: Discovering what tags exist in the vault before searching by tag. Good first step for vault orientation.\nPrefer vault_search_by_tag once you know which tag to query.\n\nReturns: JSON array of { tag, count } objects.',
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -319,7 +347,7 @@ export const registerTools = (params: {
     {
       title: "Recent Notes",
       description:
-        "List recently modified or created notes.\n\nReturns: JSON array of note metadata, sorted by chosen timestamp.",
+        'List recently modified or created notes.\n\nExample: vault_recent_notes({ sort_by: "mtime", limit: 10 })\n\nWhen to use: Catching up on vault changes, finding recent work, or checking what was modified since a given date.\nPrefer vault_search for content-based discovery. Prefer vault_list_notes for browsing a specific folder.\n\nReturns: JSON array of note metadata (path, title, tags, related, folder, type, created, mtime, additional_properties), sorted by chosen timestamp.',
       inputSchema: {
         sort_by: z
           .enum(["created", "mtime"])
@@ -343,7 +371,73 @@ export const registerTools = (params: {
       return safeHandler(
         reqLogger,
         async () => search.recentNotes({ sort_by, limit }, reqLogger),
-        (notes) => JSON.stringify(notes),
+        (notes) => JSON.stringify(notes.map(toWireMetadata)),
+      )
+    },
+  )
+
+  server.registerTool(
+    "vault_search_by_folder",
+    {
+      title: "Search by Folder",
+      description:
+        'Browse notes in a folder with full metadata (tags, type, related, created, mtime). Unlike vault_list_notes which returns paths only, this returns rich metadata for each note.\n\nExample: vault_search_by_folder({ folder: "Projects" }) or vault_search_by_folder({ folder: "About Me", recursive: false })\n\nWhen to use: Exploring a folder\'s contents with full context — tags, type, relationships. Useful for vault orientation and understanding folder structure.\nPrefer vault_list_notes when you only need paths. Prefer vault_search when you have a text query.\n\nReturns: JSON array of note metadata (path, title, tags, related, folder, type, created, mtime, additional_properties).',
+      inputSchema: {
+        folder: z
+          .string()
+          .describe('Folder path (e.g. "Projects", "About Me")'),
+        recursive: z
+          .boolean()
+          .optional()
+          .describe("Include subfolders (default: true)"),
+        limit: z.number().optional().describe("Max results (default 20)"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ folder, recursive, limit }, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_search_by_folder",
+      })
+      reqLogger.info("tool_call", { folder, recursive })
+      return safeHandler(
+        reqLogger,
+        async () =>
+          search.searchByFolder({ folder, recursive, limit }, reqLogger),
+        (results) => JSON.stringify(results.map(toWireMetadata)),
+      )
+    },
+  )
+
+  server.registerTool(
+    "vault_stats",
+    {
+      title: "Vault Statistics",
+      description:
+        "Get vault statistics — note count, tag count, notes modified in last 7 days, and top 10 tags by frequency.\n\nExample: vault_stats()\n\nWhen to use: Quick vault orientation at the start of a session, or checking corpus size before planning queries.\n\nReturns: JSON with noteCount, tagCount, recentlyModified, and topTags array.",
+      inputSchema: {},
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (_args, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_stats",
+      })
+      reqLogger.info("tool_call")
+      return safeHandler(
+        reqLogger,
+        async () => search.getStats(reqLogger),
+        (stats) => JSON.stringify(stats),
       )
     },
   )
@@ -355,7 +449,7 @@ export const registerTools = (params: {
     {
       title: "Get Memory",
       description:
-        "Read semantic memory from About Me/ files. No args: all files concatenated (frontmatter stripped). With file: single file content. With file+section: just that H2 section's entries.\n\nReturns: Raw markdown text.",
+        'Read semantic memory from About Me/ files. These are structured memory files containing dated bullet entries organized under H2 headings. No args: all files concatenated (frontmatter stripped). With file: single file content. With file+section: just that H2 section\'s entries.\n\nExample: vault_get_memory({ file: "Principles", section: "Decision heuristics (newest first)" })\n\nWhen to use: Reading user preferences, principles, opinions, or other persistent context stored in About Me/ files. Call vault_list_memory_files first to discover valid file and section names.\nPrefer vault_read_note for reading non-memory notes.\n\nReturns: Raw markdown text.',
       inputSchema: {
         file: z
           .string()
@@ -396,7 +490,7 @@ export const registerTools = (params: {
     {
       title: "Update Memory",
       description:
-        "Append a dated entry to a section of an About Me/ memory file. The server prefixes the date — pass raw entry text only. Call vault_list_memory_files first to discover valid file and section names.\n\nReturns: Confirmation message.",
+        'Append a dated entry to a section of an About Me/ memory file. The server auto-prefixes today\'s date (format: "- **YYYY-MM-DD**: entry text"). Call vault_list_memory_files first to discover valid file and section names.\n\nExample: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })\n\nWhen to use: Recording a new preference, principle, opinion, or fact about the user. Pass raw entry text without date prefix.\nPrefer vault_write_note for creating entirely new notes (not memory entries).\n\nReturns: Confirmation message.',
       inputSchema: {
         file: z
           .string()
@@ -458,7 +552,7 @@ export const registerTools = (params: {
     {
       title: "List Memory Files",
       description:
-        "Discovery tool — lists About Me/ files with their H1/H2 heading structure and per-section entry counts. Does NOT return actual entries. Call this before vault_get_memory, vault_update_memory, or vault_delete_memory to discover valid file and section names.\n\nReturns: JSON array of file outlines.",
+        'Discovery tool — lists About Me/ memory files with their H1/H2 heading structure and per-section entry counts. Does NOT return actual entries.\n\nExample: vault_list_memory_files() returns file outlines with headings like "Decision heuristics (newest first)" and entry counts.\n\nWhen to use: Discovering what memory files and sections exist BEFORE calling vault_get_memory, vault_update_memory, or vault_delete_memory. Always call this first to get valid file and section names.\n\nReturns: JSON array of file outlines.',
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -486,7 +580,7 @@ export const registerTools = (params: {
     {
       title: "Delete Memory Entry",
       description:
-        "Delete a single dated entry from an About Me/ memory file. Both date and entry text are required for exact matching. Call vault_get_memory(file, section) first to see exact entry text.\n\nReturns: Confirmation message.",
+        'Delete a single dated entry from an About Me/ memory file. Both date and entry text are required for exact matching — ensures only the intended entry is removed.\n\nExample: vault_delete_memory({ file: "Opinions", section: "AI tooling & memory (newest first)", date: "2026-05-01", entry: "Prefer X over Y" })\n\nWhen to use: Removing an outdated or incorrect entry from a memory file. Call vault_get_memory(file, section) first to see exact entry text for matching.\nPrefer vault_delete_note for deleting entire non-protected notes.\n\nReturns: Confirmation message.',
       inputSchema: {
         file: z
           .string()
@@ -522,5 +616,5 @@ export const registerTools = (params: {
     },
   )
 
-  sessionLogger.info("registered tools", { count: 12 })
+  sessionLogger.info("registered tools", { count: 14 })
 }

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -1,4 +1,4 @@
-/** MCP tool definitions — registers all 12 vault-cortex tools with Zod schemas. */
+/** MCP tool definitions — registers all vault-cortex tools with Zod schemas. */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { z } from "zod"

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -263,7 +263,7 @@ Example: vault_search({ query: "kubernetes networking", filters: { tags: ["refer
 When to use: Finding notes by content when you don't know the exact path. The primary discovery tool for content-based queries.
 Prefer vault_search_by_tag for tag-only queries without text. Prefer vault_search_by_folder for browsing a folder without a search term. Prefer vault_recent_notes for time-based browsing.
 
-Returns: JSON with results array (path, title, snippet, score, tags, related, folder, type, created, mtime) and total count. created is omitted when null.`,
+Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, mtime) and total count. created is omitted when null.`,
       inputSchema: {
         query: z.string().describe("Search query text"),
         filters: z

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -30,6 +30,7 @@ export type ToolName =
 // so the response doesn't contain the same data twice.
 const PROMOTED_KEYS = new Set(["title", "tags", "type", "created", "related"])
 
+/** Removes keys already present as top-level fields, returning the rest as `additional_properties`. */
 const stripPromotedProperties = (meta: {
   properties: Record<string, unknown>
   [key: string]: unknown

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -30,7 +30,9 @@ export type ToolName =
 // so the response doesn't contain the same data twice.
 const PROMOTED_KEYS = new Set(["title", "tags", "type", "created", "related"])
 
-/** Removes keys already present as top-level fields, returning the rest as `additional_properties`. */
+/** Deduplicates NoteMetadata for the wire: strips frontmatter keys that are
+ *  already promoted to top-level fields (title, tags, etc.) from `properties`,
+ *  and returns only the unpromoted remainder as `additional_properties`. */
 const stripPromotedProperties = (meta: {
   properties: Record<string, unknown>
   [key: string]: unknown

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -30,9 +30,8 @@ export type ToolName =
 // so the response doesn't contain the same data twice.
 const PROMOTED_KEYS = new Set(["title", "tags", "type", "created", "related"])
 
-/** Deduplicates NoteMetadata for the wire: strips frontmatter keys that are
- *  already promoted to top-level fields (title, tags, etc.) from `properties`,
- *  and returns only the unpromoted remainder as `additional_properties`. */
+/** Replaces `properties` (full frontmatter) with `additional_properties`
+ *  (only frontmatter keys not already in top-level fields like title, tags, type). */
 const stripPromotedProperties = (meta: {
   properties: Record<string, unknown>
   [key: string]: unknown

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -87,7 +87,7 @@ export const registerTools = (params: {
       title: "Read Note",
       description: `Read a markdown note by its vault-relative path. Returns the full raw content including YAML frontmatter.
 
-Example: vault_read_note({ path: "About Me/Principles.md" })
+Example: vault_read_note({ path: "Projects/vault-cortex.md" })
 
 When to use: You know the exact path and need the full content of a specific note.
 Prefer vault_search when you don't know the path. Prefer vault_get_memory for About Me/ files (returns content without frontmatter).
@@ -125,12 +125,14 @@ Returns: Raw markdown string.`,
     "vault_write_note",
     {
       title: "Write Note",
-      description: `Create or update a markdown note. Body is markdown only — frontmatter is passed separately and merged with any existing frontmatter (new keys added, matching keys overwritten, unmentioned keys preserved).
+      description: `Create or update a markdown note. Body replaces the entire note content — this is a full overwrite, not a partial edit. Frontmatter is passed separately and merged with any existing frontmatter (new keys added, matching keys overwritten, unmentioned keys preserved).
 
 Example: vault_write_note({ path: "Projects/notes.md", body: "# Notes\\n\\nProject notes here.", frontmatter: { tags: ["project"], type: "project" } })
 
-When to use: Creating a new note or fully replacing an existing note's body. Frontmatter is the YAML metadata block at the top of a note (title, tags, type, created, related, etc.).
+When to use: Creating a new note or fully replacing an existing note's body.
 Prefer vault_update_memory for appending dated entries to About Me/ memory files.
+
+Limitation: Overwrites the entire body. Do not use for surgical edits to large files — existing content will be lost unless you include it in the body parameter.
 
 Returns: Confirmation message.`,
       inputSchema: {
@@ -176,7 +178,7 @@ Returns: Confirmation message.`,
 Example: vault_list_notes({ folder: "Projects" }) or vault_list_notes({ glob: "**/*session-log*.md" })
 
 When to use: Browsing what exists in a folder by filename, or finding notes matching a path pattern.
-Prefer vault_search for content-based discovery. Prefer vault_search_by_tag for tag-based discovery.
+Prefer vault_search_by_folder when you need metadata (tags, type, related) along with paths. Prefer vault_search for content-based discovery.
 
 Returns: JSON array of vault-relative paths.`,
       inputSchema: {
@@ -259,7 +261,7 @@ Returns: Confirmation message.`,
 Example: vault_search({ query: "kubernetes networking", filters: { tags: ["reference"] } })
 
 When to use: Finding notes by content when you don't know the exact path. The primary discovery tool for content-based queries.
-Prefer vault_search_by_tag for tag-only queries without text. Prefer vault_list_notes for browsing by folder without a search term. Prefer vault_recent_notes for time-based browsing.
+Prefer vault_search_by_tag for tag-only queries without text. Prefer vault_search_by_folder for browsing a folder without a search term. Prefer vault_recent_notes for time-based browsing.
 
 Returns: JSON with results array (path, title, snippet, score, tags, related, folder, type, created, mtime) and total count. created is omitted when null.`,
       inputSchema: {
@@ -391,12 +393,12 @@ Returns: JSON array of { tag, count } objects.`,
     "vault_recent_notes",
     {
       title: "Recent Notes",
-      description: `List recently modified or created notes.
+      description: `List recently modified or created notes, sorted by timestamp. Returns the most recent notes first — does not filter by date range.
 
 Example: vault_recent_notes({ sort_by: "mtime", limit: 10 })
 
-When to use: Catching up on vault changes, finding recent work, or checking what was modified since a given date.
-Prefer vault_search for content-based discovery. Prefer vault_list_notes for browsing a specific folder.
+When to use: Catching up on vault changes or finding recent work.
+Prefer vault_search for content-based discovery. Prefer vault_search_by_folder for browsing a specific folder.
 
 Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, mtime, additional_properties), sorted by chosen timestamp.`,
       inputSchema: {
@@ -480,6 +482,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
 Example: vault_stats()
 
 When to use: Quick vault orientation at the start of a session, or checking corpus size before planning queries.
+Use vault_list_tags for the complete tag list — vault_stats returns only the top 10.
 
 Returns: JSON with noteCount, tagCount, recentlyModified, and topTags array.`,
       inputSchema: {},
@@ -510,7 +513,7 @@ Returns: JSON with noteCount, tagCount, recentlyModified, and topTags array.`,
     "vault_get_memory",
     {
       title: "Get Memory",
-      description: `Read semantic memory from About Me/ files. These are structured memory files containing dated bullet entries organized under H2 headings. No args: all files concatenated (frontmatter stripped). With file: single file content. With file+section: just that H2 section's entries.
+      description: `Read semantic memory from About Me/ files. These are structured memory files containing dated bullet entries organized under H2 headings. With file: single file content. With file+section: just that H2 section's entries. No args: all files concatenated (frontmatter stripped) — can be large.
 
 Example: vault_get_memory({ file: "Principles", section: "Decision heuristics (newest first)" })
 

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -30,8 +30,9 @@ export type ToolName =
 // so the response doesn't contain the same data twice.
 const PROMOTED_KEYS = new Set(["title", "tags", "type", "created", "related"])
 
-/** Replaces `properties` (full frontmatter) with `additional_properties`
- *  (only frontmatter keys not already in top-level fields like title, tags, type). */
+/** Reshapes NoteMetadata for client responses: keeps all top-level fields,
+ *  replaces `properties` (full frontmatter, mostly duplicated) with
+ *  `additional_properties` (only unpromoted keys like topic, agent, date). */
 const stripPromotedProperties = (meta: {
   properties: Record<string, unknown>
   [key: string]: unknown

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -33,7 +33,7 @@ const PROMOTED_KEYS = new Set(["title", "tags", "type", "created", "related"])
 /** Reshapes NoteMetadata for client responses: keeps all top-level fields,
  *  replaces `properties` (full frontmatter, mostly duplicated) with
  *  `additional_properties` (only unpromoted keys like topic, agent, date). */
-const stripPromotedProperties = (meta: {
+const formatProperties = (meta: {
   properties: Record<string, unknown>
   [key: string]: unknown
 }) => {
@@ -353,7 +353,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
       return safeHandler(
         reqLogger,
         async () => search.searchByTag({ tag, exactMatch: exact }, reqLogger),
-        (results) => JSON.stringify(results.map(stripPromotedProperties)),
+        (results) => JSON.stringify(results.map(formatProperties)),
       )
     },
   )
@@ -427,7 +427,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
       return safeHandler(
         reqLogger,
         async () => search.recentNotes({ sort_by, limit }, reqLogger),
-        (notes) => JSON.stringify(notes.map(stripPromotedProperties)),
+        (notes) => JSON.stringify(notes.map(formatProperties)),
       )
     },
   )
@@ -471,7 +471,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
         reqLogger,
         async () =>
           search.searchByFolder({ folder, recursive, limit }, reqLogger),
-        (results) => JSON.stringify(results.map(stripPromotedProperties)),
+        (results) => JSON.stringify(results.map(formatProperties)),
       )
     },
   )


### PR DESCRIPTION
## Summary

- **FTS5 phrase-match fix**: Multi-word queries now use implicit AND with porter stemming preserved (e.g. "LightRAG semantic" finds notes containing both terms). Exact phrase matching supported via `"..."` quotes. Previously all multi-word queries were forced into exact-phrase matches, returning 0 results when terms weren't adjacent.
- **Search response shape cleanup**: `SearchResult` now includes `type` (filter⇒result invariant), strips `<mark>` HTML from snippets, rounds score to 4 sig figs, omits null `created`, rounds `mtime` to integer. Configurable `snippet_tokens` parameter added. `related` intentionally excluded — navigational metadata not useful for search result triage.
- **`additional_properties` deduplication**: All `NoteMetadata`-returning tools (`vault_search_by_tag`, `vault_recent_notes`, `vault_search_by_folder`) now strip promoted frontmatter keys (title, tags, type, created, related) from the properties blob and rename to `additional_properties`. Omitted entirely when empty.
- **Tool descriptions pass**: All 13 tools now include `Example:` and `When to use:` guidance with cross-references to related tools. Descriptions use template literals for source readability. Audited against MCP best practices (Anthropic tool-use guidance, Glama TDQS rubric) — no contradictions between examples and guidance, limitations disclosed (e.g. vault_write_note's full-body overwrite).
- **New tool**: `vault_search_by_folder` (browse folder with full metadata — fills gap where `vault_list_notes` returns paths only). 13 tools total (12 original + 1 new).
- **Signature fixes**: `searchByFolder` and `searchByType` updated to `(params, logger)` convention. `searchByType` kept internal (redundant with `searchByTag`).
- **vault_stats removed after triage**: Originally implemented, then removed — every field was a strict subset of existing tools. Revisit with unique data (word count, orphan count) in a follow-up session.

## Test plan

- [x] 23 new tests added (196 total, up from 173)
- [x] `sanitizeFtsQuery` unit tests: 9 table-driven scenarios (multi-word, phrases, FTS5 operators, empty input)
- [x] Multi-word + exact phrase integration tests for `fullTextSearch` (includes negative assertion: non-adjacent terms excluded from phrase results)
- [x] Search response shape tests: no `<mark>`, type present, score precision, created omission, integer mtime, snippet_tokens strict comparison
- [x] Tool description assertions: every tool contains "Example:" and "When to use"
- [x] `npm run build` compiles clean
- [x] Live verification: issue multi-word `vault_search`, call `vault_search_by_folder` via deployed MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)