### PR TITLE
docs: add Glama listing badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D24-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![MCP Server](https://badge.mcpx.dev?type=server&features=tools)](https://modelcontextprotocol.io)
+[![vault-cortex MCP server](https://glama.ai/mcp/servers/aliasunder/vault-cortex/badges/score.svg)](https://glama.ai/mcp/servers/aliasunder/vault-cortex)
 
 <p align="center">
   <img src="./assets/banner.svg" width="720" alt="vault-cortex">


### PR DESCRIPTION
## Summary

Adds the Glama score badge to the README badge row, linking to the claimed listing at https://glama.ai/mcp/servers/aliasunder/vault-cortex.

```
[[vault-cortex MCP server](https://glama.ai/mcp/servers/aliasunder/vault-cortex/badges/score.svg)](https://glama.ai/mcp/servers/aliasunder/vault-cortex)
```

The badge renders once the listing is public (it's currently claimed; the score grade fills in if/when a Glama release is created — until then it shows the license/maintenance grades).

If you'd prefer the larger **card** badge (server name + license/quality/maintenance grades + language) somewhere instead of/alongside the compact score badge, swap the `score.svg` for `card.svg` — happy to adjust.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhC7JaxaPNn9XrVDRdWuW)_