### PR TITLE
fix: hardcode transport.url port for MCP Registry validation

### DIFF
--- a/server.json
+++ b/server.json
@@ -21,15 +21,7 @@
           "type": "named",
           "name": "-p",
           "description": "Publish the container's port 8000 on the host.",
-          "value": "{PORT}:8000",
-          "isRequired": true,
-          "variables": {
-            "PORT": {
-              "description": "Host port to expose vault-mcp on.",
-              "default": "8000",
-              "format": "number"
-            }
-          }
+          "value": "8000:8000"
         },
         {
           "type": "named",
@@ -54,7 +46,7 @@
       ],
       "transport": {
         "type": "streamable-http",
-        "url": "http://localhost:{PORT}/mcp",
+        "url": "http://localhost:8000/mcp",
         "headers": [
           {
             "name": "Authorization",


### PR DESCRIPTION
## Summary

`mcp-publisher publish` failed validation:
```
packages[0].transport.url (semantic)
invalid package transport URL: template variables in URL http://localhost:{PORT}/mcp reference undefined variables.
Available variables: [MCP_AUTH_TOKEN PUBLIC_URL MEMORY_DIR TZ LOG_LEVEL LOG_DIR LOG_RETENTION_DAYS PROTECTED_PATHS ORPHAN_EXCLUDE_FOLDERS SERVICE_DOCUMENTATION_URL -p -v -v]
```

The MCP Registry only allows a `transport.url` template variable to reference **env-var names or argument names** — not an argument's *local* `variables`. `{PORT}` existed only as the `-p` argument's local variable, so it's "undefined" for the URL.

### Fix
- `transport.url`: `http://localhost:{PORT}/mcp` → `http://localhost:8000/mcp`
- `-p` runtime arg: `{PORT}:8000` (with a `PORT` variable) → fixed `8000:8000`

The container always listens on `8000` (Dockerfile `ENV PORT=8000`), so the hardcoded URL is correct. Hardcoding the `-p` mapping too keeps the published URL consistent with the port mapping (no override footgun). Host-port customization via the registry wasn't actually supportable anyway, since the URL can't follow a templated port.

This is registry-metadata only — no image rebuild/release needed (`packages[0].version` stays `0.15.4`).

### Validation
- `jq`: valid; `transport.url` has no remaining `{templates}`
- prettier clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhC7JaxaPNn9XrVDRdWuW)_