### PR TITLE
feat(vault-mcp): backlinks, outgoing links, and orphan detection (19 → 22)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ connector is typically loaded as deferred tools (names like
 check the deferred-tools list and load schemas via `ToolSearch`. The
 connector exposes `vault_read_note`, `vault_search`, `vault_get_memory`,
 `vault_write_note`, `vault_patch_note`, `vault_replace_in_note`, and the
-rest of the API (15 tools) in `src/vault-mcp/tool-definitions.ts`.
+rest of the API (18 tools) in `src/vault-mcp/tool-definitions.ts`.
 
 ## Logging
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -196,6 +196,16 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 | `vault_delete_memory`     | `file, section, date, entry`     | destructiveHint |
 | `vault_list_memory_files` | —                                | readOnlyHint    |
 
+### Phase 1: Link Queries
+
+| Tool                       | Input                      | Annotation   |
+| -------------------------- | -------------------------- | ------------ |
+| `vault_get_backlinks`      | `path`                     | readOnlyHint |
+| `vault_get_outgoing_links` | `path`                     | readOnlyHint |
+| `vault_find_orphans`       | `exclude_folders?, limit?` | readOnlyHint |
+
+Link queries use a `links` table populated from `[[wikilink]]` and `[text](path.md)` regex during indexing, with fence-aware parsing (skips code blocks). Links are resolved against all known note paths (shortest-path-first for ambiguous basenames). `vault_find_orphans` excludes `Daily Notes`, `Templates`, and `About Me` folders by default.
+
 ### Phase 2: Knowledge Base (R8)
 
 | Tool             | Input          | Annotation   |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Context Protocol.
 
-> **Status:** Phase 1 complete — 15 MCP tools, deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
+> **Status:** Phase 1 complete — 18 MCP tools, deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
 
 ## Contents
 

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import { createSearchIndex, sanitizeFtsQuery } from "../search-index.js"
+import {
+  createSearchIndex,
+  sanitizeFtsQuery,
+  extractLinks,
+  resolveLink,
+} from "../search-index.js"
 import type { SearchIndex } from "../search-index.js"
 import { logger } from "../../logger.js"
 
@@ -511,5 +516,278 @@ describe("rebuildFromVault", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
     expect(results).toHaveLength(1)
     expect(results[0].path).toBe("About Me/Principles.md")
+  })
+})
+
+// ── extractLinks ─────────────────────────────────────────────────
+
+describe("extractLinks", () => {
+  it("extracts basic wikilinks", () => {
+    const links = extractLinks("See [[Note A]] and [[Note B]].")
+    expect(links).toContain("Note A")
+    expect(links).toContain("Note B")
+  })
+
+  it("extracts wikilinks with display text", () => {
+    const links = extractLinks("See [[Note A|my note]].")
+    expect(links).toEqual(["Note A"])
+  })
+
+  it("extracts wikilinks with heading anchors", () => {
+    const links = extractLinks("See [[Note A#Section One]].")
+    expect(links).toEqual(["Note A"])
+  })
+
+  it("extracts wikilinks with heading and display text", () => {
+    const links = extractLinks("See [[Note A#Section|display]].")
+    expect(links).toEqual(["Note A"])
+  })
+
+  it("extracts wikilinks with folder paths", () => {
+    const links = extractLinks("See [[Projects/vault-cortex]].")
+    expect(links).toEqual(["Projects/vault-cortex"])
+  })
+
+  it("extracts embeds as links", () => {
+    const links = extractLinks("![[Embedded Note]]")
+    expect(links).toEqual(["Embedded Note"])
+  })
+
+  it("extracts markdown internal links", () => {
+    const links = extractLinks("[click here](Projects/plan.md)")
+    expect(links).toContain("Projects/plan")
+  })
+
+  it("excludes external URLs", () => {
+    const links = extractLinks("[Google](https://google.com) and [[Internal]]")
+    expect(links).toEqual(["Internal"])
+  })
+
+  it("excludes mailto links", () => {
+    const links = extractLinks("[email](mailto:test@example.com)")
+    expect(links).toHaveLength(0)
+  })
+
+  it("excludes same-page anchors", () => {
+    const links = extractLinks("[section](#heading)")
+    expect(links).toHaveLength(0)
+  })
+
+  it("deduplicates repeated targets", () => {
+    const links = extractLinks("[[Note A]] and again [[Note A]]")
+    expect(links).toEqual(["Note A"])
+  })
+
+  it("skips links inside fenced code blocks", () => {
+    const content = [
+      "before [[Real Link]]",
+      "```",
+      "[[Fake Link]]",
+      "```",
+      "after [[Another Real Link]]",
+    ].join("\n")
+    const links = extractLinks(content)
+    expect(links).toContain("Real Link")
+    expect(links).toContain("Another Real Link")
+    expect(links).not.toContain("Fake Link")
+  })
+
+  it("skips links inside tilde fenced blocks", () => {
+    const content = ["~~~", "[[Fake]]", "~~~"].join("\n")
+    const links = extractLinks(content)
+    expect(links).not.toContain("Fake")
+  })
+
+  it("handles nested fences correctly", () => {
+    const content = [
+      "````",
+      "```",
+      "[[Inside Nested]]",
+      "```",
+      "````",
+      "[[Outside]]",
+    ].join("\n")
+    const links = extractLinks(content)
+    expect(links).not.toContain("Inside Nested")
+    expect(links).toContain("Outside")
+  })
+
+  it("returns empty for content with no links", () => {
+    expect(extractLinks("Just plain text.")).toEqual([])
+  })
+})
+
+// ── resolveLink ──────────────────────────────────────────────────
+
+describe("resolveLink", () => {
+  const allPaths = [
+    "Projects/vault-cortex.md",
+    "About Me/Principles.md",
+    "notes/random.md",
+    "deep/nested/note.md",
+    "note.md",
+  ]
+
+  it("resolves exact path match", () => {
+    expect(resolveLink("Projects/vault-cortex", allPaths)).toBe(
+      "Projects/vault-cortex.md",
+    )
+  })
+
+  it("resolves exact path with .md extension", () => {
+    expect(resolveLink("Projects/vault-cortex.md", allPaths)).toBe(
+      "Projects/vault-cortex.md",
+    )
+  })
+
+  it("resolves basename match", () => {
+    expect(resolveLink("Principles", allPaths)).toBe("About Me/Principles.md")
+  })
+
+  it("resolves to shortest path when multiple basename matches exist", () => {
+    expect(resolveLink("note", allPaths)).toBe("note.md")
+  })
+
+  it("returns null for unresolvable target", () => {
+    expect(resolveLink("NonExistent", allPaths)).toBeNull()
+  })
+})
+
+// ── Link query methods ───────────────────────────────────────────
+
+describe("getBacklinks", () => {
+  beforeEach(() => {
+    // Index targets before sources so link resolution finds them
+    index.upsertNote("spoke-a.md", "# Spoke A\n\nBody.\n", 1000)
+    index.upsertNote("spoke-b.md", "# Spoke B\n\nNo backlink.\n", 2000)
+    index.upsertNote("island.md", "# Island\n\nNo links at all.\n", 3000)
+    index.upsertNote(
+      "hub.md",
+      "# Hub\n\nLinks to [[spoke-a]] and [[spoke-b]].\n",
+      4000,
+    )
+    // Re-index spoke-a now that hub exists, so its [[hub]] link resolves
+    index.upsertNote(
+      "spoke-a.md",
+      "# Spoke A\n\nLinks back to [[hub]].\n",
+      5000,
+    )
+  })
+
+  it("finds notes linking to the target", () => {
+    const backlinks = index.getBacklinks({ path: "spoke-a.md" }, logger)
+    expect(backlinks).toHaveLength(1)
+    expect(backlinks[0].path).toBe("hub.md")
+  })
+
+  it("returns multiple backlinks", () => {
+    const backlinks = index.getBacklinks({ path: "hub.md" }, logger)
+    expect(backlinks).toHaveLength(1)
+    expect(backlinks[0].path).toBe("spoke-a.md")
+  })
+
+  it("returns empty for notes with no backlinks", () => {
+    const backlinks = index.getBacklinks({ path: "island.md" }, logger)
+    expect(backlinks).toHaveLength(0)
+  })
+
+  it("includes title in results", () => {
+    const backlinks = index.getBacklinks({ path: "spoke-a.md" }, logger)
+    expect(backlinks[0].title).toBe("hub")
+  })
+})
+
+describe("getOutgoingLinks", () => {
+  beforeEach(() => {
+    index.upsertNote(
+      "target-exists.md",
+      "---\ntitle: Target\n---\n\n# Target\n\nBody.\n",
+      1000,
+    )
+    index.upsertNote(
+      "source.md",
+      "# Source\n\n[[target-exists]] and [[NonExistent]].\n",
+      2000,
+    )
+  })
+
+  it("returns outgoing links with exists flag", () => {
+    const links = index.getOutgoingLinks({ path: "source.md" }, logger)
+    expect(links.length).toBeGreaterThanOrEqual(1)
+
+    const existing = links.find((l) => l.path === "target-exists.md")
+    expect(existing).toBeDefined()
+    expect(existing!.exists).toBe(true)
+    expect(existing!.title).toBe("Target")
+  })
+
+  it("marks unresolved links as exists: false", () => {
+    const links = index.getOutgoingLinks({ path: "source.md" }, logger)
+    const missing = links.find((l) => l.path === "NonExistent")
+    expect(missing).toBeDefined()
+    expect(missing!.exists).toBe(false)
+    expect(missing!.title).toBeNull()
+  })
+
+  it("returns empty for notes with no outgoing links", () => {
+    index.upsertNote("lonely.md", "# Lonely\n\nNo links.\n", 3000)
+    const links = index.getOutgoingLinks({ path: "lonely.md" }, logger)
+    expect(links).toHaveLength(0)
+  })
+})
+
+describe("findOrphans", () => {
+  beforeEach(() => {
+    index.upsertNote("connected.md", "# Connected\n\nBody.\n", 1000)
+    index.upsertNote("hub.md", "# Hub\n\n[[connected]].\n", 2000)
+    index.upsertNote(
+      "Projects/orphan.md",
+      "---\ntitle: Orphan\ntype: project\ntags: [project]\n---\n\n# Orphan\n\nNobody links here.\n",
+      3000,
+    )
+    index.upsertNote(
+      "Daily Notes/2026-05-13.md",
+      "---\ntitle: 2026-05-13\n---\n\n# Daily\n",
+      4000,
+    )
+  })
+
+  it("finds notes with no incoming links", () => {
+    const orphans = index.findOrphans({}, logger)
+    const orphanPaths = orphans.map((o) => o.path)
+    expect(orphanPaths).toContain("Projects/orphan.md")
+  })
+
+  it("excludes connected notes", () => {
+    const orphans = index.findOrphans({}, logger)
+    const orphanPaths = orphans.map((o) => o.path)
+    expect(orphanPaths).not.toContain("connected.md")
+  })
+
+  it("excludes Daily Notes by default", () => {
+    const orphans = index.findOrphans({}, logger)
+    const orphanPaths = orphans.map((o) => o.path)
+    expect(orphanPaths).not.toContain("Daily Notes/2026-05-13.md")
+  })
+
+  it("includes Daily Notes when excluded folders are overridden", () => {
+    const orphans = index.findOrphans({ excludeFolders: [] }, logger)
+    const orphanPaths = orphans.map((o) => o.path)
+    expect(orphanPaths).toContain("Daily Notes/2026-05-13.md")
+  })
+
+  it("respects limit", () => {
+    const orphans = index.findOrphans({ limit: 1 }, logger)
+    expect(orphans).toHaveLength(1)
+  })
+
+  it("returns NoteMetadata with all fields", () => {
+    const orphans = index.findOrphans({}, logger)
+    const orphan = orphans.find((o) => o.path === "Projects/orphan.md")
+    expect(orphan).toBeDefined()
+    expect(orphan).toHaveProperty("title")
+    expect(orphan).toHaveProperty("tags")
+    expect(orphan).toHaveProperty("folder")
+    expect(orphan).toHaveProperty("modified")
   })
 })

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -615,6 +615,41 @@ describe("extractLinks", () => {
   it("returns empty for content with no links", () => {
     expect(extractLinks("Just plain text.")).toEqual([])
   })
+
+  it("skips wikilinks inside inline code spans", () => {
+    const links = extractLinks("Use the `[[Note Name]]` syntax to link.")
+    expect(links).not.toContain("Note Name")
+  })
+
+  it("skips markdown links inside inline code spans", () => {
+    const links = extractLinks("Pattern `[text](file.md)` does X.")
+    expect(links).not.toContain("file")
+  })
+
+  it("skips links inside indented fences (CommonMark §4.5)", () => {
+    const content = [
+      "- list item:",
+      "  ```",
+      "  [[Fake Link]]",
+      "  ```",
+      "[[Real Link]]",
+    ].join("\n")
+    const links = extractLinks(content)
+    expect(links).not.toContain("Fake Link")
+    expect(links).toContain("Real Link")
+  })
+
+  it("excludes non-.md assets (images, PDFs)", () => {
+    const links = extractLinks(
+      "![photo](pics/photo.png) and [doc](papers/report.pdf)",
+    )
+    expect(links).toHaveLength(0)
+  })
+
+  it("handles malformed percent-encoding without throwing", () => {
+    const links = extractLinks("[done](100%25complete.md)")
+    expect(links).toBeDefined()
+  })
 })
 
 // ── resolveLink ──────────────────────────────────────────────────
@@ -657,21 +692,20 @@ describe("resolveLink", () => {
 
 describe("getBacklinks", () => {
   beforeEach(() => {
-    // Index targets before sources so link resolution finds them
-    index.upsertNote("spoke-a.md", "# Spoke A\n\nBody.\n", 1000)
-    index.upsertNote("spoke-b.md", "# Spoke B\n\nNo backlink.\n", 2000)
-    index.upsertNote("island.md", "# Island\n\nNo links at all.\n", 3000)
+    // hub links to spoke-a and spoke-b; spoke-a links back to hub.
+    // upsertNote re-resolves stale targets, so ordering doesn't matter.
     index.upsertNote(
       "hub.md",
       "# Hub\n\nLinks to [[spoke-a]] and [[spoke-b]].\n",
-      4000,
+      1000,
     )
-    // Re-index spoke-a now that hub exists, so its [[hub]] link resolves
     index.upsertNote(
       "spoke-a.md",
       "# Spoke A\n\nLinks back to [[hub]].\n",
-      5000,
+      2000,
     )
+    index.upsertNote("spoke-b.md", "# Spoke B\n\nNo backlink.\n", 3000)
+    index.upsertNote("island.md", "# Island\n\nNo links at all.\n", 4000)
   })
 
   it("finds notes linking to the target", () => {
@@ -699,14 +733,15 @@ describe("getBacklinks", () => {
 
 describe("getOutgoingLinks", () => {
   beforeEach(() => {
-    index.upsertNote(
-      "target-exists.md",
-      "---\ntitle: Target\n---\n\n# Target\n\nBody.\n",
-      1000,
-    )
+    // source links to target-exists (will be resolved) and NonExistent (unresolved)
     index.upsertNote(
       "source.md",
       "# Source\n\n[[target-exists]] and [[NonExistent]].\n",
+      1000,
+    )
+    index.upsertNote(
+      "target-exists.md",
+      "---\ntitle: Target\n---\n\n# Target\n\nBody.\n",
       2000,
     )
   })
@@ -738,8 +773,8 @@ describe("getOutgoingLinks", () => {
 
 describe("findOrphans", () => {
   beforeEach(() => {
-    index.upsertNote("connected.md", "# Connected\n\nBody.\n", 1000)
-    index.upsertNote("hub.md", "# Hub\n\n[[connected]].\n", 2000)
+    index.upsertNote("hub.md", "# Hub\n\n[[connected]].\n", 1000)
+    index.upsertNote("connected.md", "# Connected\n\nBody.\n", 2000)
     index.upsertNote(
       "Projects/orphan.md",
       "---\ntitle: Orphan\ntype: project\ntags: [project]\n---\n\n# Orphan\n\nNobody links here.\n",
@@ -789,5 +824,23 @@ describe("findOrphans", () => {
     expect(orphan).toHaveProperty("tags")
     expect(orphan).toHaveProperty("folder")
     expect(orphan).toHaveProperty("modified")
+  })
+
+  it("treats self-linking notes as orphans", () => {
+    index.upsertNote("self-ref.md", "# Self\n\nLinks to [[self-ref]].\n", 5000)
+    const orphans = index.findOrphans({}, logger)
+    const orphanPaths = orphans.map((o) => o.path)
+    expect(orphanPaths).toContain("self-ref.md")
+  })
+})
+
+describe("forward reference resolution", () => {
+  it("resolves backlinks when target is indexed after source", () => {
+    index.upsertNote("source.md", "# Source\n\nLinks to [[target]].\n", 1000)
+    index.upsertNote("target.md", "# Target\n\nBody.\n", 2000)
+
+    const backlinks = index.getBacklinks({ path: "target.md" }, logger)
+    expect(backlinks).toHaveLength(1)
+    expect(backlinks[0].path).toBe("source.md")
   })
 })

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -646,9 +646,9 @@ describe("extractLinks", () => {
     expect(links).toHaveLength(0)
   })
 
-  it("handles malformed percent-encoding without throwing", () => {
-    const links = extractLinks("[done](100%25complete.md)")
-    expect(links).toBeDefined()
+  it("falls back to raw target when percent-encoding is malformed", () => {
+    const links = extractLinks("[done](100%zzcomplete.md)")
+    expect(links).toContain("100%zzcomplete")
   })
 })
 
@@ -714,7 +714,7 @@ describe("getBacklinks", () => {
     expect(backlinks[0].path).toBe("hub.md")
   })
 
-  it("returns multiple backlinks", () => {
+  it("finds backlinks from notes that link to the target", () => {
     const backlinks = index.getBacklinks({ path: "hub.md" }, logger)
     expect(backlinks).toHaveLength(1)
     expect(backlinks[0].path).toBe("spoke-a.md")
@@ -748,9 +748,9 @@ describe("getOutgoingLinks", () => {
 
   it("returns outgoing links with exists flag", () => {
     const links = index.getOutgoingLinks({ path: "source.md" }, logger)
-    expect(links.length).toBeGreaterThanOrEqual(1)
+    expect(links).toHaveLength(2)
 
-    const existing = links.find((l) => l.path === "target-exists.md")
+    const existing = links.find((link) => link.path === "target-exists.md")
     expect(existing).toBeDefined()
     expect(existing!.exists).toBe(true)
     expect(existing!.title).toBe("Target")
@@ -758,7 +758,7 @@ describe("getOutgoingLinks", () => {
 
   it("marks unresolved links as exists: false", () => {
     const links = index.getOutgoingLinks({ path: "source.md" }, logger)
-    const missing = links.find((l) => l.path === "NonExistent")
+    const missing = links.find((link) => link.path === "NonExistent")
     expect(missing).toBeDefined()
     expect(missing!.exists).toBe(false)
     expect(missing!.title).toBeNull()
@@ -789,25 +789,25 @@ describe("findOrphans", () => {
 
   it("finds notes with no incoming links", () => {
     const orphans = index.findOrphans({}, logger)
-    const orphanPaths = orphans.map((o) => o.path)
+    const orphanPaths = orphans.map((orphan) => orphan.path)
     expect(orphanPaths).toContain("Projects/orphan.md")
   })
 
   it("excludes connected notes", () => {
     const orphans = index.findOrphans({}, logger)
-    const orphanPaths = orphans.map((o) => o.path)
+    const orphanPaths = orphans.map((orphan) => orphan.path)
     expect(orphanPaths).not.toContain("connected.md")
   })
 
   it("excludes Daily Notes by default", () => {
     const orphans = index.findOrphans({}, logger)
-    const orphanPaths = orphans.map((o) => o.path)
+    const orphanPaths = orphans.map((orphan) => orphan.path)
     expect(orphanPaths).not.toContain("Daily Notes/2026-05-13.md")
   })
 
   it("includes Daily Notes when excluded folders are overridden", () => {
     const orphans = index.findOrphans({ excludeFolders: [] }, logger)
-    const orphanPaths = orphans.map((o) => o.path)
+    const orphanPaths = orphans.map((orphan) => orphan.path)
     expect(orphanPaths).toContain("Daily Notes/2026-05-13.md")
   })
 
@@ -818,18 +818,20 @@ describe("findOrphans", () => {
 
   it("returns NoteMetadata with all fields", () => {
     const orphans = index.findOrphans({}, logger)
-    const orphan = orphans.find((o) => o.path === "Projects/orphan.md")
-    expect(orphan).toBeDefined()
-    expect(orphan).toHaveProperty("title")
-    expect(orphan).toHaveProperty("tags")
-    expect(orphan).toHaveProperty("folder")
-    expect(orphan).toHaveProperty("modified")
+    const projectOrphan = orphans.find(
+      (orphan) => orphan.path === "Projects/orphan.md",
+    )
+    expect(projectOrphan).toBeDefined()
+    expect(projectOrphan).toHaveProperty("title")
+    expect(projectOrphan).toHaveProperty("tags")
+    expect(projectOrphan).toHaveProperty("folder")
+    expect(projectOrphan).toHaveProperty("modified")
   })
 
   it("treats self-linking notes as orphans", () => {
     index.upsertNote("self-ref.md", "# Self\n\nLinks to [[self-ref]].\n", 5000)
     const orphans = index.findOrphans({}, logger)
-    const orphanPaths = orphans.map((o) => o.path)
+    const orphanPaths = orphans.map((orphan) => orphan.path)
     expect(orphanPaths).toContain("self-ref.md")
   })
 })

--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -20,6 +20,9 @@ const TOOL_NAMES = [
   "vault_update_memory",
   "vault_list_memory_files",
   "vault_delete_memory",
+  "vault_get_backlinks",
+  "vault_get_outgoing_links",
+  "vault_find_orphans",
 ] as const
 
 const READ_ONLY_TOOLS = [
@@ -32,6 +35,9 @@ const READ_ONLY_TOOLS = [
   "vault_recent_notes",
   "vault_get_memory",
   "vault_list_memory_files",
+  "vault_get_backlinks",
+  "vault_get_outgoing_links",
+  "vault_find_orphans",
 ] as const
 
 const DESTRUCTIVE_TOOLS = [
@@ -69,8 +75,8 @@ const findCall = (name: string): RegisterToolCall | undefined =>
   calls.find((c) => c[0] === name)
 
 describe("registerTools", () => {
-  it("registers exactly 15 tools", () => {
-    expect(mockServer.registerTool).toHaveBeenCalledTimes(15)
+  it("registers exactly 18 tools", () => {
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(18)
   })
 
   it.each(TOOL_NAMES)("registers %s", (name) => {

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -89,19 +89,19 @@ type NoteRow = {
 
 // ── Link extraction ─────────────────────────────────────────────
 
-/** Matches fenced code block openers: 3+ backticks or 3+ tildes. */
-const FENCE_OPEN = /^(`{3,}|~{3,})/
+/** Matches fenced code block openers: 0-3 spaces indent + 3+ backticks or tildes (CommonMark §4.5). */
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/
 
 /** Matches wikilinks: [[target]], [[target|text]], [[target#heading]],
  *  [[target#heading|text]], and embeds ![[target]]. Captures the
  *  target path/name (group 1) before any # or |. */
 const WIKILINK_RE = /!?\[\[([^\]#|]+)(?:#[^\]|]*)?(?:\|[^\]]+)?\]\]/g
 
-/** Matches markdown internal links: [text](path) or [text](path#heading).
- *  Excludes external URLs (http://, https://, mailto:) and same-page
- *  anchors (#heading). Captures the path (group 1). */
+/** Matches markdown internal links to .md files: [text](path.md) or
+ *  [text](path.md#heading). Excludes external URLs and non-.md assets
+ *  (images, PDFs). Captures the path without extension (group 1). */
 const MD_LINK_RE =
-  /\[[^\]]*\]\((?!https?:\/\/|mailto:|#)([^)#\s]+?)(?:\.md)?(?:#[^)\s]*)?\)/g
+  /\[[^\]]*\]\((?!https?:\/\/|mailto:|#)([^)#\s]+?)\.md(?:#[^)\s]*)?\)/g
 
 /** Extracts link targets from markdown content, skipping fenced code blocks.
  *  Returns deduplicated raw targets (pre-resolution). */
@@ -113,12 +113,13 @@ export const extractLinks = (content: string): string[] => {
   for (const line of lines) {
     const fenceMatch = FENCE_OPEN.exec(line)
     if (fenceMatch) {
+      const fenceChars = fenceMatch[1]!
       if (currentFenceOpener === null) {
-        currentFenceOpener = fenceMatch[1][0]!.repeat(fenceMatch[1].length)
+        currentFenceOpener = fenceChars[0]!.repeat(fenceChars.length)
       } else if (
-        line.startsWith(currentFenceOpener[0]!) &&
-        line.trimEnd().length >= currentFenceOpener.length &&
-        line.trimEnd() === line.trimEnd()[0]!.repeat(line.trimEnd().length)
+        fenceChars[0] === currentFenceOpener[0] &&
+        fenceChars.length >= currentFenceOpener.length &&
+        line.trim() === fenceChars[0]!.repeat(line.trim().length)
       ) {
         currentFenceOpener = null
       }
@@ -126,12 +127,20 @@ export const extractLinks = (content: string): string[] => {
     }
     if (currentFenceOpener !== null) continue
 
-    for (const match of line.matchAll(WIKILINK_RE)) {
+    const stripped = line.replace(/`+[^`\n]*`+/g, (m) => " ".repeat(m.length))
+
+    for (const match of stripped.matchAll(WIKILINK_RE)) {
       const target = match[1]!.trim()
       if (target.length > 0) targets.add(target)
     }
-    for (const match of line.matchAll(MD_LINK_RE)) {
-      const target = decodeURIComponent(match[1]!.trim())
+    for (const match of stripped.matchAll(MD_LINK_RE)) {
+      const raw = match[1]!.trim()
+      let target: string
+      try {
+        target = decodeURIComponent(raw)
+      } catch {
+        target = raw
+      }
       if (target.length > 0) targets.add(target)
     }
   }
@@ -215,11 +224,18 @@ export const createSearchIndex = (dbPath: string) => {
   // FTS rows are managed manually (delete-then-insert) because SQLite triggers
   // combined with INSERT OR REPLACE cause FTS5 corruption.
 
-  /** Parses a note's content and frontmatter, then indexes it for search. */
+  const reResolveStmt = db.prepare(
+    `UPDATE links SET target = @resolved WHERE target = @raw`,
+  )
+
+  /** Parses a note's content and frontmatter, then indexes it for search.
+   *  Set skipLinks to true during bulk rebuild (rebuildFromVault handles
+   *  links in a separate pass with a complete path list). */
   const upsertNote = (
     filePath: string,
     rawContent: string,
     lastModifiedMs: number,
+    skipLinks = false,
   ): void => {
     const parsed = matter(rawContent)
     const { data } = parsed
@@ -268,15 +284,22 @@ export const createSearchIndex = (dbPath: string) => {
     )
     insertFtsStmt.run(note.path, note.title, note.content)
 
-    const allPaths = db.prepare("SELECT path FROM notes").all() as Array<{
-      path: string
-    }>
-    const pathList = allPaths.map((r) => r.path)
+    if (!skipLinks) {
+      const allPaths = db.prepare("SELECT path FROM notes").all() as Array<{
+        path: string
+      }>
+      const pathList = allPaths.map((r) => r.path)
 
-    deleteLinksStmt.run(note.path)
-    for (const rawTarget of extractLinks(parsed.content)) {
-      const resolved = resolveLink(rawTarget, pathList)
-      insertLinkStmt.run(note.path, resolved ?? rawTarget)
+      deleteLinksStmt.run(note.path)
+      for (const rawTarget of extractLinks(parsed.content)) {
+        const resolved = resolveLink(rawTarget, pathList)
+        insertLinkStmt.run(note.path, resolved ?? rawTarget)
+      }
+
+      // Re-resolve stale unresolved targets that now match the newly added note
+      const fileBasename = basename(note.path, ".md")
+      reResolveStmt.run({ resolved: note.path, raw: fileBasename })
+      reResolveStmt.run({ resolved: note.path, raw: note.path })
     }
   }
 
@@ -322,9 +345,10 @@ export const createSearchIndex = (dbPath: string) => {
     )
 
     db.transaction(() => {
-      // Pass 1: index all notes (content, frontmatter, FTS)
+      // Pass 1: index all notes (content, frontmatter, FTS) — skip link
+      // extraction here; Pass 2 handles it with the complete path list.
       for (const item of items) {
-        upsertNote(item.rel, item.content, item.mtime)
+        upsertNote(item.rel, item.content, item.mtime, true)
       }
 
       // Pass 2: re-extract links now that all paths are in the notes table,
@@ -647,7 +671,7 @@ export const createSearchIndex = (dbPath: string) => {
     const limit = params.limit ?? 50
 
     const folderExclusions = excludeFolders
-      .map(() => "folder != ?")
+      .map(() => "path NOT LIKE ? || '/%'")
       .join(" AND ")
     const whereClause =
       folderExclusions.length > 0 ? `AND ${folderExclusions}` : ""
@@ -655,7 +679,7 @@ export const createSearchIndex = (dbPath: string) => {
     const sql = `
       SELECT path, title, tags, related, folder, type, created, mtime, properties
       FROM notes
-      WHERE path NOT IN (SELECT DISTINCT target FROM links)
+      WHERE path NOT IN (SELECT DISTINCT target FROM links WHERE source != target)
         ${whereClause}
       ORDER BY mtime DESC
       LIMIT ?

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -280,11 +280,13 @@ export const createSearchIndex = (dbPath: string) => {
   `)
   // path UNINDEXED: stored for JOIN/DELETE but not searchable, saves index space
 
+  // Prepared statements are compiled once here and reused across all calls.
+  // db.prepare() caches the compiled SQL — calling it inside a function
+  // would re-compile on every invocation.
   const upsertNotesStmt = db.prepare(`
     INSERT OR REPLACE INTO notes (path, title, content, tags, related, folder, type, created, mtime, properties)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
-
   const deleteFtsStmt = db.prepare(`DELETE FROM notes_fts WHERE path = ?`)
   const insertFtsStmt = db.prepare(
     `INSERT INTO notes_fts (path, title, content) VALUES (?, ?, ?)`,
@@ -293,6 +295,9 @@ export const createSearchIndex = (dbPath: string) => {
   const deleteLinksStmt = db.prepare(`DELETE FROM links WHERE source = ?`)
   const insertLinkStmt = db.prepare(
     `INSERT OR IGNORE INTO links (source, target) VALUES (?, ?)`,
+  )
+  const reResolveStmt = db.prepare(
+    `UPDATE links SET target = @resolved WHERE target = @raw`,
   )
 
   // ── Index maintenance ──────────────────────────────────────────
@@ -371,9 +376,6 @@ export const createSearchIndex = (dbPath: string) => {
     // Re-resolve stale unresolved targets that match the newly added note.
     // Two forms: wikilinks store just the basename ("Note"), markdown links
     // may store the full path ("folder/Note.md").
-    const reResolveStmt = db.prepare(
-      `UPDATE links SET target = @resolved WHERE target = @raw`,
-    )
     const fileBasename = basename(note.path, ".md")
     reResolveStmt.run({ resolved: note.path, raw: fileBasename })
     reResolveStmt.run({ resolved: note.path, raw: note.path })

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -332,7 +332,9 @@ export const createSearchIndex = (dbPath: string) => {
       insertLinkStmt.run(note.path, resolved ?? rawTarget)
     }
 
-    // Re-resolve stale unresolved targets that now match the newly added note
+    // Re-resolve stale unresolved targets that match the newly added note.
+    // Two forms: wikilinks store just the basename ("Note"), markdown links
+    // may store the full path ("folder/Note.md").
     const fileBasename = basename(note.path, ".md")
     reResolveStmt.run({ resolved: note.path, raw: fileBasename })
     reResolveStmt.run({ resolved: note.path, raw: note.path })
@@ -702,8 +704,10 @@ export const createSearchIndex = (dbPath: string) => {
       .map(() => "path NOT LIKE ? || '/%'")
       .join(" AND ")
     const whereClause =
-      folderExclusions.length > 0 ? `AND ${folderExclusions}` : ""
+      excludeFolders.length > 0 ? `AND ${folderExclusions}` : ""
 
+    // Self-links (source = target) are excluded from the backlink subquery
+    // so a note that only links to itself is still considered an orphan.
     const sql = `
       SELECT path, title, tags, related, folder, type, created, mtime, properties
       FROM notes

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -122,6 +122,24 @@ type OutgoingLinkEntry = {
 }
 
 // ── Link extraction ─────────────────────────────────────────────
+//
+// Links between notes are tracked in a `links` table (source → target)
+// to power backlink queries, outgoing link lookups, and orphan detection.
+//
+// Indexing flow:
+//   1. extractLinks() parses wikilinks ([[target]]) and markdown links
+//      ([text](path.md)) from note body, skipping fenced code blocks
+//      and inline code spans.
+//   2. resolveLink() maps each raw target to a vault-relative path by
+//      trying exact match → basename match → shortest-path heuristic.
+//   3. upsertNote stores resolved links in the `links` table. Unresolved
+//      targets are stored as-is (raw text) for broken-link detection.
+//   4. When a new note is created, upsertNote re-resolves any stale
+//      unresolved targets that now match the new note's path or basename
+//      (handles Obsidian's "link first, create later" workflow).
+//   5. rebuildFromVault uses a two-pass approach: Pass 1 indexes all
+//      notes without links (skipLinks), Pass 2 extracts links with the
+//      complete path list so all targets can resolve.
 
 /** Matches fenced code block openers: 0-3 spaces indent + 3+ backticks or tildes (CommonMark §4.5). */
 const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/
@@ -282,22 +300,14 @@ export const createSearchIndex = (dbPath: string) => {
   // FTS rows are managed manually (delete-then-insert) because SQLite triggers
   // combined with INSERT OR REPLACE cause FTS5 corruption.
 
-  // When a new note is indexed, any previously-unresolved link targets that
-  // match the new note's path or basename are updated to the resolved path.
-  // This handles the "link first, create later" workflow common in Obsidian.
-  const reResolveStmt = db.prepare(
-    `UPDATE links SET target = @resolved WHERE target = @raw`,
-  )
-
-  /** Parses a note's content and frontmatter, then indexes it for search.
-   *  Set skipLinks to true during bulk rebuild (rebuildFromVault handles
-   *  links in a separate pass with a complete path list). */
+  /** Parses a note's content and frontmatter, then indexes it for search. */
   const upsertNote = (
     filePath: string,
     rawContent: string,
     lastModifiedMs: number,
-    skipLinks = false,
+    options?: { skipLinks?: boolean },
   ): void => {
+    const skipLinks = options?.skipLinks ?? false
     const parsed = matter(rawContent)
     const { data } = parsed
 
@@ -361,6 +371,9 @@ export const createSearchIndex = (dbPath: string) => {
     // Re-resolve stale unresolved targets that match the newly added note.
     // Two forms: wikilinks store just the basename ("Note"), markdown links
     // may store the full path ("folder/Note.md").
+    const reResolveStmt = db.prepare(
+      `UPDATE links SET target = @resolved WHERE target = @raw`,
+    )
     const fileBasename = basename(note.path, ".md")
     reResolveStmt.run({ resolved: note.path, raw: fileBasename })
     reResolveStmt.run({ resolved: note.path, raw: note.path })
@@ -411,7 +424,9 @@ export const createSearchIndex = (dbPath: string) => {
       // Pass 1: index all notes (content, frontmatter, FTS) — skip link
       // extraction here; Pass 2 handles it with the complete path list.
       for (const item of items) {
-        upsertNote(item.rel, item.content, item.mtime, true)
+        // Skip link extraction here — Pass 2 handles it with the complete
+        // path list so all forward references can resolve correctly.
+        upsertNote(item.rel, item.content, item.mtime, { skipLinks: true })
       }
 
       // Pass 2: re-extract links now that all paths are in the notes table,

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -87,6 +87,14 @@ type NoteRow = {
   properties: string
 }
 
+type BacklinkEntry = { path: string; title: string }
+
+type OutgoingLinkEntry = {
+  path: string
+  title: string | null
+  exists: boolean
+}
+
 // ── Link extraction ─────────────────────────────────────────────
 
 /** Matches fenced code block openers: 0-3 spaces indent + 3+ backticks or tildes (CommonMark §4.5). */
@@ -103,11 +111,30 @@ const WIKILINK_RE = /!?\[\[([^\]#|]+)(?:#[^\]|]*)?(?:\|[^\]]+)?\]\]/g
 const MD_LINK_RE =
   /\[[^\]]*\]\((?!https?:\/\/|mailto:|#)([^)#\s]+?)\.md(?:#[^)\s]*)?\)/g
 
-/** Extracts link targets from markdown content, skipping fenced code blocks.
- *  Returns deduplicated raw targets (pre-resolution). */
+/** Safely decodes a URI component, falling back to the raw string
+ *  if the percent-encoding is malformed (e.g. "100%complete"). */
+const safeDecodeURIComponent = (encoded: string): string => {
+  try {
+    return decodeURIComponent(encoded)
+  } catch {
+    return encoded
+  }
+}
+
+/** Strips inline code spans from a line so links inside backticks
+ *  (e.g. `[[Note]]`) are not extracted as real links. */
+const INLINE_CODE_RE = /`+[^`\n]*`+/g
+
+/** Extracts link targets from markdown content, skipping fenced code
+ *  blocks and inline code spans. Returns deduplicated raw targets
+ *  (pre-resolution). */
 export const extractLinks = (content: string): string[] => {
   const lines = content.split("\n")
   const targets = new Set<string>()
+
+  // Mutable state: tracks whether we're inside a fenced code block.
+  // A state machine needs mutable state — no immutable alternative
+  // without restructuring into a reduce over line-state pairs.
   let currentFenceOpener: string | null = null
 
   for (const line of lines) {
@@ -117,6 +144,8 @@ export const extractLinks = (content: string): string[] => {
       if (currentFenceOpener === null) {
         currentFenceOpener = fenceChars[0]!.repeat(fenceChars.length)
       } else if (
+        // Closer must use the same character as the opener (backtick vs tilde),
+        // be at least as long, and contain only fence characters (no trailing content)
         fenceChars[0] === currentFenceOpener[0] &&
         fenceChars.length >= currentFenceOpener.length &&
         line.trim() === fenceChars[0]!.repeat(line.trim().length)
@@ -127,20 +156,17 @@ export const extractLinks = (content: string): string[] => {
     }
     if (currentFenceOpener !== null) continue
 
-    const stripped = line.replace(/`+[^`\n]*`+/g, (m) => " ".repeat(m.length))
+    // Replace inline code spans with spaces so links inside backticks are ignored
+    const withoutInlineCode = line.replace(INLINE_CODE_RE, (match) =>
+      " ".repeat(match.length),
+    )
 
-    for (const match of stripped.matchAll(WIKILINK_RE)) {
+    for (const match of withoutInlineCode.matchAll(WIKILINK_RE)) {
       const target = match[1]!.trim()
       if (target.length > 0) targets.add(target)
     }
-    for (const match of stripped.matchAll(MD_LINK_RE)) {
-      const raw = match[1]!.trim()
-      let target: string
-      try {
-        target = decodeURIComponent(raw)
-      } catch {
-        target = raw
-      }
+    for (const match of withoutInlineCode.matchAll(MD_LINK_RE)) {
+      const target = safeDecodeURIComponent(match[1]!.trim())
       if (target.length > 0) targets.add(target)
     }
   }
@@ -153,16 +179,22 @@ export const resolveLink = (
   target: string,
   allPaths: string[],
 ): string | null => {
-  const withExt = target.endsWith(".md") ? target : `${target}.md`
-  if (allPaths.includes(withExt)) return withExt
+  const targetWithExtension = target.endsWith(".md") ? target : `${target}.md`
 
+  // Exact path match: "folder/Note.md" or "Note.md"
+  if (allPaths.includes(targetWithExtension)) return targetWithExtension
+
+  // Basename match: find all paths that end with the target filename
   const basenameMatches = allPaths.filter(
-    (p) => p === withExt || p.endsWith(`/${withExt}`),
+    (candidatePath) =>
+      candidatePath === targetWithExtension ||
+      candidatePath.endsWith(`/${targetWithExtension}`),
   )
   if (basenameMatches.length === 1) return basenameMatches[0]!
+  // Multiple matches: prefer the shortest path (Obsidian's resolution heuristic)
   if (basenameMatches.length > 1) {
-    return basenameMatches.reduce((shortest, p) =>
-      p.length < shortest.length ? p : shortest,
+    return basenameMatches.reduce((shortest, candidatePath) =>
+      candidatePath.length < shortest.length ? candidatePath : shortest,
     )
   }
 
@@ -224,6 +256,9 @@ export const createSearchIndex = (dbPath: string) => {
   // FTS rows are managed manually (delete-then-insert) because SQLite triggers
   // combined with INSERT OR REPLACE cause FTS5 corruption.
 
+  // When a new note is indexed, any previously-unresolved link targets that
+  // match the new note's path or basename are updated to the resolved path.
+  // This handles the "link first, create later" workflow common in Obsidian.
   const reResolveStmt = db.prepare(
     `UPDATE links SET target = @resolved WHERE target = @raw`,
   )
@@ -288,7 +323,7 @@ export const createSearchIndex = (dbPath: string) => {
       const allPaths = db.prepare("SELECT path FROM notes").all() as Array<{
         path: string
       }>
-      const pathList = allPaths.map((r) => r.path)
+      const pathList = allPaths.map((row) => row.path)
 
       deleteLinksStmt.run(note.path)
       for (const rawTarget of extractLinks(parsed.content)) {
@@ -357,7 +392,7 @@ export const createSearchIndex = (dbPath: string) => {
       const allPaths = db.prepare("SELECT path FROM notes").all() as Array<{
         path: string
       }>
-      const pathList = allPaths.map((r) => r.path)
+      const pathList = allPaths.map((row) => row.path)
 
       db.exec("DELETE FROM links")
       for (const item of items) {
@@ -597,13 +632,6 @@ export const createSearchIndex = (dbPath: string) => {
 
   // ── Link queries ────────────────────────────────────────────────
 
-  type BacklinkEntry = { path: string; title: string }
-  type OutgoingLinkEntry = {
-    path: string
-    title: string | null
-    exists: boolean
-  }
-
   /** Returns notes that link TO the given path (incoming links / backlinks). */
   const getBacklinks = (
     params: { path: string },
@@ -646,10 +674,10 @@ export const createSearchIndex = (dbPath: string) => {
       title: string | null
       exists_flag: number
     }>
-    const results = rows.map((r) => ({
-      path: r.path,
-      title: r.title,
-      exists: r.exists_flag === 1,
+    const results = rows.map((row) => ({
+      path: row.path,
+      title: row.title,
+      exists: row.exists_flag === 1,
     }))
     logger.info("get outgoing links", {
       path: params.path,

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -87,6 +87,79 @@ type NoteRow = {
   properties: string
 }
 
+// ── Link extraction ─────────────────────────────────────────────
+
+/** Matches fenced code block openers: 3+ backticks or 3+ tildes. */
+const FENCE_OPEN = /^(`{3,}|~{3,})/
+
+/** Matches wikilinks: [[target]], [[target|text]], [[target#heading]],
+ *  [[target#heading|text]], and embeds ![[target]]. Captures the
+ *  target path/name (group 1) before any # or |. */
+const WIKILINK_RE = /!?\[\[([^\]#|]+)(?:#[^\]|]*)?(?:\|[^\]]+)?\]\]/g
+
+/** Matches markdown internal links: [text](path) or [text](path#heading).
+ *  Excludes external URLs (http://, https://, mailto:) and same-page
+ *  anchors (#heading). Captures the path (group 1). */
+const MD_LINK_RE =
+  /\[[^\]]*\]\((?!https?:\/\/|mailto:|#)([^)#\s]+?)(?:\.md)?(?:#[^)\s]*)?\)/g
+
+/** Extracts link targets from markdown content, skipping fenced code blocks.
+ *  Returns deduplicated raw targets (pre-resolution). */
+export const extractLinks = (content: string): string[] => {
+  const lines = content.split("\n")
+  const targets = new Set<string>()
+  let currentFenceOpener: string | null = null
+
+  for (const line of lines) {
+    const fenceMatch = FENCE_OPEN.exec(line)
+    if (fenceMatch) {
+      if (currentFenceOpener === null) {
+        currentFenceOpener = fenceMatch[1][0]!.repeat(fenceMatch[1].length)
+      } else if (
+        line.startsWith(currentFenceOpener[0]!) &&
+        line.trimEnd().length >= currentFenceOpener.length &&
+        line.trimEnd() === line.trimEnd()[0]!.repeat(line.trimEnd().length)
+      ) {
+        currentFenceOpener = null
+      }
+      continue
+    }
+    if (currentFenceOpener !== null) continue
+
+    for (const match of line.matchAll(WIKILINK_RE)) {
+      const target = match[1]!.trim()
+      if (target.length > 0) targets.add(target)
+    }
+    for (const match of line.matchAll(MD_LINK_RE)) {
+      const target = decodeURIComponent(match[1]!.trim())
+      if (target.length > 0) targets.add(target)
+    }
+  }
+  return [...targets]
+}
+
+/** Resolves a wikilink target to a vault-relative path using all known paths.
+ *  Returns null if unresolvable. */
+export const resolveLink = (
+  target: string,
+  allPaths: string[],
+): string | null => {
+  const withExt = target.endsWith(".md") ? target : `${target}.md`
+  if (allPaths.includes(withExt)) return withExt
+
+  const basenameMatches = allPaths.filter(
+    (p) => p === withExt || p.endsWith(`/${withExt}`),
+  )
+  if (basenameMatches.length === 1) return basenameMatches[0]!
+  if (basenameMatches.length > 1) {
+    return basenameMatches.reduce((shortest, p) =>
+      p.length < shortest.length ? p : shortest,
+    )
+  }
+
+  return null
+}
+
 // ── Factory ─────────────────────────────────────────────────────
 
 export const createSearchIndex = (dbPath: string) => {
@@ -111,6 +184,14 @@ export const createSearchIndex = (dbPath: string) => {
     CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
       path UNINDEXED, title, content, tokenize='porter unicode61'
     );
+
+    CREATE TABLE IF NOT EXISTS links (
+      source TEXT NOT NULL,
+      target TEXT NOT NULL,
+      PRIMARY KEY (source, target)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_links_target ON links(target);
   `)
   // path UNINDEXED: stored for JOIN/DELETE but not searchable, saves index space
 
@@ -124,6 +205,10 @@ export const createSearchIndex = (dbPath: string) => {
     `INSERT INTO notes_fts (path, title, content) VALUES (?, ?, ?)`,
   )
   const removeNotesStmt = db.prepare(`DELETE FROM notes WHERE path = ?`)
+  const deleteLinksStmt = db.prepare(`DELETE FROM links WHERE source = ?`)
+  const insertLinkStmt = db.prepare(
+    `INSERT OR IGNORE INTO links (source, target) VALUES (?, ?)`,
+  )
 
   // ── Index maintenance ──────────────────────────────────────────
 
@@ -182,18 +267,31 @@ export const createSearchIndex = (dbPath: string) => {
       note.properties,
     )
     insertFtsStmt.run(note.path, note.title, note.content)
+
+    const allPaths = db.prepare("SELECT path FROM notes").all() as Array<{
+      path: string
+    }>
+    const pathList = allPaths.map((r) => r.path)
+
+    deleteLinksStmt.run(note.path)
+    for (const rawTarget of extractLinks(parsed.content)) {
+      const resolved = resolveLink(rawTarget, pathList)
+      insertLinkStmt.run(note.path, resolved ?? rawTarget)
+    }
   }
 
-  /** Removes a note from both the notes table and FTS index. */
+  /** Removes a note from the notes table, FTS index, and links. */
   const removeNote = (filePath: string): void => {
     deleteFtsStmt.run(filePath)
     removeNotesStmt.run(filePath)
+    deleteLinksStmt.run(filePath)
   }
 
   /** Drops the entire index and re-indexes every .md file in the vault. */
   const rebuildFromVault = async (vaultPath: string): Promise<number> => {
     db.exec("DELETE FROM notes_fts")
     db.exec("DELETE FROM notes")
+    db.exec("DELETE FROM links")
 
     const normalizedVault = resolve(vaultPath)
     const entries = await readdir(vaultPath, {
@@ -224,8 +322,26 @@ export const createSearchIndex = (dbPath: string) => {
     )
 
     db.transaction(() => {
+      // Pass 1: index all notes (content, frontmatter, FTS)
       for (const item of items) {
         upsertNote(item.rel, item.content, item.mtime)
+      }
+
+      // Pass 2: re-extract links now that all paths are in the notes table,
+      // resolving targets that the per-note upsertNote pass may have missed
+      // (e.g. Note A links to Note B, but Note B was indexed after Note A).
+      const allPaths = db.prepare("SELECT path FROM notes").all() as Array<{
+        path: string
+      }>
+      const pathList = allPaths.map((r) => r.path)
+
+      db.exec("DELETE FROM links")
+      for (const item of items) {
+        const parsed = matter(item.content)
+        for (const rawTarget of extractLinks(parsed.content)) {
+          const resolved = resolveLink(rawTarget, pathList)
+          insertLinkStmt.run(item.rel, resolved ?? rawTarget)
+        }
       }
     })()
 
@@ -455,6 +571,102 @@ export const createSearchIndex = (dbPath: string) => {
     return results
   }
 
+  // ── Link queries ────────────────────────────────────────────────
+
+  type BacklinkEntry = { path: string; title: string }
+  type OutgoingLinkEntry = {
+    path: string
+    title: string | null
+    exists: boolean
+  }
+
+  /** Returns notes that link TO the given path (incoming links / backlinks). */
+  const getBacklinks = (
+    params: { path: string },
+    logger: Logger,
+  ): BacklinkEntry[] => {
+    const sql = `
+      SELECT n.path, n.title
+      FROM links l
+      JOIN notes n ON n.path = l.source
+      WHERE l.target = ?
+      ORDER BY n.title
+    `
+    const rows = db.prepare(sql).all(params.path) as Array<{
+      path: string
+      title: string
+    }>
+    logger.info("get backlinks", {
+      path: params.path,
+      count: rows.length,
+    })
+    return rows
+  }
+
+  /** Returns notes that the given path links TO (outgoing links). */
+  const getOutgoingLinks = (
+    params: { path: string },
+    logger: Logger,
+  ): OutgoingLinkEntry[] => {
+    const sql = `
+      SELECT l.target as path,
+             n.title,
+             CASE WHEN n.path IS NOT NULL THEN 1 ELSE 0 END as exists_flag
+      FROM links l
+      LEFT JOIN notes n ON n.path = l.target
+      WHERE l.source = ?
+      ORDER BY l.target
+    `
+    const rows = db.prepare(sql).all(params.path) as Array<{
+      path: string
+      title: string | null
+      exists_flag: number
+    }>
+    const results = rows.map((r) => ({
+      path: r.path,
+      title: r.title,
+      exists: r.exists_flag === 1,
+    }))
+    logger.info("get outgoing links", {
+      path: params.path,
+      count: results.length,
+    })
+    return results
+  }
+
+  /** Finds notes with no incoming links (orphans). */
+  const findOrphans = (
+    params: { excludeFolders?: string[]; limit?: number },
+    logger: Logger,
+  ): NoteMetadata[] => {
+    const excludeFolders = params.excludeFolders ?? [
+      "Daily Notes",
+      "Templates",
+      "About Me",
+    ]
+    const limit = params.limit ?? 50
+
+    const folderExclusions = excludeFolders
+      .map(() => "folder != ?")
+      .join(" AND ")
+    const whereClause =
+      folderExclusions.length > 0 ? `AND ${folderExclusions}` : ""
+
+    const sql = `
+      SELECT path, title, tags, related, folder, type, created, mtime, properties
+      FROM notes
+      WHERE path NOT IN (SELECT DISTINCT target FROM links)
+        ${whereClause}
+      ORDER BY mtime DESC
+      LIMIT ?
+    `
+
+    const rows = db.prepare(sql).all(...excludeFolders, limit) as NoteRow[]
+    const results = rows.map(rowToMetadata)
+    logger.info("find orphans", { count: results.length })
+    return results
+  }
+
   return {
     upsertNote,
     removeNote,
@@ -465,6 +677,9 @@ export const createSearchIndex = (dbPath: string) => {
     searchByType,
     listAllTags,
     recentNotes,
+    getBacklinks,
+    getOutgoingLinks,
+    findOrphans,
   }
 }
 

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -319,23 +319,23 @@ export const createSearchIndex = (dbPath: string) => {
     )
     insertFtsStmt.run(note.path, note.title, note.content)
 
-    if (!skipLinks) {
-      const allPaths = db.prepare("SELECT path FROM notes").all() as Array<{
-        path: string
-      }>
-      const pathList = allPaths.map((row) => row.path)
+    if (skipLinks) return
 
-      deleteLinksStmt.run(note.path)
-      for (const rawTarget of extractLinks(parsed.content)) {
-        const resolved = resolveLink(rawTarget, pathList)
-        insertLinkStmt.run(note.path, resolved ?? rawTarget)
-      }
+    const allPaths = db.prepare("SELECT path FROM notes").all() as Array<{
+      path: string
+    }>
+    const pathList = allPaths.map((row) => row.path)
 
-      // Re-resolve stale unresolved targets that now match the newly added note
-      const fileBasename = basename(note.path, ".md")
-      reResolveStmt.run({ resolved: note.path, raw: fileBasename })
-      reResolveStmt.run({ resolved: note.path, raw: note.path })
+    deleteLinksStmt.run(note.path)
+    for (const rawTarget of extractLinks(parsed.content)) {
+      const resolved = resolveLink(rawTarget, pathList)
+      insertLinkStmt.run(note.path, resolved ?? rawTarget)
     }
+
+    // Re-resolve stale unresolved targets that now match the newly added note
+    const fileBasename = basename(note.path, ".md")
+    reResolveStmt.run({ resolved: note.path, raw: fileBasename })
+    reResolveStmt.run({ resolved: note.path, raw: note.path })
   }
 
   /** Removes a note from the notes table, FTS index, and links. */

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -24,6 +24,9 @@ export type ToolName =
   | "vault_update_memory"
   | "vault_list_memory_files"
   | "vault_delete_memory"
+  | "vault_get_backlinks"
+  | "vault_get_outgoing_links"
+  | "vault_find_orphans"
 
 // ── Response shaping ─────────────────────────────────────────────
 
@@ -820,5 +823,141 @@ Returns: Confirmation message.`,
     },
   )
 
-  sessionLogger.info("registered tools", { count: 15 })
+  // ── Links ──────────────────────────────────────────────────
+
+  server.registerTool(
+    "vault_get_backlinks",
+    {
+      title: "Get Backlinks",
+      description: `Find all notes that link to a given note (incoming wikilinks and markdown links). Shows which notes reference the target — useful for understanding a note's context and importance in the vault's knowledge graph.
+
+Example: vault_get_backlinks({ path: "Projects/vault-cortex.md" })
+
+When to use: When you need to understand what references a note, find related context, or assess a note's connectivity. Core Obsidian concept — backlinks are invisible without a database query.
+For outgoing links (what a note links TO), use vault_get_outgoing_links. For orphan detection, use vault_find_orphans.
+
+Errors:
+- No error if the note has zero backlinks — returns an empty array.
+
+Returns: JSON with path (the queried note), backlinks (array of { path, title }), and count.`,
+      inputSchema: {
+        path: z
+          .string()
+          .describe(
+            'Vault-relative path to the note (e.g. "Projects/vault-cortex.md")',
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ path }, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_get_backlinks",
+      })
+      reqLogger.info("tool_call", { path })
+      return safeHandler(
+        reqLogger,
+        async () => search.getBacklinks({ path }, reqLogger),
+        (backlinks) =>
+          JSON.stringify({ path, backlinks, count: backlinks.length }),
+      )
+    },
+  )
+
+  server.registerTool(
+    "vault_get_outgoing_links",
+    {
+      title: "Get Outgoing Links",
+      description: `Find all notes that a given note links to (outgoing wikilinks and markdown links). Each link includes an exists flag — false means the target note doesn't exist (broken link).
+
+Example: vault_get_outgoing_links({ path: "Projects/vault-cortex.md" })
+
+When to use: When you need to see what a note references, navigate the knowledge graph forward, or detect broken links in a specific note.
+For incoming links (what links TO a note), use vault_get_backlinks.
+
+Errors:
+- No error if the note has zero outgoing links — returns an empty array.
+
+Returns: JSON with path (the queried note), outgoing_links (array of { path, title, exists }), and count.`,
+      inputSchema: {
+        path: z.string().describe("Vault-relative path to the note"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ path }, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_get_outgoing_links",
+      })
+      reqLogger.info("tool_call", { path })
+      return safeHandler(
+        reqLogger,
+        async () => search.getOutgoingLinks({ path }, reqLogger),
+        (outgoingLinks) =>
+          JSON.stringify({
+            path,
+            outgoing_links: outgoingLinks,
+            count: outgoingLinks.length,
+          }),
+      )
+    },
+  )
+
+  server.registerTool(
+    "vault_find_orphans",
+    {
+      title: "Find Orphans",
+      description: `Find notes with no incoming links from other notes. Orphan notes are disconnected from the vault's knowledge graph — they may be forgotten or need linking from relevant notes.
+
+Example: vault_find_orphans() or vault_find_orphans({ exclude_folders: ["Daily Notes", "Templates", "About Me"] })
+
+When to use: Vault maintenance and organization. Helps identify notes that might be forgotten or need integration into the knowledge graph. Daily Notes, Templates, and About Me folders are excluded by default since those are standalone by design.
+To add links to an orphan, use vault_patch_note to mention it from a relevant note.
+
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified.`,
+      inputSchema: {
+        exclude_folders: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Folders to exclude (default: ["Daily Notes", "Templates", "About Me"])',
+          ),
+        limit: z.number().optional().describe("Max results (default 50)"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ exclude_folders, limit }, extra) => {
+      const reqLogger = sessionLogger.child({
+        requestId: extra.requestId,
+        tool: "vault_find_orphans",
+      })
+      reqLogger.info("tool_call", { exclude_folders, limit })
+      return safeHandler(
+        reqLogger,
+        async () =>
+          search.findOrphans(
+            { excludeFolders: exclude_folders, limit },
+            reqLogger,
+          ),
+        (results) => JSON.stringify(results.map(formatNoteMetadata)),
+      )
+    },
+  )
+
+  sessionLogger.info("registered tools", { count: 18 })
 }

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -110,6 +110,7 @@ Returns: Raw markdown string.`,
       inputSchema: {
         path: z
           .string()
+          .min(1)
           .describe(
             'Vault-relative path to the note (e.g. "About Me/Principles.md")',
           ),
@@ -150,7 +151,7 @@ Limitation: Overwrites the entire body. Do not use for surgical edits to large f
 
 Returns: Confirmation message.`,
       inputSchema: {
-        path: z.string().describe("Vault-relative path for the note"),
+        path: z.string().min(1).describe("Vault-relative path for the note"),
         body: z
           .string()
           .describe("Markdown body content (no frontmatter fences)"),
@@ -210,7 +211,7 @@ Errors:
 
 Returns: Confirmation message.`,
       inputSchema: {
-        path: z.string().describe("Vault-relative path to the note"),
+        path: z.string().min(1).describe("Vault-relative path to the note"),
         operation: z
           .enum(["append", "prepend", "replace", "insert_before"])
           .describe("Patch operation to apply"),
@@ -283,7 +284,7 @@ Errors:
 
 Returns: Confirmation message with replacement count.`,
       inputSchema: {
-        path: z.string().describe("Vault-relative path to the note"),
+        path: z.string().min(1).describe("Vault-relative path to the note"),
         old_text: z
           .string()
           .min(1)
@@ -385,7 +386,10 @@ Prefer vault_delete_memory for removing individual dated entries from About Me/ 
 
 Returns: Confirmation message.`,
       inputSchema: {
-        path: z.string().describe("Vault-relative path of the note to delete"),
+        path: z
+          .string()
+          .min(1)
+          .describe("Vault-relative path of the note to delete"),
       },
       annotations: {
         readOnlyHint: false,
@@ -1018,6 +1022,7 @@ Returns: JSON with path (the queried note), backlinks (array of { path, title })
       inputSchema: {
         path: z
           .string()
+          .min(1)
           .describe(
             'Vault-relative path to the note (e.g. "Projects/vault-cortex.md")',
           ),
@@ -1060,7 +1065,7 @@ Errors:
 
 Returns: JSON with path (the queried note), outgoing_links (array of { path, title, exists }), and count.`,
       inputSchema: {
-        path: z.string().describe("Vault-relative path to the note"),
+        path: z.string().min(1).describe("Vault-relative path to the note"),
       },
       annotations: {
         readOnlyHint: true,


### PR DESCRIPTION
## Summary

- **`vault_get_backlinks`** — finds notes linking TO a given path. Core Obsidian concept — backlinks are invisible without a database query.
- **`vault_get_outgoing_links`** — finds notes a given path links TO, with `exists: true/false` for broken-link detection at the single-note level.
- **`vault_find_orphans`** — finds notes with no incoming links (disconnected from the knowledge graph). Excludes Daily Notes, Templates, and About Me by default.

New `links` table (deduplicated by source+target pair, indexed on target for fast backlink lookups). Link extraction uses fence-aware regex parsing — skips `[[wikilinks]]` and `[markdown](links.md)` inside fenced code blocks. Resolution: exact path → basename match → shortest path for ambiguous basenames.

Indexing pipeline changes:
- `upsertNote` — extracts links from body, resolves against known paths, stores in `links` table
- `removeNote` — cleans up outgoing links from deleted notes
- `rebuildFromVault` — two-pass: index all notes first, then re-extract links with the complete path list for accurate resolution

39 new tests (284 → 323).

**Note:** This PR branches from `main`. PR #15 (property + daily note tools) modifies the same files — expect trivial merge conflicts (list appends, count updates) after #15 lands.

## Test plan

- [x] `npm test` — 323 tests pass
- [x] `npm run build` — TypeScript compiles clean
- [x] Pre-commit hooks pass
- [x] Deploy to Lightsail, verify 18 tools via Claude Desktop
- [x] Test backlinks: pick a well-linked note, verify results match Obsidian's backlinks pane
- [x] Test outgoing links: verify `exists: false` for links to non-existent notes
- [x] Test orphans: verify Daily Notes/About Me excluded, known orphans appear
- [x] Test file watcher: edit a note's links, verify backlinks update without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)