### PR TITLE
docs: add community files for open-source release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo
+* @aliasunder

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug Report
+description: Report a bug with vault-cortex
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Connect to the MCP server with '...'
+        2. Call tool '...' with arguments '...'
+        3. See error '...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Include error messages or logs if available.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of vault-cortex is affected?
+      options:
+        - MCP Tools
+        - Search / Indexing
+        - Auth / OAuth
+        - Docker / Deployment
+        - Docs
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Please provide your environment details.
+      value: |
+        - Node.js version:
+        - OS:
+        - MCP client (e.g. Claude Desktop, Claude Code, Cursor):
+        - Docker version (if applicable):
+        - vault-cortex version/commit:
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, or log output.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature Request
+description: Suggest an idea for vault-cortex
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear description of the problem. E.g. "I'm always frustrated when..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of vault-cortex does this relate to?
+      options:
+        - MCP Tools
+        - Search / Indexing
+        - Auth / OAuth
+        - Docker / Deployment
+        - Docs
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context or screenshots about the feature request.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## What does this PR do?
+
+<!-- A brief description of the change. -->
+
+## Type of change
+
+- [ ] New MCP tool
+- [ ] Bug fix
+- [ ] Refactoring
+- [ ] Documentation
+- [ ] CI / workflow change
+- [ ] Infrastructure (SST, Docker)
+- [ ] Other: <!-- specify -->
+
+## Checklist
+
+- [ ] `npm test` passes
+- [ ] `npm run lint` passes
+- [ ] `npm run prettier:check` passes
+- [ ] `npm run build` succeeds
+- [ ] New MCP tools follow the naming and description conventions in AGENTS.md
+- [ ] README or ARCHITECTURE.md updated (if user-facing behavior changed)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      production:
+        dependency-type: production
+      development:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,62 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of background
+or identity.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by [opening a GitHub issue](https://github.com/aliasunder/vault-cortex/issues/new?labels=conduct)
+with the label **conduct**. If you need to report privately, you can use
+[GitHub's private vulnerability reporting](https://github.com/aliasunder/vault-cortex/security/advisories/new)
+to reach the maintainer confidentially.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing
+
+Thanks for your interest in vault-cortex! This guide covers everything you need
+to get started.
+
+## Quick Start
+
+1. **Prerequisites:** Node.js >= 22 (see `.nvmrc`), Docker (optional, for
+   container mode)
+
+2. **Clone and install:**
+
+   ```bash
+   git clone https://github.com/aliasunder/vault-cortex.git
+   cd vault-cortex
+   npm install
+   ```
+
+3. **Run the checks:**
+   ```bash
+   npm test
+   npm run lint
+   npm run build
+   ```
+
+## Development Modes
+
+vault-cortex can run in three modes during development:
+
+### MCP server (no Docker)
+
+The fastest feedback loop — runs the MCP server directly with hot reload:
+
+```bash
+PUBLIC_URL=http://localhost:8000 MCP_AUTH_TOKEN=local-dev-token VAULT_PATH=~/your-vault npm run dev:mcp
+```
+
+### Docker (local)
+
+Runs vault-mcp in Docker against your local vault (no Lightsail, no
+obsidian-sync):
+
+```bash
+npm run dev:docker
+```
+
+### MCP Inspector
+
+Interactive browser UI for testing all tools:
+
+```bash
+# Terminal 1 — start the server
+PUBLIC_URL=http://localhost:8000 MCP_AUTH_TOKEN=local-dev-token VAULT_PATH=~/your-vault npm run dev:mcp
+
+# Terminal 2 — launch the inspector
+npx @modelcontextprotocol/inspector
+```
+
+See the [README](./README.md#local-development) for full details on each mode.
+
+## Code Conventions
+
+All code conventions — style, naming, logging, test patterns, MCP tool naming —
+are documented in [AGENTS.md](./AGENTS.md). That file is the single source of
+truth. Key points:
+
+- Functional over OOP, arrow functions, factory/closure pattern
+- TypeScript strict mode, Zod for MCP schemas, no `any`
+- MCP wire format uses `snake_case`; internal TypeScript uses `camelCase`
+- Tests read as a behavioral spec — one focused `it()` per behavior
+
+## Pull Request Process
+
+1. **Branch from `main`** — use a descriptive prefix (`feat/`, `fix/`, `docs/`,
+   `refactor/`, `chore/`)
+2. **Keep PRs focused** — one logical change per PR
+3. **Run the full check suite** before pushing:
+   ```bash
+   npm run prettier:check && npm run lint && npm test && npm run build
+   ```
+4. **Fill out the PR template** — the checklist mirrors CI
+5. **CI must pass** — the `CI` workflow runs prettier, lint, test, and build on
+   every PR
+
+## Issues
+
+- **Bug reports:** use the bug report template — include steps to reproduce and
+  your environment
+- **Feature requests:** use the feature request template — describe the problem
+  before the solution
+- **Security issues:** see [SECURITY.md](./SECURITY.md) — report privately, not
+  as a public issue
+
+## Release Process
+
+Releases are cut by the maintainer. Two paths:
+
+- **Manual Release:** Actions tab → "Manual Release" → choose
+  `patch`/`minor`/`major`. Bumps version, deploys, creates GitHub Release.
+- **Tag push:** bump `package.json`, commit on `main`, then
+  `git tag v<version> && git push --tags`
+
+See the [README CI/CD section](./README.md#cicd) for details on each workflow.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](./LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 aliasunder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+[![CI](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/ci.yml?branch=main&logo=github&label=CI)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/aliasunder/vault-cortex)](https://github.com/aliasunder/vault-cortex/releases)
+[![License: MIT](https://img.shields.io/github/license/aliasunder/vault-cortex)](https://github.com/aliasunder/vault-cortex/blob/main/LICENSE)
+[![Node.js](https://img.shields.io/badge/Node.js-%3E%3D22-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![MCP Server](https://badge.mcpx.dev?type=server&features=tools)](https://modelcontextprotocol.io)
+
 # vault-cortex
 
 Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Context Protocol.
@@ -15,6 +22,7 @@ Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Contex
 - [Troubleshooting](#troubleshooting)
 - [Monitoring](#monitoring)
 - [Further reading](#further-reading)
+- [Contributing](#contributing)
 
 ## Architecture
 
@@ -452,3 +460,8 @@ Set `LOG_LEVEL` in `.env` to control the threshold (default: `info`).
 
 - [`ARCHITECTURE.md`](./ARCHITECTURE.md) — full design, MCP tool surface, Phase 1/2 boundaries
 - [`AGENTS.md`](./AGENTS.md) — code conventions for AI-assisted development
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — development setup and PR guidelines
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, code conventions, and PR guidelines.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Scope
+
+vault-cortex is a remote MCP server that exposes an Obsidian vault over HTTPS.
+The attack surface includes:
+
+- **Authentication and authorization** — OAuth 2.0 (Authorization Code + PKCE),
+  JWT tokens (HS256), static bearer token fallback, Lambda authorizer, Express
+  middleware (defense in depth)
+- **API Gateway** — HTTP API fronting the Lightsail instance, path-aware
+  authorization (OAuth discovery endpoints pass through, `/mcp` requires valid
+  bearer)
+- **Express server** — handles MCP protocol messages, OAuth flows, consent page
+- **SQLite** — FTS5 search index and OAuth token persistence. User-supplied
+  search queries are parameterized, not interpolated
+- **File system access** — vault reads and writes. Path traversal is blocked by
+  `resolveSafePath()` (resolve + prefix check). Protected paths prevent deletion
+  of sensitive folders
+- **Docker Compose** — two long-running containers on Lightsail sharing a
+  `/vault` volume (UID 1000)
+- **CI/CD workflows** — GitHub Actions with OIDC AWS auth, SSH to Lightsail,
+  GHCR image push
+
+## Reporting a Vulnerability
+
+If you discover a security issue, please report it through
+[GitHub's private vulnerability reporting](https://github.com/aliasunder/vault-cortex/security/advisories/new)
+rather than opening a public issue.
+
+Please include:
+
+- A description of the vulnerability
+- Steps to reproduce or a proof of concept
+- The potential impact
+
+You should receive an acknowledgment within **48 hours**. I'll work with you to
+understand the issue and coordinate a fix before any public disclosure.
+
+## Supported Versions
+
+Only the latest release is actively maintained. If you're using an older
+version, please upgrade before reporting.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | Yes       |
+| Older   | No        |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,24 @@
 {
   "name": "vault-cortex",
+  "version": "0.8.1",
   "private": true,
+  "description": "Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Context Protocol",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aliasunder/vault-cortex.git"
+  },
+  "homepage": "https://github.com/aliasunder/vault-cortex",
+  "bugs": {
+    "url": "https://github.com/aliasunder/vault-cortex/issues"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "obsidian",
+    "vault",
+    "remote-mcp-server"
+  ],
   "type": "module",
   "engines": {
     "node": ">=22.0.0 <23.0.0"
@@ -62,6 +80,5 @@
     "typescript": "^5.8.0",
     "typescript-eslint": "8.59.2",
     "vitest": "4.1.5"
-  },
-  "version": "0.8.1"
+  }
 }


### PR DESCRIPTION
## Summary

- Add LICENSE (MIT), CODE_OF_CONDUCT.md (Contributor Covenant 2.1), SECURITY.md (scoped to MCP server attack surface), CONTRIBUTING.md (quickstart + dev modes + PR process)
- Add `.github/` community files: CODEOWNERS, YAML issue templates (bug report + feature request with Area dropdowns), PR template with CI-mirrored checklist, dependabot.yml (weekly npm + GitHub Actions)
- Add 6 README badges (CI, Release, License, Node.js, TypeScript, MCP Server) and Contributing section
- Update package.json metadata (description, license, repository, homepage, bugs, keywords)

**Secret scan:** `gitleaks detect` run against full git history — clean. Only finding is `local-dev-token` in the README curl example (intentional placeholder, not a real credential).

**Note:** Enable [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository) in repo Settings → Security before going public — SECURITY.md links to it.

## Test plan

- [x] `npm run prettier:check` — all new files pass
- [x] `npm run lint` — clean
- [x] `npm test` — 461 tests pass
- [x] `npm run build` — clean
- [x] `gitleaks detect` — no real secrets in git history
- [ ] Verify issue template YAML renders correctly on GitHub (navigate to Issues → New issue on the branch)
- [ ] Verify PR template auto-fills on new PR creation
- [ ] Verify badges render after merge (License badge needs LICENSE on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)