### PR TITLE
fix: OCI package version in identifier tag (MCP Registry validation)

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -71,7 +71,7 @@ jobs:
           NEXT: ${{ steps.next.outputs.version }}
         run: |
           npm version "$NEXT" --no-git-tag-version
-          jq --arg v "$NEXT" '.version = $v | .packages[0].version = $v' server.json > server.json.tmp && mv server.json.tmp server.json
+          jq --arg v "$NEXT" '.version = $v | .packages[0].identifier = "ghcr.io/aliasunder/vault-mcp:" + $v' server.json > server.json.tmp && mv server.json.tmp server.json
           npx prettier --write server.json
 
       - name: Commit, tag, and push

--- a/server.json
+++ b/server.json
@@ -13,8 +13,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/aliasunder/vault-mcp",
-      "version": "0.15.4",
+      "identifier": "ghcr.io/aliasunder/vault-mcp:0.15.4",
       "runtimeHint": "docker",
       "runtimeArguments": [
         {


### PR DESCRIPTION
## Summary

`mcp-publisher publish` failed again:
```
registry validation failed for package 0 (ghcr.io/aliasunder/vault-mcp):
OCI packages must not have 'version' field — include version in 'identifier' instead (e.g., 'docker.io/owner/image:1.0.0')
```

The MCP Registry's semantic validation requires OCI packages to put the version **in the identifier tag** and **omit** the separate `version` field (newer than the 2025-12-11 schema we built against).

### Fix
- **`server.json`** — `packages[0].identifier`: `ghcr.io/aliasunder/vault-mcp` → `ghcr.io/aliasunder/vault-mcp:0.15.4`; removed `packages[0].version`.
- **`.github/workflows/manual_release.yml`** — the release jq bump now sets the identifier tag (`ghcr.io/aliasunder/vault-mcp:$NEXT`) instead of the now-invalid `packages[0].version`, so each release keeps the OCI reference in lockstep:
  ```
  jq --arg v "$NEXT" '.version = $v | .packages[0].identifier = "ghcr.io/aliasunder/vault-mcp:" + $v' …
  ```

### Notes
- Registry-metadata only — no image rebuild/release needed.
- The `:0.15.4` tag already exists on GHCR (deploy.yml pushes the clean-semver tag) and carries the `io.modelcontextprotocol.server.name` ownership label.
- Top-level `version` (the server version) is unchanged — only the *package* version field was disallowed.

### Validation
- `jq`: `packages[0]` has no `version`; identifier is tagged
- Simulated a `0.15.5` release bump → identifier becomes `…:0.15.5`, still no package version field
- prettier clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhC7JaxaPNn9XrVDRdWuW)_