### PR TITLE
fix: prevent port 8000 wipe by avoiding ForceNew on InstancePublicPorts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,10 @@ GHCR_TOKEN=
 # Generate once: ssh-keygen -t ed25519 -f ~/.ssh/vault-cortex -C vault-cortex-deploy
 # LIGHTSAIL_SSH_KEY=~/.ssh/vault-cortex
 
+# SSH host — override the SSH target for Tailscale or custom DNS.
+# Use the MagicDNS hostname or Tailscale IP instead of the public IP.
+# LIGHTSAIL_SSH_HOST=vault-cortex
+
 # Docker
 GHCR_USER=
 PUID=1000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,16 @@ jobs:
       - name: SST deploy
         env:
           SSH_PUBKEY: ${{ secrets.SSH_PUBKEY }}
+          SSH_CIDRS: ${{ vars.SSH_CIDRS }}
         run: npx sst deploy --stage "$SST_STAGE"
+
+      - name: Connect to Tailscale
+        if: vars.TAILSCALE_SSH_HOST != ''
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:ci
 
       - name: Read Lightsail IP from SST outputs
         id: sst
@@ -50,6 +59,18 @@ jobs:
           fi
           ip=$(jq -er '.lightsailIp' .sst/outputs.json)
           echo "ip=$ip" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve SSH target
+        id: ssh
+        env:
+          TAILSCALE_HOST: ${{ vars.TAILSCALE_SSH_HOST }}
+          PUBLIC_IP: ${{ steps.sst.outputs.ip }}
+        run: |
+          if [ -n "$TAILSCALE_HOST" ]; then
+            echo "host=$TAILSCALE_HOST" >> "$GITHUB_OUTPUT"
+          else
+            echo "host=$PUBLIC_IP" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: docker/setup-buildx-action@v4
 
@@ -78,7 +99,7 @@ jobs:
 
       - name: Wait for Docker on Lightsail
         env:
-          IP: ${{ steps.sst.outputs.ip }}
+          IP: ${{ steps.ssh.outputs.host }}
         run: |
           deadline=$((SECONDS + 120))
           until ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" 'docker --version' >/dev/null 2>&1; do
@@ -91,7 +112,7 @@ jobs:
 
       - name: Bootstrap deploy directory and GHCR login on instance
         env:
-          IP: ${{ steps.sst.outputs.ip }}
+          IP: ${{ steps.ssh.outputs.host }}
           GHCR_USER: ${{ vars.GHCR_USER }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
         run: |
@@ -137,14 +158,14 @@ jobs:
 
       - name: Ship compose + .env to instance
         env:
-          IP: ${{ steps.sst.outputs.ip }}
+          IP: ${{ steps.ssh.outputs.host }}
         run: |
           scp -o StrictHostKeyChecking=accept-new docker-compose.yml ubuntu@"$IP":/opt/vault-cortex/docker-compose.yml
           scp -o StrictHostKeyChecking=accept-new "$RUNNER_TEMP/lightsail.env" ubuntu@"$IP":/opt/vault-cortex/.env
 
       - name: Pull and restart compose stack
         env:
-          IP: ${{ steps.sst.outputs.ip }}
+          IP: ${{ steps.ssh.outputs.host }}
         run: |
           ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
             'cd /opt/vault-cortex && docker compose pull && docker compose up -d --wait --wait-timeout 180'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Connect to Tailscale
         if: vars.TAILSCALE_SSH_HOST != ''
-        uses: tailscale/github-action@v3
+        uses: tailscale/github-action@v4
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -388,7 +388,7 @@ The deploy workflow supports optional Tailscale connectivity for SSH steps. Gate
 
 **Tailscale admin setup:**
 
-1. Create an OAuth client at Tailscale admin → Settings → Trust Credentials → +Credential — scopes: Devices Core (Read + Write), tag: `tag:ci`
+1. Create an OAuth client at Tailscale admin → Settings → Trust Credentials → +Credential → OAuth → Continue — scopes: Devices Core (Read + Write), tag: `tag:ci`
 2. Add tag owners and ACL grants in https://login.tailscale.com/admin/acls:
    ```json
    {

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -409,13 +409,13 @@ CI nodes are ephemeral (auto-removed after inactivity) thanks to the OAuth clien
 
 `SSH_CIDRS` accepts any of these values:
 
-| Value                          | Effect                                                  |
-| ------------------------------ | ------------------------------------------------------- |
-| (unset)                        | `0.0.0.0/0` — open to all (default, backward-compat)    |
-| `none`                         | Port 22 removed from firewall entirely (Tailscale-only) |
-| `100.64.0.0/10`                | Tailscale CIDR only (belt-and-suspenders)               |
-| `203.0.113.42/32`              | Single IP (e.g., home IP)                               |
-| `100.64.0.0/10,203.0.113.0/24` | Multiple CIDRs (comma-separated)                        |
+| Value                          | Effect                                               |
+| ------------------------------ | ---------------------------------------------------- |
+| (unset)                        | `0.0.0.0/0` — open to all (default, backward-compat) |
+| `none`                         | Port 22 set to non-routable CIDR (Tailscale-only)    |
+| `100.64.0.0/10`                | Tailscale CIDR only (belt-and-suspenders)            |
+| `203.0.113.42/32`              | Single IP (e.g., home IP)                            |
+| `100.64.0.0/10,203.0.113.0/24` | Multiple CIDRs (comma-separated)                     |
 
 ### Fresh VM bootstrap (chicken-and-egg)
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -344,10 +344,10 @@ Tailscale creates a WireGuard mesh network between your devices. Traffic between
 ```bash
 ssh -i ~/.ssh/vault-cortex ubuntu@<lightsailIp>
 curl -fsSL https://tailscale.com/install.sh | sh
-sudo tailscale up --auth-key=<YOUR_AUTH_KEY> --hostname=vault-cortex --advertise-tags=tag:server
+sudo tailscale up --auth-key=<YOUR_AUTH_KEY> --hostname=vault-cortex --advertise-tags=tag:server --reset
 ```
 
-Use a **reusable, non-expiring** auth key from https://login.tailscale.com/admin/settings/keys with tag `tag:server`. Do NOT use `--ssh` (that replaces OpenSSH with Tailscale SSH — we want standard SSH over the Tailscale network).
+Use a **reusable, non-expiring** auth key from https://login.tailscale.com/admin/settings/keys with tag `tag:server`. The `--reset` flag clears any prior registration state. Do NOT use `--ssh` (that replaces OpenSSH with Tailscale SSH — we want standard SSH over the Tailscale network).
 
 **2. Verify Tailscale SSH** from your laptop:
 
@@ -379,31 +379,27 @@ The deploy workflow supports optional Tailscale connectivity for SSH steps. Gate
 
 **GitHub repo settings:**
 
-| Type     | Name                            | Value                                           |
-| -------- | ------------------------------- | ----------------------------------------------- |
-| Variable | `TAILSCALE_SSH_HOST`            | `vault-cortex` (MagicDNS) or the Tailscale IP   |
-| Variable | `SSH_CIDRS`                     | `none` (removes port 22 from public firewall)   |
-| Secret   | `TAILSCALE_OAUTH_CLIENT_ID`     | From Tailscale admin → Settings → OAuth clients |
-| Secret   | `TAILSCALE_OAUTH_CLIENT_SECRET` | (same)                                          |
+| Type     | Name                            | Value                                               |
+| -------- | ------------------------------- | --------------------------------------------------- |
+| Variable | `TAILSCALE_SSH_HOST`            | `vault-cortex` (MagicDNS) or the Tailscale IP       |
+| Variable | `SSH_CIDRS`                     | `none` (removes port 22 from public firewall)       |
+| Secret   | `TAILSCALE_OAUTH_CLIENT_ID`     | From Tailscale admin → Settings → Trust Credentials |
+| Secret   | `TAILSCALE_OAUTH_CLIENT_SECRET` | (same)                                              |
 
 **Tailscale admin setup:**
 
-1. Create an OAuth client at https://login.tailscale.com/admin/settings/oauth — scopes: `devices:write`, tag: `tag:ci`
-2. Add ACL rules in https://login.tailscale.com/admin/acls:
+1. Create an OAuth client at Tailscale admin → Settings → Trust Credentials → +Credential — scopes: Devices Core (Read + Write), tag: `tag:ci`
+2. Add tag owners and ACL grants in https://login.tailscale.com/admin/acls:
    ```json
    {
-     "acls": [
-       { "action": "accept", "src": ["tag:ci"], "dst": ["tag:server:22"] },
-       {
-         "action": "accept",
-         "src": ["autogroup:owner"],
-         "dst": ["tag:server:*"]
-       }
-     ],
      "tagOwners": {
-       "tag:ci": ["autogroup:owner"],
-       "tag:server": ["autogroup:owner"]
-     }
+       "tag:server": ["autogroup:owner"],
+       "tag:ci": ["autogroup:owner"]
+     },
+     "grants": [
+       { "src": ["autogroup:owner"], "dst": ["*"], "ip": ["*"] },
+       { "src": ["tag:ci"], "dst": ["tag:server"], "ip": ["22"] }
+     ]
    }
    ```
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -237,6 +237,8 @@ Changing the deploy keypair **triggers a VM replacement**. The `SSH_PUBKEY` GitH
 
 **Data implications:** vault re-syncs from Obsidian and the search index rebuilds automatically, so the MCP server recovers quickly. What you lose: OAuth state (`oauth.db` — clients re-authenticate on next use), accumulated Docker logs, and anything manually installed on the VM outside of IaC (ad-hoc `apt install`, Tailscale, cron jobs, etc.).
 
+**Tailscale note:** If using `SSH_CIDRS=none` (Tailscale-only SSH), the new VM won't have Tailscale. Temporarily set `SSH_CIDRS=0.0.0.0/0` for the replacement deploy, SSH in to reinstall Tailscale, then set `SSH_CIDRS=none` and redeploy. See [SSH Hardening with Tailscale](#ssh-hardening-with-tailscale-optional).
+
 **Adding a personal SSH key (no rotation):** To SSH with an additional key without touching SST, add it to `authorized_keys` directly:
 
 ```bash
@@ -325,11 +327,133 @@ Set `LOG_LEVEL` in `.env` to control the threshold (default: `info`).
 
 ---
 
+## SSH Hardening with Tailscale (Optional)
+
+By default, SSH (port 22) is open to all IPs on the Lightsail firewall. For production or public-facing deployments, restrict SSH to your Tailscale network.
+
+### How it works
+
+Tailscale creates a WireGuard mesh network between your devices. Traffic between Tailscale nodes flows through the `tailscale0` interface, which **bypasses** the Lightsail public-IP firewall entirely. By removing port 22 from the firewall, public SSH is blocked while SSH via the Tailscale IP continues to work.
+
+### Setup
+
+**Prerequisites:** Tailscale installed on your laptop/phone (client) and the Lightsail VM (server).
+
+**1. Install Tailscale on the Lightsail VM** (one-time, via SSH):
+
+```bash
+ssh -i ~/.ssh/vault-cortex ubuntu@<lightsailIp>
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up --auth-key=<YOUR_AUTH_KEY> --hostname=vault-cortex --advertise-tags=tag:server
+```
+
+Use a **reusable, non-expiring** auth key from https://login.tailscale.com/admin/settings/keys with tag `tag:server`. Do NOT use `--ssh` (that replaces OpenSSH with Tailscale SSH — we want standard SSH over the Tailscale network).
+
+**2. Verify Tailscale SSH** from your laptop:
+
+```bash
+ssh -i ~/.ssh/vault-cortex ubuntu@vault-cortex
+```
+
+This connects via MagicDNS. You can also use the Tailscale IP directly (`100.x.y.z` from `tailscale status`).
+
+**3. Close public SSH** — set `SSH_CIDRS=none` and deploy:
+
+```bash
+SSH_CIDRS=none npx sst deploy
+```
+
+This removes port 22 from the Lightsail firewall. SSH via the public IP is now blocked; SSH via Tailscale continues to work.
+
+**4. Update local dev** — add to `~/.config/vault-cortex/.env`:
+
+```
+LIGHTSAIL_SSH_HOST=vault-cortex
+```
+
+Now `npm run lightsail:up` connects via Tailscale instead of the public IP.
+
+### CI/CD with Tailscale
+
+The deploy workflow supports optional Tailscale connectivity for SSH steps. Gated by the presence of `TAILSCALE_SSH_HOST` — if not set, CI uses the public IP (default behavior).
+
+**GitHub repo settings:**
+
+| Type     | Name                            | Value                                           |
+| -------- | ------------------------------- | ----------------------------------------------- |
+| Variable | `TAILSCALE_SSH_HOST`            | `vault-cortex` (MagicDNS) or the Tailscale IP   |
+| Variable | `SSH_CIDRS`                     | `none` (removes port 22 from public firewall)   |
+| Secret   | `TAILSCALE_OAUTH_CLIENT_ID`     | From Tailscale admin → Settings → OAuth clients |
+| Secret   | `TAILSCALE_OAUTH_CLIENT_SECRET` | (same)                                          |
+
+**Tailscale admin setup:**
+
+1. Create an OAuth client at https://login.tailscale.com/admin/settings/oauth — scopes: `devices:write`, tag: `tag:ci`
+2. Add ACL rules in https://login.tailscale.com/admin/acls:
+   ```json
+   {
+     "acls": [
+       { "action": "accept", "src": ["tag:ci"], "dst": ["tag:server:22"] },
+       {
+         "action": "accept",
+         "src": ["autogroup:owner"],
+         "dst": ["tag:server:*"]
+       }
+     ],
+     "tagOwners": {
+       "tag:ci": ["autogroup:owner"],
+       "tag:server": ["autogroup:owner"]
+     }
+   }
+   ```
+
+CI nodes are ephemeral (auto-removed after inactivity) thanks to the OAuth client auth method.
+
+### SSH_CIDRS reference
+
+`SSH_CIDRS` accepts any of these values:
+
+| Value                          | Effect                                                  |
+| ------------------------------ | ------------------------------------------------------- |
+| (unset)                        | `0.0.0.0/0` — open to all (default, backward-compat)    |
+| `none`                         | Port 22 removed from firewall entirely (Tailscale-only) |
+| `100.64.0.0/10`                | Tailscale CIDR only (belt-and-suspenders)               |
+| `203.0.113.42/32`              | Single IP (e.g., home IP)                               |
+| `100.64.0.0/10,203.0.113.0/24` | Multiple CIDRs (comma-separated)                        |
+
+### Fresh VM bootstrap (chicken-and-egg)
+
+If the VM is replaced (key rotation, bundle upgrade) and `SSH_CIDRS=none`, port 22 is closed on the public IP — but Tailscale isn't yet running on the new VM. Recovery:
+
+1. Temporarily set `SSH_CIDRS=0.0.0.0/0` (or remove the variable)
+2. Deploy — port 22 re-opens
+3. SSH in, install Tailscale, authenticate with the reusable auth key
+4. Set `SSH_CIDRS=none` and redeploy
+
+### Rollback
+
+To revert to public SSH at any time:
+
+```bash
+# Re-open port 22 via SST (no SSH needed — runs from your laptop)
+SSH_CIDRS=0.0.0.0/0 npx sst deploy
+```
+
+Or via AWS CLI for immediate effect (overwritten on next SST deploy):
+
+```bash
+aws lightsail put-instance-public-ports \
+  --instance-name vault-cortex-<stage> \
+  --port-infos '[{"protocol":"tcp","fromPort":22,"toPort":22,"cidrs":["0.0.0.0/0"]},{"protocol":"tcp","fromPort":8000,"toPort":8000,"cidrs":["0.0.0.0/0"]}]'
+```
+
+---
+
 ## Troubleshooting
 
 - **`npm run build` fails with `Property 'McpAuthToken' does not exist`** — `sst-env.d.ts` hasn't been generated. Run `npx sst deploy` (or `sst dev`) once for your stage.
 - **`sst dev` errors with `SecretMissingError`** — set the three secrets first (one-time setup step 2).
-- **`curl <lightsailIp>` hangs** — use `:8000`. The security group only allows ports 22 and 8000.
+- **`curl <lightsailIp>` hangs** — use `:8000`. The firewall only allows ports 22 and 8000 by default (port 22 may be closed if `SSH_CIDRS=none`).
 - **`scp` / `ssh` fails with `Permission denied (publickey)`** — your local SSH key doesn't match what SST deployed to the Lightsail KeyPair. Verify `~/.ssh/vault-cortex` exists (generate with `ssh-keygen -t ed25519 -f ~/.ssh/vault-cortex -C vault-cortex-deploy -N ""`), then redeploy. To also use your personal key, add it post-provision: `ssh -i ~/.ssh/vault-cortex ubuntu@<IP> "cat >> ~/.ssh/authorized_keys" < ~/.ssh/id_ed25519.pub`.
 - **`docker: command not found` on `lightsail:up`** — cloud-init hasn't finished installing Docker. The script waits up to 120s automatically; if it still times out, SSH in and check `tail /var/log/cloud-init-output.log`.
 - **Host key changed warning** — the Lightsail instance was replaced (e.g. `userData` changed in `sst.config.ts`). The deploy key convention prevents key-change replacements, but other properties can still trigger it. Run `ssh-keygen -R <lightsailIp>` and retry.

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -70,7 +70,9 @@ const waitForDocker = (ip: string, id: string, timeoutSec = 120): void => {
   process.exit(1)
 }
 
-const lightsailIp = (): string => {
+const sshHost = (): string => {
+  if (env.LIGHTSAIL_SSH_HOST) return env.LIGHTSAIL_SSH_HOST
+
   if (!existsSync(".sst/outputs.json")) {
     console.error("✕  .sst/outputs.json not found. Run `npx sst deploy` first.")
     process.exit(1)
@@ -129,7 +131,7 @@ switch (sub) {
       )
       process.exit(1)
     }
-    const ip = lightsailIp()
+    const ip = sshHost()
     const id = sshIdentity()
     run(
       `ssh ${id} ${sshOpts} ubuntu@${ip} 'sudo mkdir -p /opt/vault-cortex && sudo chown ubuntu:ubuntu /opt/vault-cortex'`,

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -160,29 +160,24 @@ export default $config({
       instanceName: instance.name,
     })
 
-    // GOTCHA: InstancePublicPorts is DECLARATIVE — it replaces ALL
-    // existing rules on every deploy. If you omit port 22 here,
-    // you lock yourself out of SSH via the public IP (but Tailscale
-    // SSH still works — it bypasses the Lightsail firewall entirely).
+    // GOTCHA #1: InstancePublicPorts is DECLARATIVE — it replaces ALL
+    // existing rules on every deploy.
+    // GOTCHA #2: port_info is ForceNew in the Pulumi/Terraform provider.
+    // Adding or removing entries triggers a resource REPLACEMENT (delete
+    // all ports → recreate). Only cidrs can be changed in-place. So we
+    // ALWAYS keep both entries and map "none" to a non-routable CIDR
+    // instead of removing the port 22 entry.
+    const sshFirewallCidrs =
+      sshCidrs?.toLowerCase() === "none"
+        ? ["192.0.2.1/32"] // RFC 5737 TEST-NET — non-routable, effectively blocks all SSH
+        : sshCidrs
+          ? sshCidrs.split(",").map((cidr) => cidr.trim())
+          : ["0.0.0.0/0"]
+
     new aws.lightsail.InstancePublicPorts("VaultCortexPorts", {
       instanceName: instance.name,
       portInfos: [
-        // SSH: configurable via SSH_CIDRS env var.
-        // "none" removes port 22 from the public firewall (Tailscale-only).
-        // Comma-separated CIDRs restrict to specific IPs (e.g. "100.64.0.0/10").
-        // Default (unset): 0.0.0.0/0 (backward-compat).
-        ...(sshCidrs?.toLowerCase() === "none"
-          ? []
-          : [
-              {
-                protocol: "tcp",
-                fromPort: 22,
-                toPort: 22,
-                cidrs: sshCidrs
-                  ? sshCidrs.split(",").map((cidr) => cidr.trim())
-                  : ["0.0.0.0/0"],
-              },
-            ]),
+        { protocol: "tcp", fromPort: 22, toPort: 22, cidrs: sshFirewallCidrs },
         // API Gateway calls Lightsail on this port. Bearer token is
         // enforced upstream by the Lambda authorizer, so 0.0.0.0/0
         // is acceptable — the token is the real security boundary.

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -29,6 +29,10 @@ export default $config({
     const sshPubkey = env("SSH_PUBKEY").asString()
     const sshPubkeyPath = env("SSH_PUBKEY_PATH").asString()
 
+    // SSH firewall CIDRs. Comma-separated. Default: open (backward-compat).
+    // Set to "none" to remove port 22 entirely (Tailscale-only SSH).
+    const sshCidrs = env("SSH_CIDRS").asString()
+
     const expandHome = (p: string): string =>
       p.startsWith("~/") ? `${homedir()}${p.slice(1)}` : p
 
@@ -158,12 +162,27 @@ export default $config({
 
     // GOTCHA: InstancePublicPorts is DECLARATIVE — it replaces ALL
     // existing rules on every deploy. If you omit port 22 here,
-    // you lock yourself out of SSH permanently.
+    // you lock yourself out of SSH via the public IP (but Tailscale
+    // SSH still works — it bypasses the Lightsail firewall entirely).
     new aws.lightsail.InstancePublicPorts("VaultCortexPorts", {
       instanceName: instance.name,
       portInfos: [
-        // TODO: Restrict SSH to your admin IP (e.g. "203.0.113.42/32")
-        { protocol: "tcp", fromPort: 22, toPort: 22, cidrs: ["0.0.0.0/0"] },
+        // SSH: configurable via SSH_CIDRS env var.
+        // "none" removes port 22 from the public firewall (Tailscale-only).
+        // Comma-separated CIDRs restrict to specific IPs (e.g. "100.64.0.0/10").
+        // Default (unset): 0.0.0.0/0 (backward-compat for forkers).
+        ...(sshCidrs?.toLowerCase() === "none"
+          ? []
+          : [
+              {
+                protocol: "tcp",
+                fromPort: 22,
+                toPort: 22,
+                cidrs: sshCidrs
+                  ? sshCidrs.split(",").map((cidr) => cidr.trim())
+                  : ["0.0.0.0/0"],
+              },
+            ]),
         // API Gateway calls Lightsail on this port. Bearer token is
         // enforced upstream by the Lambda authorizer, so 0.0.0.0/0
         // is acceptable — the token is the real security boundary.

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -170,7 +170,7 @@ export default $config({
         // SSH: configurable via SSH_CIDRS env var.
         // "none" removes port 22 from the public firewall (Tailscale-only).
         // Comma-separated CIDRs restrict to specific IPs (e.g. "100.64.0.0/10").
-        // Default (unset): 0.0.0.0/0 (backward-compat for forkers).
+        // Default (unset): 0.0.0.0/0 (backward-compat).
         ...(sshCidrs?.toLowerCase() === "none"
           ? []
           : [


### PR DESCRIPTION
## Summary

- `port_info` is `ForceNew` in the Pulumi/Terraform AWS provider — adding or removing entries triggers a resource replacement (delete all ports → recreate). PR #40's approach removed port 22 when `SSH_CIDRS=none`, triggering replacement and leaving port 8000 closed (503 on healthcheck)
- Fix: always keep both port entries. Map `none` to a non-routable CIDR (`192.0.2.1/32`, RFC 5737 TEST-NET) instead of removing the entry. Since `cidrs` is NOT `ForceNew`, this is an in-place update — no replacement, no port clearing

## Root cause

The Terraform AWS provider marks `port_info` (the set itself), `from_port`, `to_port`, and `protocol` as `ForceNew`. Changing any of these triggers destroy+create. Only `cidrs` can be updated in-place. Verified via [provider source](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/lightsail/instance_public_ports.go).

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Deploy with `SSH_CIDRS` unset → both ports open at `0.0.0.0/0`
- [ ] Deploy with `SSH_CIDRS=none` → port 22 set to `192.0.2.1/32`, port 8000 unchanged
- [ ] Healthcheck passes after both deploys
- [ ] Verify via `aws lightsail get-instance-port-states` that both ports are always present

🤖 Generated with [Claude Code](https://claude.com/claude-code)