### PR TITLE
test(vault-mcp): cover server.ts helpers and mcp-router.ts

### DIFF
--- a/src/vault-mcp/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/__tests__/mcp-router.test.ts
@@ -8,6 +8,7 @@ import {
   vi,
 } from "vitest"
 import express from "express"
+import { randomUUID } from "node:crypto"
 import type { Server } from "node:http"
 import type { AddressInfo } from "node:net"
 import { createMcpRouter } from "../mcp-router.js"
@@ -95,8 +96,6 @@ const denyAuth: express.RequestHandler = (_req, res) => {
   res.status(401).json({ error: "unauthorized" })
 }
 
-let sessionCounter = 0
-
 const setupHarness = async (
   opts: { authMiddleware?: express.RequestHandler } = {},
 ): Promise<Harness> => {
@@ -105,9 +104,8 @@ const setupHarness = async (
 
   vi.mocked(StreamableHTTPServerTransport).mockImplementation(
     function MockStreamableHTTPServerTransport() {
-      sessionCounter += 1
       const transport: TransportMock = {
-        sessionId: `session-${sessionCounter}`,
+        sessionId: randomUUID(),
         handleRequest: vi.fn(
           async (_req: express.Request, res: express.Response) => {
             res.status(202).json({ ok: true, handled: "transport-mock" })
@@ -181,22 +179,34 @@ const createSession = async (
   return { sessionId: transport.sessionId, transport }
 }
 
-let infoSpy: ReturnType<typeof vi.spyOn>
-let warnSpy: ReturnType<typeof vi.spyOn>
-let childSpy: ReturnType<typeof vi.spyOn>
+// Sets up a harness and immediately runs the initialize handshake so a
+// test can assert on the side-effects of session creation without
+// repeating the two-step setup in every it().
+const setupInitializedSession = async (): Promise<{
+  harness: Harness
+  sessionId: string
+  transport: TransportMock
+}> => {
+  const harness = await setupHarness()
+  const session = await createSession(harness)
+  return { harness, ...session }
+}
 
 beforeEach(() => {
   vi.mocked(isInitializeRequest).mockReturnValue(true)
-  infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {})
-  warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
-  childSpy = vi.spyOn(logger, "child")
+  vi.spyOn(logger, "info").mockImplementation(() => {})
+  vi.spyOn(logger, "warn").mockImplementation(() => {})
+  vi.spyOn(logger, "child")
 })
 
+// restoreAllMocks restores every vi.spyOn-created spy (logger.* go back to
+// real methods). clearAllMocks then clears call/instance history on the
+// vi.fn() instances created by vi.mock factories (restoreAllMocks doesn't
+// touch those). Together they leave every mock fresh for the next test;
+// the next beforeEach + setupHarness reinstall implementations.
 afterEach(() => {
+  vi.restoreAllMocks()
   vi.clearAllMocks()
-  infoSpy.mockRestore()
-  warnSpy.mockRestore()
-  childSpy.mockRestore()
 })
 
 describe("createMcpRouter — construction", () => {
@@ -212,40 +222,34 @@ describe("createMcpRouter — construction", () => {
 
 describe("createMcpRouter — POST /mcp", () => {
   describe("on a fresh initialize request", () => {
-    let harness: Harness
-    let transport: TransportMock
-    let sessionId: string
-
-    beforeEach(async () => {
-      harness = await setupHarness()
-      const session = await createSession(harness)
-      transport = session.transport
-      sessionId = session.sessionId
-    })
-
-    it("constructs exactly one transport", () => {
+    it("constructs exactly one transport", async () => {
+      const { harness } = await setupInitializedSession()
       expect(harness.transportInstances).toHaveLength(1)
     })
 
-    it("constructs exactly one McpServer with the documented metadata", () => {
+    it("constructs exactly one McpServer with the documented metadata", async () => {
+      await setupInitializedSession()
       expect(McpServer).toHaveBeenCalledTimes(1)
       const [info, options] = vi.mocked(McpServer).mock.calls[0]!
       expect(info).toEqual(SERVER_INFO)
       expect(options).toEqual(SERVER_OPTIONS)
     })
 
-    it("connects the new server to the new transport", () => {
+    it("connects the new server to the new transport", async () => {
+      const { harness, transport } = await setupInitializedSession()
       expect(harness.serverInstances[0]!.connect).toHaveBeenCalledWith(
         transport,
       )
     })
 
-    it("forwards the request body to transport.handleRequest", () => {
+    it("forwards the request body to transport.handleRequest", async () => {
+      const { transport } = await setupInitializedSession()
       expect(transport.handleRequest).toHaveBeenCalledTimes(1)
       expect(transport.handleRequest.mock.calls[0]![2]).toEqual(initializeBody)
     })
 
-    it("registers tools on the new server with vault context", () => {
+    it("registers tools on the new server with vault context", async () => {
+      const { harness } = await setupInitializedSession()
       expect(registerTools).toHaveBeenCalledTimes(1)
       const arg = vi.mocked(registerTools).mock.calls[0]![0]
       expect(arg.server).toBe(harness.serverInstances[0])
@@ -254,15 +258,17 @@ describe("createMcpRouter — POST /mcp", () => {
       expect(arg.logger).toBeDefined()
     })
 
-    it("scopes the logger for registerTools to the sessionId and clientIp", () => {
-      expect(childSpy).toHaveBeenCalledWith({
+    it("scopes the logger for registerTools to the sessionId and clientIp", async () => {
+      const { sessionId } = await setupInitializedSession()
+      expect(vi.mocked(logger.child)).toHaveBeenCalledWith({
         sessionId,
         clientIp: FORWARDED_IP,
       })
     })
 
-    it("logs the 'session created' response", () => {
-      expect(infoSpy).toHaveBeenCalledWith("mcp_response", {
+    it("logs the 'session created' response", async () => {
+      const { sessionId } = await setupInitializedSession()
+      expect(vi.mocked(logger.info)).toHaveBeenCalledWith("mcp_response", {
         sessionId,
         clientIp: FORWARDED_IP,
         status: 200,
@@ -270,8 +276,9 @@ describe("createMcpRouter — POST /mcp", () => {
       })
     })
 
-    it("logs an 'mcp_request' for the incoming POST", () => {
-      expect(infoSpy).toHaveBeenCalledWith("mcp_request", {
+    it("logs an 'mcp_request' for the incoming POST", async () => {
+      await setupInitializedSession()
+      expect(vi.mocked(logger.info)).toHaveBeenCalledWith("mcp_request", {
         sessionId: undefined,
         clientIp: FORWARDED_IP,
         method: "POST",
@@ -283,7 +290,7 @@ describe("createMcpRouter — POST /mcp", () => {
     const harness = await setupHarness()
     const { sessionId, transport } = await createSession(harness)
     transport.handleRequest.mockClear()
-    infoSpy.mockClear()
+    vi.mocked(logger.info).mockClear()
     vi.mocked(isInitializeRequest).mockReturnValue(false)
 
     const followUp = { jsonrpc: "2.0", id: 2, method: "tools/list" }
@@ -297,7 +304,7 @@ describe("createMcpRouter — POST /mcp", () => {
     expect(harness.transportInstances).toHaveLength(1)
     expect(transport.handleRequest).toHaveBeenCalledTimes(1)
     expect(transport.handleRequest.mock.calls[0]![2]).toEqual(followUp)
-    expect(infoSpy).toHaveBeenCalledWith("mcp_response", {
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith("mcp_response", {
       sessionId,
       clientIp: FORWARDED_IP,
       status: 200,
@@ -318,7 +325,7 @@ describe("createMcpRouter — POST /mcp", () => {
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({ error: "no session" })
     expect(harness.transportInstances).toHaveLength(0)
-    expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith("mcp_response", {
       clientIp: FORWARDED_IP,
       status: 400,
       outcome: "no session, non-initialize request",
@@ -337,7 +344,7 @@ describe("createMcpRouter — POST /mcp", () => {
     expect(response.status).toBe(404)
     expect(await response.json()).toEqual({ error: "session not found" })
     expect(harness.transportInstances).toHaveLength(0)
-    expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith("mcp_response", {
       sessionId: "ghost-session",
       clientIp: FORWARDED_IP,
       status: 404,
@@ -356,7 +363,7 @@ describe("createMcpRouter — POST /mcp", () => {
 
     expect(response.status).toBe(401)
     expect(harness.transportInstances).toHaveLength(0)
-    expect(infoSpy).not.toHaveBeenCalled()
+    expect(vi.mocked(logger.info)).not.toHaveBeenCalled()
   })
 })
 
@@ -386,7 +393,7 @@ describe("createMcpRouter — GET /mcp", () => {
 
     expect(response.status).toBe(404)
     expect(await response.json()).toEqual({ error: "session not found" })
-    expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith("mcp_response", {
       sessionId: undefined,
       clientIp: FORWARDED_IP,
       status: 404,
@@ -431,7 +438,7 @@ describe("createMcpRouter — DELETE /mcp", () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({ ok: true })
     expect(transport.close).toHaveBeenCalledTimes(1)
-    expect(infoSpy).toHaveBeenCalledWith("mcp_response", {
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith("mcp_response", {
       sessionId,
       clientIp: FORWARDED_IP,
       status: 200,
@@ -488,11 +495,13 @@ describe("createMcpRouter — transport.onclose", () => {
   it("removes the session from the map and logs 'session_closed'", async () => {
     const harness = await setupHarness()
     const { sessionId, transport } = await createSession(harness)
-    infoSpy.mockClear()
+    vi.mocked(logger.info).mockClear()
 
     transport.onclose!()
 
-    expect(infoSpy).toHaveBeenCalledWith("session_closed", { sessionId })
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith("session_closed", {
+      sessionId,
+    })
     // The session should be gone — confirm with a GET that should 404.
     const followUp = await fetch(harness.url(), {
       method: "GET",
@@ -506,9 +515,9 @@ describe("createMcpRouter — transport.onclose", () => {
     const harness = await setupHarness()
     const { transport } = await createSession(harness)
     transport.sessionId = undefined
-    infoSpy.mockClear()
+    vi.mocked(logger.info).mockClear()
 
     expect(() => transport.onclose!()).not.toThrow()
-    expect(infoSpy).not.toHaveBeenCalled()
+    expect(vi.mocked(logger.info)).not.toHaveBeenCalled()
   })
 })

--- a/src/vault-mcp/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/__tests__/mcp-router.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import express, { type Express } from "express"
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  onTestFinished,
+  vi,
+} from "vitest"
+import express from "express"
 import type { Server } from "node:http"
 import type { AddressInfo } from "node:net"
 import { createMcpRouter } from "../mcp-router.js"
@@ -75,7 +83,6 @@ type TransportMock = {
 type ServerMock = { connect: ReturnType<typeof vi.fn> }
 
 type Harness = {
-  server: Server
   url: (path?: string) => string
   transportInstances: TransportMock[]
   serverInstances: ServerMock[]
@@ -89,7 +96,6 @@ const denyAuth: express.RequestHandler = (_req, res) => {
 }
 
 let sessionCounter = 0
-let currentHarness: Harness | undefined
 
 const setupHarness = async (
   opts: { authMiddleware?: express.RequestHandler } = {},
@@ -130,37 +136,45 @@ const setupHarness = async (
   const search = {} as SearchIndex
   const provider = {} as OAuthServerProvider
 
-  const app: Express = express()
+  const app = express()
   app.set("trust proxy", true)
   app.use(express.json())
   app.use(createMcpRouter({ vaultPath: VAULT_PATH, search, provider }))
 
-  const server = await new Promise<Server>((resolve) => {
-    const s = app.listen(0, () => resolve(s))
+  const httpServer = await new Promise<Server>((resolve) => {
+    const listener = app.listen(0, () => resolve(listener))
   })
-  const port = (server.address() as AddressInfo).port
+  const port = (httpServer.address() as AddressInfo).port
 
-  currentHarness = {
-    server,
+  // Close the listening socket when the test ends — vitest's onTestFinished
+  // ties cleanup to the same test that called setupHarness, so we don't
+  // need a module-level "current harness" reference to find it in afterEach.
+  onTestFinished(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => (err ? reject(err) : resolve()))
+      }),
+  )
+
+  return {
     url: (path = "/mcp") => `http://127.0.0.1:${port}${path}`,
     transportInstances,
     serverInstances,
     search,
     provider,
   }
-  return currentHarness
 }
 
 const createSession = async (
-  h: Harness,
+  harness: Harness,
 ): Promise<{ sessionId: string; transport: TransportMock }> => {
-  const response = await fetch(h.url(), {
+  const response = await fetch(harness.url(), {
     method: "POST",
     headers: baseHeaders,
     body: JSON.stringify(initializeBody),
   })
   await response.arrayBuffer()
-  const transport = h.transportInstances.at(-1)
+  const transport = harness.transportInstances.at(-1)
   if (!transport || !transport.sessionId) {
     throw new Error("session was not created")
   }
@@ -178,13 +192,7 @@ beforeEach(() => {
   childSpy = vi.spyOn(logger, "child")
 })
 
-afterEach(async () => {
-  if (currentHarness) {
-    await new Promise<void>((resolve, reject) => {
-      currentHarness!.server.close((err) => (err ? reject(err) : resolve()))
-    })
-    currentHarness = undefined
-  }
+afterEach(() => {
   vi.clearAllMocks()
   infoSpy.mockRestore()
   warnSpy.mockRestore()
@@ -193,30 +201,30 @@ afterEach(async () => {
 
 describe("createMcpRouter — construction", () => {
   it("wires the OAuth provider into requireBearerAuth as the verifier", async () => {
-    const h = await setupHarness()
+    const harness = await setupHarness()
 
     expect(requireBearerAuth).toHaveBeenCalledTimes(1)
     expect(vi.mocked(requireBearerAuth).mock.calls[0]![0]).toEqual({
-      verifier: h.provider,
+      verifier: harness.provider,
     })
   })
 })
 
 describe("createMcpRouter — POST /mcp", () => {
   describe("on a fresh initialize request", () => {
-    let h: Harness
+    let harness: Harness
     let transport: TransportMock
     let sessionId: string
 
     beforeEach(async () => {
-      h = await setupHarness()
-      const session = await createSession(h)
+      harness = await setupHarness()
+      const session = await createSession(harness)
       transport = session.transport
       sessionId = session.sessionId
     })
 
     it("constructs exactly one transport", () => {
-      expect(h.transportInstances).toHaveLength(1)
+      expect(harness.transportInstances).toHaveLength(1)
     })
 
     it("constructs exactly one McpServer with the documented metadata", () => {
@@ -227,7 +235,9 @@ describe("createMcpRouter — POST /mcp", () => {
     })
 
     it("connects the new server to the new transport", () => {
-      expect(h.serverInstances[0]!.connect).toHaveBeenCalledWith(transport)
+      expect(harness.serverInstances[0]!.connect).toHaveBeenCalledWith(
+        transport,
+      )
     })
 
     it("forwards the request body to transport.handleRequest", () => {
@@ -238,9 +248,9 @@ describe("createMcpRouter — POST /mcp", () => {
     it("registers tools on the new server with vault context", () => {
       expect(registerTools).toHaveBeenCalledTimes(1)
       const arg = vi.mocked(registerTools).mock.calls[0]![0]
-      expect(arg.server).toBe(h.serverInstances[0])
+      expect(arg.server).toBe(harness.serverInstances[0])
       expect(arg.vaultPath).toBe(VAULT_PATH)
-      expect(arg.search).toBe(h.search)
+      expect(arg.search).toBe(harness.search)
       expect(arg.logger).toBeDefined()
     })
 
@@ -270,21 +280,21 @@ describe("createMcpRouter — POST /mcp", () => {
   })
 
   it("routes a follow-up POST to the existing transport when the session id matches", async () => {
-    const h = await setupHarness()
-    const { sessionId, transport } = await createSession(h)
+    const harness = await setupHarness()
+    const { sessionId, transport } = await createSession(harness)
     transport.handleRequest.mockClear()
     infoSpy.mockClear()
     vi.mocked(isInitializeRequest).mockReturnValue(false)
 
     const followUp = { jsonrpc: "2.0", id: 2, method: "tools/list" }
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "POST",
       headers: { ...baseHeaders, "mcp-session-id": sessionId },
       body: JSON.stringify(followUp),
     })
     await response.arrayBuffer()
 
-    expect(h.transportInstances).toHaveLength(1)
+    expect(harness.transportInstances).toHaveLength(1)
     expect(transport.handleRequest).toHaveBeenCalledTimes(1)
     expect(transport.handleRequest.mock.calls[0]![2]).toEqual(followUp)
     expect(infoSpy).toHaveBeenCalledWith("mcp_response", {
@@ -296,10 +306,10 @@ describe("createMcpRouter — POST /mcp", () => {
   })
 
   it("returns 400 with 'no session' when there is no session and the body is not an initialize request", async () => {
-    const h = await setupHarness()
+    const harness = await setupHarness()
     vi.mocked(isInitializeRequest).mockReturnValue(false)
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "POST",
       headers: baseHeaders,
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
@@ -307,7 +317,7 @@ describe("createMcpRouter — POST /mcp", () => {
 
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({ error: "no session" })
-    expect(h.transportInstances).toHaveLength(0)
+    expect(harness.transportInstances).toHaveLength(0)
     expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
       clientIp: FORWARDED_IP,
       status: 400,
@@ -316,9 +326,9 @@ describe("createMcpRouter — POST /mcp", () => {
   })
 
   it("returns 404 when the session id is unknown", async () => {
-    const h = await setupHarness()
+    const harness = await setupHarness()
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "POST",
       headers: { ...baseHeaders, "mcp-session-id": "ghost-session" },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
@@ -326,7 +336,7 @@ describe("createMcpRouter — POST /mcp", () => {
 
     expect(response.status).toBe(404)
     expect(await response.json()).toEqual({ error: "session not found" })
-    expect(h.transportInstances).toHaveLength(0)
+    expect(harness.transportInstances).toHaveLength(0)
     expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
       sessionId: "ghost-session",
       clientIp: FORWARDED_IP,
@@ -336,27 +346,27 @@ describe("createMcpRouter — POST /mcp", () => {
   })
 
   it("returns 401 and never enters the route handler when bearer auth rejects", async () => {
-    const h = await setupHarness({ authMiddleware: denyAuth })
+    const harness = await setupHarness({ authMiddleware: denyAuth })
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "POST",
       headers: baseHeaders,
       body: JSON.stringify(initializeBody),
     })
 
     expect(response.status).toBe(401)
-    expect(h.transportInstances).toHaveLength(0)
+    expect(harness.transportInstances).toHaveLength(0)
     expect(infoSpy).not.toHaveBeenCalled()
   })
 })
 
 describe("createMcpRouter — GET /mcp", () => {
   it("forwards the request to the existing transport without a body argument", async () => {
-    const h = await setupHarness()
-    const { sessionId, transport } = await createSession(h)
+    const harness = await setupHarness()
+    const { sessionId, transport } = await createSession(harness)
     transport.handleRequest.mockClear()
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "GET",
       headers: { ...baseHeaders, "mcp-session-id": sessionId },
     })
@@ -367,9 +377,9 @@ describe("createMcpRouter — GET /mcp", () => {
   })
 
   it("returns 404 when the mcp-session-id header is missing", async () => {
-    const h = await setupHarness()
+    const harness = await setupHarness()
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "GET",
       headers: baseHeaders,
     })
@@ -385,9 +395,9 @@ describe("createMcpRouter — GET /mcp", () => {
   })
 
   it("returns 404 when the session id is unknown", async () => {
-    const h = await setupHarness()
+    const harness = await setupHarness()
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "GET",
       headers: { ...baseHeaders, "mcp-session-id": "missing" },
     })
@@ -397,9 +407,9 @@ describe("createMcpRouter — GET /mcp", () => {
   })
 
   it("returns 401 when bearer auth rejects", async () => {
-    const h = await setupHarness({ authMiddleware: denyAuth })
+    const harness = await setupHarness({ authMiddleware: denyAuth })
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "GET",
       headers: { ...baseHeaders, "mcp-session-id": "anything" },
     })
@@ -410,10 +420,10 @@ describe("createMcpRouter — GET /mcp", () => {
 
 describe("createMcpRouter — DELETE /mcp", () => {
   it("closes the transport, removes the session, and returns 200", async () => {
-    const h = await setupHarness()
-    const { sessionId, transport } = await createSession(h)
+    const harness = await setupHarness()
+    const { sessionId, transport } = await createSession(harness)
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "DELETE",
       headers: { ...baseHeaders, "mcp-session-id": sessionId },
     })
@@ -430,7 +440,7 @@ describe("createMcpRouter — DELETE /mcp", () => {
 
     // The session should be gone from the map — verified via a follow-up
     // GET that should now 404.
-    const followUp = await fetch(h.url(), {
+    const followUp = await fetch(harness.url(), {
       method: "GET",
       headers: { ...baseHeaders, "mcp-session-id": sessionId },
     })
@@ -439,9 +449,9 @@ describe("createMcpRouter — DELETE /mcp", () => {
   })
 
   it("returns 404 when the mcp-session-id header is missing", async () => {
-    const h = await setupHarness()
+    const harness = await setupHarness()
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "DELETE",
       headers: baseHeaders,
     })
@@ -451,9 +461,9 @@ describe("createMcpRouter — DELETE /mcp", () => {
   })
 
   it("returns 404 when the session id is unknown", async () => {
-    const h = await setupHarness()
+    const harness = await setupHarness()
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "DELETE",
       headers: { ...baseHeaders, "mcp-session-id": "ghost" },
     })
@@ -463,9 +473,9 @@ describe("createMcpRouter — DELETE /mcp", () => {
   })
 
   it("returns 401 when bearer auth rejects", async () => {
-    const h = await setupHarness({ authMiddleware: denyAuth })
+    const harness = await setupHarness({ authMiddleware: denyAuth })
 
-    const response = await fetch(h.url(), {
+    const response = await fetch(harness.url(), {
       method: "DELETE",
       headers: { ...baseHeaders, "mcp-session-id": "anything" },
     })
@@ -476,15 +486,15 @@ describe("createMcpRouter — DELETE /mcp", () => {
 
 describe("createMcpRouter — transport.onclose", () => {
   it("removes the session from the map and logs 'session_closed'", async () => {
-    const h = await setupHarness()
-    const { sessionId, transport } = await createSession(h)
+    const harness = await setupHarness()
+    const { sessionId, transport } = await createSession(harness)
     infoSpy.mockClear()
 
     transport.onclose!()
 
     expect(infoSpy).toHaveBeenCalledWith("session_closed", { sessionId })
     // The session should be gone — confirm with a GET that should 404.
-    const followUp = await fetch(h.url(), {
+    const followUp = await fetch(harness.url(), {
       method: "GET",
       headers: { ...baseHeaders, "mcp-session-id": sessionId },
     })
@@ -493,8 +503,8 @@ describe("createMcpRouter — transport.onclose", () => {
   })
 
   it("is a no-op when the transport has no sessionId", async () => {
-    const h = await setupHarness()
-    const { transport } = await createSession(h)
+    const harness = await setupHarness()
+    const { transport } = await createSession(harness)
     transport.sessionId = undefined
     infoSpy.mockClear()
 

--- a/src/vault-mcp/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/__tests__/mcp-router.test.ts
@@ -21,6 +21,11 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js"
 import { registerTools } from "../tool-definitions.js"
 import { logger } from "../../logger.js"
 
+// `logger` is a real exported object; its methods become spies inside
+// beforeEach (vi.spyOn). vi.mocked is a type-only cast that gives us
+// typed access to the spy state — at runtime, mockedLogger === logger.
+const mockedLogger = vi.mocked(logger)
+
 // We stub the MCP SDK so tests focus on the router's own logic — the
 // session map, the route dispatch, and the onclose cleanup — rather than
 // the SDK's transport state machine. Each mocked module captures real
@@ -260,7 +265,7 @@ describe("createMcpRouter — POST /mcp", () => {
 
     it("scopes the logger for registerTools to the sessionId and clientIp", async () => {
       const { sessionId } = await setupInitializedSession()
-      expect(vi.mocked(logger.child)).toHaveBeenCalledWith({
+      expect(mockedLogger.child).toHaveBeenCalledWith({
         sessionId,
         clientIp: FORWARDED_IP,
       })
@@ -268,7 +273,7 @@ describe("createMcpRouter — POST /mcp", () => {
 
     it("logs the 'session created' response", async () => {
       const { sessionId } = await setupInitializedSession()
-      expect(vi.mocked(logger.info)).toHaveBeenCalledWith("mcp_response", {
+      expect(mockedLogger.info).toHaveBeenCalledWith("mcp_response", {
         sessionId,
         clientIp: FORWARDED_IP,
         status: 200,
@@ -278,7 +283,7 @@ describe("createMcpRouter — POST /mcp", () => {
 
     it("logs an 'mcp_request' for the incoming POST", async () => {
       await setupInitializedSession()
-      expect(vi.mocked(logger.info)).toHaveBeenCalledWith("mcp_request", {
+      expect(mockedLogger.info).toHaveBeenCalledWith("mcp_request", {
         sessionId: undefined,
         clientIp: FORWARDED_IP,
         method: "POST",
@@ -290,7 +295,7 @@ describe("createMcpRouter — POST /mcp", () => {
     const harness = await setupHarness()
     const { sessionId, transport } = await createSession(harness)
     transport.handleRequest.mockClear()
-    vi.mocked(logger.info).mockClear()
+    mockedLogger.info.mockClear()
     vi.mocked(isInitializeRequest).mockReturnValue(false)
 
     const followUp = { jsonrpc: "2.0", id: 2, method: "tools/list" }
@@ -304,7 +309,7 @@ describe("createMcpRouter — POST /mcp", () => {
     expect(harness.transportInstances).toHaveLength(1)
     expect(transport.handleRequest).toHaveBeenCalledTimes(1)
     expect(transport.handleRequest.mock.calls[0]![2]).toEqual(followUp)
-    expect(vi.mocked(logger.info)).toHaveBeenCalledWith("mcp_response", {
+    expect(mockedLogger.info).toHaveBeenCalledWith("mcp_response", {
       sessionId,
       clientIp: FORWARDED_IP,
       status: 200,
@@ -325,7 +330,7 @@ describe("createMcpRouter — POST /mcp", () => {
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({ error: "no session" })
     expect(harness.transportInstances).toHaveLength(0)
-    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith("mcp_response", {
+    expect(mockedLogger.warn).toHaveBeenCalledWith("mcp_response", {
       clientIp: FORWARDED_IP,
       status: 400,
       outcome: "no session, non-initialize request",
@@ -344,7 +349,7 @@ describe("createMcpRouter — POST /mcp", () => {
     expect(response.status).toBe(404)
     expect(await response.json()).toEqual({ error: "session not found" })
     expect(harness.transportInstances).toHaveLength(0)
-    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith("mcp_response", {
+    expect(mockedLogger.warn).toHaveBeenCalledWith("mcp_response", {
       sessionId: "ghost-session",
       clientIp: FORWARDED_IP,
       status: 404,
@@ -363,7 +368,7 @@ describe("createMcpRouter — POST /mcp", () => {
 
     expect(response.status).toBe(401)
     expect(harness.transportInstances).toHaveLength(0)
-    expect(vi.mocked(logger.info)).not.toHaveBeenCalled()
+    expect(mockedLogger.info).not.toHaveBeenCalled()
   })
 })
 
@@ -393,7 +398,7 @@ describe("createMcpRouter — GET /mcp", () => {
 
     expect(response.status).toBe(404)
     expect(await response.json()).toEqual({ error: "session not found" })
-    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith("mcp_response", {
+    expect(mockedLogger.warn).toHaveBeenCalledWith("mcp_response", {
       sessionId: undefined,
       clientIp: FORWARDED_IP,
       status: 404,
@@ -438,7 +443,7 @@ describe("createMcpRouter — DELETE /mcp", () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({ ok: true })
     expect(transport.close).toHaveBeenCalledTimes(1)
-    expect(vi.mocked(logger.info)).toHaveBeenCalledWith("mcp_response", {
+    expect(mockedLogger.info).toHaveBeenCalledWith("mcp_response", {
       sessionId,
       clientIp: FORWARDED_IP,
       status: 200,
@@ -495,11 +500,11 @@ describe("createMcpRouter — transport.onclose", () => {
   it("removes the session from the map and logs 'session_closed'", async () => {
     const harness = await setupHarness()
     const { sessionId, transport } = await createSession(harness)
-    vi.mocked(logger.info).mockClear()
+    mockedLogger.info.mockClear()
 
     transport.onclose!()
 
-    expect(vi.mocked(logger.info)).toHaveBeenCalledWith("session_closed", {
+    expect(mockedLogger.info).toHaveBeenCalledWith("session_closed", {
       sessionId,
     })
     // The session should be gone — confirm with a GET that should 404.
@@ -515,9 +520,9 @@ describe("createMcpRouter — transport.onclose", () => {
     const harness = await setupHarness()
     const { transport } = await createSession(harness)
     transport.sessionId = undefined
-    vi.mocked(logger.info).mockClear()
+    mockedLogger.info.mockClear()
 
     expect(() => transport.onclose!()).not.toThrow()
-    expect(vi.mocked(logger.info)).not.toHaveBeenCalled()
+    expect(mockedLogger.info).not.toHaveBeenCalled()
   })
 })

--- a/src/vault-mcp/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/__tests__/mcp-router.test.ts
@@ -72,6 +72,7 @@ type Harness = {
   transportInstances: TransportMock[]
   serverInstances: ServerMock[]
   search: SearchIndex
+  provider: OAuthServerProvider
 }
 
 const harnesses: Harness[] = []
@@ -103,20 +104,16 @@ const setupHarness = async (
   const serverInstances: ServerMock[] = []
 
   vi.mocked(StreamableHTTPServerTransport).mockImplementation(
-    function MockStreamableHTTPServerTransport(this: TransportMock) {
+    function MockStreamableHTTPServerTransport() {
       const t = createTransportMock()
       transportInstances.push(t)
-      Object.assign(this, t)
       return t
     } as unknown as typeof StreamableHTTPServerTransport,
   )
 
-  vi.mocked(McpServer).mockImplementation(function MockMcpServer(
-    this: ServerMock,
-  ) {
+  vi.mocked(McpServer).mockImplementation(function MockMcpServer() {
     const s = createServerMock()
     serverInstances.push(s)
-    Object.assign(this, s)
     return s
   } as unknown as typeof McpServer)
 
@@ -147,6 +144,7 @@ const setupHarness = async (
     transportInstances,
     serverInstances,
     search,
+    provider,
   }
   harnesses.push(h)
   return h
@@ -175,24 +173,19 @@ const baseHeaders = {
 
 const createSession = async (
   h: Harness,
-): Promise<{
-  sessionId: string
-  transport: TransportMock
-  response: Response
-}> => {
+): Promise<{ sessionId: string; transport: TransportMock }> => {
   vi.mocked(isInitializeRequest).mockReturnValue(true)
   const response = await fetch(h.url(), {
     method: "POST",
     headers: baseHeaders,
     body: JSON.stringify(initializeBody),
   })
-  // drain so the connection releases
   await response.arrayBuffer()
   const transport = h.transportInstances.at(-1)
   if (!transport || !transport.sessionId) {
     throw new Error("session was not created")
   }
-  return { sessionId: transport.sessionId, transport, response }
+  return { sessionId: transport.sessionId, transport }
 }
 
 let infoSpy: ReturnType<typeof vi.spyOn>
@@ -204,13 +197,21 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
-  while (harnesses.length > 0) {
-    const h = harnesses.pop()
-    if (h) await teardownHarness(h)
-  }
+  await Promise.all(harnesses.splice(0).map(teardownHarness))
   vi.clearAllMocks()
   infoSpy.mockRestore()
   warnSpy.mockRestore()
+})
+
+describe("createMcpRouter — construction", () => {
+  it("wires the OAuth provider into requireBearerAuth as the verifier", async () => {
+    const h = await setupHarness()
+
+    expect(requireBearerAuth).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(requireBearerAuth).mock.calls[0]![0]).toEqual({
+      verifier: h.provider,
+    })
+  })
 })
 
 describe("createMcpRouter — POST /mcp", () => {
@@ -366,12 +367,9 @@ describe("createMcpRouter — POST /mcp", () => {
 
     expect(response.status).toBe(401)
     expect(h.transportInstances).toHaveLength(0)
-    // The route handler never runs, so neither mcp_request nor mcp_response
-    // info logs should fire.
-    expect(infoSpy).not.toHaveBeenCalledWith(
-      "mcp_request",
-      expect.objectContaining({ method: "POST" }),
-    )
+    // The route handler never runs, so its mcp_request / mcp_response info
+    // logs should never fire.
+    expect(infoSpy).not.toHaveBeenCalled()
   })
 
   it("logs mcp_request for every accepted POST", async () => {
@@ -391,18 +389,13 @@ describe("createMcpRouter — GET /mcp", () => {
     const h = await setupHarness()
     const { sessionId, transport } = await createSession(h)
     transport.handleRequest.mockClear()
-    transport.handleRequest.mockImplementationOnce(async (_req, res) => {
-      res.status(200).json({ ok: true, via: "GET" })
-    })
 
     const response = await fetch(h.url(), {
       method: "GET",
       headers: { ...baseHeaders, "mcp-session-id": sessionId },
     })
-    const body = (await response.json()) as { via: string }
+    await response.arrayBuffer()
 
-    expect(response.status).toBe(200)
-    expect(body).toEqual({ ok: true, via: "GET" })
     expect(transport.handleRequest).toHaveBeenCalledTimes(1)
     expect(transport.handleRequest.mock.calls[0]).toHaveLength(2)
   })

--- a/src/vault-mcp/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/__tests__/mcp-router.test.ts
@@ -12,148 +12,42 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js"
 import { registerTools } from "../tool-definitions.js"
 import { logger } from "../../logger.js"
 
+// We stub the MCP SDK so tests focus on the router's own logic — the
+// session map, the route dispatch, and the onclose cleanup — rather than
+// the SDK's transport state machine. Each mocked module captures real
+// router-side calls; none short-circuits a code path the router would
+// otherwise execute, so a test cannot pass because of an impossible
+// mock condition.
 vi.mock("@modelcontextprotocol/sdk/server/streamableHttp.js", () => ({
   StreamableHTTPServerTransport: vi.fn(),
 }))
-
 vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
   McpServer: vi.fn(),
 }))
-
 vi.mock(
   "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js",
-  () => ({
-    requireBearerAuth: vi.fn(),
-  }),
+  () => ({ requireBearerAuth: vi.fn() }),
 )
-
-vi.mock("@modelcontextprotocol/sdk/types.js", async (importOriginal) => {
-  const original = await importOriginal<Record<string, unknown>>()
-  return {
-    ...original,
-    isInitializeRequest: vi.fn(),
-  }
-})
-
-vi.mock("../tool-definitions.js", () => ({
-  registerTools: vi.fn(),
+vi.mock("@modelcontextprotocol/sdk/types.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isInitializeRequest: vi.fn(),
 }))
+vi.mock("../tool-definitions.js", () => ({ registerTools: vi.fn() }))
 
 const FORWARDED_IP = "192.0.2.10"
+const VAULT_PATH = "/test-vault"
 
-type TransportMock = {
-  sessionId: string | undefined
-  handleRequest: ReturnType<typeof vi.fn>
-  close: ReturnType<typeof vi.fn>
-  onclose: (() => void) | undefined
+const SERVER_INFO = {
+  name: "vault-cortex",
+  version: "1.0.0",
+  description:
+    "Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (About Me/) for personalization across conversations.",
 }
 
-type ServerMock = {
-  connect: ReturnType<typeof vi.fn>
+const SERVER_OPTIONS = {
+  instructions:
+    "Read, write, and search an Obsidian vault. Use vault_search and vault_read_note to find and read notes. Use vault_get_memory to retrieve user preferences and context from About Me/ files. Use vault_write_note and vault_update_memory for writes.",
 }
-
-type AuthMiddleware = (
-  req: express.Request,
-  res: express.Response,
-  next: express.NextFunction,
-) => void
-
-const allowAuth: AuthMiddleware = (_req, _res, next) => next()
-
-const denyAuth: AuthMiddleware = (_req, res) => {
-  res.status(401).json({ error: "unauthorized" })
-}
-
-type Harness = {
-  app: Express
-  server: Server
-  port: number
-  url: (path?: string) => string
-  transportInstances: TransportMock[]
-  serverInstances: ServerMock[]
-  search: SearchIndex
-  provider: OAuthServerProvider
-}
-
-const harnesses: Harness[] = []
-
-let sessionCounter = 0
-
-const createTransportMock = (): TransportMock => {
-  sessionCounter += 1
-  return {
-    sessionId: `session-${sessionCounter}`,
-    handleRequest: vi.fn(
-      async (_req: express.Request, res: express.Response, _body?: unknown) => {
-        res.status(202).json({ ok: true, handled: "transport-mock" })
-      },
-    ),
-    close: vi.fn(async () => {}),
-    onclose: undefined,
-  }
-}
-
-const createServerMock = (): ServerMock => ({
-  connect: vi.fn(async () => {}),
-})
-
-const setupHarness = async (
-  opts: { authMiddleware?: AuthMiddleware } = {},
-): Promise<Harness> => {
-  const transportInstances: TransportMock[] = []
-  const serverInstances: ServerMock[] = []
-
-  vi.mocked(StreamableHTTPServerTransport).mockImplementation(
-    function MockStreamableHTTPServerTransport() {
-      const t = createTransportMock()
-      transportInstances.push(t)
-      return t
-    } as unknown as typeof StreamableHTTPServerTransport,
-  )
-
-  vi.mocked(McpServer).mockImplementation(function MockMcpServer() {
-    const s = createServerMock()
-    serverInstances.push(s)
-    return s
-  } as unknown as typeof McpServer)
-
-  vi.mocked(requireBearerAuth).mockReturnValue(
-    (opts.authMiddleware ?? allowAuth) as unknown as ReturnType<
-      typeof requireBearerAuth
-    >,
-  )
-
-  const search = {} as SearchIndex
-  const provider = {} as OAuthServerProvider
-
-  const app = express()
-  app.set("trust proxy", true)
-  app.use(express.json())
-  app.use(createMcpRouter({ vaultPath: "/test-vault", search, provider }))
-
-  const server = await new Promise<Server>((resolve) => {
-    const s = app.listen(0, () => resolve(s))
-  })
-  const port = (server.address() as AddressInfo).port
-
-  const h: Harness = {
-    app,
-    server,
-    port,
-    url: (path = "/mcp") => `http://127.0.0.1:${port}${path}`,
-    transportInstances,
-    serverInstances,
-    search,
-    provider,
-  }
-  harnesses.push(h)
-  return h
-}
-
-const teardownHarness = (h: Harness): Promise<void> =>
-  new Promise<void>((resolve, reject) => {
-    h.server.close((err) => (err ? reject(err) : resolve()))
-  })
 
 const initializeBody = {
   jsonrpc: "2.0",
@@ -171,10 +65,95 @@ const baseHeaders = {
   "x-forwarded-for": FORWARDED_IP,
 }
 
+type TransportMock = {
+  sessionId: string | undefined
+  handleRequest: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+  onclose: (() => void) | undefined
+}
+
+type ServerMock = { connect: ReturnType<typeof vi.fn> }
+
+type Harness = {
+  server: Server
+  url: (path?: string) => string
+  transportInstances: TransportMock[]
+  serverInstances: ServerMock[]
+  search: SearchIndex
+  provider: OAuthServerProvider
+}
+
+const allowAuth: express.RequestHandler = (_req, _res, next) => next()
+const denyAuth: express.RequestHandler = (_req, res) => {
+  res.status(401).json({ error: "unauthorized" })
+}
+
+let sessionCounter = 0
+let currentHarness: Harness | undefined
+
+const setupHarness = async (
+  opts: { authMiddleware?: express.RequestHandler } = {},
+): Promise<Harness> => {
+  const transportInstances: TransportMock[] = []
+  const serverInstances: ServerMock[] = []
+
+  vi.mocked(StreamableHTTPServerTransport).mockImplementation(
+    function MockStreamableHTTPServerTransport() {
+      sessionCounter += 1
+      const transport: TransportMock = {
+        sessionId: `session-${sessionCounter}`,
+        handleRequest: vi.fn(
+          async (_req: express.Request, res: express.Response) => {
+            res.status(202).json({ ok: true, handled: "transport-mock" })
+          },
+        ),
+        close: vi.fn(async () => {}),
+        onclose: undefined,
+      }
+      transportInstances.push(transport)
+      return transport
+    } as unknown as typeof StreamableHTTPServerTransport,
+  )
+
+  vi.mocked(McpServer).mockImplementation(function MockMcpServer() {
+    const server: ServerMock = { connect: vi.fn(async () => {}) }
+    serverInstances.push(server)
+    return server
+  } as unknown as typeof McpServer)
+
+  vi.mocked(requireBearerAuth).mockReturnValue(
+    (opts.authMiddleware ?? allowAuth) as unknown as ReturnType<
+      typeof requireBearerAuth
+    >,
+  )
+
+  const search = {} as SearchIndex
+  const provider = {} as OAuthServerProvider
+
+  const app: Express = express()
+  app.set("trust proxy", true)
+  app.use(express.json())
+  app.use(createMcpRouter({ vaultPath: VAULT_PATH, search, provider }))
+
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s))
+  })
+  const port = (server.address() as AddressInfo).port
+
+  currentHarness = {
+    server,
+    url: (path = "/mcp") => `http://127.0.0.1:${port}${path}`,
+    transportInstances,
+    serverInstances,
+    search,
+    provider,
+  }
+  return currentHarness
+}
+
 const createSession = async (
   h: Harness,
 ): Promise<{ sessionId: string; transport: TransportMock }> => {
-  vi.mocked(isInitializeRequest).mockReturnValue(true)
   const response = await fetch(h.url(), {
     method: "POST",
     headers: baseHeaders,
@@ -190,17 +169,26 @@ const createSession = async (
 
 let infoSpy: ReturnType<typeof vi.spyOn>
 let warnSpy: ReturnType<typeof vi.spyOn>
+let childSpy: ReturnType<typeof vi.spyOn>
 
 beforeEach(() => {
+  vi.mocked(isInitializeRequest).mockReturnValue(true)
   infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {})
   warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+  childSpy = vi.spyOn(logger, "child")
 })
 
 afterEach(async () => {
-  await Promise.all(harnesses.splice(0).map(teardownHarness))
+  if (currentHarness) {
+    await new Promise<void>((resolve, reject) => {
+      currentHarness!.server.close((err) => (err ? reject(err) : resolve()))
+    })
+    currentHarness = undefined
+  }
   vi.clearAllMocks()
   infoSpy.mockRestore()
   warnSpy.mockRestore()
+  childSpy.mockRestore()
 })
 
 describe("createMcpRouter — construction", () => {
@@ -215,85 +203,79 @@ describe("createMcpRouter — construction", () => {
 })
 
 describe("createMcpRouter — POST /mcp", () => {
-  it("creates a new session on initialize request", async () => {
-    const h = await setupHarness()
-    vi.mocked(isInitializeRequest).mockReturnValue(true)
+  describe("on a fresh initialize request", () => {
+    let h: Harness
+    let transport: TransportMock
+    let sessionId: string
 
-    const response = await fetch(h.url(), {
-      method: "POST",
-      headers: baseHeaders,
-      body: JSON.stringify(initializeBody),
+    beforeEach(async () => {
+      h = await setupHarness()
+      const session = await createSession(h)
+      transport = session.transport
+      sessionId = session.sessionId
     })
-    const body = (await response.json()) as { handled: string }
 
-    expect(response.status).toBe(202)
-    expect(body).toEqual({ ok: true, handled: "transport-mock" })
-    expect(h.transportInstances).toHaveLength(1)
-    expect(h.serverInstances).toHaveLength(1)
-    expect(h.serverInstances[0]!.connect).toHaveBeenCalledWith(
-      h.transportInstances[0],
-    )
-    expect(h.transportInstances[0]!.handleRequest).toHaveBeenCalledTimes(1)
-    expect(h.transportInstances[0]!.handleRequest.mock.calls[0]![2]).toEqual(
-      initializeBody,
-    )
-  })
-
-  it("constructs McpServer with the documented name, version, description and instructions", async () => {
-    const h = await setupHarness()
-    await createSession(h)
-
-    expect(McpServer).toHaveBeenCalledTimes(1)
-    const [info, options] = vi.mocked(McpServer).mock.calls[0]!
-    expect(info).toEqual({
-      name: "vault-cortex",
-      version: "1.0.0",
-      description:
-        "Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (About Me/) for personalization across conversations.",
+    it("constructs exactly one transport", () => {
+      expect(h.transportInstances).toHaveLength(1)
     })
-    expect(options).toEqual({
-      instructions:
-        "Read, write, and search an Obsidian vault. Use vault_search and vault_read_note to find and read notes. Use vault_get_memory to retrieve user preferences and context from About Me/ files. Use vault_write_note and vault_update_memory for writes.",
+
+    it("constructs exactly one McpServer with the documented metadata", () => {
+      expect(McpServer).toHaveBeenCalledTimes(1)
+      const [info, options] = vi.mocked(McpServer).mock.calls[0]!
+      expect(info).toEqual(SERVER_INFO)
+      expect(options).toEqual(SERVER_OPTIONS)
     })
-  })
 
-  it("registers tools with a session-scoped child logger including the sessionId", async () => {
-    const h = await setupHarness()
-    const childSpy = vi.spyOn(logger, "child")
-    await createSession(h)
-
-    expect(registerTools).toHaveBeenCalledTimes(1)
-    const registerArg = vi.mocked(registerTools).mock.calls[0]![0]
-    expect(registerArg.server).toBe(h.serverInstances[0])
-    expect(registerArg.vaultPath).toBe("/test-vault")
-    expect(registerArg.search).toBe(h.search)
-    expect(registerArg.logger).toBeDefined()
-    expect(childSpy).toHaveBeenCalledWith({
-      sessionId: h.transportInstances[0]!.sessionId,
-      clientIp: FORWARDED_IP,
+    it("connects the new server to the new transport", () => {
+      expect(h.serverInstances[0]!.connect).toHaveBeenCalledWith(transport)
     })
-    childSpy.mockRestore()
-  })
 
-  it("logs mcp_response with outcome 'session created' after creating a session", async () => {
-    const h = await setupHarness()
-    const { sessionId } = await createSession(h)
+    it("forwards the request body to transport.handleRequest", () => {
+      expect(transport.handleRequest).toHaveBeenCalledTimes(1)
+      expect(transport.handleRequest.mock.calls[0]![2]).toEqual(initializeBody)
+    })
 
-    expect(infoSpy).toHaveBeenCalledWith("mcp_response", {
-      sessionId,
-      clientIp: FORWARDED_IP,
-      status: 200,
-      outcome: "session created",
+    it("registers tools on the new server with vault context", () => {
+      expect(registerTools).toHaveBeenCalledTimes(1)
+      const arg = vi.mocked(registerTools).mock.calls[0]![0]
+      expect(arg.server).toBe(h.serverInstances[0])
+      expect(arg.vaultPath).toBe(VAULT_PATH)
+      expect(arg.search).toBe(h.search)
+      expect(arg.logger).toBeDefined()
+    })
+
+    it("scopes the logger for registerTools to the sessionId and clientIp", () => {
+      expect(childSpy).toHaveBeenCalledWith({
+        sessionId,
+        clientIp: FORWARDED_IP,
+      })
+    })
+
+    it("logs the 'session created' response", () => {
+      expect(infoSpy).toHaveBeenCalledWith("mcp_response", {
+        sessionId,
+        clientIp: FORWARDED_IP,
+        status: 200,
+        outcome: "session created",
+      })
+    })
+
+    it("logs an 'mcp_request' for the incoming POST", () => {
+      expect(infoSpy).toHaveBeenCalledWith("mcp_request", {
+        sessionId: undefined,
+        clientIp: FORWARDED_IP,
+        method: "POST",
+      })
     })
   })
 
-  it("routes to the existing transport when mcp-session-id matches an active session", async () => {
+  it("routes a follow-up POST to the existing transport when the session id matches", async () => {
     const h = await setupHarness()
     const { sessionId, transport } = await createSession(h)
     transport.handleRequest.mockClear()
     infoSpy.mockClear()
-
     vi.mocked(isInitializeRequest).mockReturnValue(false)
+
     const followUp = { jsonrpc: "2.0", id: 2, method: "tools/list" }
     const response = await fetch(h.url(), {
       method: "POST",
@@ -302,7 +284,6 @@ describe("createMcpRouter — POST /mcp", () => {
     })
     await response.arrayBuffer()
 
-    expect(response.status).toBe(202)
     expect(h.transportInstances).toHaveLength(1)
     expect(transport.handleRequest).toHaveBeenCalledTimes(1)
     expect(transport.handleRequest.mock.calls[0]![2]).toEqual(followUp)
@@ -314,7 +295,7 @@ describe("createMcpRouter — POST /mcp", () => {
     })
   })
 
-  it("returns 400 when there is no session and the body is not an initialize request", async () => {
+  it("returns 400 with 'no session' when there is no session and the body is not an initialize request", async () => {
     const h = await setupHarness()
     vi.mocked(isInitializeRequest).mockReturnValue(false)
 
@@ -323,10 +304,9 @@ describe("createMcpRouter — POST /mcp", () => {
       headers: baseHeaders,
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
     })
-    const body = (await response.json()) as { error: string }
 
     expect(response.status).toBe(400)
-    expect(body).toEqual({ error: "no session" })
+    expect(await response.json()).toEqual({ error: "no session" })
     expect(h.transportInstances).toHaveLength(0)
     expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
       clientIp: FORWARDED_IP,
@@ -335,7 +315,7 @@ describe("createMcpRouter — POST /mcp", () => {
     })
   })
 
-  it("returns 404 when mcp-session-id is set but the session is unknown", async () => {
+  it("returns 404 when the session id is unknown", async () => {
     const h = await setupHarness()
 
     const response = await fetch(h.url(), {
@@ -343,10 +323,9 @@ describe("createMcpRouter — POST /mcp", () => {
       headers: { ...baseHeaders, "mcp-session-id": "ghost-session" },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
     })
-    const body = (await response.json()) as { error: string }
 
     expect(response.status).toBe(404)
-    expect(body).toEqual({ error: "session not found" })
+    expect(await response.json()).toEqual({ error: "session not found" })
     expect(h.transportInstances).toHaveLength(0)
     expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
       sessionId: "ghost-session",
@@ -356,7 +335,7 @@ describe("createMcpRouter — POST /mcp", () => {
     })
   })
 
-  it("returns 401 when the bearer auth middleware rejects the request", async () => {
+  it("returns 401 and never enters the route handler when bearer auth rejects", async () => {
     const h = await setupHarness({ authMiddleware: denyAuth })
 
     const response = await fetch(h.url(), {
@@ -367,25 +346,12 @@ describe("createMcpRouter — POST /mcp", () => {
 
     expect(response.status).toBe(401)
     expect(h.transportInstances).toHaveLength(0)
-    // The route handler never runs, so its mcp_request / mcp_response info
-    // logs should never fire.
     expect(infoSpy).not.toHaveBeenCalled()
-  })
-
-  it("logs mcp_request for every accepted POST", async () => {
-    const h = await setupHarness()
-    await createSession(h)
-
-    expect(infoSpy).toHaveBeenCalledWith("mcp_request", {
-      sessionId: undefined,
-      clientIp: FORWARDED_IP,
-      method: "POST",
-    })
   })
 })
 
 describe("createMcpRouter — GET /mcp", () => {
-  it("routes to the existing transport (no body argument)", async () => {
+  it("forwards the request to the existing transport without a body argument", async () => {
     const h = await setupHarness()
     const { sessionId, transport } = await createSession(h)
     transport.handleRequest.mockClear()
@@ -400,17 +366,16 @@ describe("createMcpRouter — GET /mcp", () => {
     expect(transport.handleRequest.mock.calls[0]).toHaveLength(2)
   })
 
-  it("returns 404 when mcp-session-id header is missing", async () => {
+  it("returns 404 when the mcp-session-id header is missing", async () => {
     const h = await setupHarness()
 
     const response = await fetch(h.url(), {
       method: "GET",
       headers: baseHeaders,
     })
-    const body = (await response.json()) as { error: string }
 
     expect(response.status).toBe(404)
-    expect(body).toEqual({ error: "session not found" })
+    expect(await response.json()).toEqual({ error: "session not found" })
     expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
       sessionId: undefined,
       clientIp: FORWARDED_IP,
@@ -419,23 +384,16 @@ describe("createMcpRouter — GET /mcp", () => {
     })
   })
 
-  it("returns 404 when mcp-session-id is set but unknown", async () => {
+  it("returns 404 when the session id is unknown", async () => {
     const h = await setupHarness()
 
     const response = await fetch(h.url(), {
       method: "GET",
       headers: { ...baseHeaders, "mcp-session-id": "missing" },
     })
-    const body = (await response.json()) as { error: string }
 
     expect(response.status).toBe(404)
-    expect(body).toEqual({ error: "session not found" })
-    expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
-      sessionId: "missing",
-      clientIp: FORWARDED_IP,
-      status: 404,
-      outcome: "session not found",
-    })
+    expect(await response.json()).toEqual({ error: "session not found" })
   })
 
   it("returns 401 when bearer auth rejects", async () => {
@@ -451,7 +409,7 @@ describe("createMcpRouter — GET /mcp", () => {
 })
 
 describe("createMcpRouter — DELETE /mcp", () => {
-  it("closes the transport and removes the session", async () => {
+  it("closes the transport, removes the session, and returns 200", async () => {
     const h = await setupHarness()
     const { sessionId, transport } = await createSession(h)
 
@@ -459,10 +417,9 @@ describe("createMcpRouter — DELETE /mcp", () => {
       method: "DELETE",
       headers: { ...baseHeaders, "mcp-session-id": sessionId },
     })
-    const body = (await response.json()) as { ok: boolean }
 
     expect(response.status).toBe(200)
-    expect(body).toEqual({ ok: true })
+    expect(await response.json()).toEqual({ ok: true })
     expect(transport.close).toHaveBeenCalledTimes(1)
     expect(infoSpy).toHaveBeenCalledWith("mcp_response", {
       sessionId,
@@ -471,6 +428,8 @@ describe("createMcpRouter — DELETE /mcp", () => {
       outcome: "session deleted",
     })
 
+    // The session should be gone from the map — verified via a follow-up
+    // GET that should now 404.
     const followUp = await fetch(h.url(), {
       method: "GET",
       headers: { ...baseHeaders, "mcp-session-id": sessionId },
@@ -479,30 +438,28 @@ describe("createMcpRouter — DELETE /mcp", () => {
     expect(followUp.status).toBe(404)
   })
 
-  it("returns 404 when mcp-session-id is missing", async () => {
+  it("returns 404 when the mcp-session-id header is missing", async () => {
     const h = await setupHarness()
 
     const response = await fetch(h.url(), {
       method: "DELETE",
       headers: baseHeaders,
     })
-    const body = (await response.json()) as { error: string }
 
     expect(response.status).toBe(404)
-    expect(body).toEqual({ error: "session not found" })
+    expect(await response.json()).toEqual({ error: "session not found" })
   })
 
-  it("returns 404 when mcp-session-id is set but unknown", async () => {
+  it("returns 404 when the session id is unknown", async () => {
     const h = await setupHarness()
 
     const response = await fetch(h.url(), {
       method: "DELETE",
       headers: { ...baseHeaders, "mcp-session-id": "ghost" },
     })
-    const body = (await response.json()) as { error: string }
 
     expect(response.status).toBe(404)
-    expect(body).toEqual({ error: "session not found" })
+    expect(await response.json()).toEqual({ error: "session not found" })
   })
 
   it("returns 401 when bearer auth rejects", async () => {
@@ -517,17 +474,16 @@ describe("createMcpRouter — DELETE /mcp", () => {
   })
 })
 
-describe("createMcpRouter — transport.onclose lifecycle", () => {
-  it("removes the session from the map when transport.onclose fires", async () => {
+describe("createMcpRouter — transport.onclose", () => {
+  it("removes the session from the map and logs 'session_closed'", async () => {
     const h = await setupHarness()
     const { sessionId, transport } = await createSession(h)
     infoSpy.mockClear()
 
-    expect(typeof transport.onclose).toBe("function")
     transport.onclose!()
 
     expect(infoSpy).toHaveBeenCalledWith("session_closed", { sessionId })
-
+    // The session should be gone — confirm with a GET that should 404.
     const followUp = await fetch(h.url(), {
       method: "GET",
       headers: { ...baseHeaders, "mcp-session-id": sessionId },
@@ -536,16 +492,13 @@ describe("createMcpRouter — transport.onclose lifecycle", () => {
     expect(followUp.status).toBe(404)
   })
 
-  it("is a no-op when transport.onclose fires without a sessionId", async () => {
+  it("is a no-op when the transport has no sessionId", async () => {
     const h = await setupHarness()
     const { transport } = await createSession(h)
     transport.sessionId = undefined
     infoSpy.mockClear()
 
     expect(() => transport.onclose!()).not.toThrow()
-    expect(infoSpy).not.toHaveBeenCalledWith(
-      "session_closed",
-      expect.anything(),
-    )
+    expect(infoSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/vault-mcp/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/__tests__/mcp-router.test.ts
@@ -1,0 +1,558 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import express, { type Express } from "express"
+import type { Server } from "node:http"
+import type { AddressInfo } from "node:net"
+import { createMcpRouter } from "../mcp-router.js"
+import type { SearchIndex } from "../search-index.js"
+import type { OAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/provider.js"
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js"
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js"
+import { registerTools } from "../tool-definitions.js"
+import { logger } from "../../logger.js"
+
+vi.mock("@modelcontextprotocol/sdk/server/streamableHttp.js", () => ({
+  StreamableHTTPServerTransport: vi.fn(),
+}))
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+  McpServer: vi.fn(),
+}))
+
+vi.mock(
+  "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js",
+  () => ({
+    requireBearerAuth: vi.fn(),
+  }),
+)
+
+vi.mock("@modelcontextprotocol/sdk/types.js", async (importOriginal) => {
+  const original = await importOriginal<Record<string, unknown>>()
+  return {
+    ...original,
+    isInitializeRequest: vi.fn(),
+  }
+})
+
+vi.mock("../tool-definitions.js", () => ({
+  registerTools: vi.fn(),
+}))
+
+const FORWARDED_IP = "192.0.2.10"
+
+type TransportMock = {
+  sessionId: string | undefined
+  handleRequest: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+  onclose: (() => void) | undefined
+}
+
+type ServerMock = {
+  connect: ReturnType<typeof vi.fn>
+}
+
+type AuthMiddleware = (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+) => void
+
+const allowAuth: AuthMiddleware = (_req, _res, next) => next()
+
+const denyAuth: AuthMiddleware = (_req, res) => {
+  res.status(401).json({ error: "unauthorized" })
+}
+
+type Harness = {
+  app: Express
+  server: Server
+  port: number
+  url: (path?: string) => string
+  transportInstances: TransportMock[]
+  serverInstances: ServerMock[]
+  search: SearchIndex
+}
+
+const harnesses: Harness[] = []
+
+let sessionCounter = 0
+
+const createTransportMock = (): TransportMock => {
+  sessionCounter += 1
+  return {
+    sessionId: `session-${sessionCounter}`,
+    handleRequest: vi.fn(
+      async (_req: express.Request, res: express.Response, _body?: unknown) => {
+        res.status(202).json({ ok: true, handled: "transport-mock" })
+      },
+    ),
+    close: vi.fn(async () => {}),
+    onclose: undefined,
+  }
+}
+
+const createServerMock = (): ServerMock => ({
+  connect: vi.fn(async () => {}),
+})
+
+const setupHarness = async (
+  opts: { authMiddleware?: AuthMiddleware } = {},
+): Promise<Harness> => {
+  const transportInstances: TransportMock[] = []
+  const serverInstances: ServerMock[] = []
+
+  vi.mocked(StreamableHTTPServerTransport).mockImplementation(
+    function MockStreamableHTTPServerTransport(this: TransportMock) {
+      const t = createTransportMock()
+      transportInstances.push(t)
+      Object.assign(this, t)
+      return t
+    } as unknown as typeof StreamableHTTPServerTransport,
+  )
+
+  vi.mocked(McpServer).mockImplementation(function MockMcpServer(
+    this: ServerMock,
+  ) {
+    const s = createServerMock()
+    serverInstances.push(s)
+    Object.assign(this, s)
+    return s
+  } as unknown as typeof McpServer)
+
+  vi.mocked(requireBearerAuth).mockReturnValue(
+    (opts.authMiddleware ?? allowAuth) as unknown as ReturnType<
+      typeof requireBearerAuth
+    >,
+  )
+
+  const search = {} as SearchIndex
+  const provider = {} as OAuthServerProvider
+
+  const app = express()
+  app.set("trust proxy", true)
+  app.use(express.json())
+  app.use(createMcpRouter({ vaultPath: "/test-vault", search, provider }))
+
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s))
+  })
+  const port = (server.address() as AddressInfo).port
+
+  const h: Harness = {
+    app,
+    server,
+    port,
+    url: (path = "/mcp") => `http://127.0.0.1:${port}${path}`,
+    transportInstances,
+    serverInstances,
+    search,
+  }
+  harnesses.push(h)
+  return h
+}
+
+const teardownHarness = (h: Harness): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    h.server.close((err) => (err ? reject(err) : resolve()))
+  })
+
+const initializeBody = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "test-client", version: "0.0.0" },
+  },
+}
+
+const baseHeaders = {
+  "content-type": "application/json",
+  "x-forwarded-for": FORWARDED_IP,
+}
+
+const createSession = async (
+  h: Harness,
+): Promise<{
+  sessionId: string
+  transport: TransportMock
+  response: Response
+}> => {
+  vi.mocked(isInitializeRequest).mockReturnValue(true)
+  const response = await fetch(h.url(), {
+    method: "POST",
+    headers: baseHeaders,
+    body: JSON.stringify(initializeBody),
+  })
+  // drain so the connection releases
+  await response.arrayBuffer()
+  const transport = h.transportInstances.at(-1)
+  if (!transport || !transport.sessionId) {
+    throw new Error("session was not created")
+  }
+  return { sessionId: transport.sessionId, transport, response }
+}
+
+let infoSpy: ReturnType<typeof vi.spyOn>
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {})
+  warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+})
+
+afterEach(async () => {
+  while (harnesses.length > 0) {
+    const h = harnesses.pop()
+    if (h) await teardownHarness(h)
+  }
+  vi.clearAllMocks()
+  infoSpy.mockRestore()
+  warnSpy.mockRestore()
+})
+
+describe("createMcpRouter — POST /mcp", () => {
+  it("creates a new session on initialize request", async () => {
+    const h = await setupHarness()
+    vi.mocked(isInitializeRequest).mockReturnValue(true)
+
+    const response = await fetch(h.url(), {
+      method: "POST",
+      headers: baseHeaders,
+      body: JSON.stringify(initializeBody),
+    })
+    const body = (await response.json()) as { handled: string }
+
+    expect(response.status).toBe(202)
+    expect(body).toEqual({ ok: true, handled: "transport-mock" })
+    expect(h.transportInstances).toHaveLength(1)
+    expect(h.serverInstances).toHaveLength(1)
+    expect(h.serverInstances[0]!.connect).toHaveBeenCalledWith(
+      h.transportInstances[0],
+    )
+    expect(h.transportInstances[0]!.handleRequest).toHaveBeenCalledTimes(1)
+    expect(h.transportInstances[0]!.handleRequest.mock.calls[0]![2]).toEqual(
+      initializeBody,
+    )
+  })
+
+  it("constructs McpServer with the documented name, version, description and instructions", async () => {
+    const h = await setupHarness()
+    await createSession(h)
+
+    expect(McpServer).toHaveBeenCalledTimes(1)
+    const [info, options] = vi.mocked(McpServer).mock.calls[0]!
+    expect(info).toEqual({
+      name: "vault-cortex",
+      version: "1.0.0",
+      description:
+        "Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (About Me/) for personalization across conversations.",
+    })
+    expect(options).toEqual({
+      instructions:
+        "Read, write, and search an Obsidian vault. Use vault_search and vault_read_note to find and read notes. Use vault_get_memory to retrieve user preferences and context from About Me/ files. Use vault_write_note and vault_update_memory for writes.",
+    })
+  })
+
+  it("registers tools with a session-scoped child logger including the sessionId", async () => {
+    const h = await setupHarness()
+    const childSpy = vi.spyOn(logger, "child")
+    await createSession(h)
+
+    expect(registerTools).toHaveBeenCalledTimes(1)
+    const registerArg = vi.mocked(registerTools).mock.calls[0]![0]
+    expect(registerArg.server).toBe(h.serverInstances[0])
+    expect(registerArg.vaultPath).toBe("/test-vault")
+    expect(registerArg.search).toBe(h.search)
+    expect(registerArg.logger).toBeDefined()
+    expect(childSpy).toHaveBeenCalledWith({
+      sessionId: h.transportInstances[0]!.sessionId,
+      clientIp: FORWARDED_IP,
+    })
+    childSpy.mockRestore()
+  })
+
+  it("logs mcp_response with outcome 'session created' after creating a session", async () => {
+    const h = await setupHarness()
+    const { sessionId } = await createSession(h)
+
+    expect(infoSpy).toHaveBeenCalledWith("mcp_response", {
+      sessionId,
+      clientIp: FORWARDED_IP,
+      status: 200,
+      outcome: "session created",
+    })
+  })
+
+  it("routes to the existing transport when mcp-session-id matches an active session", async () => {
+    const h = await setupHarness()
+    const { sessionId, transport } = await createSession(h)
+    transport.handleRequest.mockClear()
+    infoSpy.mockClear()
+
+    vi.mocked(isInitializeRequest).mockReturnValue(false)
+    const followUp = { jsonrpc: "2.0", id: 2, method: "tools/list" }
+    const response = await fetch(h.url(), {
+      method: "POST",
+      headers: { ...baseHeaders, "mcp-session-id": sessionId },
+      body: JSON.stringify(followUp),
+    })
+    await response.arrayBuffer()
+
+    expect(response.status).toBe(202)
+    expect(h.transportInstances).toHaveLength(1)
+    expect(transport.handleRequest).toHaveBeenCalledTimes(1)
+    expect(transport.handleRequest.mock.calls[0]![2]).toEqual(followUp)
+    expect(infoSpy).toHaveBeenCalledWith("mcp_response", {
+      sessionId,
+      clientIp: FORWARDED_IP,
+      status: 200,
+      outcome: "routed to existing session",
+    })
+  })
+
+  it("returns 400 when there is no session and the body is not an initialize request", async () => {
+    const h = await setupHarness()
+    vi.mocked(isInitializeRequest).mockReturnValue(false)
+
+    const response = await fetch(h.url(), {
+      method: "POST",
+      headers: baseHeaders,
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    })
+    const body = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(400)
+    expect(body).toEqual({ error: "no session" })
+    expect(h.transportInstances).toHaveLength(0)
+    expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
+      clientIp: FORWARDED_IP,
+      status: 400,
+      outcome: "no session, non-initialize request",
+    })
+  })
+
+  it("returns 404 when mcp-session-id is set but the session is unknown", async () => {
+    const h = await setupHarness()
+
+    const response = await fetch(h.url(), {
+      method: "POST",
+      headers: { ...baseHeaders, "mcp-session-id": "ghost-session" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    })
+    const body = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(404)
+    expect(body).toEqual({ error: "session not found" })
+    expect(h.transportInstances).toHaveLength(0)
+    expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
+      sessionId: "ghost-session",
+      clientIp: FORWARDED_IP,
+      status: 404,
+      outcome: "session not found",
+    })
+  })
+
+  it("returns 401 when the bearer auth middleware rejects the request", async () => {
+    const h = await setupHarness({ authMiddleware: denyAuth })
+
+    const response = await fetch(h.url(), {
+      method: "POST",
+      headers: baseHeaders,
+      body: JSON.stringify(initializeBody),
+    })
+
+    expect(response.status).toBe(401)
+    expect(h.transportInstances).toHaveLength(0)
+    // The route handler never runs, so neither mcp_request nor mcp_response
+    // info logs should fire.
+    expect(infoSpy).not.toHaveBeenCalledWith(
+      "mcp_request",
+      expect.objectContaining({ method: "POST" }),
+    )
+  })
+
+  it("logs mcp_request for every accepted POST", async () => {
+    const h = await setupHarness()
+    await createSession(h)
+
+    expect(infoSpy).toHaveBeenCalledWith("mcp_request", {
+      sessionId: undefined,
+      clientIp: FORWARDED_IP,
+      method: "POST",
+    })
+  })
+})
+
+describe("createMcpRouter — GET /mcp", () => {
+  it("routes to the existing transport (no body argument)", async () => {
+    const h = await setupHarness()
+    const { sessionId, transport } = await createSession(h)
+    transport.handleRequest.mockClear()
+    transport.handleRequest.mockImplementationOnce(async (_req, res) => {
+      res.status(200).json({ ok: true, via: "GET" })
+    })
+
+    const response = await fetch(h.url(), {
+      method: "GET",
+      headers: { ...baseHeaders, "mcp-session-id": sessionId },
+    })
+    const body = (await response.json()) as { via: string }
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ ok: true, via: "GET" })
+    expect(transport.handleRequest).toHaveBeenCalledTimes(1)
+    expect(transport.handleRequest.mock.calls[0]).toHaveLength(2)
+  })
+
+  it("returns 404 when mcp-session-id header is missing", async () => {
+    const h = await setupHarness()
+
+    const response = await fetch(h.url(), {
+      method: "GET",
+      headers: baseHeaders,
+    })
+    const body = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(404)
+    expect(body).toEqual({ error: "session not found" })
+    expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
+      sessionId: undefined,
+      clientIp: FORWARDED_IP,
+      status: 404,
+      outcome: "session not found",
+    })
+  })
+
+  it("returns 404 when mcp-session-id is set but unknown", async () => {
+    const h = await setupHarness()
+
+    const response = await fetch(h.url(), {
+      method: "GET",
+      headers: { ...baseHeaders, "mcp-session-id": "missing" },
+    })
+    const body = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(404)
+    expect(body).toEqual({ error: "session not found" })
+    expect(warnSpy).toHaveBeenCalledWith("mcp_response", {
+      sessionId: "missing",
+      clientIp: FORWARDED_IP,
+      status: 404,
+      outcome: "session not found",
+    })
+  })
+
+  it("returns 401 when bearer auth rejects", async () => {
+    const h = await setupHarness({ authMiddleware: denyAuth })
+
+    const response = await fetch(h.url(), {
+      method: "GET",
+      headers: { ...baseHeaders, "mcp-session-id": "anything" },
+    })
+
+    expect(response.status).toBe(401)
+  })
+})
+
+describe("createMcpRouter — DELETE /mcp", () => {
+  it("closes the transport and removes the session", async () => {
+    const h = await setupHarness()
+    const { sessionId, transport } = await createSession(h)
+
+    const response = await fetch(h.url(), {
+      method: "DELETE",
+      headers: { ...baseHeaders, "mcp-session-id": sessionId },
+    })
+    const body = (await response.json()) as { ok: boolean }
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+    expect(transport.close).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledWith("mcp_response", {
+      sessionId,
+      clientIp: FORWARDED_IP,
+      status: 200,
+      outcome: "session deleted",
+    })
+
+    const followUp = await fetch(h.url(), {
+      method: "GET",
+      headers: { ...baseHeaders, "mcp-session-id": sessionId },
+    })
+    await followUp.arrayBuffer()
+    expect(followUp.status).toBe(404)
+  })
+
+  it("returns 404 when mcp-session-id is missing", async () => {
+    const h = await setupHarness()
+
+    const response = await fetch(h.url(), {
+      method: "DELETE",
+      headers: baseHeaders,
+    })
+    const body = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(404)
+    expect(body).toEqual({ error: "session not found" })
+  })
+
+  it("returns 404 when mcp-session-id is set but unknown", async () => {
+    const h = await setupHarness()
+
+    const response = await fetch(h.url(), {
+      method: "DELETE",
+      headers: { ...baseHeaders, "mcp-session-id": "ghost" },
+    })
+    const body = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(404)
+    expect(body).toEqual({ error: "session not found" })
+  })
+
+  it("returns 401 when bearer auth rejects", async () => {
+    const h = await setupHarness({ authMiddleware: denyAuth })
+
+    const response = await fetch(h.url(), {
+      method: "DELETE",
+      headers: { ...baseHeaders, "mcp-session-id": "anything" },
+    })
+
+    expect(response.status).toBe(401)
+  })
+})
+
+describe("createMcpRouter — transport.onclose lifecycle", () => {
+  it("removes the session from the map when transport.onclose fires", async () => {
+    const h = await setupHarness()
+    const { sessionId, transport } = await createSession(h)
+    infoSpy.mockClear()
+
+    expect(typeof transport.onclose).toBe("function")
+    transport.onclose!()
+
+    expect(infoSpy).toHaveBeenCalledWith("session_closed", { sessionId })
+
+    const followUp = await fetch(h.url(), {
+      method: "GET",
+      headers: { ...baseHeaders, "mcp-session-id": sessionId },
+    })
+    await followUp.arrayBuffer()
+    expect(followUp.status).toBe(404)
+  })
+
+  it("is a no-op when transport.onclose fires without a sessionId", async () => {
+    const h = await setupHarness()
+    const { transport } = await createSession(h)
+    transport.sessionId = undefined
+    infoSpy.mockClear()
+
+    expect(() => transport.onclose!()).not.toThrow()
+    expect(infoSpy).not.toHaveBeenCalledWith(
+      "session_closed",
+      expect.anything(),
+    )
+  })
+})

--- a/src/vault-mcp/__tests__/server.test.ts
+++ b/src/vault-mcp/__tests__/server.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import type { Request, Response, NextFunction } from "express"
+import { createErrorMiddleware, requireEnv } from "../server.js"
+import { logger } from "../../logger.js"
+
+type MockRes = {
+  headersSent: boolean
+  status: ReturnType<typeof vi.fn>
+  json: ReturnType<typeof vi.fn>
+}
+
+const createMockReqRes = (
+  reqOverrides: Partial<{
+    headers: Record<string, string | undefined>
+    ip: string
+    method: string
+    path: string
+  }> = {},
+  headersSent = false,
+) => {
+  const req = {
+    headers: reqOverrides.headers ?? {},
+    ip: reqOverrides.ip ?? "10.0.0.1",
+    method: reqOverrides.method ?? "POST",
+    path: reqOverrides.path ?? "/mcp",
+  } as unknown as Request
+
+  const resJson = vi.fn()
+  const resStatus = vi.fn().mockReturnValue({ json: resJson })
+  const res = {
+    headersSent,
+    status: resStatus,
+    json: resJson,
+  } as unknown as Response & MockRes
+
+  const next = vi.fn() as unknown as NextFunction
+
+  return { req, res, resStatus, resJson, next }
+}
+
+describe("createErrorMiddleware", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+  })
+
+  it("returns 500 with json error when headers have not been sent", () => {
+    const middleware = createErrorMiddleware()
+    const { req, res, resStatus, resJson, next } = createMockReqRes()
+    const err = new Error("boom")
+
+    middleware(err, req, res, next)
+
+    expect(resStatus).toHaveBeenCalledWith(500)
+    expect(resJson).toHaveBeenCalledWith({ error: "internal server error" })
+  })
+
+  it("does not call res.status or res.json when headers have already been sent", () => {
+    const middleware = createErrorMiddleware()
+    const { req, res, resStatus, resJson, next } = createMockReqRes({}, true)
+    const err = new Error("boom")
+
+    middleware(err, req, res, next)
+
+    expect(resStatus).not.toHaveBeenCalled()
+    expect(resJson).not.toHaveBeenCalled()
+  })
+
+  it("logs unhandled_error with session, ip, method, path, and error message", () => {
+    const middleware = createErrorMiddleware()
+    const { req, res, next } = createMockReqRes({
+      headers: { "mcp-session-id": "session-123" },
+      ip: "192.0.2.5",
+      method: "POST",
+      path: "/mcp",
+    })
+    const err = new Error("kaboom")
+
+    middleware(err, req, res, next)
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledWith("unhandled_error", {
+      sessionId: "session-123",
+      clientIp: "192.0.2.5",
+      method: "POST",
+      path: "/mcp",
+      error: "kaboom",
+    })
+  })
+
+  it("logs sessionId as undefined when mcp-session-id header is absent", () => {
+    const middleware = createErrorMiddleware()
+    const { req, res, next } = createMockReqRes({
+      headers: {},
+      ip: "192.0.2.6",
+      method: "GET",
+      path: "/healthz",
+    })
+    const err = new Error("nope")
+
+    middleware(err, req, res, next)
+
+    expect(errorSpy).toHaveBeenCalledWith("unhandled_error", {
+      sessionId: undefined,
+      clientIp: "192.0.2.6",
+      method: "GET",
+      path: "/healthz",
+      error: "nope",
+    })
+  })
+
+  it("does not call next() (terminal error handler)", () => {
+    const middleware = createErrorMiddleware()
+    const { req, res, next } = createMockReqRes()
+
+    middleware(new Error("x"), req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+  })
+})
+
+describe("requireEnv", () => {
+  const envSnapshot = { ...process.env }
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env = { ...envSnapshot }
+    errorSpy.mockRestore()
+  })
+
+  it("returns the value when the env var is set", () => {
+    process.env.VAULT_CORTEX_TEST_VAR = "the-value"
+    expect(requireEnv("VAULT_CORTEX_TEST_VAR")).toBe("the-value")
+  })
+
+  it("throws a descriptive error when the env var is undefined", () => {
+    delete process.env.VAULT_CORTEX_TEST_VAR
+    expect(() => requireEnv("VAULT_CORTEX_TEST_VAR")).toThrow(
+      "VAULT_CORTEX_TEST_VAR environment variable is required",
+    )
+  })
+
+  it("throws when the env var is set to an empty string", () => {
+    process.env.VAULT_CORTEX_TEST_VAR = ""
+    expect(() => requireEnv("VAULT_CORTEX_TEST_VAR")).toThrow(
+      "VAULT_CORTEX_TEST_VAR environment variable is required",
+    )
+  })
+
+  it("logs 'missing required env' with the var name before throwing", () => {
+    delete process.env.VAULT_CORTEX_TEST_VAR
+    expect(() => requireEnv("VAULT_CORTEX_TEST_VAR")).toThrow()
+    expect(errorSpy).toHaveBeenCalledWith("missing required env", {
+      var: "VAULT_CORTEX_TEST_VAR",
+    })
+  })
+
+  it("does not log when the env var is set", () => {
+    process.env.VAULT_CORTEX_TEST_VAR = "present"
+    requireEnv("VAULT_CORTEX_TEST_VAR")
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/vault-mcp/server.ts
+++ b/src/vault-mcp/server.ts
@@ -11,7 +11,7 @@ import { createOAuthRoutes } from "./oauth-routes.js"
 import { createMcpRouter } from "./mcp-router.js"
 import { logger } from "../logger.js"
 
-const createErrorMiddleware =
+export const createErrorMiddleware =
   () =>
   (err: Error, req: Request, res: Response, _next: NextFunction): void => {
     logger.error("unhandled_error", {
@@ -26,7 +26,7 @@ const createErrorMiddleware =
     }
   }
 
-const requireEnv = (name: string): string => {
+export const requireEnv = (name: string): string => {
   const value = process.env[name]
   if (!value) {
     logger.error("missing required env", { var: name })


### PR DESCRIPTION
## Summary

The 251-test suite covered every data-layer module but stopped at the wiring layer. `mcp-router.ts` in particular owns the `transports` Map, three HTTP routes with branching session-id logic, and the `onclose` cleanup — regressions there would silently break session reuse with no test signal. `server.ts` contributes the only unhandled-error path (`createErrorMiddleware`) and the boot gate (`requireEnv`). This PR closes that gap.

**Suite: 251 → 280 tests (+29).**

## Changes

- **`src/vault-mcp/server.ts`** — added `export` to `createErrorMiddleware` and `requireEnv`. No behavior change. `startServer` stays private.
- **`src/vault-mcp/__tests__/server.test.ts`** (10 tests) — `createErrorMiddleware` response/log behavior including the `headersSent` guard; `requireEnv` missing/empty/present cases plus log assertion.
- **`src/vault-mcp/__tests__/mcp-router.test.ts`** (19 tests) — real `express()` + `app.listen(0)` + `fetch`, with the MCP SDK (`StreamableHTTPServerTransport`, `McpServer`, `requireBearerAuth`, `isInitializeRequest`) and `registerTools` mocked via `vi.mock` so tests focus on our routing and session-map logic. Covers every branch of `POST`/`GET`/`DELETE` `/mcp`, the `transport.onclose` cleanup (with and without `sessionId`), and the 401 bearer-auth rejection path. `app.set("trust proxy", true)` + `X-Forwarded-For` gives exact-match `clientIp` assertions.

## Test plan

- [x] `npm test` — 11 files, 280 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — `tsc` clean
- [x] `npm run prettier:check` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01DUuNWVUu3QLuCNsdoSK1Zz)_