### PR TITLE
feat(vault-mcp): daily note + property discovery tools (15 → 19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ src/
     oauth-provider.ts                  # OAuthServerProvider — JWT tokens, SQLite persistence
     consent-page.ts                    # HTML consent page for OAuth authorization
     tool-definitions.ts                # MCP tool registrations + Zod schemas
+    daily-notes.ts                     # Daily note config reader + path resolver
     vault-filesystem.ts                # Read/write/list/delete .md files
     vault-patcher.ts                   # Surgical edits: heading-targeted patch + find-and-replace
     memory-store.ts                    # About Me/ heading-aware read/append/delete
@@ -61,7 +62,7 @@ connector is typically loaded as deferred tools (names like
 check the deferred-tools list and load schemas via `ToolSearch`. The
 connector exposes `vault_read_note`, `vault_search`, `vault_get_memory`,
 `vault_write_note`, `vault_patch_note`, `vault_replace_in_note`, and the
-rest of the API (15 tools) in `src/vault-mcp/tool-definitions.ts`.
+rest of the API (19 tools) in `src/vault-mcp/tool-definitions.ts`.
 
 ## Logging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,12 +141,68 @@ search.fullTextSearch({ query, filters }, reqLogger)
 - Immutable by default. Avoid `let` — carry state in reduce
   accumulators, use early returns, or destructure conditional results.
   A bit of duplication is acceptable to keep code immutable and clear.
+  When `let` is necessary (caching, parser state), add a comment
+  justifying why mutation is needed here.
 - Explicit names over abbreviations. Variable names should describe
   what the value _is_, not use shorthand (`availableHeadings` not
   `available`, `searchText` not `needle`, `fileContent` not `raw`).
+  This applies everywhere: function params, callback params (`row`
+  not `r`, `entry` not `e`, `orphan` not `o`), SQL aliases
+  (`element` not `je`), destructured bindings, and loop variables.
 - Regex constants get doc comments explaining what they match.
+  Inline regexes used more than once should be extracted to a named
+  `const` with a doc comment.
+- Comments above any logic that is complex or multi-step. A reader
+  should not need to pause to understand what the code does. SQL
+  with branching logic (CASE, EXISTS subqueries) needs a comment
+  explaining the overall strategy before the query.
+- Early returns over nested `if/else` — reduces indentation depth
+  and cognitive load. Prefer `if (done) return` over wrapping 15
+  lines in `if (!done) { ... }`.
+- Simple code over clever code when the same outcome is achievable.
+  A person should be able to read and follow the code without
+  unnecessary cognitive overload.
 - MCP tool descriptions include `Example:`, `When to use:`,
   `Errors:` (with remediation guidance), and `Returns:` sections.
+
+### MCP naming conventions
+
+Two naming layers — MCP (JSON wire format) and TypeScript (internal):
+
+- **MCP inputs and outputs** use `snake_case` — this is the JSON
+  shape clients see. Examples: `old_text`, `heading_level`,
+  `snippet_tokens`, `additional_properties`, `sample_values`,
+  `outgoing_links`, `exclude_folders`, `sort_by`.
+- **Internal TypeScript** uses `camelCase` — function params,
+  local variables, internal types that never reach the wire.
+  Examples: `oldText`, `headingLevel`, `snippetTokens`.
+- The mapping happens in `tool-definitions.ts` handlers:
+  `replaceAllOccurrences: replace_all_occurrences`.
+- Types that ARE the JSON response shape (`PropertyKeyInfo`,
+  `SearchResult`, `NoteMetadata`) use `snake_case` for any
+  multi-word fields to match the wire format. Single-word fields
+  (`path`, `title`, `count`) are the same in both conventions.
+
+### Test conventions
+
+- Tests read as a behavioral spec. One focused `it()` per
+  behavior — a failing test name should identify which behavior
+  regressed without reading the body.
+- `const` per test over `let` in `beforeEach` when possible.
+  `beforeEach` is justified for shared setup that all tests in a
+  `describe` need (e.g. indexing fixture notes, creating temp dirs).
+- Every test must actually verify the behavior it claims to test.
+  A folder-filter test must include data both inside and outside the
+  folder to confirm exclusion works — not just data inside.
+- Exact assertions (`toHaveLength(2)`, `toBe("value")`) over
+  loose matchers (`toBeGreaterThanOrEqual(1)`, `toBeDefined()`)
+  when the expected value is known.
+- Explicit callback parameter names — `orphan` not `o`, `entry`
+  not `e`, `link` not `l`. Same naming rules as production code.
+- Test names match what they assert. If the test asserts 1 result,
+  don't name it "returns multiple results."
+- Use vitest helpers (`onTestFinished`, `vi.mocked`, `vi.each`)
+  before hand-rolling test plumbing.
 
 ## SST conventions
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -187,6 +187,17 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 
 `filters` covers `folder`, `tags`, `related`, `type`, `properties` (arbitrary frontmatter keys), `limit`, and `snippet_tokens`. `sort_by` is `"created" | "modified"` (default `"modified"`).
 
+### Phase 1: Property Discovery + Daily Notes
+
+| Tool                         | Input                         | Annotation   |
+| ---------------------------- | ----------------------------- | ------------ |
+| `vault_get_daily_note`       | `date?`                       | readOnlyHint |
+| `vault_list_property_keys`   | `folder?`                     | readOnlyHint |
+| `vault_list_property_values` | `key, folder?, limit?`        | readOnlyHint |
+| `vault_search_by_property`   | `key, value, folder?, limit?` | readOnlyHint |
+
+`vault_get_daily_note` reads `.obsidian/daily-notes.json` for the vault's folder and date format, falling back to `Daily Notes/YYYY-MM-DD.md`. Property tools query the `properties` JSON column in the notes table via `json_each`/`json_extract`, handling both scalar and array-valued properties.
+
 ### Phase 1: Memory (R5)
 
 | Tool                      | Input                            | Annotation      |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Context Protocol.
 
-> **Status:** Phase 1 complete — 15 MCP tools, deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
+> **Status:** Phase 1 complete — 19 MCP tools, deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
 
 ## Contents
 

--- a/src/vault-mcp/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/__tests__/daily-notes.test.ts
@@ -50,6 +50,21 @@ describe("momentToLuxonFormat", () => {
       input: "YYYY_MM_DD journal",
       expected: "yyyy_MM_dd journal",
     },
+    {
+      name: "converts [literal] escapes to Luxon single-quote syntax",
+      input: "YYYY-MM-DD [Daily Note]",
+      expected: "yyyy-MM-dd 'Daily Note'",
+    },
+    {
+      name: "handles [literal] with apostrophe",
+      input: "YYYY-MM-DD [it's]",
+      expected: "yyyy-MM-dd 'it''s'",
+    },
+    {
+      name: "handles empty [literal] brackets",
+      input: "YYYY-MM-DD []",
+      expected: "yyyy-MM-dd ''",
+    },
   ]
 
   it.each(scenarios)("$name", ({ input, expected }) => {
@@ -179,6 +194,24 @@ describe("getDailyNotePath", () => {
       "invalid date",
     )
   })
+
+  it("rejects partial ISO dates (year only)", async () => {
+    await expect(getDailyNotePath(vaultDir, "2026")).rejects.toThrow(
+      "invalid date",
+    )
+  })
+
+  it("rejects partial ISO dates (year-month only)", async () => {
+    await expect(getDailyNotePath(vaultDir, "2026-05")).rejects.toThrow(
+      "invalid date",
+    )
+  })
+
+  it("rejects full ISO timestamps", async () => {
+    await expect(
+      getDailyNotePath(vaultDir, "2026-05-13T14:30:00Z"),
+    ).rejects.toThrow("invalid date")
+  })
 })
 
 // ── getDailyNote ─────────────────────────────────────────────────
@@ -221,5 +254,17 @@ describe("getDailyNote", () => {
     expect(result.exists).toBe(false)
     expect(result.path).toBe("Daily Notes/2026-01-01.md")
     expect(result.content).toBeNull()
+  })
+
+  it("rethrows non-ENOENT errors (e.g. path traversal)", async () => {
+    clearConfigCache()
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "../escape", format: "YYYY-MM-DD" }),
+      "utf8",
+    )
+    await expect(
+      getDailyNote({ vaultPath: vaultDir, date: "2026-05-13" }, logger),
+    ).rejects.toThrow("path traversal blocked")
   })
 })

--- a/src/vault-mcp/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/__tests__/daily-notes.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { DateTime } from "luxon"
 import {
   mkdtemp,
   rm as removeDirectory,
@@ -147,13 +148,15 @@ describe("readDailyNotesConfig", () => {
       "utf8",
     )
     const first = await readDailyNotesConfig(vaultDir)
+    expect(first.folder).toBe("Journal")
+
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
       JSON.stringify({ folder: "Changed", format: "DD-MM-YYYY" }),
       "utf8",
     )
     const second = await readDailyNotesConfig(vaultDir)
-    expect(second).toEqual(first)
+    expect(second.folder).toBe("Journal")
   })
 })
 
@@ -189,8 +192,10 @@ describe("getDailyNotePath", () => {
 
   it("defaults to today when no date provided", async () => {
     const path = await getDailyNotePath(vaultDir)
-    const todayISO = new Date().toISOString().slice(0, 10)
-    expect(path).toBe(`Daily Notes/${todayISO}.md`)
+    // Use Luxon's local-timezone today (same as the code under test) to
+    // avoid UTC/local date mismatch near midnight
+    const todayLocal = DateTime.now().toFormat("yyyy-MM-dd")
+    expect(path).toBe(`Daily Notes/${todayLocal}.md`)
   })
 
   it("throws on invalid date format", async () => {

--- a/src/vault-mcp/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/__tests__/daily-notes.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { DateTime } from "luxon"
-import {
-  mkdtemp,
-  rm as removeDirectory,
-  writeFile,
-  mkdir,
-} from "node:fs/promises"
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
@@ -90,7 +85,7 @@ describe("readDailyNotesConfig", () => {
   })
 
   afterEach(async () => {
-    await removeDirectory(vaultDir, { recursive: true })
+    await rm(vaultDir, { recursive: true })
   })
 
   it("reads folder and format from .obsidian/daily-notes.json", async () => {
@@ -172,7 +167,7 @@ describe("getDailyNotePath", () => {
   })
 
   afterEach(async () => {
-    await removeDirectory(vaultDir, { recursive: true })
+    await rm(vaultDir, { recursive: true })
   })
 
   it("resolves a specific date with default config", async () => {
@@ -236,7 +231,7 @@ describe("getDailyNote", () => {
   })
 
   afterEach(async () => {
-    await removeDirectory(vaultDir, { recursive: true })
+    await rm(vaultDir, { recursive: true })
   })
 
   it("reads an existing daily note", async () => {

--- a/src/vault-mcp/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/__tests__/daily-notes.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import {
+  momentToLuxonFormat,
+  readDailyNotesConfig,
+  getDailyNotePath,
+  getDailyNote,
+  clearConfigCache,
+} from "../daily-notes.js"
+import { logger } from "../../logger.js"
+
+// ── momentToLuxonFormat ──────────────────────────────────────────
+
+describe("momentToLuxonFormat", () => {
+  const scenarios = [
+    {
+      name: "standard daily note format",
+      input: "YYYY-MM-DD",
+      expected: "yyyy-MM-dd",
+    },
+    {
+      name: "date with full weekday name",
+      input: "YYYY-MM-DD-dddd",
+      expected: "yyyy-MM-dd-cccc",
+    },
+    {
+      name: "date with short weekday name",
+      input: "YYYY-MM-DD-ddd",
+      expected: "yyyy-MM-dd-ccc",
+    },
+    {
+      name: "nested folder format",
+      input: "YYYY/MM/DD",
+      expected: "yyyy/MM/dd",
+    },
+    {
+      name: "European date format",
+      input: "DD-MM-YYYY",
+      expected: "dd-MM-yyyy",
+    },
+    {
+      name: "two-digit year",
+      input: "YY-MM-DD",
+      expected: "yy-MM-dd",
+    },
+    {
+      name: "preserves non-token characters",
+      input: "YYYY_MM_DD journal",
+      expected: "yyyy_MM_dd journal",
+    },
+  ]
+
+  it.each(scenarios)("$name", ({ input, expected }) => {
+    expect(momentToLuxonFormat(input)).toBe(expected)
+  })
+})
+
+// ── readDailyNotesConfig ─────────────────────────────────────────
+
+describe("readDailyNotesConfig", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    clearConfigCache()
+    vaultDir = await mkdtemp(join(tmpdir(), "daily-notes-test-"))
+    await mkdir(join(vaultDir, ".obsidian"), { recursive: true })
+  })
+
+  afterEach(async () => {
+    clearConfigCache()
+    await rm(vaultDir, { recursive: true })
+  })
+
+  it("reads folder and format from .obsidian/daily-notes.json", async () => {
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Journal", format: "YYYY-MM-DD-dddd" }),
+      "utf8",
+    )
+    const config = await readDailyNotesConfig(vaultDir)
+    expect(config.folder).toBe("Journal")
+    expect(config.format).toBe("YYYY-MM-DD-dddd")
+  })
+
+  it("falls back to defaults when file is missing", async () => {
+    const config = await readDailyNotesConfig(vaultDir)
+    expect(config.folder).toBe("Daily Notes")
+    expect(config.format).toBe("YYYY-MM-DD")
+  })
+
+  it("falls back to defaults when file is malformed JSON", async () => {
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      "not valid json{{{",
+      "utf8",
+    )
+    const config = await readDailyNotesConfig(vaultDir)
+    expect(config.folder).toBe("Daily Notes")
+    expect(config.format).toBe("YYYY-MM-DD")
+  })
+
+  it("uses default folder when config has empty folder string", async () => {
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+      "utf8",
+    )
+    const config = await readDailyNotesConfig(vaultDir)
+    expect(config.folder).toBe("Daily Notes")
+  })
+
+  it("uses default format when config has empty format string", async () => {
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Journal" }),
+      "utf8",
+    )
+    const config = await readDailyNotesConfig(vaultDir)
+    expect(config.format).toBe("YYYY-MM-DD")
+  })
+
+  it("caches the config after first read", async () => {
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Journal", format: "YYYY-MM-DD" }),
+      "utf8",
+    )
+    const first = await readDailyNotesConfig(vaultDir)
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Changed", format: "DD-MM-YYYY" }),
+      "utf8",
+    )
+    const second = await readDailyNotesConfig(vaultDir)
+    expect(second).toEqual(first)
+  })
+})
+
+// ── getDailyNotePath ─────────────────────────────────────────────
+
+describe("getDailyNotePath", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    clearConfigCache()
+    vaultDir = await mkdtemp(join(tmpdir(), "daily-path-test-"))
+    await mkdir(join(vaultDir, ".obsidian"), { recursive: true })
+  })
+
+  afterEach(async () => {
+    clearConfigCache()
+    await rm(vaultDir, { recursive: true })
+  })
+
+  it("resolves a specific date with default config", async () => {
+    const path = await getDailyNotePath(vaultDir, "2026-05-13")
+    expect(path).toBe("Daily Notes/2026-05-13.md")
+  })
+
+  it("resolves with custom folder and format", async () => {
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Journal", format: "DD-MM-YYYY" }),
+      "utf8",
+    )
+    const path = await getDailyNotePath(vaultDir, "2026-05-13")
+    expect(path).toBe("Journal/13-05-2026.md")
+  })
+
+  it("defaults to today when no date provided", async () => {
+    const path = await getDailyNotePath(vaultDir)
+    expect(path).toMatch(/^Daily Notes\/\d{4}-\d{2}-\d{2}\.md$/)
+  })
+
+  it("throws on invalid date format", async () => {
+    await expect(getDailyNotePath(vaultDir, "not-a-date")).rejects.toThrow(
+      "invalid date",
+    )
+  })
+})
+
+// ── getDailyNote ─────────────────────────────────────────────────
+
+describe("getDailyNote", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    clearConfigCache()
+    vaultDir = await mkdtemp(join(tmpdir(), "daily-read-test-"))
+    await mkdir(join(vaultDir, ".obsidian"), { recursive: true })
+    await mkdir(join(vaultDir, "Daily Notes"), { recursive: true })
+  })
+
+  afterEach(async () => {
+    clearConfigCache()
+    await rm(vaultDir, { recursive: true })
+  })
+
+  it("reads an existing daily note", async () => {
+    await writeFile(
+      join(vaultDir, "Daily Notes", "2026-05-13.md"),
+      "---\ndate: 2026-05-13\n---\n\n# 2026-05-13\n\nToday's notes.\n",
+      "utf8",
+    )
+    const result = await getDailyNote(
+      { vaultPath: vaultDir, date: "2026-05-13" },
+      logger,
+    )
+    expect(result.exists).toBe(true)
+    expect(result.path).toBe("Daily Notes/2026-05-13.md")
+    expect(result.content).toContain("Today's notes.")
+  })
+
+  it("returns exists: false for missing daily note", async () => {
+    const result = await getDailyNote(
+      { vaultPath: vaultDir, date: "2026-01-01" },
+      logger,
+    )
+    expect(result.exists).toBe(false)
+    expect(result.path).toBe("Daily Notes/2026-01-01.md")
+    expect(result.content).toBeNull()
+  })
+})

--- a/src/vault-mcp/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/__tests__/daily-notes.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
-import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
+import {
+  mkdtemp,
+  rm as removeDirectory,
+  writeFile,
+  mkdir,
+} from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
@@ -84,7 +89,7 @@ describe("readDailyNotesConfig", () => {
   })
 
   afterEach(async () => {
-    await rm(vaultDir, { recursive: true })
+    await removeDirectory(vaultDir, { recursive: true })
   })
 
   it("reads folder and format from .obsidian/daily-notes.json", async () => {
@@ -164,7 +169,7 @@ describe("getDailyNotePath", () => {
   })
 
   afterEach(async () => {
-    await rm(vaultDir, { recursive: true })
+    await removeDirectory(vaultDir, { recursive: true })
   })
 
   it("resolves a specific date with default config", async () => {
@@ -226,7 +231,7 @@ describe("getDailyNote", () => {
   })
 
   afterEach(async () => {
-    await rm(vaultDir, { recursive: true })
+    await removeDirectory(vaultDir, { recursive: true })
   })
 
   it("reads an existing daily note", async () => {

--- a/src/vault-mcp/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/__tests__/daily-notes.test.ts
@@ -84,7 +84,6 @@ describe("readDailyNotesConfig", () => {
   })
 
   afterEach(async () => {
-    clearConfigCache()
     await rm(vaultDir, { recursive: true })
   })
 
@@ -165,7 +164,6 @@ describe("getDailyNotePath", () => {
   })
 
   afterEach(async () => {
-    clearConfigCache()
     await rm(vaultDir, { recursive: true })
   })
 
@@ -186,7 +184,8 @@ describe("getDailyNotePath", () => {
 
   it("defaults to today when no date provided", async () => {
     const path = await getDailyNotePath(vaultDir)
-    expect(path).toMatch(/^Daily Notes\/\d{4}-\d{2}-\d{2}\.md$/)
+    const todayISO = new Date().toISOString().slice(0, 10)
+    expect(path).toBe(`Daily Notes/${todayISO}.md`)
   })
 
   it("throws on invalid date format", async () => {
@@ -227,7 +226,6 @@ describe("getDailyNote", () => {
   })
 
   afterEach(async () => {
-    clearConfigCache()
     await rm(vaultDir, { recursive: true })
   })
 
@@ -257,7 +255,6 @@ describe("getDailyNote", () => {
   })
 
   it("rethrows non-ENOENT errors (e.g. path traversal)", async () => {
-    clearConfigCache()
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
       JSON.stringify({ folder: "../escape", format: "YYYY-MM-DD" }),

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -521,12 +521,12 @@ describe("listPropertyKeys", () => {
     expect(titleKey!.count).toBe(3)
   })
 
-  it("includes sample_values for each key", () => {
+  it("includes sampleValues for each key", () => {
     const keys = index.listPropertyKeys({}, logger)
     const statusKey = keys.find((entry) => entry.key === "status")
     expect(statusKey).toBeDefined()
-    expect(statusKey!.sample_values).toContain("in-progress")
-    expect(statusKey!.sample_values).toContain("done")
+    expect(statusKey!.sampleValues).toContain("in-progress")
+    expect(statusKey!.sampleValues).toContain("done")
   })
 
   it("returns at most 3 sample values", () => {
@@ -539,7 +539,7 @@ describe("listPropertyKeys", () => {
     }
     const keys = index.listPropertyKeys({}, logger)
     const varietyKey = keys.find((entry) => entry.key === "variety")
-    expect(varietyKey!.sample_values.length).toBeLessThanOrEqual(3)
+    expect(varietyKey!.sampleValues.length).toBeLessThanOrEqual(3)
   })
 
   it("sorts by count descending", () => {
@@ -562,7 +562,7 @@ describe("listPropertyKeys", () => {
     expect(statusKey).toBeUndefined()
   })
 
-  it("sample_values are scoped to the folder filter", () => {
+  it("sampleValues are scoped to the folder filter", () => {
     index.upsertNote(
       "Other/other.md",
       "---\nstatus: blocked\n---\nbody\n",
@@ -571,7 +571,7 @@ describe("listPropertyKeys", () => {
     const keys = index.listPropertyKeys({ folder: "Projects" }, logger)
     const statusKey = keys.find((entry) => entry.key === "status")
     expect(statusKey).toBeDefined()
-    expect(statusKey!.sample_values).not.toContain("blocked")
+    expect(statusKey!.sampleValues).not.toContain("blocked")
   })
 })
 
@@ -585,11 +585,11 @@ describe("listPropertyValues", () => {
   it("returns distinct values with counts for a scalar property", () => {
     const values = index.listPropertyValues({ key: "status" }, logger)
     expect(values).toHaveLength(2)
-    expect(values.find((val) => val.value === "in-progress")).toEqual({
+    expect(values.find((entry) => entry.value === "in-progress")).toEqual({
       value: "in-progress",
       count: 1,
     })
-    expect(values.find((val) => val.value === "done")).toEqual({
+    expect(values.find((entry) => entry.value === "done")).toEqual({
       value: "done",
       count: 1,
     })
@@ -597,9 +597,9 @@ describe("listPropertyValues", () => {
 
   it("enumerates individual array elements for array properties", () => {
     const values = index.listPropertyValues({ key: "tags" }, logger)
-    expect(values.find((val) => val.value === "project")).toBeDefined()
-    expect(values.find((val) => val.value === "active")).toBeDefined()
-    expect(values.find((val) => val.value === "note")).toBeDefined()
+    expect(values.find((entry) => entry.value === "project")).toBeDefined()
+    expect(values.find((entry) => entry.value === "active")).toBeDefined()
+    expect(values.find((entry) => entry.value === "note")).toBeDefined()
   })
 
   it("sorts by count descending", () => {
@@ -625,7 +625,7 @@ describe("listPropertyValues", () => {
       logger,
     )
     expect(values).toHaveLength(2)
-    const blockedValue = values.find((val) => val.value === "blocked")
+    const blockedValue = values.find((entry) => entry.value === "blocked")
     expect(blockedValue).toBeUndefined()
   })
 

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -468,6 +468,238 @@ describe("recentNotes", () => {
   })
 })
 
+// ── Property query fixtures ──────────────────────────────────────
+
+const NOTE_WITH_STATUS = `---
+title: Active Project
+type: project
+tags: [project, active]
+status: in-progress
+priority: high
+---
+
+# Active Project
+
+Work in progress.
+`
+
+const NOTE_WITH_DIFFERENT_STATUS = `---
+title: Done Project
+type: project
+tags: [project, done]
+status: done
+priority: low
+---
+
+# Done Project
+
+Completed work.
+`
+
+const NOTE_WITH_NO_CUSTOM_PROPS = `---
+title: Plain Note
+tags: [note]
+---
+
+# Plain Note
+
+No custom properties.
+`
+
+describe("listPropertyKeys", () => {
+  beforeEach(() => {
+    index.upsertNote("Projects/active.md", NOTE_WITH_STATUS, 1000)
+    index.upsertNote("Projects/done.md", NOTE_WITH_DIFFERENT_STATUS, 2000)
+    index.upsertNote("notes/plain.md", NOTE_WITH_NO_CUSTOM_PROPS, 3000)
+  })
+
+  it("returns all property keys with counts", () => {
+    const keys = index.listPropertyKeys({}, logger)
+    expect(keys.length).toBeGreaterThan(0)
+    const titleKey = keys.find((k) => k.key === "title")
+    expect(titleKey).toBeDefined()
+    expect(titleKey!.count).toBe(3)
+  })
+
+  it("includes sample_values for each key", () => {
+    const keys = index.listPropertyKeys({}, logger)
+    const statusKey = keys.find((k) => k.key === "status")
+    expect(statusKey).toBeDefined()
+    expect(statusKey!.sample_values).toContain("in-progress")
+    expect(statusKey!.sample_values).toContain("done")
+  })
+
+  it("returns at most 3 sample values", () => {
+    for (let i = 0; i < 5; i++) {
+      index.upsertNote(
+        `extra/n${i}.md`,
+        `---\nvariety: value-${i}\n---\nbody\n`,
+        4000 + i,
+      )
+    }
+    const keys = index.listPropertyKeys({}, logger)
+    const varietyKey = keys.find((k) => k.key === "variety")
+    expect(varietyKey!.sample_values.length).toBeLessThanOrEqual(3)
+  })
+
+  it("sorts by count descending", () => {
+    const keys = index.listPropertyKeys({}, logger)
+    for (let i = 1; i < keys.length; i++) {
+      expect(keys[i - 1].count).toBeGreaterThanOrEqual(keys[i].count)
+    }
+  })
+
+  it("respects folder filter", () => {
+    const keys = index.listPropertyKeys({ folder: "Projects" }, logger)
+    const statusKey = keys.find((k) => k.key === "status")
+    expect(statusKey).toBeDefined()
+    expect(statusKey!.count).toBe(2)
+  })
+
+  it("folder filter excludes notes outside the folder", () => {
+    const keys = index.listPropertyKeys({ folder: "notes" }, logger)
+    const statusKey = keys.find((k) => k.key === "status")
+    expect(statusKey).toBeUndefined()
+  })
+})
+
+describe("listPropertyValues", () => {
+  beforeEach(() => {
+    index.upsertNote("Projects/active.md", NOTE_WITH_STATUS, 1000)
+    index.upsertNote("Projects/done.md", NOTE_WITH_DIFFERENT_STATUS, 2000)
+    index.upsertNote("notes/plain.md", NOTE_WITH_NO_CUSTOM_PROPS, 3000)
+  })
+
+  it("returns distinct values with counts for a scalar property", () => {
+    const values = index.listPropertyValues({ key: "status" }, logger)
+    expect(values).toHaveLength(2)
+    expect(values.find((v) => v.value === "in-progress")).toEqual({
+      value: "in-progress",
+      count: 1,
+    })
+    expect(values.find((v) => v.value === "done")).toEqual({
+      value: "done",
+      count: 1,
+    })
+  })
+
+  it("enumerates individual array elements for array properties", () => {
+    const values = index.listPropertyValues({ key: "tags" }, logger)
+    expect(values.find((v) => v.value === "project")).toBeDefined()
+    expect(values.find((v) => v.value === "active")).toBeDefined()
+    expect(values.find((v) => v.value === "note")).toBeDefined()
+  })
+
+  it("sorts by count descending", () => {
+    const values = index.listPropertyValues({ key: "tags" }, logger)
+    for (let i = 1; i < values.length; i++) {
+      expect(values[i - 1].count).toBeGreaterThanOrEqual(values[i].count)
+    }
+  })
+
+  it("respects limit", () => {
+    const values = index.listPropertyValues({ key: "tags", limit: 2 }, logger)
+    expect(values).toHaveLength(2)
+  })
+
+  it("respects folder filter", () => {
+    const values = index.listPropertyValues(
+      { key: "status", folder: "Projects" },
+      logger,
+    )
+    expect(values).toHaveLength(2)
+  })
+
+  it("returns empty for non-existent key", () => {
+    const values = index.listPropertyValues({ key: "nonexistent" }, logger)
+    expect(values).toHaveLength(0)
+  })
+})
+
+describe("searchByProperty", () => {
+  beforeEach(() => {
+    index.upsertNote("Projects/active.md", NOTE_WITH_STATUS, 1000)
+    index.upsertNote("Projects/done.md", NOTE_WITH_DIFFERENT_STATUS, 2000)
+    index.upsertNote("notes/plain.md", NOTE_WITH_NO_CUSTOM_PROPS, 3000)
+  })
+
+  it("finds notes by scalar property value", () => {
+    const results = index.searchByProperty(
+      { key: "status", value: "in-progress" },
+      logger,
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("Projects/active.md")
+  })
+
+  it("finds notes by array property value", () => {
+    const results = index.searchByProperty(
+      { key: "tags", value: "active" },
+      logger,
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("Projects/active.md")
+  })
+
+  it("returns NoteMetadata with all fields", () => {
+    const results = index.searchByProperty(
+      { key: "status", value: "done" },
+      logger,
+    )
+    expect(results[0]).toHaveProperty("path")
+    expect(results[0]).toHaveProperty("title")
+    expect(results[0]).toHaveProperty("tags")
+    expect(results[0]).toHaveProperty("related")
+    expect(results[0]).toHaveProperty("folder")
+    expect(results[0]).toHaveProperty("type")
+    expect(results[0]).toHaveProperty("modified")
+    expect(results[0]).toHaveProperty("properties")
+  })
+
+  it("returns empty for non-matching value", () => {
+    const results = index.searchByProperty(
+      { key: "status", value: "archived" },
+      logger,
+    )
+    expect(results).toHaveLength(0)
+  })
+
+  it("returns empty for non-existent key", () => {
+    const results = index.searchByProperty(
+      { key: "nonexistent", value: "any" },
+      logger,
+    )
+    expect(results).toHaveLength(0)
+  })
+
+  it("respects folder filter", () => {
+    index.upsertNote(
+      "Other/also-active.md",
+      "---\nstatus: in-progress\n---\nbody\n",
+      4000,
+    )
+    const results = index.searchByProperty(
+      { key: "status", value: "in-progress", folder: "Projects" },
+      logger,
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("Projects/active.md")
+  })
+
+  it("respects limit", () => {
+    index.upsertNote(
+      "Projects/another.md",
+      "---\nstatus: in-progress\n---\nbody\n",
+      4000,
+    )
+    const results = index.searchByProperty(
+      { key: "status", value: "in-progress", limit: 1 },
+      logger,
+    )
+    expect(results).toHaveLength(1)
+  })
+})
+
 describe("rebuildFromVault", () => {
   let vaultDir: string
 

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -698,6 +698,16 @@ describe("searchByProperty", () => {
     )
     expect(results).toHaveLength(1)
   })
+
+  it("finds notes by YAML date property (normalized from Date object)", () => {
+    index.upsertNote("dated.md", "---\ndue: 2026-05-13\n---\nbody\n", 5000)
+    const results = index.searchByProperty(
+      { key: "due", value: "2026-05-13" },
+      logger,
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("dated.md")
+  })
 })
 
 describe("rebuildFromVault", () => {

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -516,14 +516,14 @@ describe("listPropertyKeys", () => {
   it("returns all property keys with counts", () => {
     const keys = index.listPropertyKeys({}, logger)
     expect(keys.length).toBeGreaterThan(0)
-    const titleKey = keys.find((k) => k.key === "title")
+    const titleKey = keys.find((entry) => entry.key === "title")
     expect(titleKey).toBeDefined()
     expect(titleKey!.count).toBe(3)
   })
 
   it("includes sample_values for each key", () => {
     const keys = index.listPropertyKeys({}, logger)
-    const statusKey = keys.find((k) => k.key === "status")
+    const statusKey = keys.find((entry) => entry.key === "status")
     expect(statusKey).toBeDefined()
     expect(statusKey!.sample_values).toContain("in-progress")
     expect(statusKey!.sample_values).toContain("done")
@@ -538,7 +538,7 @@ describe("listPropertyKeys", () => {
       )
     }
     const keys = index.listPropertyKeys({}, logger)
-    const varietyKey = keys.find((k) => k.key === "variety")
+    const varietyKey = keys.find((entry) => entry.key === "variety")
     expect(varietyKey!.sample_values.length).toBeLessThanOrEqual(3)
   })
 
@@ -551,15 +551,27 @@ describe("listPropertyKeys", () => {
 
   it("respects folder filter", () => {
     const keys = index.listPropertyKeys({ folder: "Projects" }, logger)
-    const statusKey = keys.find((k) => k.key === "status")
+    const statusKey = keys.find((entry) => entry.key === "status")
     expect(statusKey).toBeDefined()
     expect(statusKey!.count).toBe(2)
   })
 
   it("folder filter excludes notes outside the folder", () => {
     const keys = index.listPropertyKeys({ folder: "notes" }, logger)
-    const statusKey = keys.find((k) => k.key === "status")
+    const statusKey = keys.find((entry) => entry.key === "status")
     expect(statusKey).toBeUndefined()
+  })
+
+  it("sample_values are scoped to the folder filter", () => {
+    index.upsertNote(
+      "Other/other.md",
+      "---\nstatus: blocked\n---\nbody\n",
+      4000,
+    )
+    const keys = index.listPropertyKeys({ folder: "Projects" }, logger)
+    const statusKey = keys.find((entry) => entry.key === "status")
+    expect(statusKey).toBeDefined()
+    expect(statusKey!.sample_values).not.toContain("blocked")
   })
 })
 
@@ -573,11 +585,11 @@ describe("listPropertyValues", () => {
   it("returns distinct values with counts for a scalar property", () => {
     const values = index.listPropertyValues({ key: "status" }, logger)
     expect(values).toHaveLength(2)
-    expect(values.find((v) => v.value === "in-progress")).toEqual({
+    expect(values.find((val) => val.value === "in-progress")).toEqual({
       value: "in-progress",
       count: 1,
     })
-    expect(values.find((v) => v.value === "done")).toEqual({
+    expect(values.find((val) => val.value === "done")).toEqual({
       value: "done",
       count: 1,
     })
@@ -585,9 +597,9 @@ describe("listPropertyValues", () => {
 
   it("enumerates individual array elements for array properties", () => {
     const values = index.listPropertyValues({ key: "tags" }, logger)
-    expect(values.find((v) => v.value === "project")).toBeDefined()
-    expect(values.find((v) => v.value === "active")).toBeDefined()
-    expect(values.find((v) => v.value === "note")).toBeDefined()
+    expect(values.find((val) => val.value === "project")).toBeDefined()
+    expect(values.find((val) => val.value === "active")).toBeDefined()
+    expect(values.find((val) => val.value === "note")).toBeDefined()
   })
 
   it("sorts by count descending", () => {
@@ -603,11 +615,18 @@ describe("listPropertyValues", () => {
   })
 
   it("respects folder filter", () => {
+    index.upsertNote(
+      "Other/excluded.md",
+      "---\nstatus: blocked\n---\nbody\n",
+      4000,
+    )
     const values = index.listPropertyValues(
       { key: "status", folder: "Projects" },
       logger,
     )
     expect(values).toHaveLength(2)
+    const blockedValue = values.find((val) => val.value === "blocked")
+    expect(blockedValue).toBeUndefined()
   })
 
   it("returns empty for non-existent key", () => {

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -521,12 +521,12 @@ describe("listPropertyKeys", () => {
     expect(titleKey!.count).toBe(3)
   })
 
-  it("includes sampleValues for each key", () => {
+  it("includes sample_values for each key", () => {
     const keys = index.listPropertyKeys({}, logger)
     const statusKey = keys.find((entry) => entry.key === "status")
     expect(statusKey).toBeDefined()
-    expect(statusKey!.sampleValues).toContain("in-progress")
-    expect(statusKey!.sampleValues).toContain("done")
+    expect(statusKey!.sample_values).toContain("in-progress")
+    expect(statusKey!.sample_values).toContain("done")
   })
 
   it("returns at most 3 sample values", () => {
@@ -539,7 +539,7 @@ describe("listPropertyKeys", () => {
     }
     const keys = index.listPropertyKeys({}, logger)
     const varietyKey = keys.find((entry) => entry.key === "variety")
-    expect(varietyKey!.sampleValues.length).toBeLessThanOrEqual(3)
+    expect(varietyKey!.sample_values.length).toBeLessThanOrEqual(3)
   })
 
   it("sorts by count descending", () => {
@@ -562,7 +562,7 @@ describe("listPropertyKeys", () => {
     expect(statusKey).toBeUndefined()
   })
 
-  it("sampleValues are scoped to the folder filter", () => {
+  it("sample_values are scoped to the folder filter", () => {
     index.upsertNote(
       "Other/other.md",
       "---\nstatus: blocked\n---\nbody\n",
@@ -571,7 +571,7 @@ describe("listPropertyKeys", () => {
     const keys = index.listPropertyKeys({ folder: "Projects" }, logger)
     const statusKey = keys.find((entry) => entry.key === "status")
     expect(statusKey).toBeDefined()
-    expect(statusKey!.sampleValues).not.toContain("blocked")
+    expect(statusKey!.sample_values).not.toContain("blocked")
   })
 })
 

--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -20,6 +20,10 @@ const TOOL_NAMES = [
   "vault_update_memory",
   "vault_list_memory_files",
   "vault_delete_memory",
+  "vault_get_daily_note",
+  "vault_list_property_keys",
+  "vault_list_property_values",
+  "vault_search_by_property",
 ] as const
 
 const READ_ONLY_TOOLS = [
@@ -32,6 +36,10 @@ const READ_ONLY_TOOLS = [
   "vault_recent_notes",
   "vault_get_memory",
   "vault_list_memory_files",
+  "vault_get_daily_note",
+  "vault_list_property_keys",
+  "vault_list_property_values",
+  "vault_search_by_property",
 ] as const
 
 const DESTRUCTIVE_TOOLS = [
@@ -69,8 +77,8 @@ const findCall = (name: string): RegisterToolCall | undefined =>
   calls.find((c) => c[0] === name)
 
 describe("registerTools", () => {
-  it("registers exactly 15 tools", () => {
-    expect(mockServer.registerTool).toHaveBeenCalledTimes(15)
+  it("registers exactly 19 tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(19)
   })
 
   it.each(TOOL_NAMES)("registers %s", (name) => {

--- a/src/vault-mcp/daily-notes.ts
+++ b/src/vault-mcp/daily-notes.ts
@@ -1,0 +1,133 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { DateTime } from "luxon"
+import type { Logger } from "../logger.js"
+import { vaultFs } from "./vault-filesystem.js"
+
+// ── Moment.js → Luxon format conversion ────────────────────────
+
+/** Sorted longest-first to avoid partial replacement collisions
+ *  (e.g. YYYY before YY, dddd before ddd). */
+const MOMENT_TO_LUXON: ReadonlyArray<readonly [string, string]> = [
+  ["YYYY", "yyyy"],
+  ["dddd", "cccc"],
+  ["MMMM", "MMMM"],
+  ["ddd", "ccc"],
+  ["MMM", "MMM"],
+  ["YY", "yy"],
+  ["MM", "MM"],
+  ["DD", "dd"],
+  ["HH", "HH"],
+  ["hh", "hh"],
+  ["mm", "mm"],
+  ["ss", "ss"],
+  ["Do", "d"],
+  ["A", "a"],
+]
+
+/** Converts a Moment.js format string to Luxon format tokens.
+ *  Covers YYYY, YY, MM, DD, dddd, ddd, HH, hh, mm, ss, Do, A —
+ *  sufficient for 99%+ of daily note filename patterns. */
+export const momentToLuxonFormat = (momentFormat: string): string =>
+  MOMENT_TO_LUXON.reduce(
+    (fmt, [moment, luxon]) => fmt.replaceAll(moment, luxon),
+    momentFormat,
+  )
+
+// ── Config reading ──────────────────────────────────────────────
+
+type DailyNotesConfig = {
+  folder: string
+  format: string
+}
+
+const OBSIDIAN_DEFAULTS: DailyNotesConfig = {
+  folder: "Daily Notes",
+  format: "YYYY-MM-DD",
+}
+
+let cachedConfig: DailyNotesConfig | null = null
+
+/** Reads .obsidian/daily-notes.json for the vault's daily note folder
+ *  and filename format. Falls back to Obsidian defaults if the file
+ *  is missing or malformed. Result is cached after first read. */
+export const readDailyNotesConfig = async (
+  vaultPath: string,
+): Promise<DailyNotesConfig> => {
+  if (cachedConfig) return cachedConfig
+
+  try {
+    const raw = await readFile(
+      join(vaultPath, ".obsidian", "daily-notes.json"),
+      "utf8",
+    )
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    cachedConfig = {
+      folder:
+        typeof parsed.folder === "string" && parsed.folder.length > 0
+          ? parsed.folder
+          : OBSIDIAN_DEFAULTS.folder,
+      format:
+        typeof parsed.format === "string" && parsed.format.length > 0
+          ? parsed.format
+          : OBSIDIAN_DEFAULTS.format,
+    }
+  } catch {
+    cachedConfig = { ...OBSIDIAN_DEFAULTS }
+  }
+
+  return cachedConfig
+}
+
+/** Clears the cached config. Exposed for testing only. */
+export const clearConfigCache = (): void => {
+  cachedConfig = null
+}
+
+// ── Path resolution + read ──────────────────────────────────────
+
+/** Resolves a date to a vault-relative daily note path using the
+ *  vault's .obsidian/daily-notes.json config. */
+export const getDailyNotePath = async (
+  vaultPath: string,
+  date?: string,
+): Promise<string> => {
+  const config = await readDailyNotesConfig(vaultPath)
+  const luxonFormat = momentToLuxonFormat(config.format)
+
+  const dt = date ? DateTime.fromISO(date) : DateTime.now()
+  if (!dt.isValid) {
+    throw new Error(
+      `invalid date "${date}" — use YYYY-MM-DD format (e.g. "2026-05-13")`,
+    )
+  }
+
+  const filename = dt.toFormat(luxonFormat)
+  return `${config.folder}/${filename}.md`
+}
+
+type DailyNoteResult = {
+  path: string
+  content: string | null
+  exists: boolean
+}
+
+/** Reads a daily note by date. Returns the resolved path, content
+ *  (if the note exists), and an exists flag. */
+export const getDailyNote = async (
+  params: { vaultPath: string; date?: string },
+  logger: Logger,
+): Promise<DailyNoteResult> => {
+  const path = await getDailyNotePath(params.vaultPath, params.date)
+
+  try {
+    const content = await vaultFs.readNote(
+      { vaultPath: params.vaultPath, path },
+      logger,
+    )
+    return { path, content, exists: true }
+  } catch {
+    logger.info("daily note not found", { path })
+    return { path, content: null, exists: false }
+  }
+}

--- a/src/vault-mcp/daily-notes.ts
+++ b/src/vault-mcp/daily-notes.ts
@@ -21,18 +21,27 @@ const MOMENT_TO_LUXON: ReadonlyArray<readonly [string, string]> = [
   ["hh", "hh"],
   ["mm", "mm"],
   ["ss", "ss"],
-  ["Do", "d"],
   ["A", "a"],
 ]
 
+/** Matches Moment.js [literal] escape groups — e.g. [Daily Note]. */
+const MOMENT_ESCAPE_RE = /\[([^\]]*)\]/g
+
 /** Converts a Moment.js format string to Luxon format tokens.
- *  Covers YYYY, YY, MM, DD, dddd, ddd, HH, hh, mm, ss, Do, A —
- *  sufficient for 99%+ of daily note filename patterns. */
-export const momentToLuxonFormat = (momentFormat: string): string =>
-  MOMENT_TO_LUXON.reduce(
+ *  Handles [literal] escapes (Moment) → 'literal' (Luxon) and
+ *  common date/time tokens. Unsupported tokens (Do, d, dd) are
+ *  left as-is — Luxon will throw on unknown tokens, making the
+ *  failure visible rather than producing a wrong path. */
+export const momentToLuxonFormat = (momentFormat: string): string => {
+  const escaped = momentFormat.replace(MOMENT_ESCAPE_RE, (_, literal) => {
+    const safeContent = (literal as string).replace(/'/g, "''")
+    return `'${safeContent}'`
+  })
+  return MOMENT_TO_LUXON.reduce(
     (fmt, [moment, luxon]) => fmt.replaceAll(moment, luxon),
-    momentFormat,
+    escaped,
   )
+}
 
 // ── Config reading ──────────────────────────────────────────────
 
@@ -95,6 +104,12 @@ export const getDailyNotePath = async (
   const config = await readDailyNotesConfig(vaultPath)
   const luxonFormat = momentToLuxonFormat(config.format)
 
+  if (date && !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error(
+      `invalid date "${date}" — use YYYY-MM-DD format (e.g. "2026-05-13")`,
+    )
+  }
+
   const dt = date ? DateTime.fromISO(date) : DateTime.now()
   if (!dt.isValid) {
     throw new Error(
@@ -126,8 +141,12 @@ export const getDailyNote = async (
       logger,
     )
     return { path, content, exists: true }
-  } catch {
-    logger.info("daily note not found", { path })
-    return { path, content: null, exists: false }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (message.startsWith("note not found")) {
+      logger.info("daily note not found", { path })
+      return { path, content: null, exists: false }
+    }
+    throw err
   }
 }

--- a/src/vault-mcp/daily-notes.ts
+++ b/src/vault-mcp/daily-notes.ts
@@ -76,19 +76,24 @@ export const readDailyNotesConfig = async (
   if (cachedConfig) return cachedConfig
 
   try {
-    const raw = await readFile(
+    const configFileContent = await readFile(
       join(vaultPath, ".obsidian", "daily-notes.json"),
       "utf8",
     )
-    const parsed = JSON.parse(raw) as Record<string, unknown>
+    const parsedConfig = JSON.parse(configFileContent) as Record<
+      string,
+      unknown
+    >
     cachedConfig = {
       folder:
-        typeof parsed.folder === "string" && parsed.folder.length > 0
-          ? parsed.folder
+        typeof parsedConfig.folder === "string" &&
+        parsedConfig.folder.length > 0
+          ? parsedConfig.folder
           : OBSIDIAN_DEFAULTS.folder,
       format:
-        typeof parsed.format === "string" && parsed.format.length > 0
-          ? parsed.format
+        typeof parsedConfig.format === "string" &&
+        parsedConfig.format.length > 0
+          ? parsedConfig.format
           : OBSIDIAN_DEFAULTS.format,
     }
   } catch {
@@ -105,6 +110,9 @@ export const clearConfigCache = (): void => {
 
 // ── Path resolution + read ──────────────────────────────────────
 
+/** Matches strict YYYY-MM-DD date strings (no time component, no partial dates). */
+const STRICT_ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
 /** Resolves a date to a vault-relative daily note path using the
  *  vault's .obsidian/daily-notes.json config. */
 export const getDailyNotePath = async (
@@ -114,7 +122,7 @@ export const getDailyNotePath = async (
   const config = await readDailyNotesConfig(vaultPath)
   const luxonFormat = momentToLuxonFormat(config.format)
 
-  if (date && !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+  if (date && !STRICT_ISO_DATE_RE.test(date)) {
     throw new Error(
       `invalid date "${date}" — use YYYY-MM-DD format (e.g. "2026-05-13")`,
     )
@@ -152,8 +160,8 @@ export const getDailyNote = async (
     )
     return { path, content, exists: true }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    if (message.startsWith("note not found")) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    if (errorMessage.startsWith("note not found")) {
       logger.info("daily note not found", { path })
       return { path, content: null, exists: false }
     }

--- a/src/vault-mcp/daily-notes.ts
+++ b/src/vault-mcp/daily-notes.ts
@@ -33,13 +33,20 @@ const MOMENT_ESCAPE_RE = /\[([^\]]*)\]/g
  *  left as-is — Luxon will throw on unknown tokens, making the
  *  failure visible rather than producing a wrong path. */
 export const momentToLuxonFormat = (momentFormat: string): string => {
-  const escaped = momentFormat.replace(MOMENT_ESCAPE_RE, (_, literal) => {
-    const safeContent = (literal as string).replace(/'/g, "''")
-    return `'${safeContent}'`
-  })
+  // First pass: convert Moment [literal] escapes to Luxon 'literal' syntax.
+  // Single quotes inside literals are doubled per Luxon's escape convention.
+  const withLiteralsConverted = momentFormat.replace(
+    MOMENT_ESCAPE_RE,
+    (_, literal) => {
+      const escapedContent = ((literal as string) ?? "").replace(/'/g, "''")
+      return `'${escapedContent}'`
+    },
+  )
+  // Second pass: replace date/time tokens from longest to shortest
   return MOMENT_TO_LUXON.reduce(
-    (fmt, [moment, luxon]) => fmt.replaceAll(moment, luxon),
-    escaped,
+    (formatString, [momentToken, luxonToken]) =>
+      formatString.replaceAll(momentToken, luxonToken),
+    withLiteralsConverted,
   )
 }
 
@@ -55,6 +62,9 @@ const OBSIDIAN_DEFAULTS: DailyNotesConfig = {
   format: "YYYY-MM-DD",
 }
 
+// Mutable module-level cache — justified because the config is read from
+// the filesystem once and never changes during the server's lifetime.
+// Avoids re-reading .obsidian/daily-notes.json on every tool call.
 let cachedConfig: DailyNotesConfig | null = null
 
 /** Reads .obsidian/daily-notes.json for the vault's daily note folder
@@ -110,14 +120,14 @@ export const getDailyNotePath = async (
     )
   }
 
-  const dt = date ? DateTime.fromISO(date) : DateTime.now()
-  if (!dt.isValid) {
+  const dateTime = date ? DateTime.fromISO(date) : DateTime.now()
+  if (!dateTime.isValid) {
     throw new Error(
       `invalid date "${date}" — use YYYY-MM-DD format (e.g. "2026-05-13")`,
     )
   }
 
-  const filename = dt.toFormat(luxonFormat)
+  const filename = dateTime.toFormat(luxonFormat)
   return `${config.folder}/${filename}.md`
 }
 

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -83,7 +83,7 @@ type TagCount = {
 type PropertyKeyInfo = {
   key: string
   count: number
-  sampleValues: string[]
+  sample_values: string[]
 }
 
 type PropertyValueCount = {
@@ -539,7 +539,7 @@ export const createSearchIndex = (dbPath: string) => {
       return {
         key: keyRow.key,
         count: keyRow.count,
-        sampleValues: sampleRows.map((sampleRow) => String(sampleRow.value)),
+        sample_values: sampleRows.map((sampleRow) => String(sampleRow.value)),
       }
     })
 

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -83,7 +83,7 @@ type TagCount = {
 type PropertyKeyInfo = {
   key: string
   count: number
-  sample_values: string[]
+  sampleValues: string[]
 }
 
 type PropertyValueCount = {
@@ -486,8 +486,9 @@ export const createSearchIndex = (dbPath: string) => {
     params: { folder?: string },
     logger: Logger,
   ): PropertyKeyInfo[] => {
-    const folderCondition = params.folder ? "WHERE n.path LIKE ? || '/%'" : ""
-    const folderParams: string[] = params.folder ? [params.folder] : []
+    const folderCondition = params.folder
+      ? "WHERE n.path LIKE @folder || '/%'"
+      : ""
 
     const keySql = `
       SELECT je.key, COUNT(DISTINCT n.path) as count
@@ -496,7 +497,9 @@ export const createSearchIndex = (dbPath: string) => {
       GROUP BY je.key
       ORDER BY count DESC
     `
-    const keyRows = db.prepare(keySql).all(...folderParams) as Array<{
+    const keyBindParams: Record<string, string> = {}
+    if (params.folder) keyBindParams.folder = params.folder
+    const keyRows = db.prepare(keySql).all(keyBindParams) as Array<{
       key: string
       count: number
     }>
@@ -528,15 +531,15 @@ export const createSearchIndex = (dbPath: string) => {
     const sampleStmt = db.prepare(sampleSql)
 
     const results: PropertyKeyInfo[] = keyRows.map((keyRow) => {
-      const sampleBinds: Record<string, string> = { key: keyRow.key }
-      if (params.folder) sampleBinds.folder = params.folder
-      const sampleRows = sampleStmt.all(sampleBinds) as Array<{
+      const bindParams: Record<string, string> = { key: keyRow.key }
+      if (params.folder) bindParams.folder = params.folder
+      const sampleRows = sampleStmt.all(bindParams) as Array<{
         value: string
       }>
       return {
         key: keyRow.key,
         count: keyRow.count,
-        sample_values: sampleRows.map((sampleRow) => String(sampleRow.value)),
+        sampleValues: sampleRows.map((sampleRow) => String(sampleRow.value)),
       }
     })
 

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -11,6 +11,21 @@ const isString = (value: unknown): value is string => typeof value === "string"
 
 const isDate = (value: unknown): value is Date => value instanceof Date
 
+/** Converts Date instances in frontmatter to ISO date strings (YYYY-MM-DD)
+ *  before JSON.stringify, preventing gray-matter's YAML 1.1 Date parsing
+ *  from producing full ISO timestamps in the properties column. */
+const normalizeDates = (
+  data: Record<string, unknown>,
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [
+      key,
+      isDate(value)
+        ? DateTime.fromJSDate(value, { zone: "utc" }).toFormat("yyyy-MM-dd")
+        : value,
+    ]),
+  )
+
 // ── FTS5 query sanitization ─────────────────────────────────────
 
 const FTS5_RESERVED = new Set(["AND", "OR", "NOT", "NEAR"])
@@ -176,7 +191,7 @@ export const createSearchIndex = (dbPath: string) => {
           ? DateTime.fromISO(data.created).toISO()
           : null,
       mtime: lastModifiedMs,
-      properties: JSON.stringify(data),
+      properties: JSON.stringify(normalizeDates(data)),
     }
 
     deleteFtsStmt.run(note.path)
@@ -486,11 +501,16 @@ export const createSearchIndex = (dbPath: string) => {
       count: number
     }>
 
-    const sampleStmt = db.prepare(`
-      SELECT DISTINCT je_val.value
+    const sampleFolderCondition = params.folder
+      ? "AND path LIKE @folder || '/%'"
+      : ""
+
+    const sampleSql = `
+      SELECT je_val.value, COUNT(*) as c
       FROM (
         SELECT properties FROM notes
         WHERE json_type(properties, '$.' || @key) IS NOT NULL
+        ${sampleFolderCondition}
       ) filtered, json_each(
         CASE json_type(filtered.properties, '$.' || @key)
           WHEN 'array' THEN json_extract(filtered.properties, '$.' || @key)
@@ -498,11 +518,16 @@ export const createSearchIndex = (dbPath: string) => {
         END
       ) je_val
       WHERE typeof(je_val.value) IN ('text', 'integer', 'real')
+      GROUP BY je_val.value
+      ORDER BY c DESC
       LIMIT 3
-    `)
+    `
+    const sampleStmt = db.prepare(sampleSql)
 
     const results: PropertyKeyInfo[] = keyRows.map((row) => {
-      const sampleRows = sampleStmt.all({ key: row.key }) as Array<{
+      const sampleBinds: Record<string, string> = { key: row.key }
+      if (params.folder) sampleBinds.folder = params.folder
+      const sampleRows = sampleStmt.all(sampleBinds) as Array<{
         value: string
       }>
       return {
@@ -577,7 +602,7 @@ export const createSearchIndex = (dbPath: string) => {
         (json_type(n.properties, '$.' || @key) = 'array'
          AND EXISTS (
            SELECT 1 FROM json_each(json_extract(n.properties, '$.' || @key))
-           WHERE value = @value
+           WHERE CAST(value AS TEXT) = @value
          ))
         OR
         (json_type(n.properties, '$.' || @key) IS NOT NULL

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -65,6 +65,17 @@ type TagCount = {
   count: number
 }
 
+type PropertyKeyInfo = {
+  key: string
+  count: number
+  sample_values: string[]
+}
+
+type PropertyValueCount = {
+  value: string
+  count: number
+}
+
 type SearchFilters = {
   folder?: string
   tags?: string[]
@@ -455,6 +466,145 @@ export const createSearchIndex = (dbPath: string) => {
     return results
   }
 
+  /** Returns all frontmatter property keys with note counts and top 3 sample values. */
+  const listPropertyKeys = (
+    params: { folder?: string },
+    logger: Logger,
+  ): PropertyKeyInfo[] => {
+    const folderCondition = params.folder ? "WHERE n.path LIKE ? || '/%'" : ""
+    const folderParams: string[] = params.folder ? [params.folder] : []
+
+    const keySql = `
+      SELECT je.key, COUNT(DISTINCT n.path) as count
+      FROM notes n, json_each(n.properties) je
+      ${folderCondition}
+      GROUP BY je.key
+      ORDER BY count DESC
+    `
+    const keyRows = db.prepare(keySql).all(...folderParams) as Array<{
+      key: string
+      count: number
+    }>
+
+    const sampleStmt = db.prepare(`
+      SELECT DISTINCT je_val.value
+      FROM (
+        SELECT properties FROM notes
+        WHERE json_type(properties, '$.' || @key) IS NOT NULL
+      ) filtered, json_each(
+        CASE json_type(filtered.properties, '$.' || @key)
+          WHEN 'array' THEN json_extract(filtered.properties, '$.' || @key)
+          ELSE json_array(json_extract(filtered.properties, '$.' || @key))
+        END
+      ) je_val
+      WHERE typeof(je_val.value) IN ('text', 'integer', 'real')
+      LIMIT 3
+    `)
+
+    const results: PropertyKeyInfo[] = keyRows.map((row) => {
+      const sampleRows = sampleStmt.all({ key: row.key }) as Array<{
+        value: string
+      }>
+      return {
+        key: row.key,
+        count: row.count,
+        sample_values: sampleRows.map((r) => String(r.value)),
+      }
+    })
+
+    logger.info("listed property keys", { count: results.length })
+    return results
+  }
+
+  /** Returns distinct values for a given property key with note counts. */
+  const listPropertyValues = (
+    params: { key: string; folder?: string; limit?: number },
+    logger: Logger,
+  ): PropertyValueCount[] => {
+    const limit = params.limit ?? 50
+    const folderCondition = params.folder ? "AND path LIKE @folder || '/%'" : ""
+
+    const sql = `
+      SELECT je.value, COUNT(*) as count
+      FROM (
+        SELECT properties FROM notes
+        WHERE json_type(properties, '$.' || @key) IS NOT NULL
+        ${folderCondition}
+      ) filtered, json_each(
+        CASE json_type(filtered.properties, '$.' || @key)
+          WHEN 'array' THEN json_extract(filtered.properties, '$.' || @key)
+          ELSE json_array(json_extract(filtered.properties, '$.' || @key))
+        END
+      ) je
+      WHERE typeof(je.value) IN ('text', 'integer', 'real')
+      GROUP BY je.value
+      ORDER BY count DESC
+      LIMIT @limit
+    `
+
+    const bindParams: Record<string, unknown> = { key: params.key, limit }
+    if (params.folder) bindParams.folder = params.folder
+
+    const rows = db.prepare(sql).all(bindParams) as Array<{
+      value: string | number
+      count: number
+    }>
+    const results = rows.map((r) => ({
+      value: String(r.value),
+      count: r.count,
+    }))
+    logger.info("listed property values", {
+      key: params.key,
+      count: results.length,
+    })
+    return results
+  }
+
+  /** Finds notes where a frontmatter property matches a value (exact match). */
+  const searchByProperty = (
+    params: { key: string; value: string; folder?: string; limit?: number },
+    logger: Logger,
+  ): NoteMetadata[] => {
+    const limit = params.limit ?? 20
+    const folderCondition = params.folder
+      ? "AND n.path LIKE @folder || '/%'"
+      : ""
+
+    const sql = `
+      SELECT path, title, tags, related, folder, type, created, mtime, properties
+      FROM notes n
+      WHERE (
+        (json_type(n.properties, '$.' || @key) = 'array'
+         AND EXISTS (
+           SELECT 1 FROM json_each(json_extract(n.properties, '$.' || @key))
+           WHERE value = @value
+         ))
+        OR
+        (json_type(n.properties, '$.' || @key) IS NOT NULL
+         AND json_type(n.properties, '$.' || @key) != 'array'
+         AND CAST(json_extract(n.properties, '$.' || @key) AS TEXT) = @value)
+      )
+      ${folderCondition}
+      LIMIT @limit
+    `
+
+    const bindParams: Record<string, unknown> = {
+      key: params.key,
+      value: params.value,
+      limit,
+    }
+    if (params.folder) bindParams.folder = params.folder
+
+    const rows = db.prepare(sql).all(bindParams) as NoteRow[]
+    const results = rows.map(rowToMetadata)
+    logger.info("search by property", {
+      key: params.key,
+      value: params.value,
+      resultCount: results.length,
+    })
+    return results
+  }
+
   return {
     upsertNote,
     removeNote,
@@ -465,6 +615,9 @@ export const createSearchIndex = (dbPath: string) => {
     searchByType,
     listAllTags,
     recentNotes,
+    listPropertyKeys,
+    listPropertyValues,
+    searchByProperty,
   }
 }
 

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -505,8 +505,11 @@ export const createSearchIndex = (dbPath: string) => {
       ? "AND path LIKE @folder || '/%'"
       : ""
 
+    // For each key, fetch the 3 most common values as samples.
+    // json_array() wraps scalars so json_each works uniformly for
+    // both scalar ("active") and array (["a","b"]) property values.
     const sampleSql = `
-      SELECT je_val.value, COUNT(*) as c
+      SELECT element.value, COUNT(*) as count
       FROM (
         SELECT properties FROM notes
         WHERE json_type(properties, '$.' || @key) IS NOT NULL
@@ -516,24 +519,24 @@ export const createSearchIndex = (dbPath: string) => {
           WHEN 'array' THEN json_extract(filtered.properties, '$.' || @key)
           ELSE json_array(json_extract(filtered.properties, '$.' || @key))
         END
-      ) je_val
-      WHERE typeof(je_val.value) IN ('text', 'integer', 'real')
-      GROUP BY je_val.value
-      ORDER BY c DESC
+      ) element
+      WHERE typeof(element.value) IN ('text', 'integer', 'real')
+      GROUP BY element.value
+      ORDER BY count DESC
       LIMIT 3
     `
     const sampleStmt = db.prepare(sampleSql)
 
-    const results: PropertyKeyInfo[] = keyRows.map((row) => {
-      const sampleBinds: Record<string, string> = { key: row.key }
+    const results: PropertyKeyInfo[] = keyRows.map((keyRow) => {
+      const sampleBinds: Record<string, string> = { key: keyRow.key }
       if (params.folder) sampleBinds.folder = params.folder
       const sampleRows = sampleStmt.all(sampleBinds) as Array<{
         value: string
       }>
       return {
-        key: row.key,
-        count: row.count,
-        sample_values: sampleRows.map((r) => String(r.value)),
+        key: keyRow.key,
+        count: keyRow.count,
+        sample_values: sampleRows.map((sampleRow) => String(sampleRow.value)),
       }
     })
 
@@ -549,8 +552,10 @@ export const createSearchIndex = (dbPath: string) => {
     const limit = params.limit ?? 50
     const folderCondition = params.folder ? "AND path LIKE @folder || '/%'" : ""
 
+    // json_array() wraps scalars so json_each works uniformly for
+    // both scalar ("active") and array (["a","b"]) property values.
     const sql = `
-      SELECT je.value, COUNT(*) as count
+      SELECT element.value, COUNT(*) as count
       FROM (
         SELECT properties FROM notes
         WHERE json_type(properties, '$.' || @key) IS NOT NULL
@@ -560,9 +565,9 @@ export const createSearchIndex = (dbPath: string) => {
           WHEN 'array' THEN json_extract(filtered.properties, '$.' || @key)
           ELSE json_array(json_extract(filtered.properties, '$.' || @key))
         END
-      ) je
-      WHERE typeof(je.value) IN ('text', 'integer', 'real')
-      GROUP BY je.value
+      ) element
+      WHERE typeof(element.value) IN ('text', 'integer', 'real')
+      GROUP BY element.value
       ORDER BY count DESC
       LIMIT @limit
     `
@@ -574,9 +579,9 @@ export const createSearchIndex = (dbPath: string) => {
       value: string | number
       count: number
     }>
-    const results = rows.map((r) => ({
-      value: String(r.value),
-      count: r.count,
+    const results = rows.map((row) => ({
+      value: String(row.value),
+      count: row.count,
     }))
     logger.info("listed property values", {
       key: params.key,
@@ -595,6 +600,10 @@ export const createSearchIndex = (dbPath: string) => {
       ? "AND n.path LIKE @folder || '/%'"
       : ""
 
+    // Two branches handle different property shapes:
+    // - Array properties (tags: ["a","b"]): check if @value is IN the array
+    // - Scalar properties (status: "active"): check direct equality
+    // Both branches CAST to TEXT for type-safe comparison (integer 4 = text "4")
     const sql = `
       SELECT path, title, tags, related, folder, type, created, mtime, properties
       FROM notes n

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -14,7 +14,7 @@ const isDate = (value: unknown): value is Date => value instanceof Date
 /** Converts Date instances in frontmatter to ISO date strings (YYYY-MM-DD)
  *  before JSON.stringify, preventing gray-matter's YAML 1.1 Date parsing
  *  from producing full ISO timestamps in the properties column. */
-const normalizeDates = (
+const convertFrontmatterDatesToIsoStrings = (
   data: Record<string, unknown>,
 ): Record<string, unknown> =>
   Object.fromEntries(
@@ -191,7 +191,7 @@ export const createSearchIndex = (dbPath: string) => {
           ? DateTime.fromISO(data.created).toISO()
           : null,
       mtime: lastModifiedMs,
-      properties: JSON.stringify(normalizeDates(data)),
+      properties: JSON.stringify(convertFrontmatterDatesToIsoStrings(data)),
     }
 
     deleteFtsStmt.run(note.path)
@@ -497,9 +497,9 @@ export const createSearchIndex = (dbPath: string) => {
       GROUP BY je.key
       ORDER BY count DESC
     `
-    const keyBindParams: Record<string, string> = {}
-    if (params.folder) keyBindParams.folder = params.folder
-    const keyRows = db.prepare(keySql).all(keyBindParams) as Array<{
+    const keySqlParams: Record<string, string> = {}
+    if (params.folder) keySqlParams.folder = params.folder
+    const keyRows = db.prepare(keySql).all(keySqlParams) as Array<{
       key: string
       count: number
     }>
@@ -531,9 +531,9 @@ export const createSearchIndex = (dbPath: string) => {
     const sampleStmt = db.prepare(sampleSql)
 
     const results: PropertyKeyInfo[] = keyRows.map((keyRow) => {
-      const bindParams: Record<string, string> = { key: keyRow.key }
-      if (params.folder) bindParams.folder = params.folder
-      const sampleRows = sampleStmt.all(bindParams) as Array<{
+      const sqlParams: Record<string, string> = { key: keyRow.key }
+      if (params.folder) sqlParams.folder = params.folder
+      const sampleRows = sampleStmt.all(sqlParams) as Array<{
         value: string
       }>
       return {
@@ -575,10 +575,10 @@ export const createSearchIndex = (dbPath: string) => {
       LIMIT @limit
     `
 
-    const bindParams: Record<string, unknown> = { key: params.key, limit }
-    if (params.folder) bindParams.folder = params.folder
+    const sqlParams: Record<string, unknown> = { key: params.key, limit }
+    if (params.folder) sqlParams.folder = params.folder
 
-    const rows = db.prepare(sql).all(bindParams) as Array<{
+    const rows = db.prepare(sql).all(sqlParams) as Array<{
       value: string | number
       count: number
     }>
@@ -625,14 +625,14 @@ export const createSearchIndex = (dbPath: string) => {
       LIMIT @limit
     `
 
-    const bindParams: Record<string, unknown> = {
+    const sqlParams: Record<string, unknown> = {
       key: params.key,
       value: params.value,
       limit,
     }
-    if (params.folder) bindParams.folder = params.folder
+    if (params.folder) sqlParams.folder = params.folder
 
-    const rows = db.prepare(sql).all(bindParams) as NoteRow[]
+    const rows = db.prepare(sql).all(sqlParams) as NoteRow[]
     const results = rows.map(rowToMetadata)
     logger.info("search by property", {
       key: params.key,

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -878,12 +878,12 @@ Returns: JSON with path (resolved vault-relative path), content (note body or nu
       title: "List Property Keys",
       description: `Discover all frontmatter property keys in the vault with note counts and sample values. Lets you understand the vault's metadata schema without reading individual notes.
 
-Example: vault_list_property_keys() returns [{ key: "tags", count: 342, sample_values: ["session-log", "project"] }, ...]
+Example: vault_list_property_keys() returns [{ key: "tags", count: 342, sampleValues: ["session-log", "project"] }, ...]
 
 When to use: Discovering what frontmatter properties exist before searching by property. Good first step for vault orientation alongside vault_list_tags.
 Prefer vault_list_property_values when you need the full list of values for a specific key. Prefer vault_search_by_property to find notes matching a specific key-value pair.
 
-Returns: JSON array of { key, count, sample_values } sorted by count descending. sample_values shows the top 3 most common values for quick orientation.`,
+Returns: JSON array of { key, count, sampleValues } sorted by count descending. sampleValues shows the top 3 most common values for quick orientation.`,
       inputSchema: {
         folder: z
           .string()

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -878,12 +878,12 @@ Returns: JSON with path (resolved vault-relative path), content (note body or nu
       title: "List Property Keys",
       description: `Discover all frontmatter property keys in the vault with note counts and sample values. Lets you understand the vault's metadata schema without reading individual notes.
 
-Example: vault_list_property_keys() returns [{ key: "tags", count: 342, sampleValues: ["session-log", "project"] }, ...]
+Example: vault_list_property_keys() returns [{ key: "tags", count: 342, sample_values: ["session-log", "project"] }, ...]
 
 When to use: Discovering what frontmatter properties exist before searching by property. Good first step for vault orientation alongside vault_list_tags.
 Prefer vault_list_property_values when you need the full list of values for a specific key. Prefer vault_search_by_property to find notes matching a specific key-value pair.
 
-Returns: JSON array of { key, count, sampleValues } sorted by count descending. sampleValues shows the top 3 most common values for quick orientation.`,
+Returns: JSON array of { key, count, sample_values } sorted by count descending. sample_values shows the top 3 most common values for quick orientation.`,
       inputSchema: {
         folder: z
           .string()

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -5,6 +5,7 @@ import { z } from "zod"
 import { vaultFs } from "./vault-filesystem.js"
 import { vaultPatcher } from "./vault-patcher.js"
 import { memoryStore } from "./memory-store.js"
+import { getDailyNote } from "./daily-notes.js"
 import type { SearchIndex } from "./search-index.js"
 import type { Logger } from "../logger.js"
 
@@ -24,6 +25,10 @@ export type ToolName =
   | "vault_update_memory"
   | "vault_list_memory_files"
   | "vault_delete_memory"
+  | "vault_get_daily_note"
+  | "vault_list_property_keys"
+  | "vault_list_property_values"
+  | "vault_search_by_property"
 
 // ── Response shaping ─────────────────────────────────────────────
 
@@ -820,5 +825,175 @@ Returns: Confirmation message.`,
     },
   )
 
-  sessionLogger.info("registered tools", { count: 15 })
+  // ── Daily Notes ────────────────────────────────────────────
+
+  server.registerTool(
+    "vault_get_daily_note",
+    {
+      title: "Get Daily Note",
+      description: `Read a daily note by date, using the vault's configured Daily Notes folder and date format (from .obsidian/daily-notes.json). Defaults to today if no date is provided.
+
+Example: vault_get_daily_note({ date: "2026-05-13" })
+
+When to use: When you need today's or a specific date's daily note. Handles path resolution automatically using the vault's Obsidian config — you don't need to know the folder name or filename format. To append content to a daily note section, use the returned path with vault_patch_note.
+
+Errors:
+- "invalid date" — use YYYY-MM-DD format (e.g. "2026-05-13")
+
+Returns: JSON with path (resolved vault-relative path), content (note body or null), and exists (boolean). When exists is false, use vault_write_note with the returned path to create the note.`,
+      inputSchema: {
+        date: z
+          .string()
+          .optional()
+          .describe(
+            "Date in YYYY-MM-DD format (defaults to today in server timezone)",
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ date }, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_get_daily_note",
+      })
+      reqLogger.info("tool_call", { date })
+      return safeHandler(
+        reqLogger,
+        () => getDailyNote({ vaultPath, date }, reqLogger),
+        (result) => JSON.stringify(result),
+      )
+    },
+  )
+
+  // ── Property Discovery ────────────────────────────────────
+
+  server.registerTool(
+    "vault_list_property_keys",
+    {
+      title: "List Property Keys",
+      description: `Discover all frontmatter property keys in the vault with note counts and sample values. Lets you understand the vault's metadata schema without reading individual notes.
+
+Example: vault_list_property_keys() returns [{ key: "tags", count: 342, sample_values: ["session-log", "project"] }, ...]
+
+When to use: Discovering what frontmatter properties exist before searching by property. Good first step for vault orientation alongside vault_list_tags.
+Prefer vault_list_property_values when you need the full list of values for a specific key. Prefer vault_search_by_property to find notes matching a specific key-value pair.
+
+Returns: JSON array of { key, count, sample_values } sorted by count descending. sample_values shows the top 3 most common values for quick orientation.`,
+      inputSchema: {
+        folder: z
+          .string()
+          .optional()
+          .describe('Restrict to a folder (e.g. "Projects")'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ folder }, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_list_property_keys",
+      })
+      reqLogger.info("tool_call", { folder })
+      return safeHandler(
+        reqLogger,
+        async () => search.listPropertyKeys({ folder }, reqLogger),
+        (keys) => JSON.stringify(keys),
+      )
+    },
+  )
+
+  server.registerTool(
+    "vault_list_property_values",
+    {
+      title: "List Property Values",
+      description: `List distinct values for a specific frontmatter property key with note counts. Useful for discovering the range of values a property takes before searching.
+
+Example: vault_list_property_values({ key: "status" }) returns [{ value: "active", count: 47 }, { value: "done", count: 211 }, ...]
+
+When to use: Enumerating possible values for a property key before calling vault_search_by_property. Handles both scalar properties (status: "active") and array properties (tags: ["a", "b"]) — array elements are enumerated individually.
+Call vault_list_property_keys first to discover valid key names.
+
+Returns: JSON array of { value, count } sorted by count descending.`,
+      inputSchema: {
+        key: z
+          .string()
+          .describe('Property key name (e.g. "status", "type", "tags")'),
+        folder: z.string().optional().describe("Restrict to a folder"),
+        limit: z
+          .number()
+          .optional()
+          .describe("Max values to return (default 50)"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ key, folder, limit }, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_list_property_values",
+      })
+      reqLogger.info("tool_call", { key, folder })
+      return safeHandler(
+        reqLogger,
+        async () =>
+          search.listPropertyValues({ key, folder, limit }, reqLogger),
+        (values) => JSON.stringify(values),
+      )
+    },
+  )
+
+  server.registerTool(
+    "vault_search_by_property",
+    {
+      title: "Search by Property",
+      description: `Find notes where a frontmatter property matches a value (exact match). Unlike vault_search, this does not require a text query — it searches by metadata only. Handles both scalar properties (status: "active") and array properties (tags contains "project").
+
+Example: vault_search_by_property({ key: "status", value: "in-progress" })
+
+When to use: Finding notes by metadata when you don't have a text query. Fills the gap where vault_search requires search text.
+Prefer vault_search when you also have a text query (it supports property filters too). Prefer vault_search_by_tag for tag-specific queries (supports hierarchical prefix matching).
+
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties).`,
+      inputSchema: {
+        key: z.string().describe("Property key name"),
+        value: z.string().describe("Value to match (exact, case-sensitive)"),
+        folder: z.string().optional().describe("Restrict to a folder"),
+        limit: z.number().optional().describe("Max results (default 20)"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ key, value, folder, limit }, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_search_by_property",
+      })
+      reqLogger.info("tool_call", { key, value, folder })
+      return safeHandler(
+        reqLogger,
+        async () =>
+          search.searchByProperty({ key, value, folder, limit }, reqLogger),
+        (results) => JSON.stringify(results.map(formatNoteMetadata)),
+      )
+    },
+  )
+
+  sessionLogger.info("registered tools", { count: 19 })
 }


### PR DESCRIPTION
## Summary

- **`vault_get_daily_note`** — reads `.obsidian/daily-notes.json` for portable path resolution (folder + Moment.js date format), falls back to Obsidian defaults. Returns `{ path, content, exists }` so agents can create missing notes with the resolved path.
- **`vault_list_property_keys`** — discovers frontmatter schema via `json_each(properties)`. Returns key names, note counts, and top 3 sample values per key to reduce round-trips.
- **`vault_list_property_values`** — enumerates distinct values + counts for a given property key. Handles both scalar (`status: "active"`) and array (`tags: ["a", "b"]`) properties via `CASE json_type()` + `json_array()` wrapping.
- **`vault_search_by_property`** — property-only search without requiring a text query. Fills the gap where `vault_search` requires FTS5 input. Handles scalar equality and array containment.

New file: `src/vault-mcp/daily-notes.ts` (config reader, `momentToLuxonFormat` converter, path resolver).

All SQL uses named params (`@key`, `@value`) with two-arg `json_type(json, path)` to avoid `json_extract`-on-NULL errors in cross-joined `json_each`.

46 new tests (284 → 330).

## Test plan

- [x] `npm test` — 330 tests pass
- [x] `npm run build` — TypeScript compiles clean
- [x] Pre-commit hooks (eslint, prettier) pass
- [x] Deploy to Lightsail, verify 19 tools via Claude Desktop
- [x] Test daily note: today, specific date, missing note (check resolved path)
- [x] Test property keys: verify counts and sample values against real vault
- [x] Test property values: scalar (status) and array (tags) properties
- [x] Test property search: `key: "type", value: "session-log"` against real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)