### PR TITLE
fix: grant auto_release.yml the permissions deploy.yml requires

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -11,6 +11,8 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
+  packages: write
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

Every manual release leaves a **failed "Auto Release" run** (red X on v0.15.2–v0.15.5). This completes the fix PR #53 intended.

### Why PR #53 wasn't enough
PR #53 added `if: github.actor != 'vault-cortex-release[bot]'` to the `validate` job so the App-bot's tag push would skip Auto Release. But `auto_release.yml` calls `deploy.yml` (which requires `id-token: write` + `packages: write`) while only granting `contents: write`. GitHub rejects the workflow at **file-validation time — before any job `if:` is evaluated** — so the actor guard never runs and the workflow fails loudly instead of skipping.

### Fix
Grant `auto_release.yml` the permissions `deploy.yml` needs (matching `manual_release.yml`):
```yaml
permissions:
  contents: write
  id-token: write   # added
  packages: write   # added
```

### Result
- A **bot-pushed tag** (from `manual_release`) now: file validates → actor guard skips `validate` → `deploy`/`release` skip via `needs:` → run completes as a **clean skip (gray), no red X**.
- A genuine **non-bot tag push** (local `git push --tags`) now actually deploys + releases as the workflow was meant to.

### Note
GitHub triggers `on: push tags v*` regardless of actor, so a (now-benign, skipped) Auto Release **run record** will still appear for each manual release — there's no way to suppress the trigger itself. If you'd rather have *zero* Auto Release runs (e.g., you only ever release via the `manual_release` workflow button and never push tags locally), the alternative is to remove `auto_release.yml` entirely — say the word and I'll do that instead.

YAML validated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhC7JaxaPNn9XrVDRdWuW)_