### PR TITLE
feat: throttle API Gateway stage to 20 RPS / 40 burst

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -171,17 +171,9 @@ export default $config({
       ],
     })
 
-    // ── API Gateway HTTP API ──────────────────────────────────────
-    // No custom domain — you get a free HTTPS URL:
-    //   https://<id>.execute-api.<region>.amazonaws.com
-    //
-    // Free tier: 1M requests/mo for 12 months, then $1/M (HTTP API).
-    // MCP clients point at this URL with their bearer token.
-    //
     // Stage throttle: 20 req/sec, 40 burst. GOTCHA: throttlingRateLimit
     // and throttlingBurstLimit must BOTH be set — partial config is
     // interpreted as 0 and rejects all traffic (pulumi/pulumi-aws#2363).
-    // ──────────────────────────────────────────────────────────────
     const api = new sst.aws.ApiGatewayV2("VaultCortexApi", {
       transform: {
         stage: {

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -177,8 +177,31 @@ export default $config({
     //
     // Free tier: 1M requests/mo for 12 months, then $1/M (HTTP API).
     // MCP clients point at this URL with their bearer token.
+    //
+    // Stage-level throttle: caps both the runaway-bill scenario (every
+    // request bills $1/M + a Lambda authorizer invocation — authorizer
+    // result caching is disabled via empty identitySources) and the
+    // backend-saturation scenario (Lightsail small_3_0 is 2 vCPU).
+    // Sized for a personal MCP server with parallel tool fan-out;
+    // steady-state is normally << 1 RPS, so 20 RPS gives 20× headroom
+    // and a 40 burst absorbs a worst-case parallel-tool turn. Account
+    // default is 10k RPS / 5k burst region-wide — effectively unbounded
+    // for a personal server, so the stage default is opt-in protection.
+    //
+    // Tune as needed. GOTCHA: throttlingRateLimit and throttlingBurstLimit
+    // MUST be set together — setting only one is interpreted as 0 and
+    // makes the stage reject ALL traffic.
     // ──────────────────────────────────────────────────────────────
-    const api = new sst.aws.ApiGatewayV2("VaultCortexApi")
+    const api = new sst.aws.ApiGatewayV2("VaultCortexApi", {
+      transform: {
+        stage: {
+          defaultRouteSettings: {
+            throttlingRateLimit: 20,
+            throttlingBurstLimit: 40,
+          },
+        },
+      },
+    })
 
     // Smart Lambda authorizer — path-aware, defense in depth:
     //   - OAuth paths (/.well-known/*, /authorize, /token, etc.) → pass through

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -178,19 +178,9 @@ export default $config({
     // Free tier: 1M requests/mo for 12 months, then $1/M (HTTP API).
     // MCP clients point at this URL with their bearer token.
     //
-    // Stage-level throttle: caps both the runaway-bill scenario (every
-    // request bills $1/M + a Lambda authorizer invocation — authorizer
-    // result caching is disabled via empty identitySources) and the
-    // backend-saturation scenario (Lightsail small_3_0 is 2 vCPU).
-    // Sized for a personal MCP server with parallel tool fan-out;
-    // steady-state is normally << 1 RPS, so 20 RPS gives 20× headroom
-    // and a 40 burst absorbs a worst-case parallel-tool turn. Account
-    // default is 10k RPS / 5k burst region-wide — effectively unbounded
-    // for a personal server, so the stage default is opt-in protection.
-    //
-    // Tune as needed. GOTCHA: throttlingRateLimit and throttlingBurstLimit
-    // MUST be set together — setting only one is interpreted as 0 and
-    // makes the stage reject ALL traffic.
+    // Stage throttle: 20 req/sec, 40 burst. GOTCHA: throttlingRateLimit
+    // and throttlingBurstLimit must BOTH be set — partial config is
+    // interpreted as 0 and rejects all traffic (pulumi/pulumi-aws#2363).
     // ──────────────────────────────────────────────────────────────
     const api = new sst.aws.ApiGatewayV2("VaultCortexApi", {
       transform: {


### PR DESCRIPTION
Adds stage-level throttle to API Gateway: 20 req/sec sustained, 40 burst. Pulumi updates the stage in-place — no instance replace.

`/mcp` had no rate limit before this; the authorizer cache is also disabled (`identitySources: []`), so every request invokes Lambda. This caps both the runaway-bill and Lightsail-saturation scenarios.

## Test plan

- [x] `tsc --noEmit` + `eslint` clean
- [x] `sst deploy` updates stage in-place
- [x] `aws apigatewayv2 get-stage --api-id <id> --stage-name '$default' --query DefaultRouteSettings` shows `ThrottlingRateLimit: 20.0`, `ThrottlingBurstLimit: 40`

https://claude.ai/code/session_01RYAwecnFKFw8YLA5fbQGzQ