### PR TITLE
docs: improve tool descriptions for structural edit safety

### DIFF
--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -111,6 +111,17 @@ describe("registerTools", () => {
     },
   )
 
+  it("vault_replace_in_note description clarifies in-place scope", () => {
+    const call = findCall(TOOL_NAMES.VAULT_REPLACE_IN_NOTE)!
+    expect(call[1].description).toContain("in place")
+    expect(call[1].description).toContain("vault_read_note")
+  })
+
+  it("vault_patch_note description includes cross-section move guidance", () => {
+    const call = findCall(TOOL_NAMES.VAULT_PATCH_NOTE)!
+    expect(call[1].description).toContain("Cross-section move")
+  })
+
   it("every tool has all 4 annotation hints", () => {
     for (const call of calls) {
       const annotations = call[1].annotations!

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -204,8 +204,13 @@ Returns: Confirmation message.`,
 
 Example: vault_patch_note({ path: "TASKS.md", operation: "append", heading: "Active", content: "- [ ] New task" })
 
+Cross-section move (e.g. completing a task on a board):
+1. vault_read_note to get current content and verify exact text
+2. vault_replace_in_note({ path, old_text: "- [ ] Task text", new_text: "" }) to remove from source
+3. vault_patch_note({ path, operation: "append", heading: "Done", content: "- [x] Task text" }) to add at target
+
 When to use: Modifying part of an existing note without overwriting the entire body.
-Prefer vault_write_note for creating new notes or full rewrites. Prefer vault_replace_in_note for find-and-replace edits.
+Prefer vault_write_note for creating new notes or full rewrites. Prefer vault_replace_in_note for in-place text changes (typos, renaming) that stay in the same location.
 
 Operations:
 - append: add content at end of section (or end of file if no heading)
@@ -287,8 +292,8 @@ Returns: Confirmation message.`,
 
 Example: vault_replace_in_note({ path: "Projects/plan.md", old_text: "TODO: write summary", new_text: "Summary complete." })
 
-When to use: Targeted text changes — fixing typos, updating values, renaming terms in the note body.
-Prefer vault_patch_note for heading-targeted structural edits.
+When to use: Targeted text changes within a single location — fixing typos, updating values, renaming terms, or removing a specific line (new_text=""). Replaces text in place; does not move content across sections.
+To relocate content between headings, use vault_replace_in_note to remove from the source (new_text=""), then vault_patch_note to append at the target. Read the note first with vault_read_note to confirm exact text.
 
 Limitation: Exact text match only (no regex). old_text must appear in the note body or an error is returned.
 


### PR DESCRIPTION
## Summary

- **`vault_replace_in_note`** — tightened "When to use:" to positively scope the tool as "in place" edits within a single location, and added the correct two-call workflow for cross-section moves (remove + append) with a read-first step
- **`vault_patch_note`** — added a concrete "Cross-section move" example showing the 3-step read→remove→append pattern with actual tool call shapes, and refined the vault_replace_in_note cross-reference to clarify its scope
- **Tests** — 2 new assertions enforcing the key behavioral signals ("in place" scope, "Cross-section move" guidance)

### Why positive framing instead of "Not for:"

The original task proposed adding "Not for:" anti-pattern guidance. Research on LLM tool description effectiveness (Anthropic prompting docs, arxiv MCP tool study, Pink Elephant Problem analysis) showed negative framing backfires — telling a model "don't do X" activates the concept of X and raises its probability. Instead, the descriptions positively state what the tool does ("Replaces text in place") so the boundary is implicit.

### OSS consideration

Tool descriptions are self-sufficient — they carry the full cross-section move recipe because most adopters won't have a CLAUDE.md with orchestration guidance. No reliance on external system prompts.

## Test plan

- [x] `npm test` — 461 tests pass (2 new)
- [x] `npm run lint` — clean
- [x] `npm run build` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)