### PR TITLE
chore: remove dead code, unused exports, etc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Root logger at `src/logger.ts`. Structured JSON to stdout/stderr.
   "requestId": "1",
   "sessionId": "abc",
   "tool": "vault_read_note",
-  "clientIp": "73.48.22.1",
+  "clientIp": "203.0.113.42",
   "path": "About Me/Principles.md"
 }
 ```

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -307,7 +307,7 @@ docker logs vault-mcp 2>&1 | jq 'select(.level == "error")'
 docker logs vault-mcp 2>&1 | jq 'select(.requestId == "1")'
 
 # All activity from a specific client IP
-docker logs vault-mcp 2>&1 | jq 'select(.clientIp == "73.48.22.1")'
+docker logs vault-mcp 2>&1 | jq 'select(.clientIp == "203.0.113.42")'
 
 # All tool calls
 docker logs vault-mcp 2>&1 | jq 'select(.message == "tool_call")'

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, vi } from "vitest"
-import { safeEqual, parseBearer, createBearerMiddleware } from "../auth.js"
-import type { Request, Response, NextFunction } from "express"
+import { describe, it, expect } from "vitest"
+import { safeEqual, parseBearer } from "../auth.js"
 
 describe("safeEqual", () => {
   it("returns true for equal strings", () => {
@@ -52,69 +51,5 @@ describe("parseBearer", () => {
   it.each(scenarios)("$name", ({ input, expected }) => {
     const result = parseBearer(input)
     expect(result).toBe(expected)
-  })
-})
-
-describe("createBearerMiddleware", () => {
-  const createMockReqResNext = (authHeader?: string) => {
-    const req = {
-      headers: authHeader !== undefined ? { authorization: authHeader } : {},
-    } as unknown as Request
-
-    const resJson = vi.fn()
-    const resStatus = vi.fn().mockReturnValue({ json: resJson })
-    const res = { status: resStatus, json: resJson } as unknown as Response
-
-    const next = vi.fn() as unknown as NextFunction
-
-    return { req, res, resStatus, resJson, next }
-  }
-
-  it("passes valid token to next()", () => {
-    const middleware = createBearerMiddleware("valid-token")
-    const { req, res, next } = createMockReqResNext("Bearer valid-token")
-    middleware(req, res, next)
-    expect(next).toHaveBeenCalled()
-  })
-
-  it("rejects missing Authorization header with 401", () => {
-    const middleware = createBearerMiddleware("valid-token")
-    const { req, res, resStatus, next } = createMockReqResNext()
-    middleware(req, res, next)
-    expect(resStatus).toHaveBeenCalledWith(401)
-    expect(next).not.toHaveBeenCalled()
-  })
-
-  it("rejects malformed Authorization header with 401", () => {
-    const middleware = createBearerMiddleware("valid-token")
-    const { req, res, resStatus, next } = createMockReqResNext("Basic abc123")
-    middleware(req, res, next)
-    expect(resStatus).toHaveBeenCalledWith(401)
-    expect(next).not.toHaveBeenCalled()
-  })
-
-  it("rejects invalid token with 401", () => {
-    const middleware = createBearerMiddleware("valid-token")
-    const { req, res, resStatus, next } =
-      createMockReqResNext("Bearer wrong-token")
-    middleware(req, res, next)
-    expect(resStatus).toHaveBeenCalledWith(401)
-    expect(next).not.toHaveBeenCalled()
-  })
-
-  it("does not leak token value in error response", () => {
-    const middleware = createBearerMiddleware("super-secret")
-    const { req, res, resJson, next } = createMockReqResNext("Bearer wrong")
-    middleware(req, res, next)
-    const responseBody = resJson.mock.calls[0]?.[0] as { error: string }
-    expect(JSON.stringify(responseBody)).not.toContain("super-secret")
-    expect(JSON.stringify(responseBody)).not.toContain("wrong")
-  })
-
-  it("handles case-insensitive bearer prefix", () => {
-    const middleware = createBearerMiddleware("my-token")
-    const { req, res, next } = createMockReqResNext("bearer my-token")
-    middleware(req, res, next)
-    expect(next).toHaveBeenCalled()
   })
 })

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,8 +1,6 @@
 /** Shared bearer-token auth utilities — used by both the Lambda authorizer and Express middleware. */
 
 import { timingSafeEqual } from "node:crypto"
-import type { Request, Response, NextFunction } from "express"
-import { logger } from "./logger.js"
 
 /** Constant-time string comparison. Compares against itself on length mismatch to avoid timing leaks. */
 export const safeEqual = (a: string, b: string): boolean => {
@@ -20,29 +18,4 @@ export const parseBearer = (header: string | undefined): string | null => {
   if (!header) return null
   const match = /^Bearer\s+(.+)$/i.exec(header.trim())
   return match?.[1]?.trim() || null
-}
-
-/** Express middleware that validates a Bearer token. Rejects with 401 on failure. Never logs the token value. */
-export const createBearerMiddleware = (
-  expectedToken: string,
-): ((req: Request, res: Response, next: NextFunction) => void) => {
-  return (req: Request, res: Response, next: NextFunction): void => {
-    const sessionId = req.headers["mcp-session-id"] as string | undefined
-    const clientIp = req.ip
-    const token = parseBearer(req.headers.authorization)
-    if (!token) {
-      logger.warn("auth_failed: missing or malformed Authorization header", {
-        sessionId,
-        clientIp,
-      })
-      res.status(401).json({ error: "missing or malformed Authorization" })
-      return
-    }
-    if (!safeEqual(token, expectedToken)) {
-      logger.error("auth_failed: token mismatch", { sessionId, clientIp })
-      res.status(401).json({ error: "invalid token" })
-      return
-    }
-    next()
-  }
 }

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -5,7 +5,7 @@
  * two deployment targets. HS256-only — the only algorithm we need.
  */
 
-import { createHmac } from "node:crypto"
+import { createHmac, timingSafeEqual } from "node:crypto"
 
 export type JwtPayload = {
   sub: string
@@ -36,17 +36,10 @@ export const verifyJwt = (token: string, secret: string): JwtPayload | null => {
   const [header, payload, sig] = parts as [string, string, string]
   const expected = hmac(`${header}.${payload}`, secret)
 
-  if (sig.length !== expected.length) return null
   const sigBuf = Buffer.from(sig, "base64url")
   const expBuf = Buffer.from(expected, "base64url")
   if (sigBuf.length !== expBuf.length) return null
-
-  // Constant-time comparison: XOR each byte pair and accumulate.
-  // If any byte differs, `match` becomes non-zero — but every byte
-  // is always compared, preventing timing attacks that leak signature bytes.
-  let match = 0
-  for (let i = 0; i < sigBuf.length; i++) match |= sigBuf[i]! ^ expBuf[i]!
-  if (match !== 0) return null
+  if (!timingSafeEqual(sigBuf, expBuf)) return null
 
   try {
     const decoded = JSON.parse(

--- a/src/vault-mcp/auth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/auth/__tests__/oauth-provider.test.ts
@@ -52,7 +52,7 @@ describe("OAuth refresh token sliding expiry", () => {
     dbPath = join(dir, "oauth.db")
     oauth = createOAuthProvider({
       authToken: AUTH_TOKEN,
-      serverUrl: new URL("https://example.com"),
+
       dbPath,
     })
     db = new Database(dbPath)
@@ -203,7 +203,7 @@ describe("OAuth refresh token schema migration", () => {
 
     createOAuthProvider({
       authToken: AUTH_TOKEN,
-      serverUrl: new URL("https://example.com"),
+
       dbPath,
     })
 
@@ -227,14 +227,14 @@ describe("OAuth refresh token schema migration", () => {
   it("is idempotent — re-running on a migrated DB doesn't error", () => {
     createOAuthProvider({
       authToken: AUTH_TOKEN,
-      serverUrl: new URL("https://example.com"),
+
       dbPath,
     })
 
     expect(() =>
       createOAuthProvider({
         authToken: AUTH_TOKEN,
-        serverUrl: new URL("https://example.com"),
+
         dbPath,
       }),
     ).not.toThrow()

--- a/src/vault-mcp/auth/oauth-provider.ts
+++ b/src/vault-mcp/auth/oauth-provider.ts
@@ -54,7 +54,6 @@ type StoredAuthCode = {
 
 export type OAuthProviderOptions = {
   authToken: string
-  serverUrl: URL
   dbPath: string
 }
 

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -448,24 +448,6 @@ describe("searchByFolder", () => {
   })
 })
 
-describe("searchByType", () => {
-  beforeEach(() => {
-    index.upsertNote("About Me/Principles.md", NOTE_WITH_FRONTMATTER, 1000)
-    index.upsertNote("other.md", "---\ntitle: Other\n---\nbody\n", 2000)
-  })
-
-  it("finds notes by type", () => {
-    const results = index.searchByType({ type: "about-me" }, logger)
-    expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("About Me/Principles.md")
-  })
-
-  it("returns empty for unknown type", () => {
-    const results = index.searchByType({ type: "nonexistent" }, logger)
-    expect(results).toHaveLength(0)
-  })
-})
-
 describe("listAllTags", () => {
   beforeEach(() => {
     index.upsertNote("About Me/Principles.md", NOTE_WITH_FRONTMATTER, 1000)

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -632,29 +632,6 @@ export const createSearchIndex = (dbPath: string) => {
     return results
   }
 
-  /** Finds notes by their frontmatter `type` field. */
-  const searchByType = (
-    params: { type: string; limit?: number },
-    logger: Logger,
-  ): NoteMetadata[] => {
-    const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties
-      FROM notes
-      WHERE type = ?
-      LIMIT ?
-    `
-
-    const rows = db
-      .prepare(sql)
-      .all(params.type, params.limit ?? 20) as NoteRow[]
-    const results = rows.map(rowToMetadata)
-    logger.info("search by type", {
-      type: params.type,
-      resultCount: results.length,
-    })
-    return results
-  }
-
   /** Returns all tags in the vault with their note counts. */
   const listAllTags = (logger: Logger): TagCount[] => {
     const sql = `
@@ -950,7 +927,6 @@ export const createSearchIndex = (dbPath: string) => {
     fullTextSearch,
     searchByTag,
     searchByFolder,
-    searchByType,
     listAllTags,
     recentNotes,
     listPropertyKeys,

--- a/src/vault-mcp/server.ts
+++ b/src/vault-mcp/server.ts
@@ -54,7 +54,6 @@ const startServer = async (): Promise<void> => {
   const serverUrl = new URL(publicUrl)
   const oauthProvider = createOAuthProvider({
     authToken,
-    serverUrl,
     dbPath: oauthDbPath,
   })
 

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -35,8 +35,6 @@ export const TOOL_NAMES = {
   VAULT_FIND_ORPHANS: "vault_find_orphans",
 } as const
 
-export type ToolName = (typeof TOOL_NAMES)[keyof typeof TOOL_NAMES]
-
 // ── Response shaping ─────────────────────────────────────────────
 
 // Frontmatter keys that are already top-level fields on NoteMetadata.

--- a/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
@@ -1,15 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { DateTime } from "luxon"
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import {
-  momentToLuxonFormat,
-  readDailyNotesConfig,
-  getDailyNotePath,
-  getDailyNote,
-  clearConfigCache,
-} from "../daily-notes.js"
+import { momentToLuxonFormat } from "../daily-notes.js"
 import { logger } from "../../../logger.js"
 
 // ── momentToLuxonFormat ──────────────────────────────────────────
@@ -79,7 +73,7 @@ describe("readDailyNotesConfig", () => {
   let vaultDir: string
 
   beforeEach(async () => {
-    clearConfigCache()
+    vi.resetModules()
     vaultDir = await mkdtemp(join(tmpdir(), "daily-notes-test-"))
     await mkdir(join(vaultDir, ".obsidian"), { recursive: true })
   })
@@ -89,6 +83,7 @@ describe("readDailyNotesConfig", () => {
   })
 
   it("reads folder and format from .obsidian/daily-notes.json", async () => {
+    const { readDailyNotesConfig } = await import("../daily-notes.js")
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
       JSON.stringify({ folder: "Journal", format: "YYYY-MM-DD-dddd" }),
@@ -100,12 +95,14 @@ describe("readDailyNotesConfig", () => {
   })
 
   it("falls back to defaults when file is missing", async () => {
+    const { readDailyNotesConfig } = await import("../daily-notes.js")
     const config = await readDailyNotesConfig(vaultDir)
     expect(config.folder).toBe("Daily Notes")
     expect(config.format).toBe("YYYY-MM-DD")
   })
 
   it("falls back to defaults when file is malformed JSON", async () => {
+    const { readDailyNotesConfig } = await import("../daily-notes.js")
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
       "not valid json{{{",
@@ -117,6 +114,7 @@ describe("readDailyNotesConfig", () => {
   })
 
   it("uses default folder when config has empty folder string", async () => {
+    const { readDailyNotesConfig } = await import("../daily-notes.js")
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
       JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
@@ -127,6 +125,7 @@ describe("readDailyNotesConfig", () => {
   })
 
   it("uses default format when config has empty format string", async () => {
+    const { readDailyNotesConfig } = await import("../daily-notes.js")
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
       JSON.stringify({ folder: "Journal" }),
@@ -137,6 +136,7 @@ describe("readDailyNotesConfig", () => {
   })
 
   it("caches the config after first read", async () => {
+    const { readDailyNotesConfig } = await import("../daily-notes.js")
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
       JSON.stringify({ folder: "Journal", format: "YYYY-MM-DD" }),
@@ -161,7 +161,7 @@ describe("getDailyNotePath", () => {
   let vaultDir: string
 
   beforeEach(async () => {
-    clearConfigCache()
+    vi.resetModules()
     vaultDir = await mkdtemp(join(tmpdir(), "daily-path-test-"))
     await mkdir(join(vaultDir, ".obsidian"), { recursive: true })
   })
@@ -171,11 +171,13 @@ describe("getDailyNotePath", () => {
   })
 
   it("resolves a specific date with default config", async () => {
+    const { getDailyNotePath } = await import("../daily-notes.js")
     const path = await getDailyNotePath(vaultDir, "2026-05-13")
     expect(path).toBe("Daily Notes/2026-05-13.md")
   })
 
   it("resolves with custom folder and format", async () => {
+    const { getDailyNotePath } = await import("../daily-notes.js")
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
       JSON.stringify({ folder: "Journal", format: "DD-MM-YYYY" }),
@@ -186,6 +188,7 @@ describe("getDailyNotePath", () => {
   })
 
   it("defaults to today when no date provided", async () => {
+    const { getDailyNotePath } = await import("../daily-notes.js")
     const path = await getDailyNotePath(vaultDir)
     // Use Luxon's local-timezone today (same as the code under test) to
     // avoid UTC/local date mismatch near midnight
@@ -194,24 +197,28 @@ describe("getDailyNotePath", () => {
   })
 
   it("throws on invalid date format", async () => {
+    const { getDailyNotePath } = await import("../daily-notes.js")
     await expect(getDailyNotePath(vaultDir, "not-a-date")).rejects.toThrow(
       "invalid date",
     )
   })
 
   it("rejects partial ISO dates (year only)", async () => {
+    const { getDailyNotePath } = await import("../daily-notes.js")
     await expect(getDailyNotePath(vaultDir, "2026")).rejects.toThrow(
       "invalid date",
     )
   })
 
   it("rejects partial ISO dates (year-month only)", async () => {
+    const { getDailyNotePath } = await import("../daily-notes.js")
     await expect(getDailyNotePath(vaultDir, "2026-05")).rejects.toThrow(
       "invalid date",
     )
   })
 
   it("rejects full ISO timestamps", async () => {
+    const { getDailyNotePath } = await import("../daily-notes.js")
     await expect(
       getDailyNotePath(vaultDir, "2026-05-13T14:30:00Z"),
     ).rejects.toThrow("invalid date")
@@ -224,7 +231,7 @@ describe("getDailyNote", () => {
   let vaultDir: string
 
   beforeEach(async () => {
-    clearConfigCache()
+    vi.resetModules()
     vaultDir = await mkdtemp(join(tmpdir(), "daily-read-test-"))
     await mkdir(join(vaultDir, ".obsidian"), { recursive: true })
     await mkdir(join(vaultDir, "Daily Notes"), { recursive: true })
@@ -235,6 +242,7 @@ describe("getDailyNote", () => {
   })
 
   it("reads an existing daily note", async () => {
+    const { getDailyNote } = await import("../daily-notes.js")
     await writeFile(
       join(vaultDir, "Daily Notes", "2026-05-13.md"),
       "---\ndate: 2026-05-13\n---\n\n# 2026-05-13\n\nToday's notes.\n",
@@ -250,6 +258,7 @@ describe("getDailyNote", () => {
   })
 
   it("returns exists: false for missing daily note", async () => {
+    const { getDailyNote } = await import("../daily-notes.js")
     const result = await getDailyNote(
       { vaultPath: vaultDir, date: "2026-01-01" },
       logger,
@@ -260,6 +269,7 @@ describe("getDailyNote", () => {
   })
 
   it("rethrows non-ENOENT errors (e.g. path traversal)", async () => {
+    const { getDailyNote } = await import("../daily-notes.js")
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
       JSON.stringify({ folder: "../escape", format: "YYYY-MM-DD" }),

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -19,7 +19,7 @@ tags:
   - principles
 created: 2026-04-22T20:51:21-04:00
 related:
-  - "[[People/Tanisha Aberdeen|Tanisha Aberdeen]]"
+  - "[[People/Alex Rivera|Alex Rivera]]"
 ---
 
 # Principles

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -103,11 +103,6 @@ export const readDailyNotesConfig = async (
   return cachedConfig
 }
 
-/** Clears the cached config. Exposed for testing only. */
-export const clearConfigCache = (): void => {
-  cachedConfig = null
-}
-
 // ── Path resolution + read ──────────────────────────────────────
 
 /** Matches strict YYYY-MM-DD date strings (no time component, no partial dates). */

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -62,6 +62,8 @@ const OBSIDIAN_DEFAULTS: DailyNotesConfig = {
   format: "YYYY-MM-DD",
 }
 
+// TODO: Consider refactoring to factory/closure pattern (like createSearchIndex,
+// createMemoryStore) so the cache lives in the closure instead of at module scope.
 // Mutable module-level cache — justified because the config is read from
 // the filesystem once and never changes during the server's lifetime.
 // Avoids re-reading .obsidian/daily-notes.json on every tool call.

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -565,5 +565,3 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     bootstrapMemoryDir,
   }
 }
-
-export type MemoryStore = ReturnType<typeof createMemoryStore>


### PR DESCRIPTION
## Summary
- Remove pre-OAuth `createBearerMiddleware` (unused since OAuth migration)
- Remove unwired `searchByType` from search-index factory (`vault_search` type filter + `vault_search_by_property` cover the same need)
- Remove unused type exports: `ToolName`, `MemoryStore`
- Remove unused `serverUrl` from `OAuthProviderOptions` (only `createOAuthRoutes` uses it, where it's already received directly)
- Replace hand-rolled JWT XOR signature comparison with `timingSafeEqual` from `node:crypto`
- Replace test-only `clearConfigCache` export with vitest `vi.resetModules()` + dynamic imports
- Scrub real IP address (`73.48.22.1` → RFC 5737 `203.0.113.42`) from doc examples
- Replace real name in test fixture with fictional name

## Test plan
- [x] `npx tsc --noEmit` — clean compile, no dangling references
- [x] `npm test` — 461 tests pass (13 files), net -8 tests removed with dead code
- [x] `npm run lint` — clean
- [x] `grep -rn "73.48.22.1"` — no matches (IP scrubbed)
- [x] `grep -rn "Tanisha Aberdeen"` — no matches (name scrubbed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)