### PR TITLE
feat: auto-create memory files on first write

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,6 +207,8 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 | `vault_delete_memory`     | `file, section, date, entry`     | destructiveHint |
 | `vault_list_memory_files` | —                                | readOnlyHint    |
 
+**Auto-initialization:** On first startup, if the memory folder (default: `About Me/`) doesn't exist, the server creates it with template files (Principles.md, Opinions.md) so agents discover a ready structure. `vault_update_memory` also auto-creates files and sections on write — agents can save preferences without manual setup. This is the two-layer bootstrap: startup seeds the default structure, write-time handles growth beyond templates.
+
 ### Phase 1: Link Queries
 
 | Tool                       | Input                      | Annotation   |
@@ -311,7 +313,9 @@ Three services run in order via `depends_on`:
    for incremental sync — critical for Phase 2 LightRAG ingestion).
 3. **`vault-mcp`** — MCP server. Runs as the `node` user (UID 1000),
    matching obsidian-sync's `PUID` so both containers can read/write the
-   shared `/vault` volume.
+   shared `/vault` volume. On startup: builds the FTS5 search index,
+   bootstraps memory templates if the memory folder doesn't exist, then
+   starts the file watcher.
 
 ### Durability
 

--- a/README.md
+++ b/README.md
@@ -117,12 +117,9 @@ vault-cortex reads configuration from environment variables at startup. All sett
 
 The memory tools (`vault_get_memory`, `vault_update_memory`, `vault_list_memory_files`, `vault_delete_memory`) read and write structured files in a configurable folder inside the vault. These files use H2 headings as sections and dated bullets (`- **YYYY-MM-DD**: text`) as entries.
 
-Example memory files are provided in [`templates/memory/`](./templates/memory/). Copy them into your vault's memory folder to get started:
+**Auto-initialization:** On first startup, if the memory folder doesn't exist, the server creates it with template files (Principles.md, Opinions.md) so agents have a ready structure to discover. Additionally, `vault_update_memory` auto-creates files and sections on write — agents can save preferences immediately without manual setup.
 
-```bash
-cp templates/memory/Principles.md ~/your-vault/About\ Me/
-cp templates/memory/Opinions.md ~/your-vault/About\ Me/
-```
+Example memory files are also provided in [`templates/memory/`](./templates/memory/) for reference or manual setup.
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The memory tools (`vault_get_memory`, `vault_update_memory`, `vault_list_memory_
 
 **Auto-initialization:** On first startup, if the memory folder doesn't exist, the server creates it with template files (Principles.md, Opinions.md) so agents have a ready structure to discover. Additionally, `vault_update_memory` auto-creates files and sections on write — agents can save preferences immediately without manual setup.
 
-Example memory files are also provided in [`templates/memory/`](./templates/memory/) for reference or manual setup.
+Example memory files and a full explanation of the dated-entry design (why timestamps matter, how they enable temporal queries in Phase 2) are in [`templates/memory/`](./templates/memory/).
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,16 @@
 
 Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Context Protocol.
 
-> **Status:** Phase 1 complete — 22 MCP tools, deployed. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
+> **Status:** Phase 1 complete — 22 MCP tools, deployed.
+
+### Roadmap
+
+| Phase | What                                                                                | Status   |
+| ----- | ----------------------------------------------------------------------------------- | -------- |
+| **1** | Vault CRUD, full-text search (FTS5), memory layer, OAuth 2.0                        | Complete |
+| **2** | Semantic search + knowledge graph via [LightRAG](https://github.com/HKUDS/LightRAG) | Planned  |
+
+Phase 2 adds a LightRAG container for semantic and knowledge-graph queries over the vault — temporal recall, concept relationships, and richer retrieval beyond keyword search. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design and Phase 1/2 boundaries.
 
 ## Quickstart
 

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -72,6 +72,13 @@ docker compose down
 docker compose down -v
 ```
 
+## Memory
+
+On first startup, if your vault doesn't already have a memory folder (default:
+`About Me/`), the server creates one with template files (Principles.md,
+Opinions.md). Agents can also create new memory files and sections on the fly
+via `vault_update_memory` — no manual setup needed.
+
 ## Configuration
 
 Only `MCP_AUTH_TOKEN` and `VAULT_PATH` are required. For optional settings

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -188,6 +188,13 @@ docker compose down
 docker compose down -v
 ```
 
+## Memory
+
+On first startup, if your vault doesn't already have a memory folder (default:
+`About Me/`), the server creates one with template files (Principles.md,
+Opinions.md). Agents can also create new memory files and sections on the fly
+via `vault_update_memory` — no manual setup needed.
+
 ## Configuration
 
 Only `MCP_AUTH_TOKEN`, `PUBLIC_URL`, `OBSIDIAN_AUTH_TOKEN`, and `VAULT_NAME` are

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -160,6 +160,24 @@ docker logs -f obsidian-sync
 docker compose ps
 ```
 
+## Restart
+
+The server runs startup tasks on every boot: rebuilds the search index, creates
+memory template files if the memory folder doesn't exist, and starts the file
+watcher. To re-run the startup flow (e.g., after changing config or to test
+bootstrap behavior):
+
+```bash
+# Restart just vault-mcp (obsidian-sync keeps running):
+docker compose restart vault-mcp
+
+# Restart all services:
+docker compose restart
+```
+
+The container also restarts automatically on crash (`restart: unless-stopped`
+policy), Docker daemon restart, or system reboot.
+
 ## Stop
 
 ```bash

--- a/src/vault-mcp/server.ts
+++ b/src/vault-mcp/server.ts
@@ -5,6 +5,7 @@ import type { Request, Response, NextFunction } from "express"
 import { resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { createSearchIndex } from "./search/search-index.js"
+import { createMemoryStore } from "./vault-operations/memory-store.js"
 import { startFileWatcher } from "./search/file-watcher.js"
 import { createOAuthProvider } from "./auth/oauth-provider.js"
 import { createOAuthRoutes } from "./auth/oauth-routes.js"
@@ -53,6 +54,9 @@ const startServer = async (): Promise<void> => {
   const search = createSearchIndex(searchDbPath)
   const count = await search.rebuildFromVault(vaultPath)
   logger.info("initial index built", { count })
+
+  const memoryStore = createMemoryStore({ memoryDir: config.memoryDir })
+  await memoryStore.bootstrapMemoryDir({ vaultPath }, logger)
 
   await startFileWatcher(vaultPath, search)
 

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -722,7 +722,7 @@ Returns: Raw markdown text.`,
 Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
 
 When to use: Recording a new preference, principle, opinion, or fact about the user. Pass raw entry text without date prefix. Always call vault_list_memory_files first to discover existing files and sections, and use matching names to keep entries organized alongside existing content.
-Auto-creates: If the file or section does not exist, it is created automatically. New sections are stored with "(newest first)" appended to the heading (e.g. "Design preferences" becomes "Design preferences (newest first)"). Use the full heading name in subsequent vault_get_memory calls, or call vault_list_memory_files to discover the actual heading names. Use existing file and section names from vault_list_memory_files when available.
+Auto-creates: If the file or section does not exist, it is created automatically. If the section name does not already include "(newest first)", the server appends it (e.g. "Design preferences" becomes "Design preferences (newest first)"). Use the full heading name in subsequent vault_get_memory calls, or call vault_list_memory_files to discover the actual heading names. Use existing file and section names from vault_list_memory_files when available.
 Prefer vault_write_note for creating entirely new notes (not memory entries).
 
 Obsidian syntax: Entry text is rendered inline as Obsidian Flavored Markdown. Watch for: #word = tag, [[ = wikilink. Escape with backslash or backticks when unintentional.

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -722,7 +722,7 @@ Returns: Raw markdown text.`,
 Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
 
 When to use: Recording a new preference, principle, opinion, or fact about the user. Pass raw entry text without date prefix. Always call vault_list_memory_files first to discover existing files and sections, and use matching names to keep entries organized alongside existing content.
-Auto-creates: If the file or section does not exist, it is created automatically. Use existing file and section names from vault_list_memory_files when available.
+Auto-creates: If the file or section does not exist, it is created automatically. New sections are stored with "(newest first)" appended to the heading (e.g. "Design preferences" becomes "Design preferences (newest first)"). Use the full heading name in subsequent vault_get_memory calls, or call vault_list_memory_files to discover the actual heading names. Use existing file and section names from vault_list_memory_files when available.
 Prefer vault_write_note for creating entirely new notes (not memory entries).
 
 Obsidian syntax: Entry text is rendered inline as Obsidian Flavored Markdown. Watch for: #word = tag, [[ = wikilink. Escape with backslash or backticks when unintentional.

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -670,7 +670,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
     TOOL_NAMES.VAULT_GET_MEMORY,
     {
       title: "Get Memory",
-      description: `Read semantic memory from ${config.memoryDir}/ files. These are structured memory files containing dated bullet entries organized under H2 headings. With file: single file content. With file+section: just that H2 section's entries. No args: all files concatenated (frontmatter stripped) — can be large.
+      description: `Read semantic memory from ${config.memoryDir}/ files. These are structured memory files containing dated bullet entries organized under H2 headings. With file: single file content. With file+section: just that H2 section's entries. No args: all files concatenated (frontmatter stripped) — can be large. Returns empty string when no memory files exist yet.
 
 Example: vault_get_memory({ file: "Principles", section: "Decision heuristics (newest first)" })
 
@@ -722,7 +722,8 @@ Returns: Raw markdown text.`,
 Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
 
 When to use: Recording a new preference, principle, opinion, or fact about the user. Pass raw entry text without date prefix.
-Prefer vault_write_note for creating entirely new notes (not memory entries).
+Auto-creates: If the file does not exist, it is created with standard frontmatter. If the file exists but the section does not, the section is appended.
+For non-memory notes, use vault_write_note instead.
 
 Obsidian syntax: Entry text is rendered inline as Obsidian Flavored Markdown. Watch for: #word = tag, [[ = wikilink. Escape with backslash or backticks when unintentional.
 

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -721,9 +721,9 @@ Returns: Raw markdown text.`,
 
 Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
 
-When to use: Recording a new preference, principle, opinion, or fact about the user. Pass raw entry text without date prefix.
-Auto-creates: If the file does not exist, it is created with standard frontmatter. If the file exists but the section does not, the section is appended.
-For non-memory notes, use vault_write_note instead.
+When to use: Recording a new preference, principle, opinion, or fact about the user. Pass raw entry text without date prefix. Always call vault_list_memory_files first to discover existing files and sections, and use matching names to keep entries organized alongside existing content.
+Auto-creates: If the file or section does not exist, it is created automatically. Use existing file and section names from vault_list_memory_files when available.
+Prefer vault_write_note for creating entirely new notes (not memory entries).
 
 Obsidian syntax: Entry text is rendered inline as Obsidian Flavored Markdown. Watch for: #word = tag, [[ = wikilink. Escape with backslash or backticks when unintentional.
 

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -373,7 +373,7 @@ describe("updateMemory auto-creation", () => {
     expect(parsed.data.title).toBe("Working Preferences")
     expect(parsed.data.type).toBe("profile")
     expect(parsed.data.tags).toEqual(["memory", "working-preferences"])
-    expect(parsed.data.created).toBeDefined()
+    expect(parsed.data.created).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/)
     await rm(emptyVault, { recursive: true })
   })
 
@@ -740,11 +740,16 @@ describe("bootstrapMemoryDir", () => {
   })
 
   it("is a no-op when memory directory already exists", async () => {
+    const contentBefore = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
     await bootstrapMemoryDir({ vaultPath: vault }, logger)
-    const outlines = await listMemoryFiles({ vaultPath: vault }, logger)
-    expect(outlines).toHaveLength(2)
-    expect(outlines[0].file).toBe("Opinions")
-    expect(outlines[1].file).toBe("Principles")
+    const contentAfter = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+    expect(contentAfter).toBe(contentBefore)
   })
 
   it("preserves existing files when directory already exists", async () => {

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -303,7 +303,11 @@ describe("updateMemory", () => {
       logger,
     )
     const result = await getMemory(
-      { vaultPath: vault, file: "Ghost", section: "New section" },
+      {
+        vaultPath: vault,
+        file: "Ghost",
+        section: "New section (newest first)",
+      },
       logger,
     )
     expect(result).toBe("- **2026-05-15**: first entry")
@@ -321,7 +325,11 @@ describe("updateMemory", () => {
       logger,
     )
     const result = await getMemory(
-      { vaultPath: vault, file: "Principles", section: "Brand new section" },
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Brand new section (newest first)",
+      },
       logger,
     )
     expect(result).toBe("- **2026-05-15**: section entry")
@@ -345,7 +353,7 @@ describe("updateMemory auto-creation", () => {
       {
         vaultPath: emptyVault,
         file: "Preferences",
-        section: "Editor settings",
+        section: "Editor settings (newest first)",
       },
       logger,
     )
@@ -394,7 +402,7 @@ describe("updateMemory auto-creation", () => {
       "utf8",
     )
     expect(raw).toContain("# Preferences")
-    expect(raw).toContain("## Editor settings")
+    expect(raw).toContain("## Editor settings (newest first)")
     expect(raw).toContain("- **2026-05-15**: Dark mode")
     await rm(emptyVault, { recursive: true })
   })
@@ -414,7 +422,7 @@ describe("updateMemory auto-creation", () => {
     expect(raw).toContain("## Decision heuristics (newest first)")
     expect(raw).toContain("Secrets invisible at every layer")
     expect(raw).toContain("## Working style (newest first)")
-    expect(raw).toContain("## New category")
+    expect(raw).toContain("## New category (newest first)")
     expect(raw).toContain("- **2026-05-15**: appended entry")
     expect(raw).toContain("title: Principles — About Me")
   })
@@ -431,10 +439,32 @@ describe("updateMemory auto-creation", () => {
       logger,
     )
     const result = await getMemory(
-      { vaultPath: vault, file: "Opinions", section: "Design preferences" },
+      {
+        vaultPath: vault,
+        file: "Opinions",
+        section: "Design preferences (newest first)",
+      },
       logger,
     )
     expect(result).toBe("- **2026-05-15**: Minimalist UI")
+  })
+
+  it("does not double-append suffix when section already has it", async () => {
+    await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Opinions",
+        section: "Design preferences (newest first)",
+        entry: "Already suffixed",
+        date: "2026-05-15",
+      },
+      logger,
+    )
+    const raw = await readFile(join(vault, "About Me/Opinions.md"), "utf8")
+    expect(raw).toContain("## Design preferences (newest first)")
+    expect(raw).not.toContain(
+      "## Design preferences (newest first) (newest first)",
+    )
   })
 })
 

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { mkdtemp, rm, writeFile, mkdir, readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import matter from "gray-matter"
 import { createMemoryStore } from "../memory-store.js"
 import { logger } from "../../../logger.js"
 
@@ -148,11 +149,10 @@ describe("getMemory", () => {
     ).rejects.toThrow('section not found: "Nonexistent section"')
   })
 
-  it("throws when About Me directory does not exist", async () => {
+  it("returns empty string when About Me directory does not exist", async () => {
     const emptyVault = await mkdtemp(join(tmpdir(), "empty-vault-"))
-    await expect(getMemory({ vaultPath: emptyVault }, logger)).rejects.toThrow(
-      "About Me directory not found",
-    )
+    const result = await getMemory({ vaultPath: emptyVault }, logger)
+    expect(result).toBe("")
     await rm(emptyVault, { recursive: true })
   })
 })
@@ -291,27 +291,150 @@ describe("updateMemory", () => {
     expect(result).toContain("- **2026-05-08**: case test")
   })
 
-  it("throws on non-existent file", async () => {
-    await expect(
-      updateMemory(
-        { vaultPath: vault, file: "Ghost", section: "Section", entry: "entry" },
-        logger,
-      ),
-    ).rejects.toThrow('memory file not found: "About Me/Ghost.md"')
+  it("auto-creates file when it does not exist", async () => {
+    await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Ghost",
+        section: "New section",
+        entry: "first entry",
+        date: "2026-05-15",
+      },
+      logger,
+    )
+    const result = await getMemory(
+      { vaultPath: vault, file: "Ghost", section: "New section" },
+      logger,
+    )
+    expect(result).toBe("- **2026-05-15**: first entry")
   })
 
-  it("throws on non-existent section", async () => {
-    await expect(
-      updateMemory(
-        {
-          vaultPath: vault,
-          file: "Principles",
-          section: "Nonexistent",
-          entry: "entry",
-        },
-        logger,
-      ),
-    ).rejects.toThrow('section not found: "Nonexistent"')
+  it("auto-creates section in existing file", async () => {
+    await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Brand new section",
+        entry: "section entry",
+        date: "2026-05-15",
+      },
+      logger,
+    )
+    const result = await getMemory(
+      { vaultPath: vault, file: "Principles", section: "Brand new section" },
+      logger,
+    )
+    expect(result).toBe("- **2026-05-15**: section entry")
+  })
+})
+
+describe("updateMemory auto-creation", () => {
+  it("auto-creates directory and file when neither exist", async () => {
+    const emptyVault = await mkdtemp(join(tmpdir(), "no-dir-"))
+    await updateMemory(
+      {
+        vaultPath: emptyVault,
+        file: "Preferences",
+        section: "Editor settings",
+        entry: "Prefers dark mode",
+        date: "2026-05-15",
+      },
+      logger,
+    )
+    const result = await getMemory(
+      {
+        vaultPath: emptyVault,
+        file: "Preferences",
+        section: "Editor settings",
+      },
+      logger,
+    )
+    expect(result).toBe("- **2026-05-15**: Prefers dark mode")
+    await rm(emptyVault, { recursive: true })
+  })
+
+  it("auto-created file has correct frontmatter", async () => {
+    const emptyVault = await mkdtemp(join(tmpdir(), "fm-test-"))
+    await updateMemory(
+      {
+        vaultPath: emptyVault,
+        file: "Working Preferences",
+        section: "Tools",
+        entry: "Uses VS Code",
+        date: "2026-05-15",
+      },
+      logger,
+    )
+    const raw = await readFile(
+      join(emptyVault, "About Me/Working Preferences.md"),
+      "utf8",
+    )
+    const parsed = matter(raw)
+    expect(parsed.data.title).toBe("Working Preferences")
+    expect(parsed.data.type).toBe("profile")
+    expect(parsed.data.tags).toEqual(["memory", "working-preferences"])
+    expect(parsed.data.created).toBeDefined()
+    await rm(emptyVault, { recursive: true })
+  })
+
+  it("auto-created file has correct H1 and H2 structure", async () => {
+    const emptyVault = await mkdtemp(join(tmpdir(), "structure-"))
+    await updateMemory(
+      {
+        vaultPath: emptyVault,
+        file: "Preferences",
+        section: "Editor settings",
+        entry: "Dark mode",
+        date: "2026-05-15",
+      },
+      logger,
+    )
+    const raw = await readFile(
+      join(emptyVault, "About Me/Preferences.md"),
+      "utf8",
+    )
+    expect(raw).toContain("# Preferences")
+    expect(raw).toContain("## Editor settings")
+    expect(raw).toContain("- **2026-05-15**: Dark mode")
+    await rm(emptyVault, { recursive: true })
+  })
+
+  it("auto-created section preserves existing file content", async () => {
+    await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "New category",
+        entry: "appended entry",
+        date: "2026-05-15",
+      },
+      logger,
+    )
+    const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")
+    expect(raw).toContain("## Decision heuristics (newest first)")
+    expect(raw).toContain("Secrets invisible at every layer")
+    expect(raw).toContain("## Working style (newest first)")
+    expect(raw).toContain("## New category")
+    expect(raw).toContain("- **2026-05-15**: appended entry")
+    expect(raw).toContain("title: Principles — About Me")
+  })
+
+  it("auto-created section entry is readable via getMemory", async () => {
+    await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Opinions",
+        section: "Design preferences",
+        entry: "Minimalist UI",
+        date: "2026-05-15",
+      },
+      logger,
+    )
+    const result = await getMemory(
+      { vaultPath: vault, file: "Opinions", section: "Design preferences" },
+      logger,
+    )
+    expect(result).toBe("- **2026-05-15**: Minimalist UI")
   })
 })
 
@@ -556,11 +679,79 @@ describe("custom memoryDir", () => {
     await rm(customVault, { recursive: true })
   })
 
-  it("directory-not-found error references the configured name", async () => {
+  it("returns empty string when configured directory does not exist", async () => {
     const customVault = await mkdtemp(join(tmpdir(), "custom-mem-"))
-    await expect(
-      customStore.getMemory({ vaultPath: customVault }, logger),
-    ).rejects.toThrow("Profile directory not found")
+    const result = await customStore.getMemory(
+      { vaultPath: customVault },
+      logger,
+    )
+    expect(result).toBe("")
     await rm(customVault, { recursive: true })
+  })
+})
+
+describe("bootstrapMemoryDir", () => {
+  const { bootstrapMemoryDir, listMemoryFiles } = createMemoryStore({
+    memoryDir: "About Me",
+  })
+
+  it("creates memory directory and template files when dir does not exist", async () => {
+    const emptyVault = await mkdtemp(join(tmpdir(), "bootstrap-"))
+    await bootstrapMemoryDir({ vaultPath: emptyVault }, logger)
+    const outlines = await listMemoryFiles({ vaultPath: emptyVault }, logger)
+    expect(outlines).toHaveLength(2)
+    expect(outlines.map((outline) => outline.file).sort()).toEqual([
+      "Opinions",
+      "Principles",
+    ])
+    await rm(emptyVault, { recursive: true })
+  })
+
+  it("template files have correct frontmatter", async () => {
+    const emptyVault = await mkdtemp(join(tmpdir(), "bootstrap-fm-"))
+    await bootstrapMemoryDir({ vaultPath: emptyVault }, logger)
+    const raw = await readFile(
+      join(emptyVault, "About Me/Principles.md"),
+      "utf8",
+    )
+    const parsed = matter(raw)
+    expect(parsed.data.title).toBe("Principles")
+    expect(parsed.data.type).toBe("profile")
+    expect(parsed.data.tags).toEqual(["memory", "principles"])
+    await rm(emptyVault, { recursive: true })
+  })
+
+  it("template files have correct H2 sections", async () => {
+    const emptyVault = await mkdtemp(join(tmpdir(), "bootstrap-h2-"))
+    await bootstrapMemoryDir({ vaultPath: emptyVault }, logger)
+    const outlines = await listMemoryFiles({ vaultPath: emptyVault }, logger)
+    const principles = outlines.find(
+      (outline) => outline.file === "Principles",
+    )!
+    const sectionNames = principles.headings
+      .filter((heading) => heading.level === 2)
+      .map((heading) => heading.text)
+    expect(sectionNames).toEqual([
+      "Decision heuristics (newest first)",
+      "Working style (newest first)",
+      "Non-negotiables (newest first)",
+    ])
+    await rm(emptyVault, { recursive: true })
+  })
+
+  it("is a no-op when memory directory already exists", async () => {
+    await bootstrapMemoryDir({ vaultPath: vault }, logger)
+    const outlines = await listMemoryFiles({ vaultPath: vault }, logger)
+    expect(outlines).toHaveLength(2)
+    expect(outlines[0].file).toBe("Opinions")
+    expect(outlines[1].file).toBe("Principles")
+  })
+
+  it("preserves existing files when directory already exists", async () => {
+    await bootstrapMemoryDir({ vaultPath: vault }, logger)
+    const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")
+    const parsed = matter(raw)
+    expect(parsed.data.title).toBe("Principles — About Me")
+    expect(raw).toContain("Secrets invisible at every layer")
   })
 })

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -1,6 +1,7 @@
 /** Memory store factory — heading-aware parser/writer for semantic memory files. */
 
-import { readFile, writeFile, readdir, mkdir } from "node:fs/promises"
+import { readFile, writeFile, readdir, mkdir, access } from "node:fs/promises"
+import { constants } from "node:fs"
 import { join, basename, dirname } from "node:path"
 import matter from "gray-matter"
 import { DateTime } from "luxon"
@@ -129,11 +130,45 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
   }> = [
     {
       fileName: "Opinions",
-      content: `---\ntitle: Opinions\ntype: profile\ntags:\n  - memory\n  - opinions\n---\n\n# Opinions\n\n## Tools and workflows (newest first)\n\n## Code patterns (newest first)\n\n## Communication preferences (newest first)\n`,
+      content: [
+        "---",
+        "title: Opinions",
+        "type: profile",
+        "tags:",
+        "  - memory",
+        "  - opinions",
+        "---",
+        "",
+        "# Opinions",
+        "",
+        "## Tools and workflows (newest first)",
+        "",
+        "## Code patterns (newest first)",
+        "",
+        "## Communication preferences (newest first)",
+        "",
+      ].join("\n"),
     },
     {
       fileName: "Principles",
-      content: `---\ntitle: Principles\ntype: profile\ntags:\n  - memory\n  - principles\n---\n\n# Principles\n\n## Decision heuristics (newest first)\n\n## Working style (newest first)\n\n## Non-negotiables (newest first)\n`,
+      content: [
+        "---",
+        "title: Principles",
+        "type: profile",
+        "tags:",
+        "  - memory",
+        "  - principles",
+        "---",
+        "",
+        "# Principles",
+        "",
+        "## Decision heuristics (newest first)",
+        "",
+        "## Working style (newest first)",
+        "",
+        "## Non-negotiables (newest first)",
+        "",
+      ].join("\n"),
     },
   ]
 
@@ -178,7 +213,14 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       tags: ["memory", toKebabCase(params.fileName)],
       created: DateTime.now().toISO(),
     }
-    const body = `\n# ${params.fileName}\n\n## ${params.section}\n${params.bullet}\n`
+    const body = [
+      "",
+      `# ${params.fileName}`,
+      "",
+      `## ${params.section}`,
+      params.bullet,
+      "",
+    ].join("\n")
     return matter.stringify(body, frontmatter)
   }
 
@@ -314,6 +356,9 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       -1,
     )
 
+    // "top" inserts before the first existing bullet (newest-first ordering).
+    // "bottom" inserts after the last existing bullet.
+    // Empty sections (no bullets) fall back to bodyEndLine — appends at section end.
     const insertIndex =
       position === "top"
         ? firstBulletOffset >= 0
@@ -460,7 +505,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
   ): Promise<void> => {
     const dirPath = join(params.vaultPath, memoryDir)
     try {
-      await readdir(dirPath)
+      await access(dirPath, constants.F_OK)
       return
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -1,7 +1,7 @@
 /** Memory store factory — heading-aware parser/writer for semantic memory files. */
 
-import { readFile, writeFile, readdir } from "node:fs/promises"
-import { join, basename } from "node:path"
+import { readFile, writeFile, readdir, mkdir } from "node:fs/promises"
+import { join, basename, dirname } from "node:path"
 import matter from "gray-matter"
 import { DateTime } from "luxon"
 import type { Logger } from "../../logger.js"
@@ -11,6 +11,14 @@ import type { Logger } from "../../logger.js"
 const ENTRY_PATTERN = /^- \*\*\d{4}-\d{2}-\d{2}\*\*:/
 
 const isString = (value: unknown): value is string => typeof value === "string"
+
+/** Converts a string to kebab-case for use as a tag. */
+const toKebabCase = (text: string): string =>
+  text
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -115,6 +123,20 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
   const memoryFilePath = (vaultPath: string, file: string): string =>
     join(vaultPath, memoryDir, `${file}.md`)
 
+  const MEMORY_TEMPLATES: ReadonlyArray<{
+    fileName: string
+    content: string
+  }> = [
+    {
+      fileName: "Opinions",
+      content: `---\ntitle: Opinions\ntype: profile\ntags:\n  - memory\n  - opinions\n---\n\n# Opinions\n\n## Tools and workflows (newest first)\n\n## Code patterns (newest first)\n\n## Communication preferences (newest first)\n`,
+    },
+    {
+      fileName: "Principles",
+      content: `---\ntitle: Principles\ntype: profile\ntags:\n  - memory\n  - principles\n---\n\n# Principles\n\n## Decision heuristics (newest first)\n\n## Working style (newest first)\n\n## Non-negotiables (newest first)\n`,
+    },
+  ]
+
   const readMemoryFile = async (
     vaultPath: string,
     file: string,
@@ -131,6 +153,35 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     }
   }
 
+  /** Like readMemoryFile, but returns null when the file does not exist. */
+  const readMemoryFileOrNull = async (
+    vaultPath: string,
+    file: string,
+  ): Promise<string | null> => {
+    try {
+      return await readFile(memoryFilePath(vaultPath, file), "utf8")
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null
+      throw err
+    }
+  }
+
+  /** Builds a new memory file with frontmatter, H1 title, H2 section, and initial entry. */
+  const buildNewMemoryFile = (params: {
+    fileName: string
+    section: string
+    bullet: string
+  }): string => {
+    const frontmatter = {
+      title: params.fileName,
+      type: "profile",
+      tags: ["memory", toKebabCase(params.fileName)],
+      created: DateTime.now().toISO(),
+    }
+    const body = `\n# ${params.fileName}\n\n## ${params.section}\n${params.bullet}\n`
+    return matter.stringify(body, frontmatter)
+  }
+
   // ── Exported functions ──────────────────────────────────────────
 
   const getMemory = async (
@@ -144,7 +195,8 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         entries = await readdir(dir)
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-          throw new Error(`${memoryDir} directory not found`, { cause: err })
+          logger.info("get memory", { mode: "all", fileCount: 0 })
+          return ""
         }
         throw err
       }
@@ -202,23 +254,54 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     },
     logger: Logger,
   ): Promise<void> => {
-    const raw = await readMemoryFile(params.vaultPath, params.file)
-    const parsed = matter(raw)
-    const lines = parsed.content.split("\n")
-    const sections = parseSections(lines)
-    const match = findSection(sections, params.section, 2)
-    if (!match) {
-      throw new Error(
-        `section not found: "${params.section}" in ${memoryDir}/${params.file}.md`,
-      )
-    }
-
     const date = params.date ?? DateTime.now().toISODate()
     const position = params.position ?? "top"
     const bullet = `- **${date}**: ${params.entry}`
 
-    // Find the first and last dated bullet within the section body to determine
-    // where to insert. Offsets are relative to the section's bodyStartLine.
+    const raw = await readMemoryFileOrNull(params.vaultPath, params.file)
+
+    // File does not exist — create directory + file with section and entry
+    if (raw === null) {
+      const filePath = memoryFilePath(params.vaultPath, params.file)
+      await mkdir(dirname(filePath), { recursive: true })
+      const content = buildNewMemoryFile({
+        fileName: params.file,
+        section: params.section,
+        bullet,
+      })
+      await writeFile(filePath, content, "utf8")
+      logger.info("created memory file", {
+        file: params.file,
+        section: params.section,
+        date,
+      })
+      return
+    }
+
+    const parsed = matter(raw)
+    const lines = parsed.content.split("\n")
+    const sections = parseSections(lines)
+    const match = findSection(sections, params.section, 2)
+
+    // File exists but section does not — append new H2 + entry at end
+    if (!match) {
+      const appendedLines = [...lines, `## ${params.section}`, bullet]
+      const newContent = appendedLines.join("\n")
+      const serialized = matter.stringify(newContent, parsed.data)
+      await writeFile(
+        memoryFilePath(params.vaultPath, params.file),
+        serialized,
+        "utf8",
+      )
+      logger.info("created memory section", {
+        file: params.file,
+        section: params.section,
+        date,
+      })
+      return
+    }
+
+    // File + section exist — insert entry at requested position
     const bodyLines = lines.slice(match.bodyStartLine, match.bodyEndLine)
     const firstBulletOffset = bodyLines.findIndex((line) =>
       ENTRY_PATTERN.test(line),
@@ -228,10 +311,6 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       -1,
     )
 
-    // Compute the absolute line index in the full content array for insertion.
-    // "top" inserts before the first existing bullet (newest-first ordering).
-    // "bottom" inserts after the last existing bullet.
-    // Empty sections (no bullets) fall back to bodyEndLine — appends at section end.
     const insertIndex =
       position === "top"
         ? firstBulletOffset >= 0
@@ -241,7 +320,6 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
           ? match.bodyStartLine + lastBulletOffset + 1
           : match.bodyEndLine
 
-    // Splice the new bullet into the content lines
     const updatedLines = [
       ...lines.slice(0, insertIndex),
       bullet,
@@ -371,7 +449,41 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     })
   }
 
-  return { getMemory, updateMemory, listMemoryFiles, deleteMemory }
+  /** Creates the memory directory with template files if it doesn't exist. Idempotent. */
+  const bootstrapMemoryDir = async (
+    params: { vaultPath: string },
+    logger: Logger,
+  ): Promise<void> => {
+    const dirPath = join(params.vaultPath, memoryDir)
+    try {
+      await readdir(dirPath)
+      return
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+    }
+    await mkdir(dirPath, { recursive: true })
+    await Promise.all(
+      MEMORY_TEMPLATES.map((template) =>
+        writeFile(
+          join(dirPath, `${template.fileName}.md`),
+          template.content,
+          "utf8",
+        ),
+      ),
+    )
+    logger.info("bootstrapped memory directory", {
+      memoryDir,
+      fileCount: MEMORY_TEMPLATES.length,
+    })
+  }
+
+  return {
+    getMemory,
+    updateMemory,
+    listMemoryFiles,
+    deleteMemory,
+    bootstrapMemoryDir,
+  }
 }
 
 export type MemoryStore = ReturnType<typeof createMemoryStore>

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -258,10 +258,13 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     const position = params.position ?? "top"
     const bullet = `- **${date}**: ${params.entry}`
 
-    const raw = await readMemoryFileOrNull(params.vaultPath, params.file)
+    const existingContent = await readMemoryFileOrNull(
+      params.vaultPath,
+      params.file,
+    )
 
     // File does not exist — create directory + file with section and entry
-    if (raw === null) {
+    if (existingContent === null) {
       const filePath = memoryFilePath(params.vaultPath, params.file)
       await mkdir(dirname(filePath), { recursive: true })
       const content = buildNewMemoryFile({
@@ -278,14 +281,14 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       return
     }
 
-    const parsed = matter(raw)
-    const lines = parsed.content.split("\n")
-    const sections = parseSections(lines)
+    const parsed = matter(existingContent)
+    const contentLines = parsed.content.split("\n")
+    const sections = parseSections(contentLines)
     const match = findSection(sections, params.section, 2)
 
     // File exists but section does not — append new H2 + entry at end
     if (!match) {
-      const appendedLines = [...lines, `## ${params.section}`, bullet]
+      const appendedLines = [...contentLines, `## ${params.section}`, bullet]
       const newContent = appendedLines.join("\n")
       const serialized = matter.stringify(newContent, parsed.data)
       await writeFile(
@@ -302,7 +305,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     }
 
     // File + section exist — insert entry at requested position
-    const bodyLines = lines.slice(match.bodyStartLine, match.bodyEndLine)
+    const bodyLines = contentLines.slice(match.bodyStartLine, match.bodyEndLine)
     const firstBulletOffset = bodyLines.findIndex((line) =>
       ENTRY_PATTERN.test(line),
     )
@@ -320,10 +323,11 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
           ? match.bodyStartLine + lastBulletOffset + 1
           : match.bodyEndLine
 
+    // Splice the new bullet into the content lines
     const updatedLines = [
-      ...lines.slice(0, insertIndex),
+      ...contentLines.slice(0, insertIndex),
       bullet,
-      ...lines.slice(insertIndex),
+      ...contentLines.slice(insertIndex),
     ]
 
     const newContent = updatedLines.join("\n")

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -354,7 +354,8 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       return
     }
 
-    // File + section exist — insert entry at requested position
+    // File + section exist — find the first and last dated bullet within the
+    // section body to determine where to insert. Offsets are relative to bodyStartLine.
     const bodyLines = contentLines.slice(match.bodyStartLine, match.bodyEndLine)
     const firstBulletOffset = bodyLines.findIndex((line) =>
       ENTRY_PATTERN.test(line),

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -364,6 +364,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       -1,
     )
 
+    // Compute the absolute line index in the full content array for insertion.
     // "top" inserts before the first existing bullet (newest-first ordering).
     // "bottom" inserts after the last existing bullet.
     // Empty sections (no bullets) fall back to bodyEndLine — appends at section end.

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -13,6 +13,12 @@ const ENTRY_PATTERN = /^- \*\*\d{4}-\d{2}-\d{2}\*\*:/
 
 const isString = (value: unknown): value is string => typeof value === "string"
 
+/** Appends "(newest first)" to a section name if not already present (case-insensitive). */
+const ensureNewestFirstSuffix = (sectionName: string): string =>
+  sectionName.trimEnd().toLowerCase().endsWith("(newest first)")
+    ? sectionName
+    : `${sectionName} (newest first)`
+
 /** Converts a string to kebab-case for use as a tag. */
 const toKebabCase = (text: string): string =>
   text
@@ -307,17 +313,18 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
 
     // File does not exist — create directory + file with section and entry
     if (existingContent === null) {
+      const newSection = ensureNewestFirstSuffix(params.section)
       const filePath = memoryFilePath(params.vaultPath, params.file)
       await mkdir(dirname(filePath), { recursive: true })
       const content = buildNewMemoryFile({
         fileName: params.file,
-        section: params.section,
+        section: newSection,
         bullet,
       })
       await writeFile(filePath, content, "utf8")
       logger.info("created memory file", {
         file: params.file,
-        section: params.section,
+        section: newSection,
         date,
       })
       return
@@ -330,7 +337,8 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
 
     // File exists but section does not — append new H2 + entry at end
     if (!match) {
-      const appendedLines = [...contentLines, `## ${params.section}`, bullet]
+      const newSection = ensureNewestFirstSuffix(params.section)
+      const appendedLines = [...contentLines, `## ${newSection}`, bullet]
       const newContent = appendedLines.join("\n")
       const serialized = matter.stringify(newContent, parsed.data)
       await writeFile(
@@ -340,7 +348,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       )
       logger.info("created memory section", {
         file: params.file,
-        section: params.section,
+        section: newSection,
         date,
       })
       return

--- a/templates/memory/README.md
+++ b/templates/memory/README.md
@@ -1,14 +1,19 @@
 # Memory Templates
 
 These example files show the expected structure for vault-cortex's memory system.
+On first startup, the server creates these files automatically if your vault
+doesn't already have a memory folder — no manual setup needed.
 
-## Setup
+## Setup (manual alternative)
+
+If you prefer to set up memory files manually instead of using the auto-created
+templates:
 
 1. Copy the example files into your vault's memory folder (default: `About Me/`):
 
 ```bash
-cp templates/memory/Principles.md ~/your-vault/About Me/
-cp templates/memory/Opinions.md ~/your-vault/About Me/
+cp templates/memory/Principles.md ~/your-vault/About\ Me/
+cp templates/memory/Opinions.md ~/your-vault/About\ Me/
 ```
 
 2. If you use a different folder name, set `MEMORY_DIR` in your `.env`:
@@ -39,3 +44,23 @@ These templates are starting points. You can:
 - Add YAML frontmatter (tags, type, etc.)
 
 The only requirement is the H2 heading structure and the dated bullet format for entries.
+
+## Why dated entries?
+
+The `- **YYYY-MM-DD**: text` format is an intentional design choice, not just a
+convention:
+
+1. **Temporal context** — agents see when a preference was recorded and can
+   weigh recent entries over older ones when they conflict
+2. **Evolution tracking** — beliefs and opinions change over time.
+   Contradictions are natural; the timeline tells the story. An entry from six
+   months ago saying "prefers tabs" followed by a recent one saying "switched to
+   spaces" is more useful than a single overwritten value
+3. **Semantic retrieval (Phase 2)** — dated entries become the corpus for
+   LightRAG's knowledge graph, enabling temporal queries ("how has the user's
+   stance on X evolved?", "what did they believe about Y last month?")
+
+This is append-only by design. Entries are never overwritten — new entries are
+added at the top (newest first), and the full history is preserved. Agents
+retrieve context by reading the most recent entries, but the timeline remains
+available for deeper understanding.


### PR DESCRIPTION
## Summary

- Bootstrap memory directory with template files (Principles.md, Opinions.md) at server startup when the directory doesn't exist — new users get a ready-to-use structure immediately
- `updateMemory` auto-creates files and sections as a fallback for growth beyond templates (missing file → creates with frontmatter + H1 + H2 + entry; missing section → appends H2 + entry to existing file)
- `getMemory` (no args) returns empty string instead of throwing when the directory is missing
- Updated `vault_update_memory` and `vault_get_memory` tool descriptions to document auto-creation behavior

### Two-layer approach

1. **Startup bootstrap** — seeds template files so agents discover a structure on first `listMemoryFiles` call
2. **Write auto-create** — handles files/sections beyond templates (new files, new sections in existing files)

### Why

A new user deploying via the Docker quickstart has no memory folder. Without this change, agents hit `"memory file not found"` errors on first use — terrible first impression. Now the memory system bootstraps itself.

## Test plan

- [x] 471 tests pass (was 461 — 10 new tests)
- [x] `npm run lint` passes
- [x] `npm run prettier:check` passes
- [x] `npm run build` passes
- [ ] Manual: start server against empty vault → templates created
- [ ] Manual: `vault_update_memory` with new file → auto-creates
- [ ] Manual: `vault_get_memory()` on empty vault → returns `""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)