### PR TITLE
feat: externalize configuration for open-source adoption

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ PUBLIC_URL=
 #   docker run --rm -it --entrypoint get-token \
 #     ghcr.io/belphemur/obsidian-headless-sync-docker:latest
 OBSIDIAN_AUTH_TOKEN=
-VAULT_NAME=My Vault
+VAULT_NAME=
 VAULT_PASSWORD=              # only if vault has E2E encryption
 GHCR_TOKEN=
 
@@ -31,11 +31,22 @@ GHCR_TOKEN=
 # LIGHTSAIL_SSH_KEY=~/.ssh/vault-cortex
 
 # Docker
-GHCR_USER=aliasunder
+GHCR_USER=
 PUID=1000
 PGID=1000
 DEVICE_NAME=vault-cortex-lightsail
 CONFLICT_STRATEGY=merge
 SYNC_MODE=bidirectional
 LOG_LEVEL=info
-TZ=America/New_York
+TZ=UTC
+
+# vault-cortex configuration
+# Memory folder name in your vault (default: "About Me")
+MEMORY_DIR=About Me
+# Comma-separated folders protected from deletion (default: MEMORY_DIR, Daily Notes).
+# If your daily notes folder has a custom name (e.g. "Journal"), override to include it.
+# PROTECTED_PATHS=About Me,Daily Notes
+# Comma-separated folders excluded from orphan detection (default: Daily Notes, Templates, MEMORY_DIR)
+# ORPHAN_EXCLUDE_FOLDERS=Daily Notes,Templates,About Me
+# URL shown in OAuth discovery metadata (default: https://github.com/aliasunder/vault-cortex)
+# SERVICE_DOCUMENTATION_URL=https://github.com/youruser/your-fork

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,7 @@ jobs:
           VAULT_NAME: ${{ vars.VAULT_NAME }}
           VAULT_PASSWORD: ${{ secrets.VAULT_PASSWORD }}
           GHCR_USER: ${{ vars.GHCR_USER }}
+          MEMORY_DIR: ${{ vars.MEMORY_DIR }}
         run: |
           umask 077
           cat > "$RUNNER_TEMP/lightsail.env" <<EOF
@@ -117,6 +118,7 @@ jobs:
           VAULT_NAME=$VAULT_NAME
           VAULT_PASSWORD=$VAULT_PASSWORD
           GHCR_USER=$GHCR_USER
+          MEMORY_DIR=${MEMORY_DIR:-About Me}
           PUID=1000
           PGID=1000
           DEVICE_NAME=vault-cortex-lightsail

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,6 +112,7 @@ jobs:
           PROTECTED_PATHS: ${{ vars.PROTECTED_PATHS }}
           ORPHAN_EXCLUDE_FOLDERS: ${{ vars.ORPHAN_EXCLUDE_FOLDERS }}
           SERVICE_DOCUMENTATION_URL: ${{ vars.SERVICE_DOCUMENTATION_URL }}
+          TZ: ${{ vars.TZ }}
         run: |
           umask 077
           cat > "$RUNNER_TEMP/lightsail.env" <<EOF
@@ -131,7 +132,7 @@ jobs:
           CONFLICT_STRATEGY=merge
           SYNC_MODE=bidirectional
           LOG_LEVEL=info
-          TZ=UTC
+          TZ=${TZ:-UTC}
           EOF
 
       - name: Ship compose + .env to instance

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,7 @@ jobs:
           CONFLICT_STRATEGY=merge
           SYNC_MODE=bidirectional
           LOG_LEVEL=info
-          TZ=America/New_York
+          TZ=UTC
           EOF
 
       - name: Ship compose + .env to instance

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,6 +109,9 @@ jobs:
           VAULT_PASSWORD: ${{ secrets.VAULT_PASSWORD }}
           GHCR_USER: ${{ vars.GHCR_USER }}
           MEMORY_DIR: ${{ vars.MEMORY_DIR }}
+          PROTECTED_PATHS: ${{ vars.PROTECTED_PATHS }}
+          ORPHAN_EXCLUDE_FOLDERS: ${{ vars.ORPHAN_EXCLUDE_FOLDERS }}
+          SERVICE_DOCUMENTATION_URL: ${{ vars.SERVICE_DOCUMENTATION_URL }}
         run: |
           umask 077
           cat > "$RUNNER_TEMP/lightsail.env" <<EOF
@@ -119,6 +122,9 @@ jobs:
           VAULT_PASSWORD=$VAULT_PASSWORD
           GHCR_USER=$GHCR_USER
           MEMORY_DIR=${MEMORY_DIR:-About Me}
+          PROTECTED_PATHS=$PROTECTED_PATHS
+          ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS
+          SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL
           PUID=1000
           PGID=1000
           DEVICE_NAME=vault-cortex-lightsail

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,7 @@ container, a new watcher callback, and a new tool.
 | R2  | Remote vault read access        | 1     | Any MCP client can read any note by path, list notes in any folder. |
 | R3  | Remote vault write access       | 1     | Writes sync back to all Obsidian apps automatically via R1.         |
 | R4  | Full-text and structured search | 1     | SQLite FTS5 — ranked results, filter by tags/type/folder.           |
-| R5  | Memory tools                    | 1     | Read/append to `About Me/` semantic memory files.                   |
+| R5  | Memory tools                    | 1     | Read/append to configurable memory folder (default: `About Me/`).   |
 | R6  | Secure remote access            | 1     | HTTPS via API Gateway. OAuth 2.0 + static bearer token.             |
 | R7  | Low operational overhead        | 1     | Always-on, no manual intervention. ~$12/mo. IaC via SST.            |
 | R8  | Extensible for semantic search  | 2     | LightRAG plugs into existing watcher. Not a rewrite.                |
@@ -173,7 +173,7 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 
 `vault_patch_note` supports 4 operations: `append`, `prepend`, `replace`, `insert_before` — heading-targeted with optional file-level mode. `vault_replace_in_note` does exact text find-and-replace in the note body.
 
-`vault_delete_note` refuses paths under `About Me/` or `Daily Notes/` as a server-side guardrail; use `vault_delete_memory` for individual entries in those files.
+`vault_delete_note` refuses paths under folders listed in `PROTECTED_PATHS` (default: the memory dir + `Daily Notes/`) as a server-side guardrail; use `vault_delete_memory` for individual entries in memory files.
 
 ### Phase 1: Search (R4)
 
@@ -215,7 +215,7 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 | `vault_get_outgoing_links` | `path`                     | readOnlyHint |
 | `vault_find_orphans`       | `exclude_folders?, limit?` | readOnlyHint |
 
-Link queries use a `links` table populated from `[[wikilink]]` and `[text](path.md)` regex during indexing, with fence-aware parsing (skips code blocks). Links are resolved against all known note paths (shortest-path-first for ambiguous basenames). `vault_find_orphans` excludes `Daily Notes`, `Templates`, and `About Me` folders by default.
+Link queries use a `links` table populated from `[[wikilink]]` and `[text](path.md)` regex during indexing, with fence-aware parsing (skips code blocks). Links are resolved against all known note paths (shortest-path-first for ambiguous basenames). `vault_find_orphans` excludes folders listed in `ORPHAN_EXCLUDE_FOLDERS` (default: `Daily Notes`, `Templates`, and the memory dir).
 
 ### Phase 2: Knowledge Base (R8)
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ vault-cortex reads configuration from environment variables at startup. All sett
 
 The memory tools (`vault_get_memory`, `vault_update_memory`, `vault_list_memory_files`, `vault_delete_memory`) read and write structured files in a configurable folder inside the vault. These files use H2 headings as sections and dated bullets (`- **YYYY-MM-DD**: text`) as entries.
 
-Example memory files are provided in `templates/memory/`. Copy them into your vault's memory folder to get started:
+Example memory files are provided in [`templates/memory/`](./templates/memory/). Copy them into your vault's memory folder to get started:
 
 ```bash
 cp templates/memory/Principles.md ~/your-vault/About\ Me/
@@ -173,7 +173,7 @@ Then open `~/.config/vault-cortex/.env` and fill in the remaining values:
 | `VAULT_PASSWORD`      | Only if vault has E2E encryption                                         |
 | `OBSIDIAN_AUTH_TOKEN` | Generate with the command below                                          |
 
-The `.env.example` file also includes optional configuration for the memory system (`MEMORY_DIR`, `PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`), timezone (`TZ`), and OAuth metadata (`SERVICE_DOCUMENTATION_URL`). All have sensible defaults — see [Configuration](#configuration) for details.
+The [`.env.example`](./.env.example) file also includes optional configuration for the memory system (`MEMORY_DIR`, `PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`), timezone (`TZ`), and OAuth metadata (`SERVICE_DOCUMENTATION_URL`). All have sensible defaults — see [Configuration](#configuration) for details.
 
 ```bash
 docker run --rm -it --entrypoint get-token ghcr.io/belphemur/obsidian-headless-sync-docker:latest

--- a/README.md
+++ b/README.md
@@ -265,9 +265,9 @@ GitHub Actions runs lint/test/build on every PR and push to main, and handles re
 | `SST_STAGE`                 | SST stage name. Must match the stage your laptop deploys to so CI lands on the same Lightsail instance and SST state.                                                                         |
 | `VAULT_NAME`                | Exact (case-sensitive) Obsidian vault name.                                                                                                                                                   |
 | `MEMORY_DIR`                | Optional. Memory folder name in the vault (default: `About Me`). See [Configuration](#configuration).                                                                                         |
-| `PROTECTED_PATHS`           | Optional. Comma-separated folders protected from deletion. Overrides the default when set.                                                                                                    |
-| `ORPHAN_EXCLUDE_FOLDERS`    | Optional. Comma-separated folders excluded from orphan detection. Overrides the default when set.                                                                                             |
-| `SERVICE_DOCUMENTATION_URL` | Optional. URL shown in OAuth discovery metadata. Set to your fork's URL.                                                                                                                      |
+| `PROTECTED_PATHS`           | Optional. Comma-separated folders protected from deletion (default: `MEMORY_DIR, Daily Notes`). Overrides the default entirely when set.                                                      |
+| `ORPHAN_EXCLUDE_FOLDERS`    | Optional. Comma-separated folders excluded from orphan detection (default: `Daily Notes, Templates, MEMORY_DIR`). Overrides the default entirely when set.                                    |
+| `SERVICE_DOCUMENTATION_URL` | Optional. URL in OAuth discovery metadata (default: `https://github.com/aliasunder/vault-cortex`). Set to your fork's URL.                                                                    |
 | `TZ`                        | Optional. Container timezone (default: `UTC`). Affects `vault_update_memory` date stamps and `vault_get_daily_note` date resolution. Set to your IANA timezone (e.g. `America/New_York`).     |
 
 **Secrets** (Settings → Secrets and variables → Actions → Secrets tab) — sensitive credentials:

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ GitHub Actions runs lint/test/build on every PR and push to main, and handles re
 | `PUBLIC_URL`          | API Gateway URL (e.g. `https://<id>.execute-api.us-east-1.amazonaws.com`). Used for the healthcheck and written into the instance `.env` as the OAuth issuer URL.                             |
 | `SST_STAGE`           | SST stage name. Must match the stage your laptop deploys to so CI lands on the same Lightsail instance and SST state.                                                                         |
 | `VAULT_NAME`          | Exact (case-sensitive) Obsidian vault name.                                                                                                                                                   |
+| `MEMORY_DIR`          | Optional. Memory folder name in the vault (default: `About Me`). See [Configuration](#configuration).                                                                                         |
 
 **Secrets** (Settings → Secrets and variables → Actions → Secrets tab) — sensitive credentials:
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ GitHub Actions runs lint/test/build on every PR and push to main, and handles re
 | `PROTECTED_PATHS`           | Optional. Comma-separated folders protected from deletion. Overrides the default when set.                                                                                                    |
 | `ORPHAN_EXCLUDE_FOLDERS`    | Optional. Comma-separated folders excluded from orphan detection. Overrides the default when set.                                                                                             |
 | `SERVICE_DOCUMENTATION_URL` | Optional. URL shown in OAuth discovery metadata. Set to your fork's URL.                                                                                                                      |
+| `TZ`                        | Optional. Container timezone (default: `UTC`). Affects `vault_update_memory` date stamps and `vault_get_daily_note` date resolution. Set to your IANA timezone (e.g. `America/New_York`).     |
 
 **Secrets** (Settings → Secrets and variables → Actions → Secrets tab) — sensitive credentials:
 

--- a/README.md
+++ b/README.md
@@ -257,14 +257,17 @@ GitHub Actions runs lint/test/build on every PR and push to main, and handles re
 
 **Variables** (Settings → Secrets and variables → Actions → Variables tab) — non-sensitive identifiers and config:
 
-| Variable              | Purpose                                                                                                                                                                                       |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AWS_DEPLOY_ROLE_ARN` | IAM role assumed via GitHub OIDC by `aws-actions/configure-aws-credentials`. Trust policy is scoped to this repo. ARN is an identifier, not a credential — use a repo variable, not a secret. |
-| `GHCR_USER`           | GitHub username. Used in image tags and instance `.env`.                                                                                                                                      |
-| `PUBLIC_URL`          | API Gateway URL (e.g. `https://<id>.execute-api.us-east-1.amazonaws.com`). Used for the healthcheck and written into the instance `.env` as the OAuth issuer URL.                             |
-| `SST_STAGE`           | SST stage name. Must match the stage your laptop deploys to so CI lands on the same Lightsail instance and SST state.                                                                         |
-| `VAULT_NAME`          | Exact (case-sensitive) Obsidian vault name.                                                                                                                                                   |
-| `MEMORY_DIR`          | Optional. Memory folder name in the vault (default: `About Me`). See [Configuration](#configuration).                                                                                         |
+| Variable                    | Purpose                                                                                                                                                                                       |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AWS_DEPLOY_ROLE_ARN`       | IAM role assumed via GitHub OIDC by `aws-actions/configure-aws-credentials`. Trust policy is scoped to this repo. ARN is an identifier, not a credential — use a repo variable, not a secret. |
+| `GHCR_USER`                 | GitHub username. Used in image tags and instance `.env`.                                                                                                                                      |
+| `PUBLIC_URL`                | API Gateway URL (e.g. `https://<id>.execute-api.us-east-1.amazonaws.com`). Used for the healthcheck and written into the instance `.env` as the OAuth issuer URL.                             |
+| `SST_STAGE`                 | SST stage name. Must match the stage your laptop deploys to so CI lands on the same Lightsail instance and SST state.                                                                         |
+| `VAULT_NAME`                | Exact (case-sensitive) Obsidian vault name.                                                                                                                                                   |
+| `MEMORY_DIR`                | Optional. Memory folder name in the vault (default: `About Me`). See [Configuration](#configuration).                                                                                         |
+| `PROTECTED_PATHS`           | Optional. Comma-separated folders protected from deletion. Overrides the default when set.                                                                                                    |
+| `ORPHAN_EXCLUDE_FOLDERS`    | Optional. Comma-separated folders excluded from orphan detection. Overrides the default when set.                                                                                             |
+| `SERVICE_DOCUMENTATION_URL` | Optional. URL shown in OAuth discovery metadata. Set to your fork's URL.                                                                                                                      |
 
 **Secrets** (Settings → Secrets and variables → Actions → Secrets tab) — sensitive credentials:
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Then open `~/.config/vault-cortex/.env` and fill in the remaining values:
 | `VAULT_PASSWORD`      | Only if vault has E2E encryption                                         |
 | `OBSIDIAN_AUTH_TOKEN` | Generate with the command below                                          |
 
+The `.env.example` file also includes optional configuration for the memory system (`MEMORY_DIR`, `PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`), timezone (`TZ`), and OAuth metadata (`SERVICE_DOCUMENTATION_URL`). All have sensible defaults — see [Configuration](#configuration) for details.
+
 ```bash
 docker run --rm -it --entrypoint get-token ghcr.io/belphemur/obsidian-headless-sync-docker:latest
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Contex
 
 - [Architecture](#architecture)
 - [Authentication](#authentication)
+- [Configuration](#configuration)
 - [Deployment](#deployment)
 - [CI/CD](#cicd)
 - [Local development](#local-development)
@@ -79,6 +80,45 @@ npm run lightsail:up
 ```
 
 Existing JWTs signed with the old key become invalid immediately. OAuth clients will silently re-authenticate on their next token refresh.
+
+## Configuration
+
+vault-cortex reads configuration from environment variables at startup. All settings have sensible defaults — only `MCP_AUTH_TOKEN`, `VAULT_PATH`, and `PUBLIC_URL` are required.
+
+### Memory system
+
+The memory tools (`vault_get_memory`, `vault_update_memory`, `vault_list_memory_files`, `vault_delete_memory`) read and write structured files in a configurable folder inside the vault. These files use H2 headings as sections and dated bullets (`- **YYYY-MM-DD**: text`) as entries.
+
+Example memory files are provided in `templates/memory/`. Copy them into your vault's memory folder to get started:
+
+```bash
+cp templates/memory/Principles.md ~/your-vault/About\ Me/
+cp templates/memory/Opinions.md ~/your-vault/About\ Me/
+```
+
+### Environment variables
+
+| Variable                    | Default                                      | Description                                                                                                                                                             |
+| --------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MEMORY_DIR`                | `About Me`                                   | Vault folder containing memory files. Tool descriptions, error messages, and protected-path defaults all derive from this value.                                        |
+| `PROTECTED_PATHS`           | `MEMORY_DIR, Daily Notes`                    | Comma-separated folders that `vault_delete_note` refuses to delete. Overrides the default entirely when set — include your memory dir if you want it protected.         |
+| `ORPHAN_EXCLUDE_FOLDERS`    | `Daily Notes, Templates, MEMORY_DIR`         | Comma-separated folders excluded from `vault_find_orphans` results. These folders contain standalone notes (daily notes, templates, memory) that are orphans by design. |
+| `SERVICE_DOCUMENTATION_URL` | `https://github.com/aliasunder/vault-cortex` | URL returned in OAuth `.well-known` discovery metadata. Set this if you fork the project.                                                                               |
+
+**Smart defaults:** When you set `MEMORY_DIR`, the default values for `PROTECTED_PATHS` and `ORPHAN_EXCLUDE_FOLDERS` automatically include the new folder name. You only need to set those explicitly if you want a completely custom list.
+
+**Custom daily notes folder:** If you've renamed Obsidian's daily notes folder (e.g. to "Journal"), add it to `PROTECTED_PATHS` and `ORPHAN_EXCLUDE_FOLDERS` manually — the `vault_get_daily_note` tool reads the folder name from `.obsidian/daily-notes.json` at runtime, but the protection and orphan-exclusion defaults use "Daily Notes".
+
+### Validation
+
+All folder-name env vars are validated at startup:
+
+- Empty or whitespace-only values are treated as unset (defaults apply)
+- Path traversal (`..`) and absolute paths (`/`) are rejected
+- Trailing slashes are stripped automatically
+- `SERVICE_DOCUMENTATION_URL` must be a valid URL
+
+Invalid config crashes the server immediately with a descriptive error.
 
 ## Deployment
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -20,6 +20,7 @@ services:
       MCP_AUTH_TOKEN: local-dev-token
       PUBLIC_URL: http://localhost:8000
       LOG_LEVEL: debug
+      MEMORY_DIR: ${MEMORY_DIR:-About Me}
     volumes:
       - ~/Vault:/vault:ro
       - mcp_local_data:/data

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -21,6 +21,10 @@ services:
       PUBLIC_URL: http://localhost:8000
       LOG_LEVEL: debug
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
+      TZ: ${TZ:-UTC}
+      PROTECTED_PATHS: ${PROTECTED_PATHS:-}
+      ORPHAN_EXCLUDE_FOLDERS: ${ORPHAN_EXCLUDE_FOLDERS:-}
+      SERVICE_DOCUMENTATION_URL: ${SERVICE_DOCUMENTATION_URL:-}
     volumes:
       - ~/Vault:/vault:ro
       - mcp_local_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,9 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-info}
       TZ: ${TZ:-UTC}
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
+      PROTECTED_PATHS: ${PROTECTED_PATHS:-}
+      ORPHAN_EXCLUDE_FOLDERS: ${ORPHAN_EXCLUDE_FOLDERS:-}
+      SERVICE_DOCUMENTATION_URL: ${SERVICE_DOCUMENTATION_URL:-}
     volumes:
       - vault_data:/vault:rw
       - mcp_index_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       DEVICE_NAME: ${DEVICE_NAME:-vault-cortex-lightsail}
       CONFLICT_STRATEGY: ${CONFLICT_STRATEGY:-merge}
       SYNC_MODE: ${SYNC_MODE:-bidirectional}
-      TZ: ${TZ:-America/New_York}
+      TZ: ${TZ:-UTC}
     volumes:
       - vault_data:/vault
       - obsidian_config:/home/obsidian/.config
@@ -55,7 +55,7 @@ services:
       options: { max-size: "10m", max-file: "3" }
 
   vault-mcp:
-    image: ghcr.io/${GHCR_USER:-aliasunder}/vault-mcp:latest
+    image: ghcr.io/${GHCR_USER:?GHCR_USER required}/vault-mcp:latest
     container_name: vault-mcp
     restart: unless-stopped
     depends_on:
@@ -70,7 +70,8 @@ services:
       MCP_AUTH_TOKEN: ${MCP_AUTH_TOKEN:?MCP_AUTH_TOKEN required for in-process auth}
       PUBLIC_URL: ${PUBLIC_URL:?PUBLIC_URL required for OAuth metadata}
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      TZ: ${TZ:-America/New_York}
+      TZ: ${TZ:-UTC}
+      MEMORY_DIR: ${MEMORY_DIR:-About Me}
     volumes:
       - vault_data:/vault:rw
       - mcp_index_data:/data

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -37,7 +37,11 @@ const expandHome = (p: string): string =>
   p.startsWith("~/") ? `${homedir()}${p.slice(1)}` : p
 
 const env: NodeJS.ProcessEnv = { ...loadDotEnv(), ...process.env }
-const ghcrUser = env.GHCR_USER ?? "aliasunder"
+const ghcrUser = env.GHCR_USER
+if (!ghcrUser) {
+  console.error("✕  GHCR_USER not set. Set it in ~/.config/vault-cortex/.env")
+  process.exit(1)
+}
 const image = `ghcr.io/${ghcrUser}/vault-mcp:latest`
 
 const run = (cmd: string): void => {

--- a/src/vault-mcp/__tests__/config.test.ts
+++ b/src/vault-mcp/__tests__/config.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest"
+import { loadConfig } from "../config.js"
+
+const EMPTY_ENV: Record<string, string | undefined> = {}
+
+describe("loadConfig", () => {
+  describe("defaults", () => {
+    it("returns correct defaults when no env vars are set", () => {
+      const config = loadConfig(EMPTY_ENV)
+      expect(config.memoryDir).toBe("About Me")
+      expect(config.protectedPaths).toEqual(["About Me", "Daily Notes"])
+      expect(config.orphanExcludeFolders).toEqual([
+        "Daily Notes",
+        "Templates",
+        "About Me",
+      ])
+      expect(config.serviceDocumentationUrl).toBe(
+        "https://github.com/aliasunder/vault-cortex",
+      )
+    })
+
+    it("returns a frozen (immutable) config object", () => {
+      const config = loadConfig(EMPTY_ENV)
+      expect(Object.isFrozen(config)).toBe(true)
+    })
+  })
+
+  describe("MEMORY_DIR", () => {
+    it("uses the provided value", () => {
+      const config = loadConfig({ MEMORY_DIR: "Profile" })
+      expect(config.memoryDir).toBe("Profile")
+    })
+
+    it("cascades into protectedPaths when PROTECTED_PATHS is not set", () => {
+      const config = loadConfig({ MEMORY_DIR: "Profile" })
+      expect(config.protectedPaths).toEqual(["Profile", "Daily Notes"])
+    })
+
+    it("cascades into orphanExcludeFolders when ORPHAN_EXCLUDE_FOLDERS is not set", () => {
+      const config = loadConfig({ MEMORY_DIR: "Profile" })
+      expect(config.orphanExcludeFolders).toEqual([
+        "Daily Notes",
+        "Templates",
+        "Profile",
+      ])
+    })
+
+    it("trims whitespace", () => {
+      const config = loadConfig({ MEMORY_DIR: "  Profile  " })
+      expect(config.memoryDir).toBe("Profile")
+    })
+
+    it("strips trailing slashes", () => {
+      const config = loadConfig({ MEMORY_DIR: "Profile/" })
+      expect(config.memoryDir).toBe("Profile")
+    })
+
+    it("strips multiple trailing slashes", () => {
+      const config = loadConfig({ MEMORY_DIR: "Profile///" })
+      expect(config.memoryDir).toBe("Profile")
+    })
+
+    it("treats empty string as unset and uses default", () => {
+      const config = loadConfig({ MEMORY_DIR: "" })
+      expect(config.memoryDir).toBe("About Me")
+    })
+
+    it("treats blank whitespace as unset and uses default", () => {
+      const config = loadConfig({ MEMORY_DIR: "   " })
+      expect(config.memoryDir).toBe("About Me")
+    })
+
+    it("rejects path traversal", () => {
+      expect(() => loadConfig({ MEMORY_DIR: "../secrets" })).toThrow(
+        "path traversal",
+      )
+    })
+
+    it("rejects absolute paths", () => {
+      expect(() => loadConfig({ MEMORY_DIR: "/etc/passwd" })).toThrow(
+        "absolute paths",
+      )
+    })
+
+    it("accepts folder names with spaces", () => {
+      const config = loadConfig({ MEMORY_DIR: "About Me" })
+      expect(config.memoryDir).toBe("About Me")
+    })
+
+    it("accepts nested folder paths", () => {
+      const config = loadConfig({ MEMORY_DIR: "My Vault/Memory" })
+      expect(config.memoryDir).toBe("My Vault/Memory")
+    })
+  })
+
+  describe("PROTECTED_PATHS (comma-separated)", () => {
+    it("overrides the default entirely", () => {
+      const config = loadConfig({ PROTECTED_PATHS: "Secrets,Archive" })
+      expect(config.protectedPaths).toEqual(["Secrets", "Archive"])
+    })
+
+    it("does not include MEMORY_DIR when explicitly set", () => {
+      const config = loadConfig({
+        MEMORY_DIR: "Profile",
+        PROTECTED_PATHS: "Secrets,Archive",
+      })
+      expect(config.protectedPaths).toEqual(["Secrets", "Archive"])
+      expect(config.protectedPaths).not.toContain("Profile")
+    })
+
+    it("trims whitespace around entries", () => {
+      const config = loadConfig({
+        PROTECTED_PATHS: " Secrets , Archive ",
+      })
+      expect(config.protectedPaths).toEqual(["Secrets", "Archive"])
+    })
+
+    it("filters out empty entries from trailing commas", () => {
+      const config = loadConfig({
+        PROTECTED_PATHS: "Secrets,Archive,",
+      })
+      expect(config.protectedPaths).toEqual(["Secrets", "Archive"])
+    })
+
+    it("validates each entry", () => {
+      expect(() =>
+        loadConfig({ PROTECTED_PATHS: "Secrets,../escape" }),
+      ).toThrow("path traversal")
+    })
+  })
+
+  describe("ORPHAN_EXCLUDE_FOLDERS (comma-separated)", () => {
+    it("overrides the default entirely", () => {
+      const config = loadConfig({
+        ORPHAN_EXCLUDE_FOLDERS: "Archive,Scratch",
+      })
+      expect(config.orphanExcludeFolders).toEqual(["Archive", "Scratch"])
+    })
+
+    it("does not include MEMORY_DIR when explicitly set", () => {
+      const config = loadConfig({
+        MEMORY_DIR: "Profile",
+        ORPHAN_EXCLUDE_FOLDERS: "Archive,Scratch",
+      })
+      expect(config.orphanExcludeFolders).toEqual(["Archive", "Scratch"])
+      expect(config.orphanExcludeFolders).not.toContain("Profile")
+    })
+
+    it("validates each entry", () => {
+      expect(() => loadConfig({ ORPHAN_EXCLUDE_FOLDERS: "/absolute" })).toThrow(
+        "absolute paths",
+      )
+    })
+  })
+
+  describe("SERVICE_DOCUMENTATION_URL", () => {
+    it("uses the provided URL", () => {
+      const config = loadConfig({
+        SERVICE_DOCUMENTATION_URL: "https://github.com/myuser/my-fork",
+      })
+      expect(config.serviceDocumentationUrl).toBe(
+        "https://github.com/myuser/my-fork",
+      )
+    })
+
+    it("rejects invalid URLs", () => {
+      expect(() =>
+        loadConfig({ SERVICE_DOCUMENTATION_URL: "not-a-url" }),
+      ).toThrow()
+    })
+  })
+})

--- a/src/vault-mcp/__tests__/config.test.ts
+++ b/src/vault-mcp/__tests__/config.test.ts
@@ -83,8 +83,8 @@ describe("loadConfig", () => {
     })
 
     it("accepts folder names with spaces", () => {
-      const config = loadConfig({ MEMORY_DIR: "About Me" })
-      expect(config.memoryDir).toBe("About Me")
+      const config = loadConfig({ MEMORY_DIR: "My Profile" })
+      expect(config.memoryDir).toBe("My Profile")
     })
 
     it("accepts nested folder paths", () => {

--- a/src/vault-mcp/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/__tests__/mcp-router.test.ts
@@ -261,10 +261,9 @@ describe("createMcpRouter — POST /mcp", () => {
         headers: { ...baseHeaders },
         body: JSON.stringify(initializeBody),
       })
-      const [info, options] = vi.mocked(McpServer).mock.calls[0]! as [
-        { description: string },
-        { instructions: string },
-      ]
+      const callArgs = vi.mocked(McpServer).mock.calls[0]!
+      const info = callArgs[0] as { description?: string }
+      const options = callArgs[1] as { instructions?: string }
       expect(info.description).toContain("Profile/")
       expect(info.description).not.toContain("About Me/")
       expect(options.instructions).toContain("Profile/")

--- a/src/vault-mcp/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/__tests__/mcp-router.test.ts
@@ -104,7 +104,10 @@ const denyAuth: express.RequestHandler = (_req, res) => {
 }
 
 const setupHarness = async (
-  opts: { authMiddleware?: express.RequestHandler } = {},
+  opts: {
+    authMiddleware?: express.RequestHandler
+    config?: ReturnType<typeof loadConfig>
+  } = {},
 ): Promise<Harness> => {
   const transportInstances: TransportMock[] = []
   const serverInstances: ServerMock[] = []
@@ -149,7 +152,7 @@ const setupHarness = async (
       vaultPath: VAULT_PATH,
       search,
       provider,
-      config: DEFAULT_CONFIG,
+      config: opts.config ?? DEFAULT_CONFIG,
     }),
   )
 
@@ -247,6 +250,25 @@ describe("createMcpRouter — POST /mcp", () => {
       const [info, options] = vi.mocked(McpServer).mock.calls[0]!
       expect(info).toEqual(SERVER_INFO)
       expect(options).toEqual(SERVER_OPTIONS)
+    })
+
+    it("McpServer description and instructions interpolate config.memoryDir", async () => {
+      const customConfig = loadConfig({ MEMORY_DIR: "Profile" })
+      const harness = await setupHarness({ config: customConfig })
+      vi.mocked(isInitializeRequest).mockReturnValue(true)
+      await fetch(harness.url(), {
+        method: "POST",
+        headers: { ...baseHeaders },
+        body: JSON.stringify(initializeBody),
+      })
+      const [info, options] = vi.mocked(McpServer).mock.calls[0]! as [
+        { description: string },
+        { instructions: string },
+      ]
+      expect(info.description).toContain("Profile/")
+      expect(info.description).not.toContain("About Me/")
+      expect(options.instructions).toContain("Profile/")
+      expect(options.instructions).not.toContain("About Me/")
     })
 
     it("connects the new server to the new transport", async () => {

--- a/src/vault-mcp/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/__tests__/mcp-router.test.ts
@@ -12,6 +12,7 @@ import { randomUUID } from "node:crypto"
 import type { Server } from "node:http"
 import type { AddressInfo } from "node:net"
 import { createMcpRouter } from "../mcp-router.js"
+import { loadConfig } from "../config.js"
 import type { SearchIndex } from "../search/search-index.js"
 import type { OAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/provider.js"
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
@@ -50,16 +51,16 @@ vi.mock("../tool-definitions.js", () => ({ registerTools: vi.fn() }))
 
 const FORWARDED_IP = "192.0.2.10"
 const VAULT_PATH = "/test-vault"
+const DEFAULT_CONFIG = loadConfig({})
 
 const SERVER_INFO = {
   name: "vault-cortex",
   version: "1.0.0",
-  description:
-    "Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (About Me/) for personalization across conversations.",
+  description: `Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (${DEFAULT_CONFIG.memoryDir}/) for personalization across conversations.`,
 }
 
 const SERVER_OPTIONS = {
-  instructions: `Read, write, and search an Obsidian vault. Use vault_search and vault_read_note to find and read notes. Use vault_get_memory to retrieve user preferences and context from About Me/ files. Use vault_write_note and vault_update_memory for writes.
+  instructions: `Read, write, and search an Obsidian vault. Use vault_search and vault_read_note to find and read notes. Use vault_get_memory to retrieve user preferences and context from ${DEFAULT_CONFIG.memoryDir}/ files. Use vault_write_note and vault_update_memory for writes.
 
 Vault content is Obsidian Flavored Markdown. Write tools pass content through without escaping — be intentional about Obsidian syntax (#, [[, %%, etc.) in inputs.`,
 }
@@ -143,7 +144,14 @@ const setupHarness = async (
   const app = express()
   app.set("trust proxy", true)
   app.use(express.json())
-  app.use(createMcpRouter({ vaultPath: VAULT_PATH, search, provider }))
+  app.use(
+    createMcpRouter({
+      vaultPath: VAULT_PATH,
+      search,
+      provider,
+      config: DEFAULT_CONFIG,
+    }),
+  )
 
   const httpServer = await new Promise<Server>((resolve) => {
     const listener = app.listen(0, () => resolve(listener))
@@ -254,7 +262,7 @@ describe("createMcpRouter — POST /mcp", () => {
       expect(transport.handleRequest.mock.calls[0]![2]).toEqual(initializeBody)
     })
 
-    it("registers tools on the new server with vault context", async () => {
+    it("registers tools on the new server with vault context and config", async () => {
       const { harness } = await setupInitializedSession()
       expect(registerTools).toHaveBeenCalledTimes(1)
       const arg = vi.mocked(registerTools).mock.calls[0]![0]
@@ -262,6 +270,7 @@ describe("createMcpRouter — POST /mcp", () => {
       expect(arg.vaultPath).toBe(VAULT_PATH)
       expect(arg.search).toBe(harness.search)
       expect(arg.logger).toBeDefined()
+      expect(arg.config).toBe(DEFAULT_CONFIG)
     })
 
     it("scopes the logger for registerTools to the sessionId and clientIp", async () => {

--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import { registerTools, TOOL_NAMES } from "../tool-definitions.js"
+import { loadConfig } from "../config.js"
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { SearchIndex } from "../search/search-index.js"
 import { logger } from "../../logger.js"
@@ -59,6 +60,7 @@ beforeEach(() => {
     vaultPath: "/test-vault",
     search: {} as SearchIndex,
     logger,
+    config: loadConfig({}),
   })
   calls = mockServer.registerTool.mock.calls as RegisterToolCall[]
 })

--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -142,6 +142,69 @@ describe("annotations", () => {
   })
 })
 
+describe("config interpolation in descriptions", () => {
+  const CUSTOM_MEMORY_DIR = "Profile"
+  const customConfig = loadConfig({ MEMORY_DIR: CUSTOM_MEMORY_DIR })
+  let customCalls: RegisterToolCall[]
+
+  beforeEach(() => {
+    const customServer = { registerTool: vi.fn() }
+    registerTools({
+      server: customServer as unknown as McpServer,
+      vaultPath: "/test-vault",
+      search: {} as SearchIndex,
+      logger,
+      config: customConfig,
+    })
+    customCalls = customServer.registerTool.mock.calls as RegisterToolCall[]
+  })
+
+  const findCustomCall = (name: string): RegisterToolCall | undefined =>
+    customCalls.find((c) => c[0] === name)
+
+  it("vault_get_memory description references the configured memory dir", () => {
+    const call = findCustomCall(TOOL_NAMES.VAULT_GET_MEMORY)!
+    expect(call[1].description).toContain(`${CUSTOM_MEMORY_DIR}/`)
+    expect(call[1].description).not.toContain("About Me/")
+  })
+
+  it("vault_update_memory description references the configured memory dir", () => {
+    const call = findCustomCall(TOOL_NAMES.VAULT_UPDATE_MEMORY)!
+    expect(call[1].description).toContain(`${CUSTOM_MEMORY_DIR}/`)
+    expect(call[1].description).not.toContain("About Me/")
+  })
+
+  it("vault_list_memory_files description references the configured memory dir", () => {
+    const call = findCustomCall(TOOL_NAMES.VAULT_LIST_MEMORY_FILES)!
+    expect(call[1].description).toContain(`${CUSTOM_MEMORY_DIR}/`)
+    expect(call[1].description).not.toContain("About Me/")
+  })
+
+  it("vault_delete_memory description references the configured memory dir", () => {
+    const call = findCustomCall(TOOL_NAMES.VAULT_DELETE_MEMORY)!
+    expect(call[1].description).toContain(`${CUSTOM_MEMORY_DIR}/`)
+    expect(call[1].description).not.toContain("About Me/")
+  })
+
+  it("vault_delete_note description lists configured protected paths", () => {
+    const call = findCustomCall(TOOL_NAMES.VAULT_DELETE_NOTE)!
+    expect(call[1].description).toContain("Profile/")
+    expect(call[1].description).not.toContain("About Me/")
+  })
+
+  it("vault_read_note description references the configured memory dir", () => {
+    const call = findCustomCall(TOOL_NAMES.VAULT_READ_NOTE)!
+    expect(call[1].description).toContain(`${CUSTOM_MEMORY_DIR}/`)
+    expect(call[1].description).not.toContain("About Me/")
+  })
+
+  it("vault_find_orphans description references configured exclusion folders", () => {
+    const call = findCustomCall(TOOL_NAMES.VAULT_FIND_ORPHANS)!
+    expect(call[1].description).toContain(CUSTOM_MEMORY_DIR)
+    expect(call[1].description).not.toContain("About Me")
+  })
+})
+
 describe("error handling", () => {
   const mockExtra = { requestId: "test-1", sessionId: "session-1" }
 

--- a/src/vault-mcp/auth/oauth-routes.ts
+++ b/src/vault-mcp/auth/oauth-routes.ts
@@ -11,12 +11,14 @@ export type OAuthRoutesOptions = {
   authToken: string
   serverUrl: URL
   oauthProvider: OAuthProvider
+  serviceDocumentationUrl: string
 }
 
 export const createOAuthRoutes = ({
   authToken,
   serverUrl,
   oauthProvider,
+  serviceDocumentationUrl,
 }: OAuthRoutesOptions): Router => {
   const { provider, getPendingRequest, approveRequest, deletePendingRequest } =
     oauthProvider
@@ -45,9 +47,7 @@ export const createOAuthRoutes = ({
     mcpAuthRouter({
       provider,
       issuerUrl: serverUrl,
-      serviceDocumentationUrl: new URL(
-        "https://github.com/aliasunder/vault-cortex",
-      ),
+      serviceDocumentationUrl: new URL(serviceDocumentationUrl),
       scopesSupported: ["vault"],
       authorizationOptions: { rateLimit },
       clientRegistrationOptions: { rateLimit },

--- a/src/vault-mcp/config.ts
+++ b/src/vault-mcp/config.ts
@@ -62,9 +62,9 @@ export const loadConfig = (
       )
     : ["Daily Notes", "Templates", memoryDir]
 
-  const serviceDocumentationUrlRaw = env.SERVICE_DOCUMENTATION_URL?.trim()
-  const serviceDocumentationUrl = serviceDocumentationUrlRaw
-    ? z.string().url().parse(serviceDocumentationUrlRaw)
+  const serviceDocUrlRaw = env.SERVICE_DOCUMENTATION_URL?.trim()
+  const serviceDocumentationUrl = serviceDocUrlRaw
+    ? z.string().url().parse(serviceDocUrlRaw)
     : "https://github.com/aliasunder/vault-cortex"
 
   return Object.freeze({

--- a/src/vault-mcp/config.ts
+++ b/src/vault-mcp/config.ts
@@ -55,16 +55,16 @@ export const loadConfig = (
       )
     : [memoryDir, "Daily Notes"]
 
-  const orphanExcludeRaw = env.ORPHAN_EXCLUDE_FOLDERS?.trim()
-  const orphanExcludeFolders = orphanExcludeRaw
-    ? parseCommaSeparated(orphanExcludeRaw).map((folder) =>
+  const orphanExcludeFoldersRaw = env.ORPHAN_EXCLUDE_FOLDERS?.trim()
+  const orphanExcludeFolders = orphanExcludeFoldersRaw
+    ? parseCommaSeparated(orphanExcludeFoldersRaw).map((folder) =>
         vaultFolderName.parse(folder),
       )
     : ["Daily Notes", "Templates", memoryDir]
 
-  const serviceDocUrlRaw = env.SERVICE_DOCUMENTATION_URL?.trim()
-  const serviceDocumentationUrl = serviceDocUrlRaw
-    ? z.string().url().parse(serviceDocUrlRaw)
+  const serviceDocumentationUrlRaw = env.SERVICE_DOCUMENTATION_URL?.trim()
+  const serviceDocumentationUrl = serviceDocumentationUrlRaw
+    ? z.string().url().parse(serviceDocumentationUrlRaw)
     : "https://github.com/aliasunder/vault-cortex"
 
   return Object.freeze({

--- a/src/vault-mcp/config.ts
+++ b/src/vault-mcp/config.ts
@@ -1,0 +1,76 @@
+/** Centralized config — reads env vars once, validates, exports typed config. */
+
+import { z } from "zod"
+
+// ── Validation ─────────────────────────────────────────────────
+
+/** Validates a vault folder name: non-empty, no traversal, no absolute paths.
+ *  Trims whitespace and strips trailing slashes for consistency. */
+const vaultFolderName = z
+  .string()
+  .min(1, "folder name cannot be empty")
+  .transform((s) => s.trim().replace(/\/+$/, ""))
+  .pipe(
+    z
+      .string()
+      .refine((s) => s.length > 0, "folder name cannot be blank")
+      .refine((s) => !s.includes(".."), "path traversal (..) not allowed")
+      .refine((s) => !s.startsWith("/"), "absolute paths not allowed"),
+  )
+
+/** Splits a comma-separated string into an array of validated folder names.
+ *  Empty entries (from trailing commas) are filtered out. */
+const parseCommaSeparated = (raw: string): string[] =>
+  raw.split(",").reduce<string[]>((acc, entry) => {
+    const trimmed = entry.trim()
+    if (trimmed.length > 0) acc.push(trimmed)
+    return acc
+  }, [])
+
+// ── Config type ────────────────────────────────────────────────
+
+export type VaultConfig = Readonly<{
+  memoryDir: string
+  protectedPaths: readonly string[]
+  orphanExcludeFolders: readonly string[]
+  serviceDocumentationUrl: string
+}>
+
+// ── Loader ─────────────────────────────────────────────────────
+
+/** Loads and validates config from env vars. Pass a custom env record
+ *  for testing — defaults to process.env when omitted. */
+export const loadConfig = (
+  env: Record<string, string | undefined> = process.env,
+): VaultConfig => {
+  const memoryDirRaw = env.MEMORY_DIR?.trim()
+  const memoryDir = memoryDirRaw
+    ? vaultFolderName.parse(memoryDirRaw)
+    : "About Me"
+
+  const protectedPathsRaw = env.PROTECTED_PATHS?.trim()
+  const protectedPaths = protectedPathsRaw
+    ? parseCommaSeparated(protectedPathsRaw).map((folder) =>
+        vaultFolderName.parse(folder),
+      )
+    : [memoryDir, "Daily Notes"]
+
+  const orphanExcludeRaw = env.ORPHAN_EXCLUDE_FOLDERS?.trim()
+  const orphanExcludeFolders = orphanExcludeRaw
+    ? parseCommaSeparated(orphanExcludeRaw).map((folder) =>
+        vaultFolderName.parse(folder),
+      )
+    : ["Daily Notes", "Templates", memoryDir]
+
+  const serviceDocUrlRaw = env.SERVICE_DOCUMENTATION_URL?.trim()
+  const serviceDocumentationUrl = serviceDocUrlRaw
+    ? z.string().url().parse(serviceDocUrlRaw)
+    : "https://github.com/aliasunder/vault-cortex"
+
+  return Object.freeze({
+    memoryDir,
+    protectedPaths,
+    orphanExcludeFolders,
+    serviceDocumentationUrl,
+  })
+}

--- a/src/vault-mcp/config.ts
+++ b/src/vault-mcp/config.ts
@@ -9,18 +9,22 @@ import { z } from "zod"
 const vaultFolderName = z
   .string()
   .min(1, "folder name cannot be empty")
-  .transform((s) => s.trim().replace(/\/+$/, ""))
+  // Strip leading/trailing whitespace and any trailing path separators
+  .transform((value) => value.trim().replace(/\/+$/, ""))
   .pipe(
     z
       .string()
-      .refine((s) => s.length > 0, "folder name cannot be blank")
-      .refine((s) => !s.includes(".."), "path traversal (..) not allowed")
-      .refine((s) => !s.startsWith("/"), "absolute paths not allowed"),
+      .refine((value) => value.length > 0, "folder name cannot be blank")
+      .refine(
+        (value) => !value.includes(".."),
+        "path traversal (..) not allowed",
+      )
+      .refine((value) => !value.startsWith("/"), "absolute paths not allowed"),
   )
 
-/** Splits a comma-separated string into an array of validated folder names.
- *  Empty entries (from trailing commas) are filtered out. */
-const parseCommaSeparated = (raw: string): string[] =>
+/** Splits a comma-separated string into an array of folder names.
+ *  Trims each entry; empty entries (from trailing commas) are filtered out. */
+const splitCommaSeparatedFolders = (raw: string): string[] =>
   raw.split(",").reduce<string[]>((acc, entry) => {
     const trimmed = entry.trim()
     if (trimmed.length > 0) acc.push(trimmed)
@@ -50,21 +54,19 @@ export const loadConfig = (
 
   const protectedPathsRaw = env.PROTECTED_PATHS?.trim()
   const protectedPaths = protectedPathsRaw
-    ? parseCommaSeparated(protectedPathsRaw).map((folder) =>
+    ? splitCommaSeparatedFolders(protectedPathsRaw).map((folder) =>
         vaultFolderName.parse(folder),
       )
     : [memoryDir, "Daily Notes"]
 
-  const orphanExcludeFoldersRaw = env.ORPHAN_EXCLUDE_FOLDERS?.trim()
-  const orphanExcludeFolders = orphanExcludeFoldersRaw
-    ? parseCommaSeparated(orphanExcludeFoldersRaw).map((folder) =>
-        vaultFolderName.parse(folder),
+  const orphanExcludeFolders = env.ORPHAN_EXCLUDE_FOLDERS?.trim()
+    ? splitCommaSeparatedFolders(env.ORPHAN_EXCLUDE_FOLDERS.trim()).map(
+        (folder) => vaultFolderName.parse(folder),
       )
     : ["Daily Notes", "Templates", memoryDir]
 
-  const serviceDocUrlRaw = env.SERVICE_DOCUMENTATION_URL?.trim()
-  const serviceDocumentationUrl = serviceDocUrlRaw
-    ? z.string().url().parse(serviceDocUrlRaw)
+  const serviceDocumentationUrl = env.SERVICE_DOCUMENTATION_URL?.trim()
+    ? z.string().url().parse(env.SERVICE_DOCUMENTATION_URL.trim())
     : "https://github.com/aliasunder/vault-cortex"
 
   return Object.freeze({

--- a/src/vault-mcp/mcp-router.ts
+++ b/src/vault-mcp/mcp-router.ts
@@ -9,6 +9,7 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js"
 import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js"
 import type { OAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/provider.js"
 import type { SearchIndex } from "./search/search-index.js"
+import type { VaultConfig } from "./config.js"
 import { registerTools } from "./tool-definitions.js"
 import { logger } from "../logger.js"
 
@@ -16,12 +17,14 @@ export type McpRouterOptions = {
   vaultPath: string
   search: SearchIndex
   provider: OAuthServerProvider
+  config: VaultConfig
 }
 
 export const createMcpRouter = ({
   vaultPath,
   search,
   provider,
+  config,
 }: McpRouterOptions): Router => {
   const router = Router()
   const bearerAuth = requireBearerAuth({ verifier: provider })
@@ -61,11 +64,10 @@ export const createMcpRouter = ({
           {
             name: "vault-cortex",
             version: "1.0.0",
-            description:
-              "Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (About Me/) for personalization across conversations.",
+            description: `Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (${config.memoryDir}/) for personalization across conversations.`,
           },
           {
-            instructions: `Read, write, and search an Obsidian vault. Use vault_search and vault_read_note to find and read notes. Use vault_get_memory to retrieve user preferences and context from About Me/ files. Use vault_write_note and vault_update_memory for writes.
+            instructions: `Read, write, and search an Obsidian vault. Use vault_search and vault_read_note to find and read notes. Use vault_get_memory to retrieve user preferences and context from ${config.memoryDir}/ files. Use vault_write_note and vault_update_memory for writes.
 
 Vault content is Obsidian Flavored Markdown. Write tools pass content through without escaping — be intentional about Obsidian syntax (#, [[, %%, etc.) in inputs.`,
           },
@@ -75,7 +77,13 @@ Vault content is Obsidian Flavored Markdown. Write tools pass content through wi
           sessionId: transport.sessionId,
           clientIp,
         })
-        registerTools({ server, vaultPath, search, logger: sessionLogger })
+        registerTools({
+          server,
+          vaultPath,
+          search,
+          logger: sessionLogger,
+          config,
+        })
 
         await server.connect(transport)
         await transport.handleRequest(req, res, body)

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -1106,16 +1106,19 @@ describe("findOrphans", () => {
     expect(orphanPaths).not.toContain("connected.md")
   })
 
-  it("excludes Daily Notes by default", () => {
+  it("includes all folders when no exclusions provided", () => {
     const orphans = index.findOrphans({}, logger)
     const orphanPaths = orphans.map((orphan) => orphan.path)
-    expect(orphanPaths).not.toContain("Daily Notes/2026-05-13.md")
+    expect(orphanPaths).toContain("Daily Notes/2026-05-13.md")
   })
 
-  it("includes Daily Notes when excluded folders are overridden", () => {
-    const orphans = index.findOrphans({ excludeFolders: [] }, logger)
+  it("excludes Daily Notes when passed in excludeFolders", () => {
+    const orphans = index.findOrphans(
+      { excludeFolders: ["Daily Notes"] },
+      logger,
+    )
     const orphanPaths = orphans.map((orphan) => orphan.path)
-    expect(orphanPaths).toContain("Daily Notes/2026-05-13.md")
+    expect(orphanPaths).not.toContain("Daily Notes/2026-05-13.md")
   })
 
   it("respects limit", () => {

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -917,11 +917,7 @@ export const createSearchIndex = (dbPath: string) => {
     params: { excludeFolders?: string[]; limit?: number },
     logger: Logger,
   ): NoteMetadata[] => {
-    const excludeFolders = params.excludeFolders ?? [
-      "Daily Notes",
-      "Templates",
-      "About Me",
-    ]
+    const excludeFolders = params.excludeFolders ?? []
     const limit = params.limit ?? 50
 
     const folderExclusions = excludeFolders

--- a/src/vault-mcp/server.ts
+++ b/src/vault-mcp/server.ts
@@ -9,6 +9,7 @@ import { startFileWatcher } from "./search/file-watcher.js"
 import { createOAuthProvider } from "./auth/oauth-provider.js"
 import { createOAuthRoutes } from "./auth/oauth-routes.js"
 import { createMcpRouter } from "./mcp-router.js"
+import { loadConfig } from "./config.js"
 import { logger } from "../logger.js"
 
 export const createErrorMiddleware =
@@ -36,6 +37,7 @@ export const requireEnv = (name: string): string => {
 }
 
 const startServer = async (): Promise<void> => {
+  const config = loadConfig()
   const authToken = requireEnv("MCP_AUTH_TOKEN")
   const vaultPath = requireEnv("VAULT_PATH")
   const publicUrl = requireEnv("PUBLIC_URL")
@@ -71,12 +73,20 @@ const startServer = async (): Promise<void> => {
     res.json({ ok: true })
   })
 
-  app.use(createOAuthRoutes({ authToken, serverUrl, oauthProvider }))
+  app.use(
+    createOAuthRoutes({
+      authToken,
+      serverUrl,
+      oauthProvider,
+      serviceDocumentationUrl: config.serviceDocumentationUrl,
+    }),
+  )
   app.use(
     createMcpRouter({
       vaultPath,
       search,
       provider: oauthProvider.provider,
+      config,
     }),
   )
 

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -4,9 +4,10 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { z } from "zod"
 import { vaultFs } from "./vault-operations/vault-filesystem.js"
 import { vaultPatcher } from "./vault-operations/vault-patcher.js"
-import { memoryStore } from "./vault-operations/memory-store.js"
+import { createMemoryStore } from "./vault-operations/memory-store.js"
 import { getDailyNote } from "./vault-operations/daily-notes.js"
 import type { SearchIndex } from "./search/search-index.js"
+import type { VaultConfig } from "./config.js"
 import type { Logger } from "../logger.js"
 
 export const TOOL_NAMES = {
@@ -93,8 +94,10 @@ export const registerTools = (params: {
   vaultPath: string
   search: SearchIndex
   logger: Logger
+  config: VaultConfig
 }): void => {
-  const { server, vaultPath, search, logger: sessionLogger } = params
+  const { server, vaultPath, search, logger: sessionLogger, config } = params
+  const memoryStore = createMemoryStore({ memoryDir: config.memoryDir })
 
   // ── Vault CRUD ──────────────────────────────────────────────
 
@@ -107,7 +110,7 @@ export const registerTools = (params: {
 Example: vault_read_note({ path: "Projects/vault-cortex.md" })
 
 When to use: You know the exact path and need the full content of a specific note.
-Prefer vault_search when you don't know the path. Prefer vault_get_memory for About Me/ files (returns content without frontmatter).
+Prefer vault_search when you don't know the path. Prefer vault_get_memory for ${config.memoryDir}/ files (returns content without frontmatter).
 
 Returns: Raw markdown string.`,
       inputSchema: {
@@ -115,7 +118,7 @@ Returns: Raw markdown string.`,
           .string()
           .min(1)
           .describe(
-            'Vault-relative path to the note (e.g. "About Me/Principles.md")',
+            `Vault-relative path to the note (e.g. "${config.memoryDir}/Principles.md")`,
           ),
       },
       annotations: {
@@ -148,7 +151,7 @@ Returns: Raw markdown string.`,
 Example: vault_write_note({ path: "Projects/notes.md", body: "# Notes\\n\\nProject notes here.", frontmatter: { tags: ["project"], type: "project" } })
 
 When to use: Creating a new note or fully replacing an existing note's body.
-Prefer vault_update_memory for appending dated entries to About Me/ memory files.
+Prefer vault_update_memory for appending dated entries to ${config.memoryDir}/ memory files.
 
 Limitation: Overwrites the entire body. Do not use for surgical edits to large files — existing content will be lost unless you include it in the body parameter.
 
@@ -358,7 +361,7 @@ Returns: JSON array of vault-relative paths.`,
         folder: z
           .string()
           .optional()
-          .describe('Folder to list (e.g. "About Me", "Projects")'),
+          .describe(`Folder to list (e.g. "${config.memoryDir}", "Projects")`),
         glob: z
           .string()
           .optional()
@@ -391,12 +394,12 @@ Returns: JSON array of vault-relative paths.`,
     TOOL_NAMES.VAULT_DELETE_NOTE,
     {
       title: "Delete Note",
-      description: `Permanently delete a markdown note. Protected paths (About Me/, Daily Notes/) are refused to prevent accidental deletion of memory or daily notes.
+      description: `Permanently delete a markdown note. Protected paths (${config.protectedPaths.map((p) => p + "/").join(", ")}) are refused to prevent accidental deletion of memory or daily notes.
 
 Example: vault_delete_note({ path: "Scratch/temp.md" })
 
 When to use: Removing a note you no longer need.
-Prefer vault_delete_memory for removing individual dated entries from About Me/ memory files.
+Prefer vault_delete_memory for removing individual dated entries from ${config.memoryDir}/ memory files.
 
 Returns: Confirmation message.`,
       inputSchema: {
@@ -420,7 +423,11 @@ Returns: Confirmation message.`,
       reqLogger.info("tool_call", { path })
       return safeHandler(
         reqLogger,
-        () => vaultFs.deleteNote({ vaultPath, path }, reqLogger),
+        () =>
+          vaultFs.deleteNote(
+            { vaultPath, path, protectedPaths: config.protectedPaths },
+            reqLogger,
+          ),
         () => `Deleted ${path}`,
       )
     },
@@ -611,7 +618,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
       title: "Search by Folder",
       description: `Browse notes in a folder with full metadata (tags, type, related, created, modified). Unlike vault_list_notes which returns paths only, this returns rich metadata for each note.
 
-Example: vault_search_by_folder({ folder: "Projects" }) or vault_search_by_folder({ folder: "About Me", recursive: false })
+Example: vault_search_by_folder({ folder: "Projects" }) or vault_search_by_folder({ folder: "${config.memoryDir}", recursive: false })
 
 When to use: Exploring a folder's contents with full context — tags, type, relationships. Useful for vault orientation and understanding folder structure.
 Prefer vault_list_notes when you only need paths. Prefer vault_search when you have a text query.
@@ -620,7 +627,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
       inputSchema: {
         folder: z
           .string()
-          .describe('Folder path (e.g. "Projects", "About Me")'),
+          .describe(`Folder path (e.g. "Projects", "${config.memoryDir}")`),
         recursive: z
           .boolean()
           .optional()
@@ -655,11 +662,11 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
     TOOL_NAMES.VAULT_GET_MEMORY,
     {
       title: "Get Memory",
-      description: `Read semantic memory from About Me/ files. These are structured memory files containing dated bullet entries organized under H2 headings. With file: single file content. With file+section: just that H2 section's entries. No args: all files concatenated (frontmatter stripped) — can be large.
+      description: `Read semantic memory from ${config.memoryDir}/ files. These are structured memory files containing dated bullet entries organized under H2 headings. With file: single file content. With file+section: just that H2 section's entries. No args: all files concatenated (frontmatter stripped) — can be large.
 
 Example: vault_get_memory({ file: "Principles", section: "Decision heuristics (newest first)" })
 
-When to use: Reading user preferences, principles, opinions, or other persistent context stored in About Me/ files. Call vault_list_memory_files first to discover valid file and section names.
+When to use: Reading user preferences, principles, opinions, or other persistent context stored in ${config.memoryDir}/ files. Call vault_list_memory_files first to discover valid file and section names.
 Prefer vault_read_note for reading non-memory notes.
 
 Returns: Raw markdown text.`,
@@ -702,7 +709,7 @@ Returns: Raw markdown text.`,
     TOOL_NAMES.VAULT_UPDATE_MEMORY,
     {
       title: "Update Memory",
-      description: `Append a dated entry to a section of an About Me/ memory file. The server auto-prefixes today's date (format: "- **YYYY-MM-DD**: entry text"). Call vault_list_memory_files first to discover valid file and section names.
+      description: `Append a dated entry to a section of a ${config.memoryDir}/ memory file. The server auto-prefixes today's date (format: "- **YYYY-MM-DD**: entry text"). Call vault_list_memory_files first to discover valid file and section names.
 
 Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
 
@@ -763,7 +770,7 @@ Returns: Confirmation message.`,
             },
             reqLogger,
           ),
-        () => `Added entry to About Me/${file}.md → ## ${section}`,
+        () => `Added entry to ${config.memoryDir}/${file}.md → ## ${section}`,
       )
     },
   )
@@ -772,7 +779,7 @@ Returns: Confirmation message.`,
     TOOL_NAMES.VAULT_LIST_MEMORY_FILES,
     {
       title: "List Memory Files",
-      description: `Discovery tool — lists About Me/ memory files with their H1/H2 heading structure and per-section entry counts. Does NOT return actual entries.
+      description: `Discovery tool — lists ${config.memoryDir}/ memory files with their H1/H2 heading structure and per-section entry counts. Does NOT return actual entries.
 
 Example: vault_list_memory_files() returns file outlines with headings like "Decision heuristics (newest first)" and entry counts.
 
@@ -805,7 +812,7 @@ Returns: JSON array of file outlines.`,
     TOOL_NAMES.VAULT_DELETE_MEMORY,
     {
       title: "Delete Memory Entry",
-      description: `Delete a single dated entry from an About Me/ memory file. Both date and entry text are required for exact matching — ensures only the intended entry is removed.
+      description: `Delete a single dated entry from a ${config.memoryDir}/ memory file. Both date and entry text are required for exact matching — ensures only the intended entry is removed.
 
 Example: vault_delete_memory({ file: "Opinions", section: "AI tooling & memory (newest first)", date: "2026-05-01", entry: "Prefer X over Y" })
 
@@ -843,7 +850,8 @@ Returns: Confirmation message.`,
             { vaultPath, file, section, date, entry },
             reqLogger,
           ),
-        () => `Deleted entry from About Me/${file}.md → ## ${section}`,
+        () =>
+          `Deleted entry from ${config.memoryDir}/${file}.md → ## ${section}`,
       )
     },
   )
@@ -1115,9 +1123,9 @@ Returns: JSON with path (the queried note), outgoing_links (array of { path, tit
       title: "Find Orphans",
       description: `Find notes with no incoming links from other notes. Orphan notes are disconnected from the vault's knowledge graph — they may be forgotten or need linking from relevant notes.
 
-Example: vault_find_orphans() or vault_find_orphans({ exclude_folders: ["Daily Notes", "Templates", "About Me"] })
+Example: vault_find_orphans() or vault_find_orphans({ exclude_folders: ${JSON.stringify(config.orphanExcludeFolders)} })
 
-When to use: Vault maintenance and organization. Helps identify notes that might be forgotten or need integration into the knowledge graph. Daily Notes, Templates, and About Me folders are excluded by default since those are standalone by design.
+When to use: Vault maintenance and organization. Helps identify notes that might be forgotten or need integration into the knowledge graph. ${config.orphanExcludeFolders.join(", ")} folders are excluded by default since those are standalone by design.
 To add links to an orphan, use vault_patch_note to mention it from a relevant note.
 
 Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified.`,
@@ -1126,7 +1134,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
           .array(z.string())
           .optional()
           .describe(
-            'Folders to exclude (default: ["Daily Notes", "Templates", "About Me"])',
+            `Folders to exclude (default: ${JSON.stringify(config.orphanExcludeFolders)})`,
           ),
         limit: z.number().optional().describe("Max results (default 50)"),
       },
@@ -1147,7 +1155,12 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
         reqLogger,
         async () =>
           search.findOrphans(
-            { excludeFolders: exclude_folders, limit },
+            {
+              excludeFolders: exclude_folders ?? [
+                ...config.orphanExcludeFolders,
+              ],
+              limit,
+            },
             reqLogger,
           ),
         (results) => JSON.stringify(results.map(formatNoteMetadata)),

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { mkdtemp, rm, writeFile, mkdir, readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import { memoryStore } from "../memory-store.js"
+import { createMemoryStore } from "../memory-store.js"
 import { logger } from "../../../logger.js"
 
-const { getMemory, updateMemory, listMemoryFiles, deleteMemory } = memoryStore
+const { getMemory, updateMemory, listMemoryFiles, deleteMemory } =
+  createMemoryStore({ memoryDir: "About Me" })
 
 let vault: string
 
@@ -522,5 +523,44 @@ describe("listMemoryFiles", () => {
     const outlines = await listMemoryFiles({ vaultPath: emptyVault }, logger)
     expect(outlines).toEqual([])
     await rm(emptyVault, { recursive: true })
+  })
+})
+
+describe("custom memoryDir", () => {
+  const customStore = createMemoryStore({ memoryDir: "Profile" })
+
+  it("reads from the configured directory", async () => {
+    const customVault = await mkdtemp(join(tmpdir(), "custom-mem-"))
+    await mkdir(join(customVault, "Profile"), { recursive: true })
+    await writeFile(
+      join(customVault, "Profile/Principles.md"),
+      PRINCIPLES_MD,
+      "utf8",
+    )
+    const result = await customStore.getMemory(
+      { vaultPath: customVault, file: "Principles" },
+      logger,
+    )
+    expect(result).toContain("# Principles")
+    await rm(customVault, { recursive: true })
+  })
+
+  it("error messages reference the configured directory name", async () => {
+    const customVault = await mkdtemp(join(tmpdir(), "custom-mem-"))
+    await expect(
+      customStore.getMemory(
+        { vaultPath: customVault, file: "Nonexistent" },
+        logger,
+      ),
+    ).rejects.toThrow('memory file not found: "Profile/Nonexistent.md"')
+    await rm(customVault, { recursive: true })
+  })
+
+  it("directory-not-found error references the configured name", async () => {
+    const customVault = await mkdtemp(join(tmpdir(), "custom-mem-"))
+    await expect(
+      customStore.getMemory({ vaultPath: customVault }, logger),
+    ).rejects.toThrow("Profile directory not found")
+    await rm(customVault, { recursive: true })
   })
 })

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -31,7 +31,7 @@ describe("path traversal", () => {
     "deleteNote rejects %s",
     async (path) => {
       await expect(
-        deleteNote({ vaultPath: vault, path }, logger),
+        deleteNote({ vaultPath: vault, path, protectedPaths: [] }, logger),
       ).rejects.toThrow("path traversal blocked")
     },
   )
@@ -136,10 +136,19 @@ describe("writeNote", () => {
   })
 })
 
+const DEFAULT_PROTECTED = ["About Me", "Daily Notes"]
+
 describe("deleteNote", () => {
   it("deletes an existing file", async () => {
     await writeFile(join(vault, "delete-me.md"), "bye", "utf8")
-    await deleteNote({ vaultPath: vault, path: "delete-me.md" }, logger)
+    await deleteNote(
+      {
+        vaultPath: vault,
+        path: "delete-me.md",
+        protectedPaths: DEFAULT_PROTECTED,
+      },
+      logger,
+    )
     await expect(readFile(join(vault, "delete-me.md"))).rejects.toThrow()
   })
 
@@ -147,14 +156,46 @@ describe("deleteNote", () => {
     "rejects protected path %s",
     async (path) => {
       await expect(
-        deleteNote({ vaultPath: vault, path }, logger),
+        deleteNote(
+          { vaultPath: vault, path, protectedPaths: DEFAULT_PROTECTED },
+          logger,
+        ),
       ).rejects.toThrow("cannot delete protected path")
     },
   )
 
+  it("rejects custom protected paths", async () => {
+    await expect(
+      deleteNote(
+        {
+          vaultPath: vault,
+          path: "Secrets/keys.md",
+          protectedPaths: ["Secrets"],
+        },
+        logger,
+      ),
+    ).rejects.toThrow("cannot delete protected path")
+  })
+
+  it("allows deletion when path is not in protected list", async () => {
+    await writeFile(join(vault, "ok.md"), "ok", "utf8")
+    await deleteNote(
+      { vaultPath: vault, path: "ok.md", protectedPaths: ["Locked"] },
+      logger,
+    )
+    await expect(readFile(join(vault, "ok.md"))).rejects.toThrow()
+  })
+
   it("throws on non-existent file", async () => {
     await expect(
-      deleteNote({ vaultPath: vault, path: "ghost.md" }, logger),
+      deleteNote(
+        {
+          vaultPath: vault,
+          path: "ghost.md",
+          protectedPaths: DEFAULT_PROTECTED,
+        },
+        logger,
+      ),
     ).rejects.toThrow()
   })
 })

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -1,12 +1,10 @@
-/** About Me/ memory store — heading-aware parser/writer for semantic memory files. */
+/** Memory store factory — heading-aware parser/writer for semantic memory files. */
 
 import { readFile, writeFile, readdir } from "node:fs/promises"
 import { join, basename } from "node:path"
 import matter from "gray-matter"
 import { DateTime } from "luxon"
 import type { Logger } from "../../logger.js"
-
-const MEMORY_DIR = "About Me"
 
 // Matches dated bullet entries: `- **YYYY-MM-DD**: ...`
 // The date portion is the reliable anchor — entry text after `: ` may contain its own **bold**
@@ -97,254 +95,255 @@ const findSection = (
   )
 }
 
-/** Resolves the full path to a memory file in the About Me/ directory. */
-const memoryFilePath = (vaultPath: string, file: string): string =>
-  join(vaultPath, MEMORY_DIR, `${file}.md`)
+// ── Factory ────────────────────────────────────────────────────
 
-/** Reads a memory file, throwing a descriptive error if not found. */
-const readMemoryFile = async (
-  vaultPath: string,
-  file: string,
-): Promise<string> => {
-  try {
-    return await readFile(memoryFilePath(vaultPath, file), "utf8")
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error(`memory file not found: "About Me/${file}.md"`, {
-        cause: err,
-      })
-    }
-    throw err
-  }
-}
+export const createMemoryStore = (options: { memoryDir: string }) => {
+  const { memoryDir } = options
 
-// ── Exported functions ──────────────────────────────────────────
+  const memoryFilePath = (vaultPath: string, file: string): string =>
+    join(vaultPath, memoryDir, `${file}.md`)
 
-/** Reads memory content — all files concatenated, one file, or one section. */
-const getMemory = async (
-  params: { vaultPath: string; file?: string; section?: string },
-  logger: Logger,
-): Promise<string> => {
-  if (!params.file) {
-    const dir = join(params.vaultPath, MEMORY_DIR)
-    const entries = await readdir(dir).catch((err) => {
+  const readMemoryFile = async (
+    vaultPath: string,
+    file: string,
+  ): Promise<string> => {
+    try {
+      return await readFile(memoryFilePath(vaultPath, file), "utf8")
+    } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        throw new Error("About Me directory not found")
+        throw new Error(`memory file not found: "${memoryDir}/${file}.md"`, {
+          cause: err,
+        })
       }
       throw err
+    }
+  }
+
+  // ── Exported functions ──────────────────────────────────────────
+
+  const getMemory = async (
+    params: { vaultPath: string; file?: string; section?: string },
+    logger: Logger,
+  ): Promise<string> => {
+    if (!params.file) {
+      const dir = join(params.vaultPath, memoryDir)
+      const entries = await readdir(dir).catch((err) => {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          throw new Error(`${memoryDir} directory not found`)
+        }
+        throw err
+      })
+      const mdFiles = entries.filter((f) => f.endsWith(".md")).sort()
+      const contents = await Promise.all(
+        mdFiles.map(async (f) => {
+          const raw = await readFile(join(dir, f), "utf8")
+          return matter(raw).content.trim()
+        }),
+      )
+      logger.info("get memory", { mode: "all", fileCount: mdFiles.length })
+      return contents.join("\n\n---\n\n")
+    }
+
+    const raw = await readMemoryFile(params.vaultPath, params.file)
+    const parsed = matter(raw)
+
+    if (!params.section) {
+      logger.info("get memory", { mode: "file", file: params.file })
+      return parsed.content.trim()
+    }
+
+    const lines = parsed.content.split("\n")
+    const sections = parseSections(lines)
+    const match = findSection(sections, params.section, 2)
+    if (!match) {
+      throw new Error(
+        `section not found: "${params.section}" in ${memoryDir}/${params.file}.md`,
+      )
+    }
+
+    // Extract only the lines between this heading and the next
+    const body = lines
+      .slice(match.bodyStartLine, match.bodyEndLine)
+      .join("\n")
+      .trim()
+    logger.info("get memory", {
+      mode: "section",
+      file: params.file,
+      section: params.section,
     })
+    return body
+  }
+
+  const updateMemory = async (
+    params: {
+      vaultPath: string
+      file: string
+      section: string
+      entry: string
+      date?: string
+      position?: "top" | "bottom"
+    },
+    logger: Logger,
+  ): Promise<void> => {
+    const raw = await readMemoryFile(params.vaultPath, params.file)
+    const parsed = matter(raw)
+    const lines = parsed.content.split("\n")
+    const sections = parseSections(lines)
+    const match = findSection(sections, params.section, 2)
+    if (!match) {
+      throw new Error(
+        `section not found: "${params.section}" in ${memoryDir}/${params.file}.md`,
+      )
+    }
+
+    const date = params.date ?? DateTime.now().toISODate()
+    const position = params.position ?? "top"
+    const bullet = `- **${date}**: ${params.entry}`
+
+    // Find the first and last dated bullet within the section body to determine
+    // where to insert. Offsets are relative to the section's bodyStartLine.
+    const bodyLines = lines.slice(match.bodyStartLine, match.bodyEndLine)
+    const firstBulletOffset = bodyLines.findIndex((l) => ENTRY_PATTERN.test(l))
+    const lastBulletOffset = bodyLines.reduce(
+      (last, l, i) => (ENTRY_PATTERN.test(l) ? i : last),
+      -1,
+    )
+
+    // Compute the absolute line index in the full content array for insertion.
+    // "top" inserts before the first existing bullet (newest-first ordering).
+    // "bottom" inserts after the last existing bullet.
+    // Empty sections (no bullets) fall back to bodyEndLine — appends at section end.
+    const insertIndex =
+      position === "top"
+        ? firstBulletOffset >= 0
+          ? match.bodyStartLine + firstBulletOffset
+          : match.bodyEndLine
+        : lastBulletOffset >= 0
+          ? match.bodyStartLine + lastBulletOffset + 1
+          : match.bodyEndLine
+
+    // Splice the new bullet into the content lines
+    const updatedLines = [
+      ...lines.slice(0, insertIndex),
+      bullet,
+      ...lines.slice(insertIndex),
+    ]
+
+    const newContent = updatedLines.join("\n")
+    const serialized = matter.stringify(newContent, parsed.data)
+    await writeFile(
+      memoryFilePath(params.vaultPath, params.file),
+      serialized,
+      "utf8",
+    )
+    logger.info("updated memory", {
+      file: params.file,
+      section: params.section,
+      date,
+    })
+  }
+
+  const listMemoryFiles = async (
+    params: { vaultPath: string },
+    logger: Logger,
+  ): Promise<MemoryFileOutline[]> => {
+    const dir = join(params.vaultPath, memoryDir)
+    const entries = await readdir(dir).catch((err) => {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return []
+      throw err
+    })
+
     const mdFiles = entries.filter((f) => f.endsWith(".md")).sort()
-    const contents = await Promise.all(
+
+    const outlines = await Promise.all(
       mdFiles.map(async (f) => {
         const raw = await readFile(join(dir, f), "utf8")
-        return matter(raw).content.trim()
+        const parsed = matter(raw)
+        const name = basename(f, ".md")
+        const title = isString(parsed.data.title) ? parsed.data.title : name
+        const lines = parsed.content.split("\n")
+        const sections = parseSections(lines)
+
+        const headings: MemoryHeading[] = sections.map((s) =>
+          s.level === 1
+            ? { level: 1 as const, text: s.heading }
+            : { level: 2 as const, text: s.heading, entryCount: s.entryCount },
+        )
+
+        return { file: name, title, headings }
       }),
     )
-    logger.info("get memory", { mode: "all", fileCount: mdFiles.length })
-    return contents.join("\n\n---\n\n")
+
+    logger.info("listed memory files", { count: outlines.length })
+    return outlines
   }
 
-  const raw = await readMemoryFile(params.vaultPath, params.file)
-  const parsed = matter(raw)
-
-  if (!params.section) {
-    logger.info("get memory", { mode: "file", file: params.file })
-    return parsed.content.trim()
-  }
-
-  const lines = parsed.content.split("\n")
-  const sections = parseSections(lines)
-  const match = findSection(sections, params.section, 2)
-  if (!match) {
-    throw new Error(
-      `section not found: "${params.section}" in About Me/${params.file}.md`,
-    )
-  }
-
-  // Extract only the lines between this heading and the next
-  const body = lines
-    .slice(match.bodyStartLine, match.bodyEndLine)
-    .join("\n")
-    .trim()
-  logger.info("get memory", {
-    mode: "section",
-    file: params.file,
-    section: params.section,
-  })
-  return body
-}
-
-/** Appends a dated entry to a section of a memory file. */
-const updateMemory = async (
-  params: {
-    vaultPath: string
-    file: string
-    section: string
-    entry: string
-    date?: string
-    position?: "top" | "bottom"
-  },
-  logger: Logger,
-): Promise<void> => {
-  const raw = await readMemoryFile(params.vaultPath, params.file)
-  const parsed = matter(raw)
-  const lines = parsed.content.split("\n")
-  const sections = parseSections(lines)
-  const match = findSection(sections, params.section, 2)
-  if (!match) {
-    throw new Error(
-      `section not found: "${params.section}" in About Me/${params.file}.md`,
-    )
-  }
-
-  const date = params.date ?? DateTime.now().toISODate()
-  const position = params.position ?? "top"
-  const bullet = `- **${date}**: ${params.entry}`
-
-  // Find the first and last dated bullet within the section body to determine
-  // where to insert. Offsets are relative to the section's bodyStartLine.
-  const bodyLines = lines.slice(match.bodyStartLine, match.bodyEndLine)
-  const firstBulletOffset = bodyLines.findIndex((l) => ENTRY_PATTERN.test(l))
-  const lastBulletOffset = bodyLines.reduce(
-    (last, l, i) => (ENTRY_PATTERN.test(l) ? i : last),
-    -1,
-  )
-
-  // Compute the absolute line index in the full content array for insertion.
-  // "top" inserts before the first existing bullet (newest-first ordering).
-  // "bottom" inserts after the last existing bullet.
-  // Empty sections (no bullets) fall back to bodyEndLine — appends at section end.
-  const insertIndex =
-    position === "top"
-      ? firstBulletOffset >= 0
-        ? match.bodyStartLine + firstBulletOffset
-        : match.bodyEndLine
-      : lastBulletOffset >= 0
-        ? match.bodyStartLine + lastBulletOffset + 1
-        : match.bodyEndLine
-
-  // Splice the new bullet into the content lines
-  const updatedLines = [
-    ...lines.slice(0, insertIndex),
-    bullet,
-    ...lines.slice(insertIndex),
-  ]
-
-  const newContent = updatedLines.join("\n")
-  const serialized = matter.stringify(newContent, parsed.data)
-  await writeFile(
-    memoryFilePath(params.vaultPath, params.file),
-    serialized,
-    "utf8",
-  )
-  logger.info("updated memory", {
-    file: params.file,
-    section: params.section,
-    date,
-  })
-}
-
-/** Returns outlines of all About Me/ files — headings and entry counts, no content. */
-const listMemoryFiles = async (
-  params: { vaultPath: string },
-  logger: Logger,
-): Promise<MemoryFileOutline[]> => {
-  const dir = join(params.vaultPath, MEMORY_DIR)
-  const entries = await readdir(dir).catch((err) => {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return []
-    throw err
-  })
-
-  const mdFiles = entries.filter((f) => f.endsWith(".md")).sort()
-
-  const outlines = await Promise.all(
-    mdFiles.map(async (f) => {
-      const raw = await readFile(join(dir, f), "utf8")
-      const parsed = matter(raw)
-      const name = basename(f, ".md")
-      const title = isString(parsed.data.title) ? parsed.data.title : name
-      const lines = parsed.content.split("\n")
-      const sections = parseSections(lines)
-
-      const headings: MemoryHeading[] = sections.map((s) =>
-        s.level === 1
-          ? { level: 1 as const, text: s.heading }
-          : { level: 2 as const, text: s.heading, entryCount: s.entryCount },
+  const deleteMemory = async (
+    params: {
+      vaultPath: string
+      file: string
+      section: string
+      date: string
+      entry: string
+    },
+    logger: Logger,
+  ): Promise<void> => {
+    const raw = await readMemoryFile(params.vaultPath, params.file)
+    const parsed = matter(raw)
+    const lines = parsed.content.split("\n")
+    const sections = parseSections(lines)
+    const match = findSection(sections, params.section, 2)
+    if (!match) {
+      throw new Error(
+        `section not found: "${params.section}" in ${memoryDir}/${params.file}.md`,
       )
-
-      return { file: name, title, headings }
-    }),
-  )
-
-  logger.info("listed memory files", { count: outlines.length })
-  return outlines
-}
-
-/** Removes a single dated entry from a memory file by exact match. */
-const deleteMemory = async (
-  params: {
-    vaultPath: string
-    file: string
-    section: string
-    date: string
-    entry: string
-  },
-  logger: Logger,
-): Promise<void> => {
-  const raw = await readMemoryFile(params.vaultPath, params.file)
-  const parsed = matter(raw)
-  const lines = parsed.content.split("\n")
-  const sections = parseSections(lines)
-  const match = findSection(sections, params.section, 2)
-  if (!match) {
-    throw new Error(
-      `section not found: "${params.section}" in About Me/${params.file}.md`,
-    )
-  }
-
-  // Build the exact bullet string and find matching lines within the section
-  const needle = `- **${params.date}**: ${params.entry}`
-  const matchingIndices = lines.reduce<number[]>((acc, line, i) => {
-    if (i >= match.bodyStartLine && i < match.bodyEndLine && line === needle) {
-      acc.push(i)
     }
-    return acc
-  }, [])
 
-  if (matchingIndices.length === 0) {
-    throw new Error(
-      `no entry matching (${params.date}, "${params.entry}") under ## ${match.heading} in About Me/${params.file}.md`,
+    // Build the exact bullet string and find matching lines within the section
+    const needle = `- **${params.date}**: ${params.entry}`
+    const matchingIndices = lines.reduce<number[]>((acc, line, i) => {
+      if (
+        i >= match.bodyStartLine &&
+        i < match.bodyEndLine &&
+        line === needle
+      ) {
+        acc.push(i)
+      }
+      return acc
+    }, [])
+
+    if (matchingIndices.length === 0) {
+      throw new Error(
+        `no entry matching (${params.date}, "${params.entry}") under ## ${match.heading} in ${memoryDir}/${params.file}.md`,
+      )
+    }
+    if (matchingIndices.length > 1) {
+      throw new Error(
+        `ambiguous: ${matchingIndices.length} entries match (${params.date}, "${params.entry}") under ## ${match.heading} in ${memoryDir}/${params.file}.md`,
+      )
+    }
+
+    // Remove the single matched line, preserving everything before and after it
+    const updatedLines = [
+      ...lines.slice(0, matchingIndices[0]),
+      ...lines.slice(matchingIndices[0] + 1),
+    ]
+
+    const newContent = updatedLines.join("\n")
+    const serialized = matter.stringify(newContent, parsed.data)
+    await writeFile(
+      memoryFilePath(params.vaultPath, params.file),
+      serialized,
+      "utf8",
     )
-  }
-  if (matchingIndices.length > 1) {
-    throw new Error(
-      `ambiguous: ${matchingIndices.length} entries match (${params.date}, "${params.entry}") under ## ${match.heading} in About Me/${params.file}.md`,
-    )
+    logger.info("deleted memory entry", {
+      file: params.file,
+      section: params.section,
+      date: params.date,
+    })
   }
 
-  // Remove the single matched line, preserving everything before and after it
-  const updatedLines = [
-    ...lines.slice(0, matchingIndices[0]),
-    ...lines.slice(matchingIndices[0] + 1),
-  ]
-
-  const newContent = updatedLines.join("\n")
-  const serialized = matter.stringify(newContent, parsed.data)
-  await writeFile(
-    memoryFilePath(params.vaultPath, params.file),
-    serialized,
-    "utf8",
-  )
-  logger.info("deleted memory entry", {
-    file: params.file,
-    section: params.section,
-    date: params.date,
-  })
+  return { getMemory, updateMemory, listMemoryFiles, deleteMemory }
 }
 
-export const memoryStore = {
-  getMemory,
-  updateMemory,
-  listMemoryFiles,
-  deleteMemory,
-}
+export type MemoryStore = ReturnType<typeof createMemoryStore>

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -54,15 +54,25 @@ const parseSections = (lines: readonly string[]): ParsedSection[] => {
       startLine: number
       entryCount: number
     }>
-  >((acc, line, i) => {
+  >((acc, line, lineIndex) => {
     const h1 = /^# (.+)$/.exec(line)
     if (h1) {
-      acc.push({ heading: h1[1].trim(), level: 1, startLine: i, entryCount: 0 })
+      acc.push({
+        heading: h1[1].trim(),
+        level: 1,
+        startLine: lineIndex,
+        entryCount: 0,
+      })
       return acc
     }
     const h2 = /^## (.+)$/.exec(line)
     if (h2) {
-      acc.push({ heading: h2[1].trim(), level: 2, startLine: i, entryCount: 0 })
+      acc.push({
+        heading: h2[1].trim(),
+        level: 2,
+        startLine: lineIndex,
+        entryCount: 0,
+      })
       return acc
     }
     // Count dated bullets under the most recently seen heading
@@ -73,12 +83,13 @@ const parseSections = (lines: readonly string[]): ParsedSection[] => {
   }, [])
 
   // Phase 2: compute body ranges — each section's body ends where the next heading starts
-  return raw.map((section, i) => ({
+  return raw.map((section, index) => ({
     heading: section.heading,
     level: section.level,
     startLine: section.startLine,
     bodyStartLine: section.startLine + 1,
-    bodyEndLine: i + 1 < raw.length ? raw[i + 1].startLine : lines.length,
+    bodyEndLine:
+      index + 1 < raw.length ? raw[index + 1].startLine : lines.length,
     entryCount: section.entryCount,
   }))
 }
@@ -91,7 +102,8 @@ const findSection = (
 ): ParsedSection | undefined => {
   const needle = sectionName.trim().toLowerCase()
   return sections.find(
-    (s) => s.level === level && s.heading.toLowerCase() === needle,
+    (section) =>
+      section.level === level && section.heading.toLowerCase() === needle,
   )
 }
 
@@ -127,16 +139,21 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
   ): Promise<string> => {
     if (!params.file) {
       const dir = join(params.vaultPath, memoryDir)
-      const entries = await readdir(dir).catch((err) => {
+      let entries: string[]
+      try {
+        entries = await readdir(dir)
+      } catch (err) {
         if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-          throw new Error(`${memoryDir} directory not found`)
+          throw new Error(`${memoryDir} directory not found`, { cause: err })
         }
         throw err
-      })
-      const mdFiles = entries.filter((f) => f.endsWith(".md")).sort()
+      }
+      const mdFiles = entries
+        .filter((filename) => filename.endsWith(".md"))
+        .sort()
       const contents = await Promise.all(
-        mdFiles.map(async (f) => {
-          const raw = await readFile(join(dir, f), "utf8")
+        mdFiles.map(async (filename) => {
+          const raw = await readFile(join(dir, filename), "utf8")
           return matter(raw).content.trim()
         }),
       )
@@ -203,9 +220,11 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     // Find the first and last dated bullet within the section body to determine
     // where to insert. Offsets are relative to the section's bodyStartLine.
     const bodyLines = lines.slice(match.bodyStartLine, match.bodyEndLine)
-    const firstBulletOffset = bodyLines.findIndex((l) => ENTRY_PATTERN.test(l))
+    const firstBulletOffset = bodyLines.findIndex((line) =>
+      ENTRY_PATTERN.test(line),
+    )
     const lastBulletOffset = bodyLines.reduce(
-      (last, l, i) => (ENTRY_PATTERN.test(l) ? i : last),
+      (last, line, index) => (ENTRY_PATTERN.test(line) ? index : last),
       -1,
     )
 
@@ -248,26 +267,35 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     logger: Logger,
   ): Promise<MemoryFileOutline[]> => {
     const dir = join(params.vaultPath, memoryDir)
-    const entries = await readdir(dir).catch((err) => {
+    let entries: string[]
+    try {
+      entries = await readdir(dir)
+    } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return []
       throw err
-    })
+    }
 
-    const mdFiles = entries.filter((f) => f.endsWith(".md")).sort()
+    const mdFiles = entries
+      .filter((filename) => filename.endsWith(".md"))
+      .sort()
 
     const outlines = await Promise.all(
-      mdFiles.map(async (f) => {
-        const raw = await readFile(join(dir, f), "utf8")
+      mdFiles.map(async (filename) => {
+        const raw = await readFile(join(dir, filename), "utf8")
         const parsed = matter(raw)
-        const name = basename(f, ".md")
+        const name = basename(filename, ".md")
         const title = isString(parsed.data.title) ? parsed.data.title : name
         const lines = parsed.content.split("\n")
         const sections = parseSections(lines)
 
-        const headings: MemoryHeading[] = sections.map((s) =>
-          s.level === 1
-            ? { level: 1 as const, text: s.heading }
-            : { level: 2 as const, text: s.heading, entryCount: s.entryCount },
+        const headings: MemoryHeading[] = sections.map((section) =>
+          section.level === 1
+            ? { level: 1 as const, text: section.heading }
+            : {
+                level: 2 as const,
+                text: section.heading,
+                entryCount: section.entryCount,
+              },
         )
 
         return { file: name, title, headings }
@@ -301,13 +329,13 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
 
     // Build the exact bullet string and find matching lines within the section
     const needle = `- **${params.date}**: ${params.entry}`
-    const matchingIndices = lines.reduce<number[]>((acc, line, i) => {
+    const matchingIndices = lines.reduce<number[]>((acc, line, index) => {
       if (
-        i >= match.bodyStartLine &&
-        i < match.bodyEndLine &&
+        index >= match.bodyStartLine &&
+        index < match.bodyEndLine &&
         line === needle
       ) {
-        acc.push(i)
+        acc.push(index)
       }
       return acc
     }, [])

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -5,8 +5,6 @@ import matter from "gray-matter"
 import picomatch from "picomatch"
 import type { Logger } from "../../logger.js"
 
-const PROTECTED_PATHS = ["About Me/", "Daily Notes/"] as const
-
 /** Resolves a note path within the vault, throwing on traversal attempts. */
 export const resolveSafePath = (
   vaultPath: string,
@@ -90,12 +88,19 @@ const writeNote = async (
   logger.info("wrote note", { path: params.path })
 }
 
-/** Deletes a note. Rejects paths under PROTECTED_PATHS. */
+/** Deletes a note. Rejects paths under the configured protected paths. */
 const deleteNote = async (
-  params: { vaultPath: string; path: string },
+  params: {
+    vaultPath: string
+    path: string
+    protectedPaths: readonly string[]
+  },
   logger: Logger,
 ): Promise<void> => {
-  if (PROTECTED_PATHS.some((p) => params.path.startsWith(p))) {
+  const protectedPrefixes = params.protectedPaths.map((folder) =>
+    folder.endsWith("/") ? folder : `${folder}/`,
+  )
+  if (protectedPrefixes.some((prefix) => params.path.startsWith(prefix))) {
     throw new Error(
       `cannot delete protected path "${params.path}" (use vault_delete_memory for individual entries)`,
     )

--- a/templates/memory/Opinions.md
+++ b/templates/memory/Opinions.md
@@ -1,0 +1,15 @@
+---
+title: Opinions
+type: profile
+tags:
+  - memory
+  - opinions
+---
+
+# Opinions
+
+## Tools and workflows (newest first)
+
+## Code patterns (newest first)
+
+## Communication preferences (newest first)

--- a/templates/memory/Principles.md
+++ b/templates/memory/Principles.md
@@ -1,0 +1,15 @@
+---
+title: Principles
+type: profile
+tags:
+  - memory
+  - principles
+---
+
+# Principles
+
+## Decision heuristics (newest first)
+
+## Working style (newest first)
+
+## Non-negotiables (newest first)

--- a/templates/memory/README.md
+++ b/templates/memory/README.md
@@ -1,0 +1,41 @@
+# Memory Templates
+
+These example files show the expected structure for vault-cortex's memory system.
+
+## Setup
+
+1. Copy the example files into your vault's memory folder (default: `About Me/`):
+
+```
+cp templates/memory/Principles.md ~/your-vault/About Me/
+cp templates/memory/Opinions.md ~/your-vault/About Me/
+```
+
+2. If you use a different folder name, set `MEMORY_DIR` in your `.env`:
+
+```
+MEMORY_DIR=Profile
+```
+
+Then copy into that folder instead.
+
+## Structure
+
+Memory files use a specific format that vault-cortex tools understand:
+
+- **H1 heading**: file title (one per file)
+- **H2 headings**: sections (topics, categories)
+- **Dated bullets**: entries under each section, in `- **YYYY-MM-DD**: text` format
+
+The `vault_update_memory` tool appends dated entries automatically. The `vault_get_memory` tool reads them back, either a full file, a single section, or all files concatenated.
+
+## Customization
+
+These templates are starting points. You can:
+
+- Rename files to match your needs
+- Add or remove H2 sections
+- Change section names
+- Add YAML frontmatter (tags, type, etc.)
+
+The only requirement is the H2 heading structure and the dated bullet format for entries.

--- a/templates/memory/README.md
+++ b/templates/memory/README.md
@@ -6,14 +6,14 @@ These example files show the expected structure for vault-cortex's memory system
 
 1. Copy the example files into your vault's memory folder (default: `About Me/`):
 
-```
+```bash
 cp templates/memory/Principles.md ~/your-vault/About Me/
 cp templates/memory/Opinions.md ~/your-vault/About Me/
 ```
 
 2. If you use a different folder name, set `MEMORY_DIR` in your `.env`:
 
-```
+```bash
 MEMORY_DIR=Profile
 ```
 


### PR DESCRIPTION
## Summary

- **New `config.ts` module** with `loadConfig()` — reads `MEMORY_DIR`, `PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`, `SERVICE_DOCUMENTATION_URL` from env vars with Zod validation, smart defaults (MEMORY_DIR cascades into protected paths and orphan exclusions), and comma-separated parsing
- **Converted `memory-store` to factory pattern** (`createMemoryStore({ memoryDir })`) — matches existing `createSearchIndex`/`createOAuthProvider` patterns; all 7 hardcoded "About Me" error messages now reference the configured dir
- **Made `deleteNote` accept `protectedPaths` as a parameter** and moved orphan exclusion defaults from `search-index.ts` to the tool-definitions caller — single source of truth in config
- **Threaded `VaultConfig` through the full chain** (`server.ts` → `mcp-router.ts` → `tool-definitions.ts` → `oauth-routes.ts`) — all 19 "About Me/" literals in tool descriptions now interpolate from config
- **Removed hardcoded personal defaults**: `aliasunder` GHCR fallback, `America/New_York` timezone (→ UTC), `My Vault` vault name, GitHub URL in OAuth metadata
- **CI/CD**: all new config vars (`MEMORY_DIR`, `PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`, `SERVICE_DOCUMENTATION_URL`, `TZ`) flow through `deploy.yml` → instance `.env` → `docker-compose.yml` → container. `TZ` is now a configurable repo variable (default: UTC)
- **Docker Compose**: both `docker-compose.yml` and `docker-compose.local.yml` pass all config vars to the container
- **Added `templates/memory/`** with example files for new users
- **Documentation**: new Configuration section in README, updated ARCHITECTURE.md, CI variables table with defaults, one-time setup references optional config
- **Code cleanup**: memory-store callback params renamed (`f` → `filename`, `l` → `line`, `i` → `index`, `s` → `section`), `.catch()` chains → try/catch

### Verification

| Check | Result |
|-------|--------|
| `grep -rn "About Me" src/` (non-test) | Only `config.ts:59` (the default value) |
| `grep -rn "aliasunder"` (src/env/compose/scripts/CI) | Only config default + test + .env.example comment |
| `grep -rn "America/New_York"` (compose/env/CI) | Zero hits |
| `npm test` | 459 passed (37 new) |
| `npm run build` | Clean compile |

### Deploy path trace

Every config var traced through all three deployment paths:

| Config var | CI deploy.yml → .env | docker-compose.yml → container | docker-compose.local.yml | npm run dev:mcp |
|---|---|---|---|---|
| `MEMORY_DIR` | `vars.MEMORY_DIR` | `${MEMORY_DIR:-About Me}` | `${MEMORY_DIR:-About Me}` | user sets in shell |
| `PROTECTED_PATHS` | `vars.PROTECTED_PATHS` | `${PROTECTED_PATHS:-}` | `${PROTECTED_PATHS:-}` | user sets in shell |
| `ORPHAN_EXCLUDE_FOLDERS` | `vars.ORPHAN_EXCLUDE_FOLDERS` | `${ORPHAN_EXCLUDE_FOLDERS:-}` | `${ORPHAN_EXCLUDE_FOLDERS:-}` | user sets in shell |
| `SERVICE_DOCUMENTATION_URL` | `vars.SERVICE_DOCUMENTATION_URL` | `${SERVICE_DOCUMENTATION_URL:-}` | `${SERVICE_DOCUMENTATION_URL:-}` | user sets in shell |
| `TZ` | `vars.TZ` | `${TZ:-UTC}` | `${TZ:-UTC}` | inherits from shell |

### For existing deployments

Add one GitHub Actions repo variable to preserve current behavior:
- `TZ` = `America/New_York` (default changed from `America/New_York` to `UTC`)

All other new variables default to the previous hardcoded values — no action needed.

## Test plan

- [x] `loadConfig({})` returns defaults matching current hardcoded behavior
- [x] `MEMORY_DIR=Profile` cascades into `protectedPaths` and `orphanExcludeFolders`
- [x] Explicit `PROTECTED_PATHS` override replaces cascade entirely
- [x] `createMemoryStore({ memoryDir: "Profile" })` reads from `Profile/` and error messages reference `Profile/`
- [x] `deleteNote` with custom `protectedPaths` rejects the right paths
- [x] `findOrphans` with no args uses empty default (caller provides config defaults)
- [x] Tool descriptions contain `${config.memoryDir}` interpolated values (discrimination tests with non-default config)
- [x] McpServer description/instructions interpolate `config.memoryDir` (discrimination test)
- [x] mcp-router passes config to `registerTools`
- [x] `.env.example`, `docker-compose.yml`, `deploy.yml` have no personal defaults
- [x] All config vars reach the container through CI deploy path
- [x] All config vars reach the container through Docker Compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)