### PR TITLE
ci: add gitleaks secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,31 @@
+name: Gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    env:
+      GITLEAKS_VERSION: 8.21.2
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -sL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+
+      - name: Scan full git history
+        run: gitleaks detect --source . --log-opts="--all" --redact --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,7 @@
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Documented placeholder used in local-dev quickstarts (README, CONTRIBUTING, docker-compose.local.yml). Not a real credential."
+regexTarget = "match"
+regexes = ['''local-dev-token''']


### PR DESCRIPTION
## Summary

- Adds a `Gitleaks` GitHub Actions workflow that scans the full git history (`--log-opts="--all"`) on every PR and push to `main`. Pinned to `gitleaks v8.21.2`.
- Adds `.gitleaks.toml` extending the default ruleset with a global allowlist for the `local-dev-token` placeholder used in local-dev quickstarts (`README.md`, `CONTRIBUTING.md`, `docker-compose.local.yml`). Triggers `curl-auth-header` as a generic high-entropy bearer token, but it's documented placeholder text, not a credential.

## Context

Completes the **git history secret scan** blocker from [`pre-public-hardening`](https://github.com/aliasunder/vault-cortex/blob/main/ARCHITECTURE.md). A full-history scan run locally first surfaced 0 real secrets — all 3 findings were repeated occurrences of the `local-dev-token` placeholder across historical README revisions.

Wiring gitleaks into CI keeps the gate from drifting once the repo is public.

## Test plan

- [x] Local full-history scan with the allowlist returns `no leaks found` (118 commits, ~200ms)
- [x] Canary test: a fake `sk-fake-secret-12345abcdef` bearer token in a scratch file still triggers `curl-auth-header` — allowlist is targeted, not a blanket suppression
- [ ] CI: confirm `Gitleaks` job runs and passes on this PR

https://claude.ai/code/session_01X5WAhf2WRoY1CVFoQpKYfR

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5WAhf2WRoY1CVFoQpKYfR)_