### PR TITLE
fix: static token rejected by requireBearerAuth (missing expiresAt)

### DIFF
--- a/src/vault-mcp/auth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/auth/__tests__/oauth-provider.test.ts
@@ -276,6 +276,14 @@ describe("verifyAccessToken", () => {
     expect(result.token).toBe(AUTH_TOKEN)
   })
 
+  it("gives the static token a future expiresAt so requireBearerAuth accepts it", async () => {
+    const result = await oauth.provider.verifyAccessToken!(AUTH_TOKEN)
+    // requireBearerAuth rejects any AuthInfo where expiresAt is not a number,
+    // or is in the past. The static token must carry a future numeric expiry.
+    expect(typeof result.expiresAt).toBe("number")
+    expect(result.expiresAt!).toBeGreaterThan(DateTime.now().toUnixInteger())
+  })
+
   it("returns correct auth info for a valid JWT", async () => {
     const token = signJwt(
       {

--- a/src/vault-mcp/auth/oauth-provider.ts
+++ b/src/vault-mcp/auth/oauth-provider.ts
@@ -291,7 +291,16 @@ export const createOAuthProvider = ({
     /** Three-tier verification: static token (fast path for CLI) → revocation check → JWT. */
     async verifyAccessToken(token: string): Promise<AuthInfo> {
       if (safeEqual(token, authToken)) {
-        return { token, clientId: "static", scopes: ["vault"] }
+        // The static token never expires, but the SDK's requireBearerAuth
+        // rejects any AuthInfo without a numeric expiresAt ("Token has no
+        // expiration time"). Hand it a far-future timestamp so the static
+        // token is accepted while remaining effectively perpetual.
+        return {
+          token,
+          clientId: "static",
+          scopes: ["vault"],
+          expiresAt: DateTime.now().plus({ years: 10 }).toUnixInteger(),
+        }
       }
 
       if (isRevoked(token)) {


### PR DESCRIPTION
## Summary

**Real auth bug**, surfaced while bridging the HTTP server to stdio for Glama's introspector. A static `MCP_AUTH_TOKEN` bearer is rejected with `401` at the Express layer, even when the token is correct.

### Root cause (confirmed against the SDK source)
`@modelcontextprotocol/sdk` `requireBearerAuth` enforces:
```js
if (typeof authInfo.expiresAt !== 'number' || isNaN(authInfo.expiresAt)) {
    throw new InvalidTokenError('Token has no expiration time');   // → 401
}
```
But `verifyAccessToken`'s static-token fast path returned `{ token, clientId: "static", scopes: ["vault"] }` with **no `expiresAt`** → always 401 for the static bearer. The JWT/OAuth path sets `expiresAt`, so E2E (tested via OAuth) passed and this never showed. The static-bearer path — documented for `deploy/local` and CLI tools — was never exercised by a real client.

### Evidence
A `curl` straight to `/mcp` with `Authorization: Bearer <token>` (bypassing the bridge) returned `401`, while the server's `MCP_AUTH_TOKEN` was confirmed to be exactly the token sent.

### Fix
Give the static token a far-future numeric `expiresAt` (`now + 10y`, recomputed per request) so it satisfies `requireBearerAuth` while staying effectively perpetual. Added a test asserting `expiresAt` is a future number (the old test only checked `clientId`/`scopes`/`token`, which is exactly why the gap slipped through).

### Validation
- 497 / 497 tests pass (added 1)
- lint + `tsc --noEmit` clean

### Impact / follow-on
- Fixes static-bearer auth for **all** direct-Express consumers (`deploy/local`, CLI), not just Glama.
- Glama's introspection build pulls from source (`git clone` + checkout latest `main`), so once merged a re-run will pick it up.
- For the **published image** (`deploy/local` users), this needs a **v0.15.5** release to ship the fix into GHCR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhC7JaxaPNn9XrVDRdWuW)_