### PR TITLE
docs: link Obsidian, Obsidian Sync, and headless docs on first mention

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -2,7 +2,7 @@
 
 Full cloud deployment using SST v4 for infrastructure-as-code. Provisions a Lightsail VM, API Gateway with Lambda authorizer, and CI/CD via GitHub Actions.
 
-For simpler setups, see [`deploy/local/`](./deploy/local/) (Docker on your machine) or [`deploy/remote/`](./deploy/remote/) (VPS + Obsidian Sync).
+For simpler setups, see [`deploy/local/`](./deploy/local/) (Docker on your machine) or [`deploy/remote/`](./deploy/remote/) (VPS + [Obsidian Sync](https://obsidian.md/sync)).
 
 ---
 
@@ -14,6 +14,8 @@ SST uses a stage name based on your OS username (run `npx sst secret list` once 
 - Docker installed locally
 - A GitHub PAT with `read:packages` + `write:packages` scopes
 - A dedicated deploy SSH keypair at `~/.ssh/vault-cortex`. If you don't have one: `ssh-keygen -t ed25519 -f ~/.ssh/vault-cortex -C vault-cortex-deploy -N ""`. SST uploads the public key to Lightsail. Both local dev and CI use the same key so deploys never trigger an instance replacement.
+- An [Obsidian](https://obsidian.md) vault (the data this server exposes)
+- An [Obsidian Sync](https://obsidian.md/sync) subscription (the remote deploy uses obsidian-sync to mirror the vault between this VM and your Obsidian apps)
 
 ## One-time setup
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## What is this?
 
-**vault-cortex** gives any MCP client — Claude Desktop, Claude Code, Cursor, OpenCode — full access to your Obsidian vault. Search notes, read and write content, query the link graph, manage structured memory, and resolve daily notes — all through 23 tools over a single Docker container.
+**vault-cortex** gives any MCP client — Claude Desktop, Claude Code, Cursor, OpenCode — full access to your [Obsidian](https://obsidian.md) vault. Search notes, read and write content, query the link graph, manage structured memory, and resolve daily notes — all through 23 tools over a single Docker container.
 
 The typical Obsidian + MCP setup requires three moving parts running simultaneously: Obsidian open → Local REST API plugin → a separate MCP server wrapping the REST API. **vault-cortex** replaces all of that with Docker and your vault folder.
 
@@ -60,7 +60,7 @@ Connect Claude Desktop or Claude Code — add a remote MCP server with URL `http
 
 ### Remote (access from anywhere — Docker + Obsidian Sync)
 
-Run vault-cortex on a VPS with Obsidian Sync for remote access from any device.
+Run vault-cortex on a VPS with [Obsidian Sync](https://obsidian.md/sync) for remote access from any device.
 
 ```bash
 # On your VPS:
@@ -192,7 +192,7 @@ The [obsidian-vault](https://github.com/aliasunder/cowork-plugins) skill teaches
 
 ## Acknowledgments
 
-vault-cortex's remote capability exists because of [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker) — a headless Obsidian Sync client that runs in Docker without a display server. It's the piece that makes "access your vault from anywhere" possible.
+vault-cortex's remote capability exists because of [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker) — a [headless Obsidian Sync](https://obsidian.md/help/sync/headless) client that runs in Docker without a display server. It's the piece that makes "access your vault from anywhere" possible.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Adds hyperlinks for Obsidian (the app), Obsidian Sync (the paid sync service), and the official Obsidian headless-sync docs to the two top-level docs that new readers actually land on. Also surfaces Obsidian Sync explicitly in `DEPLOY.md`'s Prerequisites list — a hard requirement that previously was only discoverable by reading line 5 in passing or jumping over to `deploy/remote/README.md`.

Five edits, all inline-link-on-first-mention (matching the convention `deploy/remote/README.md` already uses at line 11):

| File | Where | Anchor → URL |
|---|---|---|
| `README.md` | line 21 (opening paragraph) | `Obsidian` → https://obsidian.md |
| `README.md` | line 63 (remote-deploy intro) | `Obsidian Sync` → https://obsidian.md/sync |
| `README.md` | line 195 (Acknowledgments) | `headless Obsidian Sync` → https://obsidian.md/help/sync/headless |
| `DEPLOY.md` | line 5 (intro cross-link) | `Obsidian Sync` → https://obsidian.md/sync |
| `DEPLOY.md` | Prerequisites (lines 17–18, new bullets) | `Obsidian` vault + `Obsidian Sync` subscription |

The existing `@Belphemur` + `obsidian-headless-sync-docker` links in Acknowledgments stay untouched — only the adjacent phrase "headless Obsidian Sync" gets newly linked.

## Test plan

- [ ] Render README.md and DEPLOY.md on the PR's Files-changed tab; click each new link.
  - `[Obsidian](https://obsidian.md)` → resolves to Obsidian homepage
  - `[Obsidian Sync](https://obsidian.md/sync)` → resolves to Obsidian Sync product page
  - `[headless Obsidian Sync](https://obsidian.md/help/sync/headless)` → resolves to official headless feature docs
- [ ] Acknowledgments paragraph (three adjacent inline links) renders cleanly — no broken markdown.
- [ ] DEPLOY.md Prerequisites list reads naturally with the two new bullets at the bottom.

https://claude.ai/code/session_01K8eXF8Fe3gjCR5e2ndU2Wo

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8eXF8Fe3gjCR5e2ndU2Wo)_