### PR TITLE
ci: skip Auto Release when triggered by release App push

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   validate:
+    if: github.actor != 'vault-cortex-release[bot]'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.tag.outputs.version }}


### PR DESCRIPTION
## Summary

- Adds `if: github.actor != 'vault-cortex-release[bot]'` to the `validate` job in `auto_release.yml`.
- `deploy` and `release` jobs depend on `validate` via `needs:`, so they inherit the skip — no need to duplicate the guard.

## Why

App installation tokens (unlike `GITHUB_TOKEN`) do not suppress workflow cascades on push events. After #52, the tag push from Manual Release's `bump-and-tag` job now triggers `auto_release.yml` in parallel — observed during the v0.15.2 release (Auto Release fired and was cancelled by the `deploy-prod` concurrency group).

Manual Release already inlines deploy + release, so the cascaded Auto Release run is fully redundant. Guarding on actor keeps Auto Release useful for the original intent (a future external `git push --tags` from a developer machine) without firing on every bot release.

## Test plan

- [ ] CI green on this PR.
- [ ] Next `Manual Release` run: confirm only one workflow chain runs end-to-end (no Auto Release sibling).
- [ ] (Optional) Push a tag manually from local: confirm Auto Release does fire in that case.

https://claude.ai/code/session_01K8eXF8Fe3gjCR5e2ndU2Wo

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8eXF8Fe3gjCR5e2ndU2Wo)_