### PR TITLE
fix: FTS5 hyphen-as-negation in vault_search

### DIFF
--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -281,10 +281,10 @@ describe("fullTextSearch", () => {
   it("hyphenated query matches content containing the hyphenated term", () => {
     index.upsertNote(
       "project.md",
-      "The vault-cortex server exposes an MCP API\n",
+      "The flux-capacitor enables time travel\n",
       6000,
     )
-    const results = index.fullTextSearch({ query: "vault-cortex" }, logger)
+    const results = index.fullTextSearch({ query: "flux-capacitor" }, logger)
     expect(results).toHaveLength(1)
     expect(results[0].path).toBe("project.md")
   })

--- a/src/vault-mcp/__tests__/search-index.test.ts
+++ b/src/vault-mcp/__tests__/search-index.test.ts
@@ -277,6 +277,17 @@ describe("fullTextSearch", () => {
       ),
     ).not.toThrow()
   })
+
+  it("hyphenated query matches content containing the hyphenated term", () => {
+    index.upsertNote(
+      "project.md",
+      "The vault-cortex server exposes an MCP API\n",
+      6000,
+    )
+    const results = index.fullTextSearch({ query: "vault-cortex" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("project.md")
+  })
 })
 
 describe("sanitizeFtsQuery", () => {
@@ -325,6 +336,41 @@ describe("sanitizeFtsQuery", () => {
       name: "caret and colon stripped",
       input: "field:value ^boost",
       expected: "field value boost",
+    },
+    {
+      name: "hyphenated compound → quoted phrase",
+      input: "vault-cortex",
+      expected: '"vault cortex"',
+    },
+    {
+      name: "multi-hyphen compound → quoted phrase",
+      input: "self-hosted-app",
+      expected: '"self hosted app"',
+    },
+    {
+      name: "hyphenated + bare terms",
+      input: "vault-cortex search",
+      expected: '"vault cortex" search',
+    },
+    {
+      name: "multiple hyphenated terms",
+      input: "vault-cortex self-hosted",
+      expected: '"vault cortex" "self hosted"',
+    },
+    {
+      name: "leading hyphen stripped",
+      input: "-excluded term",
+      expected: "excluded term",
+    },
+    {
+      name: "hyphen inside quoted phrase preserved",
+      input: '"vault-cortex"',
+      expected: '"vault-cortex"',
+    },
+    {
+      name: "mixed: quoted phrase + hyphenated + bare",
+      input: 'search "exact-match" vault-cortex',
+      expected: '"exact-match" "vault cortex" search',
     },
   ]
 

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -41,15 +41,25 @@ const HYPHENATED_COMPOUND_REGEX = /\b(\w+(?:-\w+)+)\b/g
  *  metacharacters and reserved words are stripped. */
 export const sanitizeFtsQuery = (raw: string): string => {
   const phrases: string[] = []
+
+  // Extract "quoted phrases", strip FTS5 metacharacters inside them,
+  // and collect into phrases[]. Hyphens inside quotes are left alone —
+  // the unicode61 tokenizer splits them correctly in phrase queries.
   const remaining = raw.replace(/"([^"]+)"/g, (_, phrase: string) => {
     const cleaned = phrase.replace(/[*^():]/g, "").trim()
     if (cleaned.length > 0) phrases.push(`"${cleaned}"`)
     return " "
   })
+
+  // Convert bare hyphenated compounds (vault-cortex → "vault cortex")
+  // so FTS5 doesn't interpret the hyphen as the NOT operator.
   const afterHyphens = remaining.replace(HYPHENATED_COMPOUND_REGEX, (match) => {
     phrases.push(`"${match.replace(/-/g, " ")}"`)
     return " "
   })
+
+  // Strip remaining FTS5 metacharacters (including stray/leading hyphens),
+  // split into tokens, and drop reserved words (AND, OR, NOT, NEAR).
   const tokens = afterHyphens
     .replace(/["*^():-]/g, " ")
     .split(/\s+/)

--- a/src/vault-mcp/search-index.ts
+++ b/src/vault-mcp/search-index.ts
@@ -30,9 +30,15 @@ const convertFrontmatterDatesToIsoStrings = (
 
 const FTS5_RESERVED = new Set(["AND", "OR", "NOT", "NEAR"])
 
+/** Matches hyphenated compound terms (e.g. vault-cortex, self-hosted-app)
+ *  where at least two word segments are joined by hyphens. */
+const HYPHENATED_COMPOUND_REGEX = /\b(\w+(?:-\w+)+)\b/g
+
 /** Sanitizes user input for safe FTS5 querying. Quoted phrases are preserved
- *  for exact-phrase matching; unquoted terms are left bare to preserve porter
- *  stemming. FTS5 metacharacters and reserved words are stripped. */
+ *  for exact-phrase matching. Hyphenated compound terms (e.g. vault-cortex)
+ *  are converted to quoted phrases for adjacent-token matching. Remaining
+ *  unquoted terms are left bare to preserve porter stemming. FTS5
+ *  metacharacters and reserved words are stripped. */
 export const sanitizeFtsQuery = (raw: string): string => {
   const phrases: string[] = []
   const remaining = raw.replace(/"([^"]+)"/g, (_, phrase: string) => {
@@ -40,8 +46,12 @@ export const sanitizeFtsQuery = (raw: string): string => {
     if (cleaned.length > 0) phrases.push(`"${cleaned}"`)
     return " "
   })
-  const tokens = remaining
-    .replace(/["*^():]/g, " ")
+  const afterHyphens = remaining.replace(HYPHENATED_COMPOUND_REGEX, (match) => {
+    phrases.push(`"${match.replace(/-/g, " ")}"`)
+    return " "
+  })
+  const tokens = afterHyphens
+    .replace(/["*^():-]/g, " ")
     .split(/\s+/)
     .filter((t) => t.length > 0 && !FTS5_RESERVED.has(t.toUpperCase()))
 


### PR DESCRIPTION
## Summary

- Unquoted hyphenated terms (e.g. `vault-cortex`) were interpreted by FTS5 as negation (`vault NOT cortex`), returning 0 results
- `sanitizeFtsQuery` now detects hyphenated compound terms and converts them to quoted phrases (`"vault cortex"`) for adjacent-token matching
- Stray/leading hyphens (e.g. `-excluded`) are stripped in the metacharacter cleanup pass, consistent with other FTS5 operator stripping

## Test plan

- [x] 7 new unit test scenarios for `sanitizeFtsQuery` (compound, multi-hyphen, mixed, leading hyphen, quoted phrase preservation)
- [x] 1 new integration test: index a note containing "vault-cortex", search unquoted `vault-cortex`, verify it's found
- [x] All 418 tests pass (410 existing + 8 new)
- [x] Live-verify on deployed server: `vault_search({ query: "vault-cortex" })` returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)