### PR TITLE
feat(mcp): add vault_patch_note and vault_replace_in_note tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ src/
     consent-page.ts                    # HTML consent page for OAuth authorization
     tool-definitions.ts                # MCP tool registrations + Zod schemas
     vault-filesystem.ts                # Read/write/list/delete .md files
+    vault-patcher.ts                   # Surgical edits: heading-targeted patch + find-and-replace
     memory-store.ts                    # About Me/ heading-aware read/append/delete
     search-index.ts                    # SQLite FTS5 factory (tags, folders, etc)
     file-watcher.ts                    # chokidar -> keeps index current

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,8 @@ connector is typically loaded as deferred tools (names like
 `mcp__*__vault_*`). Before claiming inability to read or write the vault,
 check the deferred-tools list and load schemas via `ToolSearch`. The
 connector exposes `vault_read_note`, `vault_search`, `vault_get_memory`,
-`vault_write_note`, and the rest of the API in
-`src/vault-mcp/tool-definitions.ts`.
+`vault_write_note`, `vault_patch_note`, `vault_replace_in_note`, and the
+rest of the API (15 tools) in `src/vault-mcp/tool-definitions.ts`.
 
 ## Logging
 
@@ -104,9 +104,9 @@ root logger (src/logger.ts)
 - `tool-definitions.ts` creates a **request logger** per tool call,
   adding `requestId` + `tool` name from the MCP SDK's
   `RequestHandlerExtra`
-- Data-layer functions (`vault-filesystem`, `memory-store`,
-  `search-index`) take the logger as a **required** second argument
-  (two-arg pattern: `(params, logger)`)
+- Data-layer functions (`vault-filesystem`, `vault-patcher`,
+  `memory-store`, `search-index`) take the logger as a **required**
+  second argument (two-arg pattern: `(params, logger)`)
 - Background callers (file-watcher, startup) use the root logger
   directly — no request context available
 
@@ -136,7 +136,16 @@ search.fullTextSearch({ query, filters }, reqLogger)
 - `type` over `interface` unless `interface` is specifically required.
 - TypeScript strict mode. `node:` prefix for built-ins.
 - Explicit return types on exports. Zod for MCP tool schemas.
-- No `any`. Prefer `async/await`.
+- No `any`. Prefer `async/await` over `.then()`/`.catch()`.
+- Immutable by default. Avoid `let` — carry state in reduce
+  accumulators, use early returns, or destructure conditional results.
+  A bit of duplication is acceptable to keep code immutable and clear.
+- Explicit names over abbreviations. Variable names should describe
+  what the value _is_, not use shorthand (`availableHeadings` not
+  `available`, `searchText` not `needle`, `fileContent` not `raw`).
+- Regex constants get doc comments explaining what they match.
+- MCP tool descriptions include `Example:`, `When to use:`,
+  `Errors:` (with remediation guidance), and `Returns:` sections.
 
 ## SST conventions
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -162,25 +162,30 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 
 ### Phase 1: Vault Read/Write (R2, R3)
 
-| Tool                | Input                      | Annotation      |
-| ------------------- | -------------------------- | --------------- |
-| `vault_read_note`   | `path`                     | readOnlyHint    |
-| `vault_write_note`  | `path, body, frontmatter?` | destructiveHint |
-| `vault_list_notes`  | `folder?, glob?`           | readOnlyHint    |
-| `vault_delete_note` | `path`                     | destructiveHint |
+| Tool                    | Input                                                | Annotation      |
+| ----------------------- | ---------------------------------------------------- | --------------- |
+| `vault_read_note`       | `path`                                               | readOnlyHint    |
+| `vault_write_note`      | `path, body, frontmatter?`                           | destructiveHint |
+| `vault_patch_note`      | `path, operation, content, heading?, heading_level?` | destructiveHint |
+| `vault_replace_in_note` | `path, old_text, new_text, replace_all_occurrences?` | destructiveHint |
+| `vault_list_notes`      | `folder?, glob?`                                     | readOnlyHint    |
+| `vault_delete_note`     | `path`                                               | destructiveHint |
+
+`vault_patch_note` supports 4 operations: `append`, `prepend`, `replace`, `insert_before` — heading-targeted with optional file-level mode. `vault_replace_in_note` does exact text find-and-replace in the note body.
 
 `vault_delete_note` refuses paths under `About Me/` or `Daily Notes/` as a server-side guardrail; use `vault_delete_memory` for individual entries in those files.
 
 ### Phase 1: Search (R4)
 
-| Tool                  | Input              | Annotation   |
-| --------------------- | ------------------ | ------------ |
-| `vault_search`        | `query, filters?`  | readOnlyHint |
-| `vault_search_by_tag` | `tag, exact?`      | readOnlyHint |
-| `vault_list_tags`     | —                  | readOnlyHint |
-| `vault_recent_notes`  | `sort_by?, limit?` | readOnlyHint |
+| Tool                     | Input                        | Annotation   |
+| ------------------------ | ---------------------------- | ------------ |
+| `vault_search`           | `query, filters?`            | readOnlyHint |
+| `vault_search_by_tag`    | `tag, exact?`                | readOnlyHint |
+| `vault_search_by_folder` | `folder, recursive?, limit?` | readOnlyHint |
+| `vault_list_tags`        | —                            | readOnlyHint |
+| `vault_recent_notes`     | `sort_by?, limit?`           | readOnlyHint |
 
-`filters` covers `folder`, `tags`, `related`, `type`, `properties` (arbitrary frontmatter keys), and `limit`. `sort_by` is `"created" | "mtime"` (default `"mtime"`).
+`filters` covers `folder`, `tags`, `related`, `type`, `properties` (arbitrary frontmatter keys), `limit`, and `snippet_tokens`. `sort_by` is `"created" | "modified"` (default `"modified"`).
 
 ### Phase 1: Memory (R5)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Context Protocol.
 
-> **Status:** Phase 1 complete — 13 MCP tools implemented and tested (196 tests). Infrastructure deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
+> **Status:** Phase 1 complete — 15 MCP tools implemented and tested (251 tests). Infrastructure deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Context Protocol.
 
-> **Status:** Phase 1 complete — 15 MCP tools implemented and tested (251 tests). Infrastructure deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
+> **Status:** Phase 1 complete — 15 MCP tools, deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
 
 ## Contents
 

--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -7,6 +7,8 @@ import { logger } from "../../logger.js"
 const TOOL_NAMES = [
   "vault_read_note",
   "vault_write_note",
+  "vault_patch_note",
+  "vault_replace_in_note",
   "vault_list_notes",
   "vault_delete_note",
   "vault_search",
@@ -67,8 +69,8 @@ const findCall = (name: string): RegisterToolCall | undefined =>
   calls.find((c) => c[0] === name)
 
 describe("registerTools", () => {
-  it("registers exactly 13 tools", () => {
-    expect(mockServer.registerTool).toHaveBeenCalledTimes(13)
+  it("registers exactly 15 tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(15)
   })
 
   it.each(TOOL_NAMES)("registers %s", (name) => {

--- a/src/vault-mcp/__tests__/vault-patcher.test.ts
+++ b/src/vault-mcp/__tests__/vault-patcher.test.ts
@@ -1,0 +1,927 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { mkdtemp, rm, writeFile, readFile, mkdir } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { vaultPatcher } from "../vault-patcher.js"
+import { logger } from "../../logger.js"
+
+const { patchNote, replaceInNote } = vaultPatcher
+
+let vault: string
+
+beforeEach(async () => {
+  vault = await mkdtemp(join(tmpdir(), "vault-patcher-test-"))
+})
+
+afterEach(async () => {
+  await rm(vault, { recursive: true })
+})
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const writeTestNote = async (name: string, content: string): Promise<void> => {
+  const dir = join(vault, ...name.split("/").slice(0, -1))
+  if (dir !== vault) await mkdir(dir, { recursive: true })
+  await writeFile(join(vault, name), content, "utf8")
+}
+
+const readTestNote = async (name: string): Promise<string> =>
+  readFile(join(vault, name), "utf8")
+
+const NOTE_WITH_SECTIONS = `---
+title: Test Note
+tags: [test]
+---
+
+# Main Title
+
+Intro paragraph.
+
+## Active
+- [ ] Task A
+- [ ] Task B
+
+### Subtasks
+- [ ] Sub-task 1
+
+## Up Next
+- [ ] Task C
+
+## Done
+- [x] Task D
+`
+
+const NOTE_NO_FRONTMATTER = `# Title
+
+## Section One
+Content one.
+
+## Section Two
+Content two.
+`
+
+const NOTE_WITH_CODE_BLOCK = `---
+title: Code Example
+---
+
+## Real Heading
+
+Some text.
+
+\`\`\`markdown
+## Fake Heading Inside Code
+This should be ignored.
+\`\`\`
+
+## Another Real Heading
+
+More text.
+`
+
+// ── parseHeadings (tested indirectly via patchNote) ─────────────
+
+describe("heading parsing", () => {
+  it("handles all 6 heading levels", async () => {
+    const content = `---
+title: Levels
+---
+
+# H1
+## H2
+### H3
+#### H4
+##### H5
+###### H6
+`
+    await writeTestNote("levels.md", content)
+    // Verify we can target each level
+    for (const [level, text] of [
+      [1, "H1"],
+      [2, "H2"],
+      [3, "H3"],
+      [4, "H4"],
+      [5, "H5"],
+      [6, "H6"],
+    ] as const) {
+      const result = await patchNote(
+        {
+          vaultPath: vault,
+          path: "levels.md",
+          operation: "append",
+          content: `Level ${level} content`,
+          heading: text,
+          headingLevel: level,
+        },
+        logger,
+      )
+      expect(result).toContain(`Applied append`)
+    }
+  })
+
+  it("ignores headings inside fenced code blocks", async () => {
+    await writeTestNote("code.md", NOTE_WITH_CODE_BLOCK)
+    // "Fake Heading Inside Code" should not be found
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "code.md",
+          operation: "append",
+          content: "new content",
+          heading: "Fake Heading Inside Code",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("heading not found")
+  })
+
+  it("targets real headings around code blocks", async () => {
+    await writeTestNote("code.md", NOTE_WITH_CODE_BLOCK)
+    const result = await patchNote(
+      {
+        vaultPath: vault,
+        path: "code.md",
+        operation: "append",
+        content: "appended text",
+        heading: "Real Heading",
+      },
+      logger,
+    )
+    expect(result).toContain("Applied append")
+    const updated = await readTestNote("code.md")
+    expect(updated).toContain("appended text")
+  })
+
+  it("strips trailing hashes from headings", async () => {
+    const content = `---
+title: Hashes
+---
+
+## Title With Hashes ##
+
+Content here.
+`
+    await writeTestNote("hashes.md", content)
+    const result = await patchNote(
+      {
+        vaultPath: vault,
+        path: "hashes.md",
+        operation: "append",
+        content: "new line",
+        heading: "Title With Hashes",
+      },
+      logger,
+    )
+    expect(result).toContain("Applied append")
+  })
+
+  it("returns empty list for file with no headings", async () => {
+    await writeTestNote("flat.md", "---\ntitle: Flat\n---\n\nJust text.\n")
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "flat.md",
+          operation: "append",
+          content: "more text",
+          heading: "Nonexistent",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("heading not found")
+  })
+})
+
+// ── findHeading (tested indirectly via error messages) ──────────
+
+describe("heading lookup", () => {
+  it("matches case-sensitively", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          operation: "append",
+          content: "text",
+          heading: "active",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("heading not found")
+  })
+
+  it("errors on heading not found with available list", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          operation: "append",
+          content: "text",
+          heading: "Missing",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(/Available headings:.*Active/)
+  })
+
+  it("errors on ambiguous heading", async () => {
+    const content = `---
+title: Ambiguous
+---
+
+## Section
+First content.
+
+## Section
+Second content.
+`
+    await writeTestNote("ambig.md", content)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "ambig.md",
+          operation: "append",
+          content: "text",
+          heading: "Section",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(/ambiguous.*2 sections.*heading_level/)
+  })
+
+  it("disambiguates with heading_level", async () => {
+    const content = `---
+title: Levels
+---
+
+# Overview
+Top-level content.
+
+## Overview
+Sub-level content.
+`
+    await writeTestNote("levels.md", content)
+    const result = await patchNote(
+      {
+        vaultPath: vault,
+        path: "levels.md",
+        operation: "append",
+        content: "added to H2",
+        heading: "Overview",
+        headingLevel: 2,
+      },
+      logger,
+    )
+    expect(result).toContain("Applied append")
+    const updated = await readTestNote("levels.md")
+    expect(updated).toContain("Sub-level content.")
+    expect(updated).toContain("added to H2")
+  })
+
+  it("errors on empty heading", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          operation: "append",
+          content: "text",
+          heading: "   ",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("heading cannot be empty")
+  })
+})
+
+// ── patchNote operations ────────────────────────────────────────
+
+describe("patchNote — file-level operations", () => {
+  it("appends to end of file", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "append",
+        content: "## New Section\nNew content.",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    expect(updated).toMatch(/Task D\n+## New Section\nNew content\./)
+  })
+
+  it("prepends after frontmatter", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "prepend",
+        content: "> [!note] Important\n> Read this first.",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    expect(updated).toContain("tags:\n  - test\n---\n> [!note] Important")
+  })
+
+  it("errors on replace without heading", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          operation: "replace",
+          content: "text",
+        },
+        logger,
+      ),
+    ).rejects.toThrow('operation "replace" requires a heading target')
+  })
+
+  it("errors on insert_before without heading", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          operation: "insert_before",
+          content: "text",
+        },
+        logger,
+      ),
+    ).rejects.toThrow('operation "insert_before" requires a heading target')
+  })
+})
+
+describe("patchNote — section-level append", () => {
+  it("appends to end of section body", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "append",
+        content: "- [ ] Task E",
+        heading: "Up Next",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    const lines = updated.split("\n")
+    const taskEIdx = lines.findIndex((l) => l === "- [ ] Task E")
+    const doneIdx = lines.findIndex((l) => l === "## Done")
+    expect(taskEIdx).toBeGreaterThan(-1)
+    expect(doneIdx).toBeGreaterThan(taskEIdx)
+  })
+
+  it("appends to section with children (end of full section)", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "append",
+        content: "- [ ] New task after subtasks",
+        heading: "Active",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    expect(updated).toMatch(
+      /Sub-task 1\n+- \[ \] New task after subtasks\n+## Up Next/,
+    )
+  })
+
+  it("appends to last section in file", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "append",
+        content: "- [x] Task E",
+        heading: "Done",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    const lines = updated.split("\n")
+    const taskDIdx = lines.findIndex((l) => l === "- [x] Task D")
+    const taskEIdx = lines.findIndex((l) => l === "- [x] Task E")
+    expect(taskDIdx).toBeGreaterThan(-1)
+    expect(taskEIdx).toBeGreaterThan(taskDIdx)
+  })
+})
+
+describe("patchNote — section-level prepend", () => {
+  it("prepends right after heading line", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "prepend",
+        content: "- [ ] Urgent task",
+        heading: "Active",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    expect(updated).toMatch(/## Active\n- \[ \] Urgent task\n- \[ \] Task A/)
+  })
+})
+
+describe("patchNote — section-level replace", () => {
+  it("replaces section body, preserving heading", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "replace",
+        content: "Completely new content.\n",
+        heading: "Up Next",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    expect(updated).toContain("## Up Next\nCompletely new content.\n")
+    expect(updated).not.toContain("Task C")
+    expect(updated).toContain("## Done")
+  })
+
+  it("replaces section with children (all children replaced)", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "replace",
+        content: "Replaced all active content.\n",
+        heading: "Active",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    expect(updated).toContain("## Active\nReplaced all active content.")
+    expect(updated).not.toContain("Subtasks")
+    expect(updated).not.toContain("Sub-task 1")
+    expect(updated).toContain("## Up Next")
+  })
+})
+
+describe("patchNote — insert_before", () => {
+  it("inserts content above the heading line", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "insert_before",
+        content: "## Context\nSome context here.\n",
+        heading: "Done",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    expect(updated).toMatch(
+      /Task C\n+## Context\nSome context here\.\n+## Done/,
+    )
+  })
+
+  it("inserts before the first heading", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "insert_before",
+        content: "# Preface\nBefore everything.\n",
+        heading: "Main Title",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    const lines = updated.split("\n")
+    const prefaceIdx = lines.findIndex((l) => l === "# Preface")
+    const mainIdx = lines.findIndex((l) => l === "# Main Title")
+    expect(prefaceIdx).toBeGreaterThan(-1)
+    expect(mainIdx).toBeGreaterThan(prefaceIdx)
+    expect(updated).toContain("Before everything.")
+  })
+})
+
+// ── Frontmatter preservation ────────────────────────────────────
+
+describe("frontmatter preservation", () => {
+  const operations = ["append", "prepend", "replace", "insert_before"] as const
+
+  it.each(
+    operations.map((op) => ({
+      name: op,
+      op,
+      heading: op === "append" || op === "prepend" ? undefined : "Active",
+    })),
+  )("$name preserves frontmatter", async ({ op, heading }) => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: op,
+        content: "new content",
+        heading,
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    expect(updated).toContain("title: Test Note")
+    expect(updated).toContain("tags:")
+    expect(updated).toContain("- test")
+  })
+
+  it("handles file with no frontmatter", async () => {
+    await writeTestNote("no-fm.md", NOTE_NO_FRONTMATTER)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "no-fm.md",
+        operation: "append",
+        content: "Appended text.",
+        heading: "Section One",
+      },
+      logger,
+    )
+    const updated = await readTestNote("no-fm.md")
+    expect(updated).toContain("Content one.")
+    expect(updated).toContain("Appended text.")
+    const lines = updated.split("\n")
+    const contentIdx = lines.findIndex((l) => l === "Content one.")
+    const appendIdx = lines.findIndex((l) => l === "Appended text.")
+    expect(appendIdx).toBeGreaterThan(contentIdx)
+  })
+
+  it("preserves complex frontmatter (nested objects, arrays)", async () => {
+    const content = `---
+title: Complex
+tags: [a, b, c]
+nested:
+  key: value
+  list:
+    - one
+    - two
+number: 42
+---
+
+## Section
+Body text.
+`
+    await writeTestNote("complex.md", content)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "complex.md",
+        operation: "replace",
+        content: "New body.",
+        heading: "Section",
+      },
+      logger,
+    )
+    const updated = await readTestNote("complex.md")
+    expect(updated).toContain("title: Complex")
+    expect(updated).toContain("number: 42")
+    expect(updated).toContain("key: value")
+    expect(updated).toContain("New body.")
+  })
+})
+
+// ── Error cases ─────────────────────────────────────────────────
+
+describe("patchNote errors", () => {
+  it("errors on file not found", async () => {
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "missing.md",
+          operation: "append",
+          content: "text",
+        },
+        logger,
+      ),
+    ).rejects.toThrow('note not found: "missing.md"')
+  })
+
+  it("errors on path traversal", async () => {
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "../escape.md",
+          operation: "append",
+          content: "text",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("path traversal blocked")
+  })
+})
+
+// ── Edge cases ──────────────────────────────────────────────────
+
+describe("patchNote edge cases", () => {
+  it("handles empty section body", async () => {
+    const content = `---
+title: Empty
+---
+
+## Empty Section
+
+## Next Section
+Content.
+`
+    await writeTestNote("empty.md", content)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "empty.md",
+        operation: "append",
+        content: "Now has content.",
+        heading: "Empty Section",
+      },
+      logger,
+    )
+    const updated = await readTestNote("empty.md")
+    expect(updated).toMatch(/## Empty Section\n+Now has content\.\n+## Next/)
+  })
+
+  it("handles note with only frontmatter", async () => {
+    await writeTestNote("only-fm.md", "---\ntitle: Empty\n---\n")
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "only-fm.md",
+        operation: "append",
+        content: "## First Section\nContent.",
+      },
+      logger,
+    )
+    const updated = await readTestNote("only-fm.md")
+    expect(updated).toContain("## First Section\nContent.")
+  })
+
+  it("handles heading at very end of file with no body", async () => {
+    const content = `---
+title: Trailing
+---
+
+## Has Content
+Some text.
+
+## Trailing Heading
+`
+    await writeTestNote("trailing.md", content)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "trailing.md",
+        operation: "append",
+        content: "Added to trailing.",
+        heading: "Trailing Heading",
+      },
+      logger,
+    )
+    const updated = await readTestNote("trailing.md")
+    const lines = updated.split("\n")
+    const headingIdx = lines.findIndex((l) => l === "## Trailing Heading")
+    const addedIdx = lines.findIndex((l) => l === "Added to trailing.")
+    expect(headingIdx).toBeGreaterThan(-1)
+    expect(addedIdx).toBeGreaterThan(headingIdx)
+  })
+
+  it("handles file in subdirectory", async () => {
+    const content = `---
+title: Nested
+---
+
+## Section
+Body.
+`
+    await writeTestNote("sub/dir/nested.md", content)
+    const result = await patchNote(
+      {
+        vaultPath: vault,
+        path: "sub/dir/nested.md",
+        operation: "append",
+        content: "More body.",
+        heading: "Section",
+      },
+      logger,
+    )
+    expect(result).toContain("sub/dir/nested.md")
+  })
+})
+
+// ── replaceInNote ───────────────────────────────────────────────
+
+describe("replaceInNote", () => {
+  it("replaces first occurrence by default", async () => {
+    const content = `---
+title: Replace Test
+---
+
+The word apple appears here.
+And apple appears here too.
+`
+    await writeTestNote("replace.md", content)
+    const result = await replaceInNote(
+      {
+        vaultPath: vault,
+        path: "replace.md",
+        oldText: "apple",
+        newText: "orange",
+      },
+      logger,
+    )
+    expect(result).toBe("Replaced 1 occurrence in replace.md")
+    const updated = await readTestNote("replace.md")
+    expect(updated).toContain("The word orange appears here.")
+    expect(updated).toContain("And apple appears here too.")
+  })
+
+  it("replaces all occurrences when flag is set", async () => {
+    const content = `---
+title: Replace All
+---
+
+apple and apple and apple.
+`
+    await writeTestNote("replace-all.md", content)
+    const result = await replaceInNote(
+      {
+        vaultPath: vault,
+        path: "replace-all.md",
+        oldText: "apple",
+        newText: "orange",
+        replaceAllOccurrences: true,
+      },
+      logger,
+    )
+    expect(result).toBe("Replaced 3 occurrences in replace-all.md")
+    const updated = await readTestNote("replace-all.md")
+    expect(updated).toContain("orange and orange and orange.")
+    expect(updated).not.toContain("apple")
+  })
+
+  it("errors when old_text not found", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await expect(
+      replaceInNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          oldText: "nonexistent text",
+          newText: "replacement",
+        },
+        logger,
+      ),
+    ).rejects.toThrow('text not found in "note.md"')
+  })
+
+  it("handles multi-line old_text", async () => {
+    const content = `---
+title: Multiline
+---
+
+Line one.
+Line two.
+Line three.
+`
+    await writeTestNote("multi.md", content)
+    await replaceInNote(
+      {
+        vaultPath: vault,
+        path: "multi.md",
+        oldText: "Line one.\nLine two.",
+        newText: "Replaced block.",
+      },
+      logger,
+    )
+    const updated = await readTestNote("multi.md")
+    expect(updated).toContain("Replaced block.\nLine three.")
+    expect(updated).not.toContain("Line one.")
+  })
+
+  it("replaces with empty string (deletion)", async () => {
+    const content = `---
+title: Delete
+---
+
+Keep this. Remove this. Keep this too.
+`
+    await writeTestNote("delete.md", content)
+    await replaceInNote(
+      {
+        vaultPath: vault,
+        path: "delete.md",
+        oldText: "Remove this. ",
+        newText: "",
+      },
+      logger,
+    )
+    const updated = await readTestNote("delete.md")
+    expect(updated).toContain("Keep this. Keep this too.")
+  })
+
+  it("preserves frontmatter during replacement", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await replaceInNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        oldText: "Task A",
+        newText: "Task Alpha",
+      },
+      logger,
+    )
+    const updated = await readTestNote("note.md")
+    expect(updated).toContain("title: Test Note")
+    expect(updated).toContain("tags:")
+    expect(updated).toContain("Task Alpha")
+  })
+
+  it("is case-sensitive", async () => {
+    const content = `---
+title: Case
+---
+
+Hello World.
+`
+    await writeTestNote("case.md", content)
+    await expect(
+      replaceInNote(
+        {
+          vaultPath: vault,
+          path: "case.md",
+          oldText: "hello world",
+          newText: "replaced",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("text not found")
+  })
+
+  it("errors on file not found", async () => {
+    await expect(
+      replaceInNote(
+        {
+          vaultPath: vault,
+          path: "missing.md",
+          oldText: "text",
+          newText: "new",
+        },
+        logger,
+      ),
+    ).rejects.toThrow('note not found: "missing.md"')
+  })
+
+  it("errors on path traversal", async () => {
+    await expect(
+      replaceInNote(
+        {
+          vaultPath: vault,
+          path: "../escape.md",
+          oldText: "text",
+          newText: "new",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("path traversal blocked")
+  })
+
+  it("truncates long old_text in error message", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    const longText = "x".repeat(100)
+    await expect(
+      replaceInNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          oldText: longText,
+          newText: "new",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(/x{80}…/)
+  })
+})

--- a/src/vault-mcp/__tests__/vault-patcher.test.ts
+++ b/src/vault-mcp/__tests__/vault-patcher.test.ts
@@ -195,6 +195,84 @@ Content here.
     expect(newLineIdx).toBeGreaterThan(contentIdx)
   })
 
+  it("ignores headings inside nested fenced code blocks", async () => {
+    const content = `---
+title: Nested Fences
+---
+
+## Real Heading
+Real content.
+
+\`\`\`\`markdown
+\`\`\`
+## Fake Heading In Nested Block
+\`\`\`
+\`\`\`\`
+
+## Another Real Heading
+More content.
+`
+    await writeTestNote("nested-fence.md", content)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "nested-fence.md",
+          operation: "append",
+          content: "text",
+          heading: "Fake Heading In Nested Block",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("heading not found")
+    // Real headings are still reachable
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "nested-fence.md",
+        operation: "append",
+        content: "appended to real",
+        heading: "Another Real Heading",
+      },
+      logger,
+    )
+    const updated = await readTestNote("nested-fence.md")
+    const lines = updated.split("\n")
+    const moreIdx = lines.findIndex((l) => l === "More content.")
+    const appendIdx = lines.findIndex((l) => l === "appended to real")
+    expect(appendIdx).toBeGreaterThan(moreIdx)
+  })
+
+  it("ignores headings inside tilde-fenced code blocks", async () => {
+    const content = `---
+title: Tilde Fence
+---
+
+## Before
+Content before.
+
+~~~
+## Fake Heading In Tilde Block
+~~~
+
+## After
+Content after.
+`
+    await writeTestNote("tilde.md", content)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "tilde.md",
+          operation: "append",
+          content: "text",
+          heading: "Fake Heading In Tilde Block",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("heading not found")
+  })
+
   it("returns empty list for file with no headings", async () => {
     await writeTestNote("flat.md", "---\ntitle: Flat\n---\n\nJust text.\n")
     await expect(
@@ -270,7 +348,33 @@ Second content.
         },
         logger,
       ),
-    ).rejects.toThrow(/ambiguous.*2 sections.*heading_level/)
+    ).rejects.toThrow(/ambiguous.*2 sections.*Rename one heading/)
+  })
+
+  it("errors on cross-level ambiguity with heading_level hint", async () => {
+    const content = `---
+title: CrossLevel
+---
+
+# Overview
+Top-level.
+
+## Overview
+Sub-level.
+`
+    await writeTestNote("cross-level.md", content)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "cross-level.md",
+          operation: "append",
+          content: "text",
+          heading: "Overview",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(/ambiguous.*heading_level/)
   })
 
   it("disambiguates with heading_level", async () => {
@@ -868,6 +972,21 @@ apple and apple and apple.
     const updated = await readTestNote("replace-all.md")
     expect(updated).toContain("orange and orange and orange.")
     expect(updated).not.toContain("apple")
+  })
+
+  it("errors on empty old_text", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await expect(
+      replaceInNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          oldText: "",
+          newText: "anything",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("old_text cannot be empty")
   })
 
   it("errors when old_text not found", async () => {

--- a/src/vault-mcp/__tests__/vault-patcher.test.ts
+++ b/src/vault-mcp/__tests__/vault-patcher.test.ts
@@ -81,41 +81,51 @@ More text.
 // ── parseHeadings (tested indirectly via patchNote) ─────────────
 
 describe("heading parsing", () => {
-  it("handles all 6 heading levels", async () => {
+  it.each([
+    { level: 1, heading: "H1" },
+    { level: 2, heading: "H2" },
+    { level: 3, heading: "H3" },
+    { level: 4, heading: "H4" },
+    { level: 5, heading: "H5" },
+    { level: 6, heading: "H6" },
+  ] as const)("appends to H$level heading", async ({ level, heading }) => {
     const content = `---
 title: Levels
 ---
 
 # H1
+Content under H1.
 ## H2
+Content under H2.
 ### H3
+Content under H3.
 #### H4
+Content under H4.
 ##### H5
+Content under H5.
 ###### H6
+Content under H6.
 `
-    await writeTestNote("levels.md", content)
-    // Verify we can target each level
-    for (const [level, text] of [
-      [1, "H1"],
-      [2, "H2"],
-      [3, "H3"],
-      [4, "H4"],
-      [5, "H5"],
-      [6, "H6"],
-    ] as const) {
-      const result = await patchNote(
-        {
-          vaultPath: vault,
-          path: "levels.md",
-          operation: "append",
-          content: `Level ${level} content`,
-          heading: text,
-          headingLevel: level,
-        },
-        logger,
-      )
-      expect(result).toContain(`Applied append`)
-    }
+    await writeTestNote(`level-${level}.md`, content)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: `level-${level}.md`,
+        operation: "append",
+        content: `Appended to ${heading}.`,
+        heading,
+        headingLevel: level,
+      },
+      logger,
+    )
+    const updated = await readTestNote(`level-${level}.md`)
+    const lines = updated.split("\n")
+    const existingIdx = lines.findIndex(
+      (l) => l === `Content under ${heading}.`,
+    )
+    const appendedIdx = lines.findIndex((l) => l === `Appended to ${heading}.`)
+    expect(existingIdx).toBeGreaterThan(-1)
+    expect(appendedIdx).toBeGreaterThan(existingIdx)
   })
 
   it("ignores headings inside fenced code blocks", async () => {
@@ -137,7 +147,7 @@ title: Levels
 
   it("targets real headings around code blocks", async () => {
     await writeTestNote("code.md", NOTE_WITH_CODE_BLOCK)
-    const result = await patchNote(
+    await patchNote(
       {
         vaultPath: vault,
         path: "code.md",
@@ -147,9 +157,14 @@ title: Levels
       },
       logger,
     )
-    expect(result).toContain("Applied append")
     const updated = await readTestNote("code.md")
-    expect(updated).toContain("appended text")
+    const lines = updated.split("\n")
+    const someTextIdx = lines.findIndex((l) => l === "Some text.")
+    const appendedIdx = lines.findIndex((l) => l === "appended text")
+    const anotherIdx = lines.findIndex((l) => l === "## Another Real Heading")
+    expect(someTextIdx).toBeGreaterThan(-1)
+    expect(appendedIdx).toBeGreaterThan(someTextIdx)
+    expect(anotherIdx).toBeGreaterThan(appendedIdx)
   })
 
   it("strips trailing hashes from headings", async () => {
@@ -162,7 +177,7 @@ title: Hashes
 Content here.
 `
     await writeTestNote("hashes.md", content)
-    const result = await patchNote(
+    await patchNote(
       {
         vaultPath: vault,
         path: "hashes.md",
@@ -172,7 +187,12 @@ Content here.
       },
       logger,
     )
-    expect(result).toContain("Applied append")
+    const updated = await readTestNote("hashes.md")
+    const lines = updated.split("\n")
+    const contentIdx = lines.findIndex((l) => l === "Content here.")
+    const newLineIdx = lines.findIndex((l) => l === "new line")
+    expect(contentIdx).toBeGreaterThan(-1)
+    expect(newLineIdx).toBeGreaterThan(contentIdx)
   })
 
   it("returns empty list for file with no headings", async () => {
@@ -265,7 +285,7 @@ Top-level content.
 Sub-level content.
 `
     await writeTestNote("levels.md", content)
-    const result = await patchNote(
+    await patchNote(
       {
         vaultPath: vault,
         path: "levels.md",
@@ -276,10 +296,19 @@ Sub-level content.
       },
       logger,
     )
-    expect(result).toContain("Applied append")
     const updated = await readTestNote("levels.md")
-    expect(updated).toContain("Sub-level content.")
-    expect(updated).toContain("added to H2")
+    const lines = updated.split("\n")
+    const h1Idx = lines.findIndex((l) => l === "# Overview")
+    const topContentIdx = lines.findIndex((l) => l === "Top-level content.")
+    const h2Idx = lines.findIndex((l) => l === "## Overview")
+    const subContentIdx = lines.findIndex((l) => l === "Sub-level content.")
+    const addedIdx = lines.findIndex((l) => l === "added to H2")
+    // added to H2 must be in the H2 section (after Sub-level content), not H1
+    expect(addedIdx).toBeGreaterThan(subContentIdx)
+    expect(addedIdx).toBeGreaterThan(h2Idx)
+    // H1 section content must be unchanged (added text is NOT between H1 and H2)
+    expect(topContentIdx).toBeGreaterThan(h1Idx)
+    expect(h2Idx).toBeGreaterThan(topContentIdx)
   })
 
   it("errors on empty heading", async () => {
@@ -378,9 +407,14 @@ describe("patchNote — section-level append", () => {
     )
     const updated = await readTestNote("note.md")
     const lines = updated.split("\n")
+    const upNextIdx = lines.findIndex((l) => l === "## Up Next")
+    const taskCIdx = lines.findIndex((l) => l === "- [ ] Task C")
     const taskEIdx = lines.findIndex((l) => l === "- [ ] Task E")
     const doneIdx = lines.findIndex((l) => l === "## Done")
-    expect(taskEIdx).toBeGreaterThan(-1)
+    // Task E must be after existing Up Next content, before ## Done
+    expect(upNextIdx).toBeGreaterThan(-1)
+    expect(taskCIdx).toBeGreaterThan(upNextIdx)
+    expect(taskEIdx).toBeGreaterThan(taskCIdx)
     expect(doneIdx).toBeGreaterThan(taskEIdx)
   })
 
@@ -416,10 +450,17 @@ describe("patchNote — section-level append", () => {
     )
     const updated = await readTestNote("note.md")
     const lines = updated.split("\n")
+    const doneIdx = lines.findIndex((l) => l === "## Done")
     const taskDIdx = lines.findIndex((l) => l === "- [x] Task D")
     const taskEIdx = lines.findIndex((l) => l === "- [x] Task E")
-    expect(taskDIdx).toBeGreaterThan(-1)
+    // Task E must be in the Done section, after existing Task D
+    expect(taskDIdx).toBeGreaterThan(doneIdx)
     expect(taskEIdx).toBeGreaterThan(taskDIdx)
+    // No heading after Task E (it's the last section)
+    const headingsAfter = lines
+      .slice(taskEIdx + 1)
+      .filter((l) => /^#{1,6} /.test(l))
+    expect(headingsAfter).toHaveLength(0)
   })
 })
 
@@ -513,11 +554,15 @@ describe("patchNote — insert_before", () => {
     )
     const updated = await readTestNote("note.md")
     const lines = updated.split("\n")
+    // Frontmatter closes with ---
+    const fmCloseIdx = lines.indexOf("---", 1)
     const prefaceIdx = lines.findIndex((l) => l === "# Preface")
     const mainIdx = lines.findIndex((l) => l === "# Main Title")
-    expect(prefaceIdx).toBeGreaterThan(-1)
+    // Preface must be after frontmatter fence, before original heading
+    expect(prefaceIdx).toBeGreaterThan(fmCloseIdx)
     expect(mainIdx).toBeGreaterThan(prefaceIdx)
-    expect(updated).toContain("Before everything.")
+    // Original content still intact after Main Title
+    expect(updated).toContain("Intro paragraph.")
   })
 })
 
@@ -532,23 +577,31 @@ describe("frontmatter preservation", () => {
       op,
       heading: op === "append" || op === "prepend" ? undefined : "Active",
     })),
-  )("$name preserves frontmatter", async ({ op, heading }) => {
-    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
-    await patchNote(
-      {
-        vaultPath: vault,
-        path: "note.md",
-        operation: op,
-        content: "new content",
-        heading,
-      },
-      logger,
-    )
-    const updated = await readTestNote("note.md")
-    expect(updated).toContain("title: Test Note")
-    expect(updated).toContain("tags:")
-    expect(updated).toContain("- test")
-  })
+  )(
+    "$name preserves frontmatter and modifies body",
+    async ({ op, heading }) => {
+      await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+      await patchNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          operation: op,
+          content: `marker-${op}`,
+          heading,
+        },
+        logger,
+      )
+      const updated = await readTestNote("note.md")
+      // Frontmatter preserved
+      expect(updated).toContain("title: Test Note")
+      expect(updated).toContain("tags:")
+      expect(updated).toContain("- test")
+      // Body was actually modified
+      expect(updated).toContain(`marker-${op}`)
+      // Frontmatter is still at the top (starts with ---)
+      expect(updated.startsWith("---\n")).toBe(true)
+    },
+  )
 
   it("handles file with no frontmatter", async () => {
     await writeTestNote("no-fm.md", NOTE_NO_FRONTMATTER)
@@ -563,12 +616,17 @@ describe("frontmatter preservation", () => {
       logger,
     )
     const updated = await readTestNote("no-fm.md")
-    expect(updated).toContain("Content one.")
-    expect(updated).toContain("Appended text.")
     const lines = updated.split("\n")
+    const sectionOneIdx = lines.findIndex((l) => l === "## Section One")
     const contentIdx = lines.findIndex((l) => l === "Content one.")
     const appendIdx = lines.findIndex((l) => l === "Appended text.")
+    const sectionTwoIdx = lines.findIndex((l) => l === "## Section Two")
+    // Appended text must be within Section One (after content, before Section Two)
+    expect(contentIdx).toBeGreaterThan(sectionOneIdx)
     expect(appendIdx).toBeGreaterThan(contentIdx)
+    expect(sectionTwoIdx).toBeGreaterThan(appendIdx)
+    // Section Two content untouched
+    expect(updated).toContain("Content two.")
   })
 
   it("preserves complex frontmatter (nested objects, arrays)", async () => {
@@ -601,7 +659,15 @@ Body text.
     expect(updated).toContain("title: Complex")
     expect(updated).toContain("number: 42")
     expect(updated).toContain("key: value")
+    // Verify list-type frontmatter values preserved
+    expect(updated).toContain("- a")
+    expect(updated).toContain("- b")
+    expect(updated).toContain("- c")
+    expect(updated).toContain("- one")
+    expect(updated).toContain("- two")
+    // Verify body was replaced
     expect(updated).toContain("New body.")
+    expect(updated).not.toContain("Body text.")
   })
 })
 
@@ -677,7 +743,12 @@ Content.
       logger,
     )
     const updated = await readTestNote("only-fm.md")
-    expect(updated).toContain("## First Section\nContent.")
+    // Frontmatter preserved
+    expect(updated).toContain("title: Empty")
+    expect(updated.startsWith("---\n")).toBe(true)
+    // Content was appended
+    expect(updated).toContain("## First Section")
+    expect(updated).toContain("Content.")
   })
 
   it("handles heading at very end of file with no body", async () => {
@@ -703,10 +774,20 @@ Some text.
     )
     const updated = await readTestNote("trailing.md")
     const lines = updated.split("\n")
+    const hasContentIdx = lines.findIndex((l) => l === "## Has Content")
+    const someTextIdx = lines.findIndex((l) => l === "Some text.")
     const headingIdx = lines.findIndex((l) => l === "## Trailing Heading")
     const addedIdx = lines.findIndex((l) => l === "Added to trailing.")
-    expect(headingIdx).toBeGreaterThan(-1)
+    // Previous section intact
+    expect(someTextIdx).toBeGreaterThan(hasContentIdx)
+    expect(headingIdx).toBeGreaterThan(someTextIdx)
+    // Added content is after the trailing heading
     expect(addedIdx).toBeGreaterThan(headingIdx)
+    // No heading after the added content
+    const headingsAfter = lines
+      .slice(addedIdx + 1)
+      .filter((l) => /^#{1,6} /.test(l))
+    expect(headingsAfter).toHaveLength(0)
   })
 
   it("handles file in subdirectory", async () => {
@@ -718,7 +799,7 @@ title: Nested
 Body.
 `
     await writeTestNote("sub/dir/nested.md", content)
-    const result = await patchNote(
+    await patchNote(
       {
         vaultPath: vault,
         path: "sub/dir/nested.md",
@@ -728,7 +809,13 @@ Body.
       },
       logger,
     )
-    expect(result).toContain("sub/dir/nested.md")
+    const updated = await readTestNote("sub/dir/nested.md")
+    const lines = updated.split("\n")
+    const bodyIdx = lines.findIndex((l) => l === "Body.")
+    const moreIdx = lines.findIndex((l) => l === "More body.")
+    expect(bodyIdx).toBeGreaterThan(-1)
+    expect(moreIdx).toBeGreaterThan(bodyIdx)
+    expect(updated).toContain("title: Nested")
   })
 })
 

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -178,7 +178,7 @@ Returns: Confirmation message.`,
     "vault_patch_note",
     {
       title: "Patch Note",
-      description: `Surgical edits to a markdown note — append, prepend, replace, or insert content by heading. Frontmatter is always preserved.
+      description: `Surgical edits to a markdown note — append, prepend, replace, or insert content by heading. Frontmatter values are preserved; YAML formatting may be normalized to block style on first edit.
 
 Example: vault_patch_note({ path: "TASKS.md", operation: "append", heading: "Active", content: "- [ ] New task" })
 
@@ -191,7 +191,9 @@ Operations:
 - replace: replace section body (heading preserved; requires heading)
 - insert_before: insert content above the heading line (requires heading)
 
-Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section.`,
+Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section.
+
+Returns: Confirmation message.`,
       inputSchema: {
         path: z.string().describe("Vault-relative path to the note"),
         operation: z
@@ -206,6 +208,7 @@ Section boundaries: a section spans from its heading to the next heading of the 
           ),
         heading_level: z
           .number()
+          .int()
           .min(1)
           .max(6)
           .optional()
@@ -249,17 +252,22 @@ Section boundaries: a section spans from its heading to the next heading of the 
     "vault_replace_in_note",
     {
       title: "Replace in Note",
-      description: `Find and replace text in a markdown note. Matches exact text (case-sensitive). Frontmatter is always preserved.
+      description: `Find and replace text in a markdown note's body. Matches exact text (case-sensitive). Frontmatter values are preserved; YAML formatting may be normalized to block style on first edit. Operates on the body only — frontmatter fields must be edited via vault_write_note's frontmatter parameter.
 
-Example: vault_replace_in_note({ path: "Projects/plan.md", old_text: "status: draft", new_text: "status: review" })
+Example: vault_replace_in_note({ path: "Projects/plan.md", old_text: "TODO: write summary", new_text: "Summary complete." })
 
-When to use: Targeted text changes — fixing typos, updating values, renaming terms.
+When to use: Targeted text changes — fixing typos, updating values, renaming terms in the note body.
 Prefer vault_patch_note for heading-targeted structural edits.
 
-Limitation: Exact text match only (no regex). old_text must appear in the note body or an error is returned.`,
+Limitation: Exact text match only (no regex). old_text must appear in the note body or an error is returned.
+
+Returns: Confirmation message with replacement count.`,
       inputSchema: {
         path: z.string().describe("Vault-relative path to the note"),
-        old_text: z.string().describe("Exact text to find (case-sensitive)"),
+        old_text: z
+          .string()
+          .min(1)
+          .describe("Exact text to find (case-sensitive, non-empty)"),
         new_text: z.string().describe("Replacement text"),
         replace_all_occurrences: z
           .boolean()
@@ -271,7 +279,7 @@ Limitation: Exact text match only (no regex). old_text must appear in the note b
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,
-        idempotentHint: true,
+        idempotentHint: false,
         openWorldHint: false,
       },
     },

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -3,6 +3,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { z } from "zod"
 import { vaultFs } from "./vault-filesystem.js"
+import { vaultPatcher } from "./vault-patcher.js"
 import { memoryStore } from "./memory-store.js"
 import type { SearchIndex } from "./search-index.js"
 import type { Logger } from "../logger.js"
@@ -10,6 +11,8 @@ import type { Logger } from "../logger.js"
 export type ToolName =
   | "vault_read_note"
   | "vault_write_note"
+  | "vault_patch_note"
+  | "vault_replace_in_note"
   | "vault_list_notes"
   | "vault_delete_note"
   | "vault_search"
@@ -167,6 +170,131 @@ Returns: Confirmation message.`,
         () =>
           vaultFs.writeNote({ vaultPath, path, body, frontmatter }, reqLogger),
         () => `Wrote ${path}`,
+      )
+    },
+  )
+
+  server.registerTool(
+    "vault_patch_note",
+    {
+      title: "Patch Note",
+      description: `Surgical edits to a markdown note — append, prepend, replace, or insert content by heading. Frontmatter is always preserved.
+
+Example: vault_patch_note({ path: "TASKS.md", operation: "append", heading: "Active", content: "- [ ] New task" })
+
+When to use: Modifying part of an existing note without overwriting the entire body.
+Prefer vault_write_note for creating new notes or full rewrites. Prefer vault_replace_in_note for find-and-replace edits.
+
+Operations:
+- append: add content at end of section (or end of file if no heading)
+- prepend: add content after heading line (or after frontmatter if no heading)
+- replace: replace section body (heading preserved; requires heading)
+- insert_before: insert content above the heading line (requires heading)
+
+Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section.`,
+      inputSchema: {
+        path: z.string().describe("Vault-relative path to the note"),
+        operation: z
+          .enum(["append", "prepend", "replace", "insert_before"])
+          .describe("Patch operation to apply"),
+        content: z.string().describe("Content to insert or replace with"),
+        heading: z
+          .string()
+          .optional()
+          .describe(
+            "Target heading text (case-sensitive exact match). Required for replace and insert_before. Optional for append/prepend (omit for file-level operation).",
+          ),
+        heading_level: z
+          .number()
+          .min(1)
+          .max(6)
+          .optional()
+          .describe(
+            "Heading level (1-6) for disambiguation when multiple headings share the same text",
+          ),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async ({ path, operation, content, heading, heading_level }, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_patch_note",
+      })
+      reqLogger.info("tool_call", { path, operation, heading })
+      return safeHandler(
+        reqLogger,
+        () =>
+          vaultPatcher.patchNote(
+            {
+              vaultPath,
+              path,
+              operation,
+              content,
+              heading,
+              headingLevel: heading_level,
+            },
+            reqLogger,
+          ),
+        (msg) => msg,
+      )
+    },
+  )
+
+  server.registerTool(
+    "vault_replace_in_note",
+    {
+      title: "Replace in Note",
+      description: `Find and replace text in a markdown note. Matches exact text (case-sensitive). Frontmatter is always preserved.
+
+Example: vault_replace_in_note({ path: "Projects/plan.md", old_text: "status: draft", new_text: "status: review" })
+
+When to use: Targeted text changes — fixing typos, updating values, renaming terms.
+Prefer vault_patch_note for heading-targeted structural edits.
+
+Limitation: Exact text match only (no regex). old_text must appear in the note body or an error is returned.`,
+      inputSchema: {
+        path: z.string().describe("Vault-relative path to the note"),
+        old_text: z.string().describe("Exact text to find (case-sensitive)"),
+        new_text: z.string().describe("Replacement text"),
+        replace_all_occurrences: z
+          .boolean()
+          .optional()
+          .describe(
+            "Replace all occurrences (default: false — replaces first occurrence only)",
+          ),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ path, old_text, new_text, replace_all_occurrences }, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_replace_in_note",
+      })
+      reqLogger.info("tool_call", { path })
+      return safeHandler(
+        reqLogger,
+        () =>
+          vaultPatcher.replaceInNote(
+            {
+              vaultPath,
+              path,
+              oldText: old_text,
+              newText: new_text,
+              replaceAllOccurrences: replace_all_occurrences,
+            },
+            reqLogger,
+          ),
+        (msg) => msg,
       )
     },
   )
@@ -672,5 +800,5 @@ Returns: Confirmation message.`,
     },
   )
 
-  sessionLogger.info("registered tools", { count: 13 })
+  sessionLogger.info("registered tools", { count: 15 })
 }

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -193,6 +193,12 @@ Operations:
 
 Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section.
 
+Errors:
+- "note not found" — path does not exist; check vault_list_notes for valid paths
+- "heading not found" — no heading matches the text; error lists available headings
+- "ambiguous heading" — multiple headings match; use heading_level to disambiguate, or rename a heading if they share the same level
+- "operation requires a heading target" — replace and insert_before need a heading
+
 Returns: Confirmation message.`,
       inputSchema: {
         path: z.string().describe("Vault-relative path to the note"),
@@ -260,6 +266,11 @@ When to use: Targeted text changes — fixing typos, updating values, renaming t
 Prefer vault_patch_note for heading-targeted structural edits.
 
 Limitation: Exact text match only (no regex). old_text must appear in the note body or an error is returned.
+
+Errors:
+- "note not found" — path does not exist; check vault_list_notes for valid paths
+- "text not found" — old_text does not appear in the note body; verify exact text with vault_read_note
+- "old_text cannot be empty" — old_text must be at least one character
 
 Returns: Confirmation message with replacement count.`,
       inputSchema: {

--- a/src/vault-mcp/vault-filesystem.ts
+++ b/src/vault-mcp/vault-filesystem.ts
@@ -8,7 +8,10 @@ import type { Logger } from "../logger.js"
 const PROTECTED_PATHS = ["About Me/", "Daily Notes/"] as const
 
 /** Resolves a note path within the vault, throwing on traversal attempts. */
-const resolveSafePath = (vaultPath: string, notePath: string): string => {
+export const resolveSafePath = (
+  vaultPath: string,
+  notePath: string,
+): string => {
   const normalizedVault = resolve(vaultPath)
   const resolved = resolve(normalizedVault, notePath)
   if (!resolved.startsWith(normalizedVault + "/")) {

--- a/src/vault-mcp/vault-patcher.ts
+++ b/src/vault-mcp/vault-patcher.ts
@@ -1,0 +1,256 @@
+/** Surgical note editing — heading-targeted patches and find-and-replace. */
+
+import { readFile, writeFile } from "node:fs/promises"
+import matter from "gray-matter"
+import { resolveSafePath } from "./vault-filesystem.js"
+import type { Logger } from "../logger.js"
+
+// ── Types ───────────────────────────────────────────────────────
+
+type Operation = "append" | "prepend" | "replace" | "insert_before"
+
+type HeadingInfo = Readonly<{
+  text: string
+  level: number
+  startLine: number
+  bodyStartLine: number
+  bodyEndLine: number
+}>
+
+// ── Internal helpers ────────────────────────────────────────────
+
+const HEADING_RE = /^(#{1,6}) (.+)$/
+
+/**
+ * Single-pass heading parser for H1–H6 with code-block awareness.
+ * Section body = heading+1 through next heading of same-or-higher level (or EOF).
+ */
+const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
+  let inCodeBlock = false
+
+  const raw = lines.reduce<
+    Array<{ text: string; level: number; startLine: number }>
+  >((acc, line, i) => {
+    if (/^```/.test(line)) {
+      inCodeBlock = !inCodeBlock
+      return acc
+    }
+    if (inCodeBlock) return acc
+
+    const match = HEADING_RE.exec(line)
+    if (match) {
+      acc.push({
+        text: match[2].replace(/\s+#+\s*$/, "").trim(),
+        level: match[1].length,
+        startLine: i,
+      })
+    }
+    return acc
+  }, [])
+
+  return raw.map((h, i) => {
+    const nextSameOrHigher = raw
+      .slice(i + 1)
+      .find((next) => next.level <= h.level)
+    return {
+      text: h.text,
+      level: h.level,
+      startLine: h.startLine,
+      bodyStartLine: h.startLine + 1,
+      bodyEndLine: nextSameOrHigher?.startLine ?? lines.length,
+    }
+  })
+}
+
+/** Case-sensitive heading lookup. Errors on 0 or 2+ matches. */
+const findHeading = (
+  headings: readonly HeadingInfo[],
+  text: string,
+  level?: number,
+): HeadingInfo => {
+  if (!text.trim()) {
+    throw new Error("heading cannot be empty")
+  }
+
+  const needle = text.trim()
+  const matches = headings.filter(
+    (h) => h.text === needle && (level === undefined || h.level === level),
+  )
+
+  if (matches.length === 0) {
+    const available = headings
+      .map((h) => `${"#".repeat(h.level)} ${h.text}`)
+      .join(", ")
+    throw new Error(
+      `heading not found: "${needle}". Available headings: ${available || "(none)"}`,
+    )
+  }
+
+  if (matches.length > 1) {
+    const details = matches
+      .map((h) => `${"#".repeat(h.level)} ${h.text} (line ${h.startLine + 1})`)
+      .join(", ")
+    throw new Error(
+      `ambiguous heading: "${needle}" matches ${matches.length} sections: ${details}. Use heading_level to disambiguate.`,
+    )
+  }
+
+  return matches[0]
+}
+
+/** Reads a note, returning parsed frontmatter data and content lines. */
+const readNoteForPatch = async (
+  vaultPath: string,
+  path: string,
+): Promise<{
+  fullPath: string
+  data: Record<string, unknown>
+  lines: string[]
+}> => {
+  const fullPath = resolveSafePath(vaultPath, path)
+  let raw: string
+  try {
+    raw = await readFile(fullPath, "utf8")
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`note not found: "${path}"`, { cause: err })
+    }
+    throw err
+  }
+  const parsed = matter(raw)
+  return {
+    fullPath,
+    data: parsed.data as Record<string, unknown>,
+    lines: parsed.content.split("\n"),
+  }
+}
+
+/** Writes modified content back with preserved frontmatter. */
+const writePatched = async (
+  fullPath: string,
+  data: Record<string, unknown>,
+  lines: string[],
+): Promise<void> => {
+  const serialized = matter.stringify(lines.join("\n"), data)
+  await writeFile(fullPath, serialized, "utf8")
+}
+
+// ── Exported functions ──────────────────────────────────────────
+
+/** Heading-targeted patch: append, prepend, replace, or insert_before. */
+const patchNote = async (
+  params: {
+    vaultPath: string
+    path: string
+    operation: Operation
+    content: string
+    heading?: string
+    headingLevel?: number
+  },
+  logger: Logger,
+): Promise<string> => {
+  const { path, operation, content, heading, headingLevel } = params
+  const { fullPath, data, lines } = await readNoteForPatch(
+    params.vaultPath,
+    path,
+  )
+  const contentLines = content.split("\n")
+
+  let updatedLines: string[]
+  let targetDesc: string
+
+  if (!heading) {
+    if (operation === "replace" || operation === "insert_before") {
+      throw new Error(`operation "${operation}" requires a heading target`)
+    }
+    targetDesc = "file body"
+    updatedLines =
+      operation === "append"
+        ? [...lines, ...contentLines]
+        : [...contentLines, ...lines]
+  } else {
+    const headings = parseHeadings(lines)
+    const target = findHeading(headings, heading, headingLevel)
+    targetDesc = `${"#".repeat(target.level)} ${target.text}`
+
+    switch (operation) {
+      case "append":
+        updatedLines = [
+          ...lines.slice(0, target.bodyEndLine),
+          ...contentLines,
+          ...lines.slice(target.bodyEndLine),
+        ]
+        break
+      case "prepend":
+        updatedLines = [
+          ...lines.slice(0, target.bodyStartLine),
+          ...contentLines,
+          ...lines.slice(target.bodyStartLine),
+        ]
+        break
+      case "replace":
+        updatedLines = [
+          ...lines.slice(0, target.bodyStartLine),
+          ...contentLines,
+          ...lines.slice(target.bodyEndLine),
+        ]
+        break
+      case "insert_before":
+        updatedLines = [
+          ...lines.slice(0, target.startLine),
+          ...contentLines,
+          ...lines.slice(target.startLine),
+        ]
+        break
+    }
+  }
+
+  await writePatched(fullPath, data, updatedLines)
+  logger.info("patched note", { path, operation, target: targetDesc })
+  return `Applied ${operation} to ${path} → ${targetDesc}`
+}
+
+/** Find-and-replace within a note's body. */
+const replaceInNote = async (
+  params: {
+    vaultPath: string
+    path: string
+    oldText: string
+    newText: string
+    replaceAllOccurrences?: boolean
+  },
+  logger: Logger,
+): Promise<string> => {
+  const { path, oldText, newText, replaceAllOccurrences } = params
+  const { fullPath, data, lines } = await readNoteForPatch(
+    params.vaultPath,
+    path,
+  )
+
+  const body = lines.join("\n")
+
+  if (!body.includes(oldText)) {
+    const preview = oldText.length > 80 ? oldText.slice(0, 80) + "…" : oldText
+    throw new Error(`text not found in "${path}": "${preview}"`)
+  }
+
+  let updatedBody: string
+  let count: number
+
+  if (replaceAllOccurrences) {
+    count = body.split(oldText).length - 1
+    updatedBody = body.split(oldText).join(newText)
+  } else {
+    count = 1
+    const idx = body.indexOf(oldText)
+    updatedBody =
+      body.slice(0, idx) + newText + body.slice(idx + oldText.length)
+  }
+
+  const updatedLines = updatedBody.split("\n")
+  await writePatched(fullPath, data, updatedLines)
+  logger.info("replaced in note", { path, count })
+  return `Replaced ${count} occurrence${count > 1 ? "s" : ""} in ${path}`
+}
+
+export const vaultPatcher = { patchNote, replaceInNote }

--- a/src/vault-mcp/vault-patcher.ts
+++ b/src/vault-mcp/vault-patcher.ts
@@ -182,17 +182,19 @@ const readNoteForPatch = async (
   lines: string[]
 }> => {
   const fullPath = resolveSafePath(vaultPath, path)
-  const raw = await readFile(fullPath, "utf8").catch((err) => {
+  try {
+    const fileContent = await readFile(fullPath, "utf8")
+    const parsed = matter(fileContent)
+    return {
+      fullPath,
+      data: parsed.data as Record<string, unknown>,
+      lines: parsed.content.split("\n"),
+    }
+  } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new Error(`note not found: "${path}"`, { cause: err })
     }
     throw err
-  })
-  const parsed = matter(raw)
-  return {
-    fullPath,
-    data: parsed.data as Record<string, unknown>,
-    lines: parsed.content.split("\n"),
   }
 }
 

--- a/src/vault-mcp/vault-patcher.ts
+++ b/src/vault-mcp/vault-patcher.ts
@@ -25,17 +25,30 @@ const HEADING_RE = /^(#{1,6}) (.+)$/
  * Single-pass heading parser for H1–H6 with code-block awareness.
  * Section body = heading+1 through next heading of same-or-higher level (or EOF).
  */
+const FENCE_OPEN_RE = /^(`{3,}|~{3,})/
+
 const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
-  let inCodeBlock = false
+  let fence: { char: string; length: number } | null = null
 
   const raw = lines.reduce<
     Array<{ text: string; level: number; startLine: number }>
   >((acc, line, i) => {
-    if (/^```/.test(line)) {
-      inCodeBlock = !inCodeBlock
+    const fenceMatch = FENCE_OPEN_RE.exec(line)
+    if (fence) {
+      if (
+        fenceMatch &&
+        fenceMatch[1][0] === fence.char &&
+        fenceMatch[1].length >= fence.length &&
+        line.trim() === fenceMatch[1]
+      ) {
+        fence = null
+      }
       return acc
     }
-    if (inCodeBlock) return acc
+    if (fenceMatch) {
+      fence = { char: fenceMatch[1][0], length: fenceMatch[1].length }
+      return acc
+    }
 
     const match = HEADING_RE.exec(line)
     if (match) {
@@ -90,8 +103,12 @@ const findHeading = (
     const details = matches
       .map((h) => `${"#".repeat(h.level)} ${h.text} (line ${h.startLine + 1})`)
       .join(", ")
+    const allSameLevel = matches.every((h) => h.level === matches[0].level)
+    const hint = allSameLevel
+      ? "Rename one heading to make it unique, or use vault_replace_in_note to target by text."
+      : "Use heading_level to disambiguate."
     throw new Error(
-      `ambiguous heading: "${needle}" matches ${matches.length} sections: ${details}. Use heading_level to disambiguate.`,
+      `ambiguous heading: "${needle}" matches ${matches.length} sections: ${details}. ${hint}`,
     )
   }
 
@@ -222,6 +239,11 @@ const replaceInNote = async (
   logger: Logger,
 ): Promise<string> => {
   const { path, oldText, newText, replaceAllOccurrences } = params
+
+  if (oldText.length === 0) {
+    throw new Error("old_text cannot be empty")
+  }
+
   const { fullPath, data, lines } = await readNoteForPatch(
     params.vaultPath,
     path,

--- a/src/vault-mcp/vault-patcher.ts
+++ b/src/vault-mcp/vault-patcher.ts
@@ -34,7 +34,7 @@ const FENCE_OPEN_REGEX = /^(`{3,}|~{3,})/
 const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
   // Phase 1: collect headings, skipping content inside fenced code blocks.
   // Fence state is carried in the accumulator to avoid mutable external state.
-  const { headings: raw } = lines.reduce<{
+  const { headings: collectedHeadings } = lines.reduce<{
     headings: Array<{ text: string; level: number; startLine: number }>
     fence: FenceState
   }>(
@@ -83,8 +83,8 @@ const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
 
   // Phase 2: compute body ranges — each section's body ends where the next
   // heading of the same or higher level starts (or at EOF)
-  return raw.map((h, i) => {
-    const nextSameOrHigher = raw
+  return collectedHeadings.map((h, i) => {
+    const nextSameOrHigher = collectedHeadings
       .slice(i + 1)
       .find((next) => next.level <= h.level)
     return {

--- a/src/vault-mcp/vault-patcher.ts
+++ b/src/vault-mcp/vault-patcher.ts
@@ -122,7 +122,7 @@ const findHeading = (
   }
 
   if (matches.length > 1) {
-    const details = matches
+    const matchedHeadings = matches
       .map((h) => `${"#".repeat(h.level)} ${h.text} (line ${h.startLine + 1})`)
       .join(", ")
     const allSameLevel = matches.every((h) => h.level === matches[0].level)
@@ -130,7 +130,7 @@ const findHeading = (
       ? "Rename one heading to make it unique, or use vault_replace_in_note to target by text."
       : "Use heading_level to disambiguate."
     throw new Error(
-      `ambiguous heading: "${searchText}" matches ${matches.length} sections: ${details}. ${hint}`,
+      `ambiguous heading: "${searchText}" matches ${matches.length} sections: ${matchedHeadings}. ${hint}`,
     )
   }
 

--- a/src/vault-mcp/vault-patcher.ts
+++ b/src/vault-mcp/vault-patcher.ts
@@ -199,7 +199,7 @@ const readNoteForPatch = async (
 }
 
 /** Writes modified content back with preserved frontmatter. */
-const writePatched = async (
+const writePatchedNote = async (
   fullPath: string,
   data: Record<string, unknown>,
   lines: readonly string[],
@@ -238,7 +238,7 @@ const patchNote = async (
       operation === "append"
         ? [...lines, ...contentLines]
         : [...contentLines, ...lines]
-    await writePatched(fullPath, data, updatedLines)
+    await writePatchedNote(fullPath, data, updatedLines)
     logger.info("patched note", {
       path,
       operation,
@@ -258,7 +258,7 @@ const patchNote = async (
     operation,
   )
 
-  await writePatched(fullPath, data, updatedLines)
+  await writePatchedNote(fullPath, data, updatedLines)
   logger.info("patched note", { path, operation, target: targetDesc })
   return `Applied ${operation} to ${path} → ${targetDesc}`
 }
@@ -306,7 +306,7 @@ const replaceInNote = async (
       }
 
   const updatedLines = updatedBody.split("\n")
-  await writePatched(fullPath, data, updatedLines)
+  await writePatchedNote(fullPath, data, updatedLines)
   logger.info("replaced in note", { path, count })
   return `Replaced ${count} occurrence${count > 1 ? "s" : ""} in ${path}`
 }

--- a/src/vault-mcp/vault-patcher.ts
+++ b/src/vault-mcp/vault-patcher.ts
@@ -113,11 +113,11 @@ const findHeading = (
   )
 
   if (matches.length === 0) {
-    const available = headings
+    const availableHeadings = headings
       .map((h) => `${"#".repeat(h.level)} ${h.text}`)
       .join(", ")
     throw new Error(
-      `heading not found: "${searchText}". Available headings: ${available || "(none)"}`,
+      `heading not found: "${searchText}". Available headings: ${availableHeadings || "(none)"}`,
     )
   }
 
@@ -286,8 +286,9 @@ const replaceInNote = async (
   const body = lines.join("\n")
 
   if (!body.includes(oldText)) {
-    const preview = oldText.length > 80 ? oldText.slice(0, 80) + "…" : oldText
-    throw new Error(`text not found in "${path}": "${preview}"`)
+    const truncatedOldText =
+      oldText.length > 80 ? oldText.slice(0, 80) + "…" : oldText
+    throw new Error(`text not found in "${path}": "${truncatedOldText}"`)
   }
 
   const idx = body.indexOf(oldText)

--- a/src/vault-mcp/vault-patcher.ts
+++ b/src/vault-mcp/vault-patcher.ts
@@ -17,50 +17,72 @@ type HeadingInfo = Readonly<{
   bodyEndLine: number
 }>
 
+type FenceState = Readonly<{ char: string; length: number }> | null
+
 // ── Internal helpers ────────────────────────────────────────────
 
-const HEADING_RE = /^(#{1,6}) (.+)$/
+/** Matches markdown headings H1–H6: captures the `#` prefix and heading text. */
+const HEADING_REGEX = /^(#{1,6}) (.+)$/
+
+/** Matches fenced code block openers: 3+ backticks or 3+ tildes (CommonMark §4.5). */
+const FENCE_OPEN_REGEX = /^(`{3,}|~{3,})/
 
 /**
  * Single-pass heading parser for H1–H6 with code-block awareness.
  * Section body = heading+1 through next heading of same-or-higher level (or EOF).
  */
-const FENCE_OPEN_RE = /^(`{3,}|~{3,})/
-
 const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
-  let fence: { char: string; length: number } | null = null
+  // Phase 1: collect headings, skipping content inside fenced code blocks.
+  // Fence state is carried in the accumulator to avoid mutable external state.
+  const { headings: raw } = lines.reduce<{
+    headings: Array<{ text: string; level: number; startLine: number }>
+    fence: FenceState
+  }>(
+    (state, line, i) => {
+      const fenceMatch = FENCE_OPEN_REGEX.exec(line)
 
-  const raw = lines.reduce<
-    Array<{ text: string; level: number; startLine: number }>
-  >((acc, line, i) => {
-    const fenceMatch = FENCE_OPEN_RE.exec(line)
-    if (fence) {
-      if (
-        fenceMatch &&
-        fenceMatch[1][0] === fence.char &&
-        fenceMatch[1].length >= fence.length &&
-        line.trim() === fenceMatch[1]
-      ) {
-        fence = null
+      if (state.fence) {
+        // Inside a fenced block — only exit when we see a closing fence of the
+        // same character with length >= the opener, and nothing else on the line
+        const isFenceClose =
+          fenceMatch &&
+          fenceMatch[1][0] === state.fence.char &&
+          fenceMatch[1].length >= state.fence.length &&
+          line.trim() === fenceMatch[1]
+        return isFenceClose ? { headings: state.headings, fence: null } : state
       }
-      return acc
-    }
-    if (fenceMatch) {
-      fence = { char: fenceMatch[1][0], length: fenceMatch[1].length }
-      return acc
-    }
 
-    const match = HEADING_RE.exec(line)
-    if (match) {
-      acc.push({
-        text: match[2].replace(/\s+#+\s*$/, "").trim(),
-        level: match[1].length,
-        startLine: i,
-      })
-    }
-    return acc
-  }, [])
+      // Opening a new fenced code block
+      if (fenceMatch) {
+        return {
+          headings: state.headings,
+          fence: { char: fenceMatch[1][0], length: fenceMatch[1].length },
+        }
+      }
 
+      const match = HEADING_REGEX.exec(line)
+      if (match) {
+        return {
+          headings: [
+            ...state.headings,
+            {
+              // Strip trailing closing hashes (e.g. "## Title ##" → "Title")
+              text: match[2].replace(/\s+#+\s*$/, "").trim(),
+              level: match[1].length,
+              startLine: i,
+            },
+          ],
+          fence: null,
+        }
+      }
+
+      return state
+    },
+    { headings: [], fence: null },
+  )
+
+  // Phase 2: compute body ranges — each section's body ends where the next
+  // heading of the same or higher level starts (or at EOF)
   return raw.map((h, i) => {
     const nextSameOrHigher = raw
       .slice(i + 1)
@@ -85,9 +107,9 @@ const findHeading = (
     throw new Error("heading cannot be empty")
   }
 
-  const needle = text.trim()
+  const searchText = text.trim()
   const matches = headings.filter(
-    (h) => h.text === needle && (level === undefined || h.level === level),
+    (h) => h.text === searchText && (level === undefined || h.level === level),
   )
 
   if (matches.length === 0) {
@@ -95,7 +117,7 @@ const findHeading = (
       .map((h) => `${"#".repeat(h.level)} ${h.text}`)
       .join(", ")
     throw new Error(
-      `heading not found: "${needle}". Available headings: ${available || "(none)"}`,
+      `heading not found: "${searchText}". Available headings: ${available || "(none)"}`,
     )
   }
 
@@ -108,11 +130,46 @@ const findHeading = (
       ? "Rename one heading to make it unique, or use vault_replace_in_note to target by text."
       : "Use heading_level to disambiguate."
     throw new Error(
-      `ambiguous heading: "${needle}" matches ${matches.length} sections: ${details}. ${hint}`,
+      `ambiguous heading: "${searchText}" matches ${matches.length} sections: ${details}. ${hint}`,
     )
   }
 
   return matches[0]
+}
+
+/** Splices new content into a line array at the position determined by operation and target. */
+const applySectionOperation = (
+  lines: readonly string[],
+  contentLines: readonly string[],
+  target: HeadingInfo,
+  operation: Operation,
+): string[] => {
+  switch (operation) {
+    case "append":
+      return [
+        ...lines.slice(0, target.bodyEndLine),
+        ...contentLines,
+        ...lines.slice(target.bodyEndLine),
+      ]
+    case "prepend":
+      return [
+        ...lines.slice(0, target.bodyStartLine),
+        ...contentLines,
+        ...lines.slice(target.bodyStartLine),
+      ]
+    case "replace":
+      return [
+        ...lines.slice(0, target.bodyStartLine),
+        ...contentLines,
+        ...lines.slice(target.bodyEndLine),
+      ]
+    case "insert_before":
+      return [
+        ...lines.slice(0, target.startLine),
+        ...contentLines,
+        ...lines.slice(target.startLine),
+      ]
+  }
 }
 
 /** Reads a note, returning parsed frontmatter data and content lines. */
@@ -125,15 +182,12 @@ const readNoteForPatch = async (
   lines: string[]
 }> => {
   const fullPath = resolveSafePath(vaultPath, path)
-  let raw: string
-  try {
-    raw = await readFile(fullPath, "utf8")
-  } catch (err) {
+  const raw = await readFile(fullPath, "utf8").catch((err) => {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new Error(`note not found: "${path}"`, { cause: err })
     }
     throw err
-  }
+  })
   const parsed = matter(raw)
   return {
     fullPath,
@@ -146,7 +200,7 @@ const readNoteForPatch = async (
 const writePatched = async (
   fullPath: string,
   data: Record<string, unknown>,
-  lines: string[],
+  lines: readonly string[],
 ): Promise<void> => {
   const serialized = matter.stringify(lines.join("\n"), data)
   await writeFile(fullPath, serialized, "utf8")
@@ -173,54 +227,34 @@ const patchNote = async (
   )
   const contentLines = content.split("\n")
 
-  let updatedLines: string[]
-  let targetDesc: string
-
+  // File-level operation (no heading target)
   if (!heading) {
     if (operation === "replace" || operation === "insert_before") {
       throw new Error(`operation "${operation}" requires a heading target`)
     }
-    targetDesc = "file body"
-    updatedLines =
+    const updatedLines =
       operation === "append"
         ? [...lines, ...contentLines]
         : [...contentLines, ...lines]
-  } else {
-    const headings = parseHeadings(lines)
-    const target = findHeading(headings, heading, headingLevel)
-    targetDesc = `${"#".repeat(target.level)} ${target.text}`
-
-    switch (operation) {
-      case "append":
-        updatedLines = [
-          ...lines.slice(0, target.bodyEndLine),
-          ...contentLines,
-          ...lines.slice(target.bodyEndLine),
-        ]
-        break
-      case "prepend":
-        updatedLines = [
-          ...lines.slice(0, target.bodyStartLine),
-          ...contentLines,
-          ...lines.slice(target.bodyStartLine),
-        ]
-        break
-      case "replace":
-        updatedLines = [
-          ...lines.slice(0, target.bodyStartLine),
-          ...contentLines,
-          ...lines.slice(target.bodyEndLine),
-        ]
-        break
-      case "insert_before":
-        updatedLines = [
-          ...lines.slice(0, target.startLine),
-          ...contentLines,
-          ...lines.slice(target.startLine),
-        ]
-        break
-    }
+    await writePatched(fullPath, data, updatedLines)
+    logger.info("patched note", {
+      path,
+      operation,
+      target: "file body",
+    })
+    return `Applied ${operation} to ${path} → file body`
   }
+
+  // Section-level operation
+  const headings = parseHeadings(lines)
+  const target = findHeading(headings, heading, headingLevel)
+  const targetDesc = `${"#".repeat(target.level)} ${target.text}`
+  const updatedLines = applySectionOperation(
+    lines,
+    contentLines,
+    target,
+    operation,
+  )
 
   await writePatched(fullPath, data, updatedLines)
   logger.info("patched note", { path, operation, target: targetDesc })
@@ -256,18 +290,17 @@ const replaceInNote = async (
     throw new Error(`text not found in "${path}": "${preview}"`)
   }
 
-  let updatedBody: string
-  let count: number
-
-  if (replaceAllOccurrences) {
-    count = body.split(oldText).length - 1
-    updatedBody = body.split(oldText).join(newText)
-  } else {
-    count = 1
-    const idx = body.indexOf(oldText)
-    updatedBody =
-      body.slice(0, idx) + newText + body.slice(idx + oldText.length)
-  }
+  const idx = body.indexOf(oldText)
+  const { updatedBody, count } = replaceAllOccurrences
+    ? {
+        count: body.split(oldText).length - 1,
+        updatedBody: body.split(oldText).join(newText),
+      }
+    : {
+        count: 1,
+        updatedBody:
+          body.slice(0, idx) + newText + body.slice(idx + oldText.length),
+      }
 
   const updatedLines = updatedBody.split("\n")
   await writePatched(fullPath, data, updatedLines)


### PR DESCRIPTION
## Summary

- **`vault_patch_note`** — surgical heading-targeted edits with 4 operations (append, prepend, replace, insert_before). Supports file-level append/prepend (no heading), CommonMark §4.5 code-fence-aware H1–H6 parser (backticks + tildes, nested fences), case-sensitive heading matching with ambiguity detection (same-level vs cross-level error messages), and frontmatter preservation.
- **`vault_replace_in_note`** — exact text find-and-replace with optional `replace_all_occurrences` flag. Empty `old_text` rejected at schema and runtime. Case-sensitive, frontmatter preserved.
- New `vault-patcher.ts` module with `applySectionOperation` helper, immutable data flow (no `let`), explicit naming throughout
- `resolveSafePath` exported from `vault-filesystem.ts` for reuse
- Tool descriptions include `Errors:` sections with remediation guidance, following MCP best practices
- 53 new tests (251 total), 15 registered tools

### Doc updates
- ARCHITECTURE.md: added `vault_patch_note`, `vault_replace_in_note`, `vault_search_by_folder` to tool tables; fixed stale `sort_by` value (`mtime` → `modified`)
- AGENTS.md: added conventions (immutability, explicit naming, regex doc comments, MCP tool description template); updated tool count and data-layer module list
- README.md: updated tool count, removed stale test count

### Ultrareview findings addressed
- Empty `oldText` silently corrupts note → runtime guard + `.min(1)` schema
- `idempotentHint` wrong on `vault_replace_in_note` → `false`
- Misleading example targeted frontmatter (body-only tool) → body-resident example
- `heading_level` accepted floats → added `.int()`
- Nested code fences mishandled → CommonMark §4.5 fence tracking
- Same-level ambiguity error suggested `heading_level` (unhelpful) → suggests rename
- Missing `Returns:` lines → added to both tools

## Test plan

- [x] 53 new tests: heading parsing (6 levels, code blocks, nested fences, tilde fences, trailing hashes), heading lookup (case sensitivity, ambiguity with same-level vs cross-level messages, disambiguation, empty heading), all 4 patchNote operations (file-level and section-level with structural position verification), frontmatter preservation (with/without/complex, list-type values), replaceInNote (first/all/multi-line/deletion/case-sensitive/empty oldText), error cases (not found, path traversal), edge cases (empty sections, trailing headings, subdirectories)
- [x] All 251 tests pass
- [x] TypeScript compiles clean
- [x] ESLint passes
- [x] CI passing on all pushes
- [x] Deploy and verify tools via MCP Inspector or Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)