### PR TITLE
docs: fix stale references, release automation, and pre-public language

### DIFF
--- a/.github/scripts/update-changelog.sh
+++ b/.github/scripts/update-changelog.sh
@@ -29,12 +29,12 @@ if os.path.exists(changelog_path):
             text, count=1, flags=re.DOTALL
         )
     else:
-        # Insert after header paragraph
+        # Insert before the first version entry (## [x.y.z])
         lines = text.split('\n')
         insert_at = next(
-            (i for i in range(1, len(lines)) if lines[i].strip() == ''),
-            1
-        ) + 1
+            (i for i in range(len(lines)) if lines[i].startswith('## [')),
+            len(lines)
+        )
         lines.insert(insert_at, f"\n{entry}\n")
         text = '\n'.join(lines)
 else:

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -58,10 +58,12 @@ jobs:
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "Bumping $CURRENT -> $NEXT ($BUMP)"
 
-      - name: Bump package.json and package-lock.json
+      - name: Bump package.json, package-lock.json, and server.json
         env:
           NEXT: ${{ steps.next.outputs.version }}
-        run: npm version "$NEXT" --no-git-tag-version
+        run: |
+          npm version "$NEXT" --no-git-tag-version
+          jq --arg v "$NEXT" '.version = $v' server.json > server.json.tmp && mv server.json.tmp server.json
 
       - name: Commit, tag, and push
         env:
@@ -69,7 +71,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json
+          git add package.json package-lock.json server.json
           git commit -m "release: v$NEXT"
           git tag "v$NEXT"
           git push origin HEAD --tags

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,16 +71,6 @@ src/
       consent-page.ts                  # HTML consent page for OAuth authorization
 ```
 
-## Tooling
-
-When working on this repo in Claude Code, the deployed `vault-cortex` MCP
-connector is typically loaded as deferred tools (names like
-`mcp__*__vault_*`). Before claiming inability to read or write the vault,
-check the deferred-tools list and load schemas via `ToolSearch`. The
-connector exposes `vault_read_note`, `vault_search`, `vault_get_memory`,
-`vault_write_note`, `vault_patch_note`, `vault_replace_in_note`, and the
-rest of the API (22 tools) in `src/vault-mcp/tool-definitions.ts`.
-
 ## Logging
 
 Root logger at `src/logger.ts`. Structured JSON to stdout/stderr.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,22 +17,25 @@ About Me/ memory layer — enough to make any MCP client personalized.
 vault. The file watcher gains a second hook for LightRAG ingestion,
 and a new `vault_query_kb` tool is added. Additive — not a rewrite.
 
-This repo will be made **public**. All solutions must be portable — they
-can't rely on one-off manual fixes, hardcoded paths, or user-specific
-configuration. If it works only on the author's machine, it's not done.
+All solutions must be portable — they can't rely on one-off manual fixes,
+hardcoded paths, or user-specific configuration. If it works only on
+the author's machine, it's not done.
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design.
 
 ## Structure
 
-```
+```text
 sst.config.ts                          # SST v4 IaC (fully implemented)
 package.json                           # single package, all deps
 tsconfig.json                          # single config
+server.json                            # MCP server registry manifest
 Dockerfile                             # vault-mcp Docker image
 docker-compose.yml                     # Lightsail: obsidian-sync + vault-mcp
 docker-compose.local.yml               # Contributor dev: builds from source
 .env.example                           # template for Lightsail .env
+templates/                             # Bootstrap templates for new vaults
+  memory/                              #   About Me/ memory file templates
 deploy/                                # End-user quickstart (no clone needed)
   local/                               #   vault-mcp + bind-mounted vault
     README.md                          #     quickstart walkthrough
@@ -107,7 +110,7 @@ Root logger at `src/logger.ts`. Structured JSON to stdout/stderr.
 
 **Logger chain — context flows via `.child()`:**
 
-```
+```text
 root logger (src/logger.ts)
   → session logger: logger.child({ sessionId, clientIp })
     → request logger: sessionLogger.child({ requestId, tool })

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -156,7 +156,7 @@ graph LR
     B --> C["vault-mcp<br/>(UID 1000)<br/>MCP server :8000"]
     B -.->|shared volume| D[("/vault<br/>source of truth")]
     C -.->|shared volume| D
-    C -.->|index + OAuth| E[("/data<br/>search.db + oauth.db")]
+    C -.->|index + OAuth| E[("/data<br/>index.db + oauth.db")]
     A -.->|fixes perms| F[("config volume<br/>/home/obsidian/.config")]
     B -.->|sync state| F
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@
 - Prevent port 8000 wipe by avoiding ForceNew on InstancePublicPorts (#42)
 
 
+## [0.12.0] — 2026-05-18
+
+### Features
+
+- Restrict SSH to Tailscale with configurable firewall CIDRs (#40)
+
+### Maintenance
+
+- Remove unneeded type
+
+
 ## [0.11.3] — 2026-05-17
 
 ### Features
@@ -44,8 +55,6 @@
 ### Maintenance
 
 - Align Node references on Node 24 and fix doc inaccuracies (#37)
-
-All notable changes to this project will be documented in this file.
 
 
 ## [0.11.1] — 2026-05-16
@@ -228,7 +237,6 @@ No notable changes.
 
 - Update CHANGELOG.md for v0.2.0
 
-All notable changes to this project will be documented in this file.
 
 ## [0.2.0] — 2026-05-11
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -573,7 +573,7 @@ aws lightsail put-instance-public-ports \
 ## Troubleshooting
 
 - **`npm run build` fails with `Property 'McpAuthToken' does not exist`** — `sst-env.d.ts` hasn't been generated. Run `npx sst deploy` (or `sst dev`) once for your stage.
-- **`sst dev` errors with `SecretMissingError`** — set the three secrets first (one-time setup step 2).
+- **`sst dev` errors with `SecretMissingError`** — set the secret first (one-time setup step 2).
 - **`curl <lightsailIp>` hangs** — use `:8000`. The firewall only allows ports 22 and 8000 by default (port 22 may be closed if `SSH_CIDRS=none`, port 8000 may be closed if `MCP_PORT_CIDRS=none`).
 - **`scp` / `ssh` fails with `Permission denied (publickey)`** — your local SSH key doesn't match what SST deployed to the Lightsail KeyPair. Verify `~/.ssh/vault-cortex` exists (generate with `ssh-keygen -t ed25519 -f ~/.ssh/vault-cortex -C vault-cortex-deploy -N ""`), then redeploy. To also use your personal key, add it post-provision: `ssh -i ~/.ssh/vault-cortex ubuntu@<IP> "cat >> ~/.ssh/authorized_keys" < ~/.ssh/id_ed25519.pub`.
 - **`docker: command not found` on `lightsail:up`** — cloud-init hasn't finished installing Docker. The script waits up to 120s automatically; if it still times out, SSH in and check `tail /var/log/cloud-init-output.log`.

--- a/README.md
+++ b/README.md
@@ -106,16 +106,17 @@ Connect via OAuth — add a remote MCP server with `<PUBLIC_URL>/mcp`. A consent
 
 All settings are environment variables with sensible defaults. Only `MCP_AUTH_TOKEN` and `VAULT_PATH` are required for local use.
 
-| Variable                 | Default                              | Description                                                |
-| ------------------------ | ------------------------------------ | ---------------------------------------------------------- |
-| `MCP_AUTH_TOKEN`         | —                                    | Bearer token for authentication (also the JWT signing key) |
-| `VAULT_PATH`             | —                                    | Path to the vault inside the container                     |
-| `PUBLIC_URL`             | —                                    | Public URL for OAuth discovery (required for remote)       |
-| `MEMORY_DIR`             | `About Me`                           | Vault folder for structured memory files                   |
-| `PROTECTED_PATHS`        | `MEMORY_DIR, Daily Notes`            | Folders that `vault_delete_note` refuses to touch          |
-| `ORPHAN_EXCLUDE_FOLDERS` | `Daily Notes, Templates, MEMORY_DIR` | Folders excluded from orphan detection                     |
-| `TZ`                     | `UTC`                                | IANA timezone for timestamps and daily note resolution     |
-| `LOG_LEVEL`              | `info`                               | Logging verbosity: `debug`, `info`, `warn`, `error`        |
+| Variable                    | Default                              | Description                                                |
+| --------------------------- | ------------------------------------ | ---------------------------------------------------------- |
+| `MCP_AUTH_TOKEN`            | —                                    | Bearer token for authentication (also the JWT signing key) |
+| `VAULT_PATH`                | —                                    | Path to the vault inside the container                     |
+| `PUBLIC_URL`                | —                                    | Public URL for OAuth discovery (required for remote)       |
+| `MEMORY_DIR`                | `About Me`                           | Vault folder for structured memory files                   |
+| `PROTECTED_PATHS`           | `MEMORY_DIR, Daily Notes`            | Folders that `vault_delete_note` refuses to touch          |
+| `ORPHAN_EXCLUDE_FOLDERS`    | `Daily Notes, Templates, MEMORY_DIR` | Folders excluded from orphan detection                     |
+| `TZ`                        | `UTC`                                | IANA timezone for timestamps and daily note resolution     |
+| `SERVICE_DOCUMENTATION_URL` | GitHub repo URL                      | URL returned in OAuth discovery metadata                   |
+| `LOG_LEVEL`                 | `info`                               | Logging verbosity: `debug`, `info`, `warn`, `error`        |
 
 **Smart defaults:** Setting `MEMORY_DIR` automatically updates the defaults for `PROTECTED_PATHS` and `ORPHAN_EXCLUDE_FOLDERS`. You only set those explicitly for a fully custom list.
 

--- a/README.md
+++ b/README.md
@@ -104,19 +104,19 @@ Connect via OAuth — add a remote MCP server with `<PUBLIC_URL>/mcp`. A consent
 
 ## Configuration
 
-All settings are environment variables with sensible defaults. Only `MCP_AUTH_TOKEN` and `VAULT_PATH` are required for local use.
+All settings are environment variables with sensible defaults.
 
-| Variable                    | Default                              | Description                                                |
-| --------------------------- | ------------------------------------ | ---------------------------------------------------------- |
-| `MCP_AUTH_TOKEN`            | —                                    | Bearer token for authentication (also the JWT signing key) |
-| `VAULT_PATH`                | —                                    | Path to the vault inside the container                     |
-| `PUBLIC_URL`                | —                                    | Public URL for OAuth discovery (required for remote)       |
-| `MEMORY_DIR`                | `About Me`                           | Vault folder for structured memory files                   |
-| `PROTECTED_PATHS`           | `MEMORY_DIR, Daily Notes`            | Folders that `vault_delete_note` refuses to touch          |
-| `ORPHAN_EXCLUDE_FOLDERS`    | `Daily Notes, Templates, MEMORY_DIR` | Folders excluded from orphan detection                     |
-| `TZ`                        | `UTC`                                | IANA timezone for timestamps and daily note resolution     |
-| `SERVICE_DOCUMENTATION_URL` | GitHub repo URL                      | URL returned in OAuth discovery metadata                   |
-| `LOG_LEVEL`                 | `info`                               | Logging verbosity: `debug`, `info`, `warn`, `error`        |
+| Variable                    | Required | Default                              | Description                                                |
+| --------------------------- | -------- | ------------------------------------ | ---------------------------------------------------------- |
+| `MCP_AUTH_TOKEN`            | Yes      | —                                    | Bearer token for authentication (also the JWT signing key) |
+| `VAULT_PATH`                | Local    | —                                    | Path to the vault inside the container                     |
+| `PUBLIC_URL`                | Remote   | —                                    | Public URL for OAuth discovery metadata                    |
+| `MEMORY_DIR`                | —        | `About Me`                           | Vault folder for structured memory files                   |
+| `PROTECTED_PATHS`           | —        | `MEMORY_DIR, Daily Notes`            | Folders that `vault_delete_note` refuses to touch          |
+| `ORPHAN_EXCLUDE_FOLDERS`    | —        | `Daily Notes, Templates, MEMORY_DIR` | Folders excluded from orphan detection                     |
+| `TZ`                        | —        | `UTC`                                | IANA timezone for timestamps and daily note resolution     |
+| `SERVICE_DOCUMENTATION_URL` | —        | GitHub repo URL                      | URL returned in OAuth discovery metadata                   |
+| `LOG_LEVEL`                 | —        | `info`                               | Logging verbosity: `debug`, `info`, `warn`, `error`        |
 
 **Smart defaults:** Setting `MEMORY_DIR` automatically updates the defaults for `PROTECTED_PATHS` and `ORPHAN_EXCLUDE_FOLDERS`. You only set those explicitly for a fully custom list.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Connect via OAuth — add a remote MCP server with `<PUBLIC_URL>/mcp`. A consent
 
 All settings are environment variables with sensible defaults.
 
-| Variable                    | Required    | Default                              | Description                                                |
+| Variable                    | Required?   | Default                              | Description                                                |
 | --------------------------- | ----------- | ------------------------------------ | ---------------------------------------------------------- |
 | `MCP_AUTH_TOKEN`            | Yes         | —                                    | Bearer token for authentication (also the JWT signing key) |
 | `VAULT_PATH`                | Local only  | —                                    | Path to the vault inside the container                     |

--- a/README.md
+++ b/README.md
@@ -106,17 +106,17 @@ Connect via OAuth — add a remote MCP server with `<PUBLIC_URL>/mcp`. A consent
 
 All settings are environment variables with sensible defaults.
 
-| Variable                    | Required?   | Default                              | Description                                                |
-| --------------------------- | ----------- | ------------------------------------ | ---------------------------------------------------------- |
-| `MCP_AUTH_TOKEN`            | Yes         | —                                    | Bearer token for authentication (also the JWT signing key) |
-| `VAULT_PATH`                | Local only  | —                                    | Path to the vault inside the container                     |
-| `PUBLIC_URL`                | Remote only | —                                    | Public URL for OAuth discovery metadata                    |
-| `MEMORY_DIR`                | —           | `About Me`                           | Vault folder for structured memory files                   |
-| `PROTECTED_PATHS`           | —           | `MEMORY_DIR, Daily Notes`            | Folders that `vault_delete_note` refuses to touch          |
-| `ORPHAN_EXCLUDE_FOLDERS`    | —           | `Daily Notes, Templates, MEMORY_DIR` | Folders excluded from orphan detection                     |
-| `TZ`                        | —           | `UTC`                                | IANA timezone for timestamps and daily note resolution     |
-| `SERVICE_DOCUMENTATION_URL` | —           | GitHub repo URL                      | URL returned in OAuth discovery metadata                   |
-| `LOG_LEVEL`                 | —           | `info`                               | Logging verbosity: `debug`, `info`, `warn`, `error`        |
+| Variable                    | Required?   | Default                              | Description                                                             |
+| --------------------------- | ----------- | ------------------------------------ | ----------------------------------------------------------------------- |
+| `MCP_AUTH_TOKEN`            | Yes         | —                                    | Bearer token for authentication (also the JWT signing key)              |
+| `VAULT_PATH`                | Local only  | —                                    | Host path to your vault (bind mount source; remote uses a named volume) |
+| `PUBLIC_URL`                | Remote only | —                                    | Public URL for OAuth discovery metadata                                 |
+| `MEMORY_DIR`                | —           | `About Me`                           | Vault folder for structured memory files                                |
+| `PROTECTED_PATHS`           | —           | `MEMORY_DIR, Daily Notes`            | Folders that `vault_delete_note` refuses to touch                       |
+| `ORPHAN_EXCLUDE_FOLDERS`    | —           | `Daily Notes, Templates, MEMORY_DIR` | Folders excluded from orphan detection                                  |
+| `TZ`                        | —           | `UTC`                                | IANA timezone for timestamps and daily note resolution                  |
+| `SERVICE_DOCUMENTATION_URL` | —           | GitHub repo URL                      | URL returned in OAuth discovery metadata                                |
+| `LOG_LEVEL`                 | —           | `info`                               | Logging verbosity: `debug`, `info`, `warn`, `error`                     |
 
 **Smart defaults:** Setting `MEMORY_DIR` automatically updates the defaults for `PROTECTED_PATHS` and `ORPHAN_EXCLUDE_FOLDERS`. You only set those explicitly for a fully custom list.
 

--- a/README.md
+++ b/README.md
@@ -106,17 +106,17 @@ Connect via OAuth — add a remote MCP server with `<PUBLIC_URL>/mcp`. A consent
 
 All settings are environment variables with sensible defaults.
 
-| Variable                    | Required | Default                              | Description                                                |
-| --------------------------- | -------- | ------------------------------------ | ---------------------------------------------------------- |
-| `MCP_AUTH_TOKEN`            | Yes      | —                                    | Bearer token for authentication (also the JWT signing key) |
-| `VAULT_PATH`                | Local    | —                                    | Path to the vault inside the container                     |
-| `PUBLIC_URL`                | Remote   | —                                    | Public URL for OAuth discovery metadata                    |
-| `MEMORY_DIR`                | —        | `About Me`                           | Vault folder for structured memory files                   |
-| `PROTECTED_PATHS`           | —        | `MEMORY_DIR, Daily Notes`            | Folders that `vault_delete_note` refuses to touch          |
-| `ORPHAN_EXCLUDE_FOLDERS`    | —        | `Daily Notes, Templates, MEMORY_DIR` | Folders excluded from orphan detection                     |
-| `TZ`                        | —        | `UTC`                                | IANA timezone for timestamps and daily note resolution     |
-| `SERVICE_DOCUMENTATION_URL` | —        | GitHub repo URL                      | URL returned in OAuth discovery metadata                   |
-| `LOG_LEVEL`                 | —        | `info`                               | Logging verbosity: `debug`, `info`, `warn`, `error`        |
+| Variable                    | Required    | Default                              | Description                                                |
+| --------------------------- | ----------- | ------------------------------------ | ---------------------------------------------------------- |
+| `MCP_AUTH_TOKEN`            | Yes         | —                                    | Bearer token for authentication (also the JWT signing key) |
+| `VAULT_PATH`                | Local only  | —                                    | Path to the vault inside the container                     |
+| `PUBLIC_URL`                | Remote only | —                                    | Public URL for OAuth discovery metadata                    |
+| `MEMORY_DIR`                | —           | `About Me`                           | Vault folder for structured memory files                   |
+| `PROTECTED_PATHS`           | —           | `MEMORY_DIR, Daily Notes`            | Folders that `vault_delete_note` refuses to touch          |
+| `ORPHAN_EXCLUDE_FOLDERS`    | —           | `Daily Notes, Templates, MEMORY_DIR` | Folders excluded from orphan detection                     |
+| `TZ`                        | —           | `UTC`                                | IANA timezone for timestamps and daily note resolution     |
+| `SERVICE_DOCUMENTATION_URL` | —           | GitHub repo URL                      | URL returned in OAuth discovery metadata                   |
+| `LOG_LEVEL`                 | —           | `info`                               | Logging verbosity: `debug`, `info`, `warn`, `error`        |
 
 **Smart defaults:** Setting `MEMORY_DIR` automatically updates the defaults for `PROTECTED_PATHS` and `ORPHAN_EXCLUDE_FOLDERS`. You only set those explicitly for a fully custom list.
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.aliasunder/vault-cortex",
   "title": "vault-cortex",
   "description": "Remote MCP server — full-text search, structured memory, link graph, and 22 tools for Obsidian vaults. Runs locally via Docker or remotely with Obsidian Sync + OAuth 2.1.",
-  "version": "0.10.0",
+  "version": "0.13.0",
   "websiteUrl": "https://github.com/aliasunder/vault-cortex",
   "repository": {
     "url": "https://github.com/aliasunder/vault-cortex",


### PR DESCRIPTION
## Summary
- **Root cause: server.json never bumped** — `manual_release.yml` now bumps `server.json` alongside `package.json` via `jq`. Fixed drift from `0.10.0` → `0.13.0`.
- **Root cause: CHANGELOG boilerplate reappearing** — `update-changelog.sh` found the first blank line instead of the first `## [` version entry, pushing boilerplate text deeper each release. Fixed insert logic.
- DEPLOY.md: "the secret" not "three secrets" (only `McpAuthToken` exists)
- ARCHITECTURE.md: `search.db` → `index.db` in Mermaid diagram (all compose files set `INDEX_DB_PATH=/data/index.db`)
- CHANGELOG.md: add missing v0.12.0 entry, remove 2 vestigial boilerplate lines
- README.md: add `SERVICE_DOCUMENTATION_URL` to config table
- AGENTS.md: add `templates/` + `server.json` to file tree, remove "will be made public" transition language, add `text` language specifiers to fenced code blocks

## Test plan
- [x] All changes are documentation/workflow — no code changes
- [x] ARCHITECTURE.md diagrams verified against code (all 3 diagrams accurate)
- [x] `grep -rn "search.db"` — only in `server.ts` fallback default (correct)
- [x] `grep -n "All notable changes" CHANGELOG.md` — zero matches after cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)