### PR TITLE
docs: cache-bust Glama score badge and simplify alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D24-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![MCP Server](https://badge.mcpx.dev?type=server&features=tools)](https://modelcontextprotocol.io)
-[![vault-cortex MCP server](https://glama.ai/mcp/servers/aliasunder/vault-cortex/badges/score.svg)](https://glama.ai/mcp/servers/aliasunder/vault-cortex)
+[![vault-cortex](https://glama.ai/mcp/servers/aliasunder/vault-cortex/badges/score.svg?v=2)](https://glama.ai/mcp/servers/aliasunder/vault-cortex)
 
 <p align="center">
   <img src="./assets/banner.svg" width="720" alt="vault-cortex">


### PR DESCRIPTION
## Summary

- The Glama score badge in the README renders blank on GitHub because GitHub's Camo proxy cached the SVG while Glama's score was still pending (badge added in #57). The markdown itself was already correct — this is a stale-image-cache issue, not a code bug.
- Appending `?v=2` to the `score.svg` URL gives GitHub a new image URL, forcing a fresh Camo fetch of the now-computed grade.
- Also simplified the alt text `vault-cortex MCP server` → `vault-cortex` to match the renamed server on Glama.

## Test plan

- [ ] After merge, view the README on github.com (hard-refresh) and confirm the Glama badge shows the computed grade instead of a blank/placeholder badge.
- [ ] If it still shows stale art, bump `?v=2` → `?v=3` to force another Camo miss.

https://claude.ai/code/session_01KnvnMoDuU6QkYrCna54CqT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnvnMoDuU6QkYrCna54CqT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MCP server Glama badge reference in README to use the latest version with improved caching parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aliasunder/vault-cortex/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->