### PR TITLE
feat: add local and remote Docker quickstart deploys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,17 @@ package.json                           # single package, all deps
 tsconfig.json                          # single config
 Dockerfile                             # vault-mcp Docker image
 docker-compose.yml                     # Lightsail: obsidian-sync + vault-mcp
+docker-compose.local.yml               # Contributor dev: builds from source
 .env.example                           # template for Lightsail .env
+deploy/                                # End-user quickstart (no clone needed)
+  local/                               #   vault-mcp + bind-mounted vault
+    README.md                          #     quickstart walkthrough
+    docker-compose.yml                 #     just: docker compose up
+    .env.example                       #     MCP_AUTH_TOKEN + VAULT_PATH
+  remote/                              #   vault-mcp + Obsidian Sync + named volumes
+    README.md                          #     quickstart walkthrough (VPS, HTTPS, etc.)
+    docker-compose.yml                 #     just: docker compose up
+    .env.example                       #     + OBSIDIAN_AUTH_TOKEN, VAULT_NAME, PUBLIC_URL
 src/
   logger.ts                            # Root logger (structured JSON, source location)
   auth.ts                              # Shared auth utilities (safeEqual, parseBearer)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,28 @@ Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Contex
 
 > **Status:** Phase 1 complete — 22 MCP tools, deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
 
+## Quickstart
+
+### Local (Docker + your vault folder)
+
+Run vault-cortex on your machine against an existing Obsidian vault. No cloud,
+no Obsidian Sync — just Docker and a folder of `.md` files.
+
+**[→ Local quickstart guide](./deploy/local/)**
+
+### Remote (Docker + Obsidian Sync on a VPS)
+
+Run vault-cortex on a VPS with Obsidian Sync for access from any device. Your
+vault stays in sync; MCP tools work from Claude Desktop, Claude Code, or any MCP
+client — anywhere.
+
+**[→ Remote quickstart guide](./deploy/remote/)**
+
+---
+
 ## Contents
 
+- [Quickstart](#quickstart)
 - [Architecture](#architecture)
 - [Authentication](#authentication)
 - [Configuration](#configuration)

--- a/deploy/local/.env.example
+++ b/deploy/local/.env.example
@@ -1,0 +1,26 @@
+# vault-cortex — local quickstart
+# Copy to .env and fill in values, then: docker compose up
+
+# Required ──────────────────────────────────────────────────
+
+# Bearer token for MCP authentication.
+# Generate one: openssl rand -hex 32
+MCP_AUTH_TOKEN=
+
+# Absolute path to your Obsidian vault on this machine.
+# Example: /Users/you/Documents/MyVault
+VAULT_PATH=
+
+# Optional ──────────────────────────────────────────────────
+
+# Your IANA timezone — affects daily note resolution and memory timestamps.
+# TZ=America/New_York
+
+# Memory folder name in your vault (default: About Me).
+# MEMORY_DIR=About Me
+
+# Host port to expose (default: 8000).
+# PORT=8000
+
+# Log verbosity: debug | info | warn | error (default: info).
+# LOG_LEVEL=info

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -1,0 +1,85 @@
+# Local Quickstart
+
+Run vault-cortex on your machine against a local Obsidian vault. No cloud, no
+Obsidian Sync — just Docker and a folder of `.md` files.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) (v20.10+)
+- An Obsidian vault (or any folder of Markdown files)
+
+## Setup
+
+**1. Get the files.** Download this directory, or clone the repo and `cd deploy/local`.
+
+**2. Create your `.env` file:**
+
+```bash
+cp .env.example .env
+```
+
+**3. Fill in the two required values:**
+
+| Variable         | Value                                                             |
+| ---------------- | ----------------------------------------------------------------- |
+| `MCP_AUTH_TOKEN` | Generate with `openssl rand -hex 32`                              |
+| `VAULT_PATH`     | Absolute path to your vault (e.g. `/Users/you/Documents/MyVault`) |
+
+**4. Start the server:**
+
+```bash
+docker compose up
+```
+
+Add `-d` to run in the background. First start pulls the image (~150MB) and
+builds the search index — this takes a few seconds depending on vault size.
+
+## Connect your MCP client
+
+The server listens at `http://localhost:8000/mcp`.
+
+**Claude Desktop / Claude Code / Claude Mobile:** Add a remote MCP server with
+URL `http://localhost:8000/mcp`. When prompted for authentication, use your
+`MCP_AUTH_TOKEN` as the bearer token.
+
+**MCP Inspector:** Enter `http://localhost:8000/mcp` as the server URL and your
+token as the Bearer token.
+
+**curl:**
+
+```bash
+curl -H "Authorization: Bearer <your-token>" http://localhost:8000/mcp
+```
+
+## Verify
+
+```bash
+# Health check (no auth required):
+curl http://localhost:8000/healthz
+# → {"ok":true}
+
+# OAuth discovery (no auth required):
+curl http://localhost:8000/.well-known/oauth-protected-resource
+```
+
+## Stop
+
+```bash
+# Stop the server (search index is preserved in a Docker volume):
+docker compose down
+
+# Stop and delete all data (index rebuilds on next start):
+docker compose down -v
+```
+
+## Configuration
+
+Only `MCP_AUTH_TOKEN` and `VAULT_PATH` are required. For optional settings
+(memory folder, protected paths, orphan exclusions, timezone), see the
+[Configuration](../../README.md#configuration) section in the main README.
+
+## Building from source
+
+If you want to modify vault-cortex and build from source, clone the repo and
+use `docker-compose.local.yml` in the repo root instead. See
+[CONTRIBUTING.md](../../CONTRIBUTING.md) for the full development setup.

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -1,0 +1,52 @@
+# vault-cortex — local quickstart
+#
+# Run vault-cortex against a local Obsidian vault with just Docker.
+# No cloud, no Obsidian Sync, no AWS — just your vault folder and a bearer token.
+#
+# 1. cp .env.example .env   (then fill in MCP_AUTH_TOKEN and VAULT_PATH)
+# 2. docker compose up
+# 3. Connect your MCP client to http://localhost:8000/mcp
+#
+# Full docs: https://github.com/aliasunder/vault-cortex
+
+name: vault-cortex
+
+services:
+  vault-mcp:
+    image: ghcr.io/aliasunder/vault-mcp:latest
+    container_name: vault-mcp
+    restart: unless-stopped
+    environment:
+      PORT: "8000"
+      HOST: "0.0.0.0"
+      VAULT_PATH: /vault
+      INDEX_DB_PATH: /data/index.db
+      MCP_AUTH_TOKEN: "${MCP_AUTH_TOKEN:?Set MCP_AUTH_TOKEN in .env — see .env.example}"
+      PUBLIC_URL: ${PUBLIC_URL:-http://localhost:8000}
+      MEMORY_DIR: ${MEMORY_DIR:-About Me}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      TZ: ${TZ:-UTC}
+      # Uncomment to override smart defaults (see Configuration in the main README):
+      # PROTECTED_PATHS: ${PROTECTED_PATHS:-}
+      # ORPHAN_EXCLUDE_FOLDERS: ${ORPHAN_EXCLUDE_FOLDERS:-}
+      # SERVICE_DOCUMENTATION_URL: ${SERVICE_DOCUMENTATION_URL:-}
+    volumes:
+      - "${VAULT_PATH:?Set VAULT_PATH to your Obsidian vault folder}:/vault:rw"
+      - mcp_data:/data
+    ports:
+      - "${PORT:-8000}:8000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:8000/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+volumes:
+  mcp_data:

--- a/deploy/remote/.env.example
+++ b/deploy/remote/.env.example
@@ -1,0 +1,51 @@
+# vault-cortex — remote quickstart (Obsidian Sync)
+# Copy to .env and fill in values, then: docker compose up -d
+
+# Required ──────────────────────────────────────────────────
+
+# Bearer token for MCP authentication.
+# Generate one: openssl rand -hex 32
+MCP_AUTH_TOKEN=
+
+# Public URL that MCP clients use to reach this server.
+# Used as the OAuth issuer URL in discovery metadata.
+# Examples: https://vault.example.com, http://203.0.113.10:8000
+PUBLIC_URL=
+
+# Obsidian Sync auth token. Generate once with:
+#   docker run --rm -it --entrypoint get-token \
+#     ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+OBSIDIAN_AUTH_TOKEN=
+
+# Exact name of your Obsidian vault (case-sensitive).
+VAULT_NAME=
+
+# Optional ──────────────────────────────────────────────────
+
+# Only if your vault has end-to-end encryption enabled.
+# VAULT_PASSWORD=
+
+# Your IANA timezone — affects daily note resolution and memory timestamps.
+# TZ=America/New_York
+
+# Memory folder name in your vault (default: About Me).
+# MEMORY_DIR=About Me
+
+# Host port to expose (default: 8000).
+# PORT=8000
+
+# Log verbosity: debug | info | warn | error (default: info).
+# LOG_LEVEL=info
+
+# User/group IDs for obsidian-sync (default: 1000).
+# PUID=1000
+# PGID=1000
+
+# Device name shown in Obsidian Sync settings.
+# DEVICE_NAME=vault-cortex
+
+# Obsidian Sync conflict resolution: merge | ours | theirs (default: merge).
+# CONFLICT_STRATEGY=merge
+
+# Sync direction: bidirectional | pull-only | push-only (default: bidirectional).
+# SYNC_MODE=bidirectional

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -82,10 +82,10 @@ Create an HTTP API in API Gateway with a route that proxies to
 URL. See the project's [full cloud deployment](../../README.md#deployment) for
 the SST IaC approach, which adds a Lambda authorizer for an extra auth layer.
 
-> **Need a VPS?** [AWS Lightsail](https://aws.amazon.com/lightsail/) starts at
-> ~$10/mo for a 1GB instance — enough for vault-cortex. Paired with API Gateway
-> (~$0) and this compose file, the total cost is ~$10/mo. For a fully automated
-> setup, vault-cortex also includes an
+> **Need a VPS?** [AWS Lightsail](https://aws.amazon.com/lightsail/) runs
+> vault-cortex on a 2 GB RAM / 60 GB SSD instance for ~$12/mo. Paired with API
+> Gateway (~$0) and this compose file, the total cost is ~$12/mo. For a fully
+> automated setup, vault-cortex also includes an
 > [SST IaC deployment](../../README.md#deployment) that provisions Lightsail, API
 > Gateway, and a Lambda authorizer in one command.
 

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -1,0 +1,152 @@
+# Remote Quickstart (Obsidian Sync)
+
+Run vault-cortex on a VPS with Obsidian Sync for remote access from any device.
+Your vault stays in sync; MCP tools work from Claude Desktop, Claude Code,
+claude.ai, or any MCP client — anywhere.
+
+## Prerequisites
+
+- A VPS or cloud server with [Docker](https://docs.docker.com/engine/install/)
+  installed (Ubuntu/Debian: `curl -fsSL https://get.docker.com | sh`)
+- An [Obsidian Sync](https://obsidian.md/sync) subscription
+- A domain name or public IP address for your server
+
+## Setup
+
+**1. SSH into your server** and create a working directory:
+
+```bash
+mkdir -p /opt/vault-cortex && cd /opt/vault-cortex
+```
+
+**2. Download the quickstart files:**
+
+```bash
+curl -O https://raw.githubusercontent.com/aliasunder/vault-cortex/main/deploy/remote/docker-compose.yml
+curl -O https://raw.githubusercontent.com/aliasunder/vault-cortex/main/deploy/remote/.env.example
+```
+
+Or clone the repo and `cd deploy/remote`.
+
+**3. Generate your Obsidian Sync auth token** (one-time):
+
+```bash
+docker run --rm -it --entrypoint get-token \
+  ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+```
+
+**4. Create your `.env` file:**
+
+```bash
+cp .env.example .env
+```
+
+**5. Fill in the required values:**
+
+| Variable              | Value                                                              |
+| --------------------- | ------------------------------------------------------------------ |
+| `MCP_AUTH_TOKEN`      | Generate with `openssl rand -hex 32`                               |
+| `PUBLIC_URL`          | Your server's public URL (see [HTTPS access](#https-access) below) |
+| `OBSIDIAN_AUTH_TOKEN` | Output from step 3                                                 |
+| `VAULT_NAME`          | Your exact Obsidian vault name (case-sensitive)                    |
+
+**6. Start the server:**
+
+```bash
+docker compose up -d
+```
+
+First start pulls images and syncs your vault from Obsidian's servers. The
+initial sync takes 30–120 seconds depending on vault size. vault-mcp builds its
+search index as files arrive.
+
+## HTTPS access
+
+MCP clients need to reach your server over the network. Three options:
+
+### Reverse proxy (recommended)
+
+Use [Caddy](https://caddyserver.com/) or nginx with a domain and TLS
+certificate. Set `PUBLIC_URL` to `https://vault.yourdomain.com`. Caddy handles
+TLS automatically:
+
+```
+vault.yourdomain.com {
+    reverse_proxy localhost:8000
+}
+```
+
+### Cloudflare Tunnel
+
+Zero-config HTTPS with no open ports. Install
+[cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-remote-tunnel/)
+and create a tunnel pointing to `http://localhost:8000`. Set `PUBLIC_URL` to the
+tunnel URL.
+
+### Direct access (testing only)
+
+Access the server directly at `http://<your-ip>:8000`. No TLS — suitable for
+testing on a private network, not for production. Set `PUBLIC_URL` to
+`http://<your-ip>:8000`.
+
+> **Note:** `PUBLIC_URL` must match exactly how MCP clients reach the server.
+> OAuth discovery metadata uses this URL, so a mismatch causes authentication
+> failures.
+
+## Connect your MCP client
+
+### OAuth (Claude Desktop, Claude Code, Claude Mobile, claude.ai)
+
+Add a remote MCP server with URL `<PUBLIC_URL>/mcp`. Leave OAuth Client ID and
+Secret empty — dynamic registration handles it. A consent page opens in your
+browser; enter your `MCP_AUTH_TOKEN` to approve. The client receives a JWT
+access token (24h) with automatic refresh (60-day sliding window).
+
+### Static bearer token (CLI tools, curl)
+
+```bash
+curl -H "Authorization: Bearer <your-MCP_AUTH_TOKEN>" <PUBLIC_URL>/mcp
+```
+
+## Verify
+
+```bash
+# Health check (no auth):
+curl http://localhost:8000/healthz
+# → {"ok":true}
+
+# Check obsidian-sync is downloading your vault:
+docker logs obsidian-sync
+
+# Check vault-mcp indexed your notes:
+docker logs vault-mcp
+```
+
+## Monitoring
+
+```bash
+# Follow vault-mcp logs:
+docker logs -f vault-mcp
+
+# Follow obsidian-sync logs:
+docker logs -f obsidian-sync
+
+# Check container status:
+docker compose ps
+```
+
+## Stop
+
+```bash
+# Stop containers — named volumes persist your vault data and search index:
+docker compose down
+
+# Stop and delete all volumes (vault re-syncs on next start; index rebuilds):
+docker compose down -v
+```
+
+## Configuration
+
+Only `MCP_AUTH_TOKEN`, `PUBLIC_URL`, `OBSIDIAN_AUTH_TOKEN`, and `VAULT_NAME` are
+required. For optional settings (memory folder, protected paths, timezone), see
+the [Configuration](../../README.md#configuration) section in the main README.

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -62,9 +62,24 @@ search index as files arrive.
 
 ## HTTPS access
 
-MCP clients need to reach your server over the network. Three options:
+MCP clients need to reach your server over the network. Four options:
 
-### Reverse proxy (recommended)
+### API Gateway (AWS — no domain needed)
+
+This is the approach vault-cortex's own production deployment uses. AWS API
+Gateway acts as a TLS-terminating reverse proxy in front of your server — no
+domain, no certificate management. You get an HTTPS URL immediately:
+
+```
+https://<id>.execute-api.<region>.amazonaws.com
+```
+
+Create an HTTP API in API Gateway with a route that proxies to
+`http://<your-server-ip>:8000/{proxy+}`. Set `PUBLIC_URL` to the API Gateway
+URL. See the project's [full cloud deployment](../../README.md#deployment) for
+the SST IaC approach, which adds a Lambda authorizer for an extra auth layer.
+
+### Reverse proxy (requires a domain)
 
 Use [Caddy](https://caddyserver.com/) or nginx with a domain and TLS
 certificate. Set `PUBLIC_URL` to `https://vault.yourdomain.com`. Caddy handles

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -74,10 +74,20 @@ domain, no certificate management. You get an HTTPS URL immediately:
 https://<id>.execute-api.<region>.amazonaws.com
 ```
 
+HTTP API pricing is $1.00 per million requests with a free tier of 1M
+requests/month for 12 months — effectively free for personal use.
+
 Create an HTTP API in API Gateway with a route that proxies to
 `http://<your-server-ip>:8000/{proxy+}`. Set `PUBLIC_URL` to the API Gateway
 URL. See the project's [full cloud deployment](../../README.md#deployment) for
 the SST IaC approach, which adds a Lambda authorizer for an extra auth layer.
+
+> **Need a VPS?** [AWS Lightsail](https://aws.amazon.com/lightsail/) starts at
+> ~$10/mo for a 1GB instance — enough for vault-cortex. Paired with API Gateway
+> (~$0) and this compose file, the total cost is ~$10/mo. For a fully automated
+> setup, vault-cortex also includes an
+> [SST IaC deployment](../../README.md#deployment) that provisions Lightsail, API
+> Gateway, and a Lambda authorizer in one command.
 
 ### Reverse proxy (requires a domain)
 

--- a/deploy/remote/docker-compose.yml
+++ b/deploy/remote/docker-compose.yml
@@ -1,0 +1,101 @@
+# vault-cortex — remote quickstart (Obsidian Sync)
+#
+# Run vault-cortex on a VPS with Obsidian Sync for remote access from any device.
+# Three services: init-config-perms → obsidian-sync → vault-mcp.
+#
+# 1. cp .env.example .env   (then fill in required values)
+# 2. docker compose up -d
+# 3. Connect your MCP client to http://<your-server>:8000/mcp
+#
+# Full docs: https://github.com/aliasunder/vault-cortex
+
+name: vault-cortex
+
+services:
+  # Workaround: the upstream Dockerfile creates /home/obsidian/.config as
+  # root. Docker named volumes inherit this root ownership, so the obsidian
+  # user (UID 1000) can't write sync state. This init container chowns the
+  # volume before obsidian-sync starts.
+  init-config-perms:
+    image: alpine:latest
+    command: sh -c "chown -R ${PUID:-1000}:${PGID:-1000} /config"
+    volumes:
+      - obsidian_config:/config
+    restart: "no"
+
+  obsidian-sync:
+    image: ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+    container_name: obsidian-sync
+    restart: unless-stopped
+    depends_on:
+      init-config-perms:
+        condition: service_completed_successfully
+    environment:
+      OBSIDIAN_AUTH_TOKEN: "${OBSIDIAN_AUTH_TOKEN:?Set OBSIDIAN_AUTH_TOKEN — see .env.example}"
+      VAULT_NAME: "${VAULT_NAME:?Set VAULT_NAME to your Obsidian vault name (case-sensitive)}"
+      VAULT_PASSWORD: ${VAULT_PASSWORD:-}
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
+      DEVICE_NAME: ${DEVICE_NAME:-vault-cortex}
+      CONFLICT_STRATEGY: ${CONFLICT_STRATEGY:-merge}
+      SYNC_MODE: ${SYNC_MODE:-bidirectional}
+      TZ: ${TZ:-UTC}
+    volumes:
+      - vault_data:/vault
+      - obsidian_config:/home/obsidian/.config
+    healthcheck:
+      test: ["CMD-SHELL", "test -d /vault && pgrep -f 'ob sync' >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+
+  vault-mcp:
+    image: ghcr.io/aliasunder/vault-mcp:latest
+    container_name: vault-mcp
+    restart: unless-stopped
+    depends_on:
+      obsidian-sync:
+        condition: service_started
+    environment:
+      PORT: "8000"
+      HOST: "0.0.0.0"
+      VAULT_PATH: /vault
+      INDEX_DB_PATH: /data/index.db
+      MCP_AUTH_TOKEN: "${MCP_AUTH_TOKEN:?Set MCP_AUTH_TOKEN in .env — see .env.example}"
+      PUBLIC_URL: "${PUBLIC_URL:?Set PUBLIC_URL to your server's public URL}"
+      MEMORY_DIR: ${MEMORY_DIR:-About Me}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      TZ: ${TZ:-UTC}
+      # Uncomment to override smart defaults (see Configuration in the main README):
+      # PROTECTED_PATHS: ${PROTECTED_PATHS:-}
+      # ORPHAN_EXCLUDE_FOLDERS: ${ORPHAN_EXCLUDE_FOLDERS:-}
+      # SERVICE_DOCUMENTATION_URL: ${SERVICE_DOCUMENTATION_URL:-}
+    volumes:
+      - vault_data:/vault:rw
+      - mcp_data:/data
+    ports:
+      - "0.0.0.0:${PORT:-8000}:8000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:8000/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+
+volumes:
+  vault_data:
+  mcp_data:
+  obsidian_config:


### PR DESCRIPTION
## Summary

- Add `deploy/local/` — self-contained quickstart for running vault-cortex against a local vault folder with just Docker (vault-mcp only, bind-mounted vault, 2 required env vars)
- Add `deploy/remote/` — self-contained quickstart for running vault-cortex on a VPS with Obsidian Sync (3 services, named Docker volumes, 4 required env vars, HTTPS guidance)
- Each directory has `docker-compose.yml`, `.env.example`, and `README.md` — users `cd` in, copy `.env`, and `docker compose up`
- Add Quickstart section to main README with links to both guides
- Update AGENTS.md Structure section with the new `deploy/` directory

### Four personas, four paths

| Persona | Path |
|---------|------|
| **Local users** (no clone) | `deploy/local/` |
| **Remote users** (no clone) | `deploy/remote/` |
| **Cloud deployers** (clone + AWS) | Root `docker-compose.yml` + SST |
| **Contributors** (clone + Node.js) | `docker-compose.local.yml` |

### Why two files instead of Docker Compose profiles?

Local mode uses bind mounts (user's existing vault). Remote/sync mode uses named Docker volumes (container-originated data from Obsidian Sync). Docker Compose can't conditionally switch volume sources per profile, so two compose files is the correct approach.

## Test plan

- [x] `docker compose config` validates both compose files (local + remote)
- [x] Error messages are clear when required env vars are missing
- [x] `npm run prettier:check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 461 tests pass (no source changes)
- [ ] Local smoke test: run `deploy/local/` with a test vault, verify healthcheck + tool call
- [ ] README links resolve correctly on GitHub (`deploy/local/` and `deploy/remote/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)