### PR TITLE
fix: server.json audit corrections + OCI ownership label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /app
 # node:24-alpine ships a `node` user at UID 1000 — matches obsidian-sync's
 # PUID so both containers can read/write the shared /vault volume.
 RUN apk add --no-cache tini libstdc++
-ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0
+ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0 VAULT_PATH=/vault
 # OCI ownership marker for the MCP Registry — must match `name` in
 # server.json. mcp-publisher reads this label off the image manifest.
 LABEL io.modelcontextprotocol.server.name="io.github.aliasunder/vault-cortex"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ WORKDIR /app
 # PUID so both containers can read/write the shared /vault volume.
 RUN apk add --no-cache tini libstdc++
 ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0
+# OCI ownership marker for the MCP Registry — must match `name` in
+# server.json. mcp-publisher reads this label off the image manifest.
+LABEL io.modelcontextprotocol.server.name="io.github.aliasunder/vault-cortex"
 COPY --from=deps  /app/node_modules ./node_modules
 COPY --from=build /app/dist/src ./dist/src
 COPY package.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /app
 # node:24-alpine ships a `node` user at UID 1000 — matches obsidian-sync's
 # PUID so both containers can read/write the shared /vault volume.
 RUN apk add --no-cache tini libstdc++
-ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0 VAULT_PATH=/vault
+ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0 VAULT_PATH=/vault INDEX_DB_PATH=/data/index.db
 # OCI ownership marker for the MCP Registry — must match `name` in
 # server.json. mcp-publisher reads this label off the image manifest.
 LABEL io.modelcontextprotocol.server.name="io.github.aliasunder/vault-cortex"

--- a/deploy/local/.env.example
+++ b/deploy/local/.env.example
@@ -25,5 +25,9 @@ VAULT_PATH=
 # Log verbosity: debug | info | warn | error (default: info).
 # LOG_LEVEL=info
 
+# Directory for persistent log files inside the container (default: /data/logs).
+# Set to empty to disable file logging (logs still go to stdout either way).
+# LOG_DIR=/data/logs
+
 # Days to retain persistent log files before cleanup (default: 30).
 # LOG_RETENTION_DAYS=30

--- a/deploy/local/.env.example
+++ b/deploy/local/.env.example
@@ -25,8 +25,9 @@ VAULT_PATH=
 # Log verbosity: debug | info | warn | error (default: info).
 # LOG_LEVEL=info
 
-# Directory for persistent log files inside the container (default: /data/logs).
-# Set to empty to disable file logging (logs still go to stdout either way).
+# Directory for persistent log files inside the container.
+# Unset by default — logs go to stdout only. Set a path to also write
+# date-stamped log files there (the /data volume persists them).
 # LOG_DIR=/data/logs
 
 # Days to retain persistent log files before cleanup (default: 30).

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -28,7 +28,11 @@ services:
       LOG_DIR: /data/logs
       LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-30}
       TZ: ${TZ:-UTC}
-      # Uncomment to override smart defaults (see Configuration in the main README):
+      # Optional overrides. When unset, the server applies smart defaults
+      # (<MEMORY_DIR> below is the resolved MEMORY_DIR value, default "About Me"):
+      #   PROTECTED_PATHS           default: "<MEMORY_DIR>, Daily Notes" (blocked from vault_delete_note)
+      #   ORPHAN_EXCLUDE_FOLDERS    default: "Daily Notes, Templates, <MEMORY_DIR>" (excluded from vault_find_orphans)
+      #   SERVICE_DOCUMENTATION_URL default: https://github.com/aliasunder/vault-cortex
       # PROTECTED_PATHS: ${PROTECTED_PATHS:-}
       # ORPHAN_EXCLUDE_FOLDERS: ${ORPHAN_EXCLUDE_FOLDERS:-}
       # SERVICE_DOCUMENTATION_URL: ${SERVICE_DOCUMENTATION_URL:-}

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:8000}
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      LOG_DIR: ${LOG_DIR:-/data/logs}
+      LOG_DIR: ${LOG_DIR:-}
       LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-30}
       TZ: ${TZ:-UTC}
       # Optional overrides. When unset, the server applies smart defaults

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:8000}
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      LOG_DIR: /data/logs
+      LOG_DIR: ${LOG_DIR:-/data/logs}
       LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-30}
       TZ: ${TZ:-UTC}
       # Optional overrides. When unset, the server applies smart defaults

--- a/deploy/remote/.env.example
+++ b/deploy/remote/.env.example
@@ -37,6 +37,10 @@ VAULT_NAME=
 # Log verbosity: debug | info | warn | error (default: info).
 # LOG_LEVEL=info
 
+# Directory for persistent log files inside the container (default: /data/logs).
+# Set to empty to disable file logging (logs still go to stdout either way).
+# LOG_DIR=/data/logs
+
 # Days to retain persistent log files before cleanup (default: 30).
 # LOG_RETENTION_DAYS=30
 

--- a/deploy/remote/docker-compose.yml
+++ b/deploy/remote/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       PUBLIC_URL: "${PUBLIC_URL:?Set PUBLIC_URL to your server's public URL}"
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      LOG_DIR: /data/logs
+      LOG_DIR: ${LOG_DIR:-/data/logs}
       LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-30}
       TZ: ${TZ:-UTC}
       # Optional overrides. When unset, the server applies smart defaults

--- a/deploy/remote/docker-compose.yml
+++ b/deploy/remote/docker-compose.yml
@@ -73,7 +73,11 @@ services:
       LOG_DIR: /data/logs
       LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-30}
       TZ: ${TZ:-UTC}
-      # Uncomment to override smart defaults (see Configuration in the main README):
+      # Optional overrides. When unset, the server applies smart defaults
+      # (<MEMORY_DIR> below is the resolved MEMORY_DIR value, default "About Me"):
+      #   PROTECTED_PATHS           default: "<MEMORY_DIR>, Daily Notes" (blocked from vault_delete_note)
+      #   ORPHAN_EXCLUDE_FOLDERS    default: "Daily Notes, Templates, <MEMORY_DIR>" (excluded from vault_find_orphans)
+      #   SERVICE_DOCUMENTATION_URL default: https://github.com/aliasunder/vault-cortex
       # PROTECTED_PATHS: ${PROTECTED_PATHS:-}
       # ORPHAN_EXCLUDE_FOLDERS: ${ORPHAN_EXCLUDE_FOLDERS:-}
       # SERVICE_DOCUMENTATION_URL: ${SERVICE_DOCUMENTATION_URL:-}

--- a/deploy/remote/docker-compose.yml
+++ b/deploy/remote/docker-compose.yml
@@ -16,6 +16,7 @@ services:
   # root. Docker named volumes inherit this root ownership, so the obsidian
   # user (UID 1000) can't write sync state. This init container chowns the
   # volume before obsidian-sync starts.
+  # Remove when upstream fixes: github.com/Belphemur/obsidian-headless-sync-docker
   init-config-perms:
     image: alpine:latest
     command: sh -c "chown -R ${PUID:-1000}:${PGID:-1000} /config"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -22,6 +22,11 @@ services:
       LOG_LEVEL: debug
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
       TZ: ${TZ:-UTC}
+      # Left empty = the server applies smart defaults
+      # (<MEMORY_DIR> below is the resolved MEMORY_DIR value, default "About Me"):
+      #   PROTECTED_PATHS           default: "<MEMORY_DIR>, Daily Notes"
+      #   ORPHAN_EXCLUDE_FOLDERS    default: "Daily Notes, Templates, <MEMORY_DIR>"
+      #   SERVICE_DOCUMENTATION_URL default: https://github.com/aliasunder/vault-cortex
       PROTECTED_PATHS: ${PROTECTED_PATHS:-}
       ORPHAN_EXCLUDE_FOLDERS: ${ORPHAN_EXCLUDE_FOLDERS:-}
       SERVICE_DOCUMENTATION_URL: ${SERVICE_DOCUMENTATION_URL:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,11 @@ services:
       LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-30}
       TZ: ${TZ:-UTC}
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
+      # Left empty = the server applies smart defaults
+      # (<MEMORY_DIR> below is the resolved MEMORY_DIR value, default "About Me"):
+      #   PROTECTED_PATHS           default: "<MEMORY_DIR>, Daily Notes"
+      #   ORPHAN_EXCLUDE_FOLDERS    default: "Daily Notes, Templates, <MEMORY_DIR>"
+      #   SERVICE_DOCUMENTATION_URL default: https://github.com/aliasunder/vault-cortex
       PROTECTED_PATHS: ${PROTECTED_PATHS:-}
       ORPHAN_EXCLUDE_FOLDERS: ${ORPHAN_EXCLUDE_FOLDERS:-}
       SERVICE_DOCUMENTATION_URL: ${SERVICE_DOCUMENTATION_URL:-}

--- a/server.json
+++ b/server.json
@@ -35,10 +35,10 @@
           "type": "named",
           "name": "-v",
           "description": "Bind-mount your Obsidian vault into the container at /vault.",
-          "value": "{HOST_VAULT_PATH}:/vault",
+          "value": "{VAULT_PATH}:/vault",
           "isRequired": true,
           "variables": {
-            "HOST_VAULT_PATH": {
+            "VAULT_PATH": {
               "description": "Absolute path to your Obsidian vault on the host machine.",
               "isRequired": true,
               "format": "filepath"
@@ -72,12 +72,6 @@
           "description": "Bearer token for MCP client authentication. Must match the Authorization header sent by clients. Generate with: openssl rand -hex 32",
           "isRequired": true,
           "isSecret": true
-        },
-        {
-          "name": "VAULT_PATH",
-          "description": "Container path to the mounted vault. The host path is bind-mounted here via the -v runtime argument.",
-          "default": "/vault",
-          "format": "filepath"
         },
         {
           "name": "PUBLIC_URL",

--- a/server.json
+++ b/server.json
@@ -8,53 +8,137 @@
   "repository": {
     "url": "https://github.com/aliasunder/vault-cortex",
     "source": "github",
-    "id": "aliasunder/vault-cortex"
+    "id": "1226067541"
   },
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/aliasunder/vault-cortex",
+      "identifier": "ghcr.io/aliasunder/vault-mcp",
       "version": "0.15.3",
+      "runtimeHint": "docker",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "-p",
+          "description": "Publish the container's port 8000 on the host.",
+          "value": "{PORT}:8000",
+          "isRequired": true,
+          "variables": {
+            "PORT": {
+              "description": "Host port to expose vault-mcp on.",
+              "default": "8000",
+              "format": "number"
+            }
+          }
+        },
+        {
+          "type": "named",
+          "name": "-v",
+          "description": "Bind-mount your Obsidian vault into the container at /vault.",
+          "value": "{HOST_VAULT_PATH}:/vault",
+          "isRequired": true,
+          "variables": {
+            "HOST_VAULT_PATH": {
+              "description": "Absolute path to your Obsidian vault on the host machine.",
+              "isRequired": true,
+              "format": "filepath"
+            }
+          }
+        }
+      ],
       "transport": {
         "type": "streamable-http",
-        "url": "http://localhost:8000/mcp"
+        "url": "http://localhost:{PORT}/mcp",
+        "headers": [
+          {
+            "name": "Authorization",
+            "description": "Bearer token used by the MCP client. Must match the MCP_AUTH_TOKEN env var passed to the container.",
+            "value": "Bearer {MCP_AUTH_TOKEN}",
+            "isRequired": true,
+            "isSecret": true,
+            "variables": {
+              "MCP_AUTH_TOKEN": {
+                "description": "Bearer token for MCP client authentication. Generate with: openssl rand -hex 32",
+                "isRequired": true,
+                "isSecret": true
+              }
+            }
+          }
+        ]
       },
       "environmentVariables": [
         {
           "name": "MCP_AUTH_TOKEN",
-          "description": "Bearer token for MCP client authentication. Generate with: openssl rand -hex 32",
+          "description": "Bearer token for MCP client authentication. Must match the Authorization header sent by clients. Generate with: openssl rand -hex 32",
           "isRequired": true,
           "isSecret": true
         },
         {
           "name": "VAULT_PATH",
-          "description": "Absolute path to your Obsidian vault (mounted into the container)",
-          "isRequired": true,
+          "description": "Container path to the mounted vault. The host path is bind-mounted here via the -v runtime argument.",
+          "default": "/vault",
           "format": "filepath"
         },
         {
           "name": "PUBLIC_URL",
-          "description": "Public URL for OAuth discovery metadata. Required for remote deployments with OAuth.",
-          "isRequired": false
+          "description": "Public URL clients use to reach this server. Used as the OAuth issuer URL in discovery metadata. Override when exposing the server outside localhost or on a non-default port.",
+          "default": "http://localhost:8000"
+        },
+        {
+          "name": "PORT",
+          "description": "Port the server listens on inside the container.",
+          "default": "8000",
+          "format": "number"
+        },
+        {
+          "name": "HOST",
+          "description": "Interface the server binds to inside the container.",
+          "default": "0.0.0.0"
         },
         {
           "name": "MEMORY_DIR",
-          "description": "Vault folder for structured memory files",
-          "default": "About Me",
-          "isRequired": false
+          "description": "Vault folder for structured memory files (About Me-style notes).",
+          "default": "About Me"
         },
         {
           "name": "TZ",
-          "description": "IANA timezone for timestamps and daily note resolution",
-          "default": "UTC",
-          "isRequired": false
+          "description": "IANA timezone for timestamps and daily note resolution.",
+          "default": "UTC"
         },
         {
           "name": "LOG_LEVEL",
-          "description": "Logging verbosity",
+          "description": "Logging verbosity.",
           "default": "info",
-          "choices": ["debug", "info", "warn", "error"],
-          "isRequired": false
+          "choices": ["debug", "info", "warn", "error"]
+        },
+        {
+          "name": "LOG_DIR",
+          "description": "Directory for persistent log files. When set, vault-mcp writes date-stamped .log files here in addition to stdout.",
+          "format": "filepath"
+        },
+        {
+          "name": "LOG_RETENTION_DAYS",
+          "description": "Days to retain persistent log files before cleanup.",
+          "default": "30",
+          "format": "number"
+        },
+        {
+          "name": "INDEX_DB_PATH",
+          "description": "SQLite FTS5 index DB path. Defaults to /data/index.db inside the container.",
+          "format": "filepath"
+        },
+        {
+          "name": "PROTECTED_PATHS",
+          "description": "Comma-separated vault folder names blocked from vault_delete_note. Default: MEMORY_DIR and \"Daily Notes\"."
+        },
+        {
+          "name": "ORPHAN_EXCLUDE_FOLDERS",
+          "description": "Comma-separated vault folder names excluded from vault_find_orphans. Default: \"Daily Notes\", \"Templates\", MEMORY_DIR."
+        },
+        {
+          "name": "SERVICE_DOCUMENTATION_URL",
+          "description": "Override the OAuth service documentation URL exposed via discovery metadata.",
+          "default": "https://github.com/aliasunder/vault-cortex"
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -107,7 +107,8 @@
         },
         {
           "name": "LOG_DIR",
-          "description": "Directory for persistent log files. When set, vault-mcp writes date-stamped .log files here in addition to stdout.",
+          "description": "Directory for persistent log files. vault-mcp writes date-stamped .log files here in addition to stdout. Set to an empty string to disable file logging.",
+          "default": "/data/logs",
           "format": "filepath"
         },
         {
@@ -118,7 +119,8 @@
         },
         {
           "name": "INDEX_DB_PATH",
-          "description": "SQLite FTS5 index DB path. Defaults to /data/index.db inside the container.",
+          "description": "SQLite FTS5 index DB path inside the container. Its parent directory also holds the OAuth token DB.",
+          "default": "/data/index.db",
           "format": "filepath"
         },
         {

--- a/server.json
+++ b/server.json
@@ -112,12 +112,6 @@
           "format": "number"
         },
         {
-          "name": "INDEX_DB_PATH",
-          "description": "SQLite FTS5 index DB path inside the container. Its parent directory also holds the OAuth token DB.",
-          "default": "/data/index.db",
-          "format": "filepath"
-        },
-        {
           "name": "PROTECTED_PATHS",
           "description": "Comma-separated vault folder names blocked from vault_delete_note. Default: MEMORY_DIR and \"Daily Notes\"."
         },

--- a/server.json
+++ b/server.json
@@ -35,7 +35,7 @@
           "type": "named",
           "name": "-v",
           "description": "Bind-mount your Obsidian vault into the container at /vault.",
-          "value": "{VAULT_PATH}:/vault",
+          "value": "{VAULT_PATH}:/vault:rw",
           "isRequired": true,
           "variables": {
             "VAULT_PATH": {
@@ -44,6 +44,12 @@
               "format": "filepath"
             }
           }
+        },
+        {
+          "type": "named",
+          "name": "-v",
+          "description": "Named volume for persistent state under /data — search index, OAuth token DB, and any log files. Keeps OAuth sessions alive across container restarts.",
+          "value": "vault-cortex-data:/data"
         }
       ],
       "transport": {
@@ -96,8 +102,7 @@
         },
         {
           "name": "LOG_DIR",
-          "description": "Directory for persistent log files. vault-mcp writes date-stamped .log files here in addition to stdout. Set to an empty string to disable file logging.",
-          "default": "/data/logs",
+          "description": "Directory for persistent log files. Unset by default — logs go to stdout only. Set to /data/logs to also write date-stamped .log files to the persistent volume.",
           "format": "filepath"
         },
         {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.aliasunder/vault-cortex",
   "title": "vault-cortex",
-  "description": "Remote MCP server for Obsidian vaults — search, memory, link graph, 23 tools, OAuth-protected.",
+  "description": "MCP server for Obsidian vaults — search, memory, link graph, 23 tools, OAuth-protected.",
   "version": "0.15.3",
   "websiteUrl": "https://github.com/aliasunder/vault-cortex",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -79,17 +79,6 @@
           "default": "http://localhost:8000"
         },
         {
-          "name": "PORT",
-          "description": "Port the server listens on inside the container.",
-          "default": "8000",
-          "format": "number"
-        },
-        {
-          "name": "HOST",
-          "description": "Interface the server binds to inside the container.",
-          "default": "0.0.0.0"
-        },
-        {
           "name": "MEMORY_DIR",
           "description": "Vault folder for structured memory files (About Me-style notes).",
           "default": "About Me"


### PR DESCRIPTION
## Summary

Follow-up to #55. A thorough audit of `server.json` against the [2025-12-11 MCP server schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json), the env vars the code actually reads, the published Docker image, the GitHub repo metadata, and all four compose files.

The guiding realization: **the MCP Registry path consumes `server.json` only — the compose files are never involved.** A client pulls the OCI image and builds a `docker run` purely from `server.json`'s `runtimeArguments` + `environmentVariables` + `transport`. So server.json must be self-sufficient, and container-internal implementation details must live in the image (Dockerfile `ENV`), not be exposed as phantom config knobs.

## Critical fixes (the published entry would not work)

1. **`Dockerfile` — OCI ownership label.** `mcp-publisher publish` verifies image ownership via `LABEL io.modelcontextprotocol.server.name`, which must match `name` in server.json. Was missing.
2. **`packages[0].identifier`** — `ghcr.io/aliasunder/vault-cortex` → `ghcr.io/aliasunder/vault-mcp`. The published image is `vault-mcp` (see `deploy.yml:22` + all compose files); the `vault-cortex` image never existed, so the old entry pointed at a 404.
3. **`repository.id`** — `"aliasunder/vault-cortex"` → `"1226067541"` (the numeric GitHub repo ID the schema requires).

## Container internals moved to the Dockerfile (removed from server.json)

These four are hardcoded in every compose file — never user-tunable — so they're implementation details, not knobs. Each was overloaded or latently buggy when exposed in `environmentVariables`:

- **`VAULT_PATH`** — was both the user's host path (in `-v`) and the container path (env var). Now baked `ENV VAULT_PATH=/vault`; the only `VAULT_PATH` a user sees is the host side of the `-v {VAULT_PATH}:/vault:rw` bind mount.
- **`PORT`** — was the host port (`-p {PORT}:8000`) AND the container listen port (env var). Overriding it desynced them (`-p 9000:8000` while the server moved to 9000 → connection refused). Now baked `ENV PORT=8000`; `PORT` survives only as the host-side mapping variable.
- **`HOST`** — overriding to `127.0.0.1` made the server unreachable through the port mapping. Now baked `ENV HOST=0.0.0.0`.
- **`INDEX_DB_PATH`** — hardcoded `/data/index.db` everywhere. Now baked `ENV INDEX_DB_PATH=/data/index.db`.

Final Dockerfile runtime ENV: `NODE_ENV=production PORT=8000 HOST=0.0.0.0 VAULT_PATH=/vault INDEX_DB_PATH=/data/index.db`.

## server.json now describes the real consumer experience

- **`transport.headers`** — declares `Authorization: Bearer {MCP_AUTH_TOKEN}` so clients know what to send to `/mcp`.
- **`runtimeHint: "docker"` + `runtimeArguments`** — `-p {PORT}:8000`, `-v {VAULT_PATH}:/vault:rw` (bind mount, the user's vault), and `-v vault-cortex-data:/data` (named volume — persists search index, OAuth token DB, and logs across restarts, matching `deploy/local`'s `mcp_data:/data`).
- **`PUBLIC_URL`** — `isRequired: false` with `default: "http://localhost:8000"` (the server `.required()`s it; the default lets the local quickstart work without manual override).
- **Env-var list trimmed to the 10 genuinely user-tunable values**, each with the correct default sourced from the code/compose: `MCP_AUTH_TOKEN`, `PUBLIC_URL`, `MEMORY_DIR`, `TZ`, `LOG_LEVEL`, `LOG_DIR`, `LOG_RETENTION_DAYS`, `PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`, `SERVICE_DOCUMENTATION_URL`.
- **`LOG_DIR`** — no default (opt-in), matching the `deploy/local` change below. Logs go to stdout unless the user sets a path.
- **Description** — dropped the misleading "Remote" prefix → `MCP server for Obsidian vaults — search, memory, link graph, 23 tools, OAuth-protected.` (87 chars, under the 100 max). "Remote" implied a hosted URL we don't offer; the package describes a local `docker run`.

## Compose + .env.example consistency

- **All four compose files** now document the runtime-derived smart defaults inline (`PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`, `SERVICE_DOCUMENTATION_URL`) instead of pointing at the README.
- **`LOG_DIR` made user-overridable** in `deploy/local` (`${LOG_DIR:-}` — opt-in, file logging off by default for a quick local trial) and `deploy/remote` (`${LOG_DIR:-/data/logs}` — on by default for an unattended server). Documented in both `.env.example` files. Root `docker-compose.yml` left hardcoded (its `.env.example` already documents LOG_DIR as intentionally fixed for the Lightsail deploy).
- **Adopter compose comment** — added the upstream-fix tracker hint to `deploy/remote`'s `init-config-perms` comment, mirroring the root file.

## Validation

- `jq` schema-shape check: all required fields present at every level
- Description: 94 → 87 chars (under the 100 max)
- All 10 declared env vars verified to be `env.get(NAME)` / `env.NAME` reads in `src/`; the 4 removed ones (`VAULT_PATH`, `PORT`, `HOST`, `INDEX_DB_PATH`) are baked into the Dockerfile `ENV`
- All four compose files re-parsed as valid YAML
- 496 / 496 tests pass; lint + `tsc --noEmit` clean; prettier clean

## ⚠️ Hard gate before registry submission: cut v0.15.4 first

`server.json` on this branch only works against an image built from **this branch's** Dockerfile. The released `v0.15.3` image bakes only `PORT` + `HOST` — not `VAULT_PATH`/`INDEX_DB_PATH`. Since `VAULT_PATH` is `.required()` (`server.ts:35`) and is no longer in `server.json`, a container spawned from this server.json against the **v0.15.3** image would crash on startup.

Required order:
1. Merge this PR
2. Cut **v0.15.4** via Manual Release — rebuilds the image with the new Dockerfile ENV and bumps `packages[0].version` → `0.15.4`
3. *Then* `mcp-publisher publish` — now the registry references the v0.15.4 image that has the bakes

Sources:
- [MCP server.json schema 2025-12-11](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json)
- [MCP Registry — Supported Package Types](https://modelcontextprotocol.io/registry/package-types)
- [GoReleaser MCP publish docs (OCI label syntax)](https://goreleaser.com/customization/publish/mcp/)
- [github-mcp-server `server.json`](https://github.com/github/github-mcp-server/blob/main/server.json)