### PR TITLE
docs: lift Glama TDQS scores on the lowest-scoring tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,9 +175,12 @@ search.fullTextSearch({ query, filters }, reqLogger)
 - Simple code over clever code when the same outcome is achievable.
   A person should be able to read and follow the code without
   unnecessary cognitive overload.
-- MCP tool descriptions include `Example:`, `When to use:`,
-  `Errors:` (with remediation guidance), `Obsidian syntax:`
-  (on write tools), and `Returns:` sections.
+- MCP tool descriptions include `Example:`, `When to use:`, and
+  `Returns:` sections. Include `Errors:` whenever the tool has
+  failure modes (with remediation guidance) or a no-match /
+  empty-result contract worth clarifying (e.g. "returns an empty
+  array, not an error"); omit it only for tools that cannot
+  meaningfully fail. Include `Obsidian syntax:` on write tools.
 
 ### MCP naming conventions
 

--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -104,6 +104,12 @@ describe("registerTools", () => {
     }
   })
 
+  it("every tool description includes a returns section", () => {
+    for (const call of calls) {
+      expect(call[1].description).toContain("Returns:")
+    }
+  })
+
   it.each(WRITE_TOOLS)(
     "%s description includes Obsidian syntax guidance",
     (name) => {

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -446,6 +446,14 @@ describe("searchByFolder", () => {
     expect(results).toHaveLength(1)
     expect(results[0].path).toBe("About Me/Principles.md")
   })
+
+  it("sorts results by most recently modified", () => {
+    const results = index.searchByFolder({ folder: "About Me" }, logger)
+    expect(results.map((note) => note.path)).toEqual([
+      "About Me/sub/deep.md",
+      "About Me/Principles.md",
+    ])
+  })
 })
 
 describe("listAllTags", () => {

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -634,6 +634,7 @@ export const createSearchIndex = (dbPath: string) => {
       SELECT path, title, tags, related, folder, type, created, mtime, properties
       FROM notes
       WHERE ${condition}
+      ORDER BY mtime DESC
       LIMIT ?
     `
 

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -415,12 +415,17 @@ Returns: JSON array of vault-relative paths.`,
     TOOL_NAMES.VAULT_DELETE_NOTE,
     {
       title: "Delete Note",
-      description: `Permanently delete a markdown note. Protected paths (${config.protectedPaths.map((p) => p + "/").join(", ")}) are refused to prevent accidental deletion of memory or daily notes.
+      description: `Permanently delete a markdown note. Deletion is irreversible — the note is removed, not moved to a trash folder, and cannot be recovered through this server. After deletion it no longer appears in search results or backlinks, and links to it from other notes become broken (detectable via vault_get_outgoing_links). Protected paths (${config.protectedPaths.map((p) => p + "/").join(", ")}) are refused to prevent accidental loss of memory or daily notes.
 
 Example: vault_delete_note({ path: "Scratch/temp.md" })
 
 When to use: Removing a note you no longer need.
 Prefer vault_delete_memory for removing individual dated entries from ${config.memoryDir}/ memory files.
+
+Errors:
+- "cannot delete protected path …" — the path sits under a protected folder; use vault_delete_memory for memory entries
+- "path traversal blocked" — path escapes the vault root; use a vault-relative path
+- note does not exist — verify the path with vault_list_notes before deleting
 
 Returns: Confirmation message.`,
       inputSchema: {
@@ -690,12 +695,17 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
     TOOL_NAMES.VAULT_SEARCH_BY_FOLDER,
     {
       title: "Search by Folder",
-      description: `Browse notes in a folder with full metadata (tags, type, related, created, modified). Unlike vault_list_notes which returns paths only, this returns rich metadata for each note.
+      description: `Browse notes in a folder with full metadata (tags, type, related, created, modified) — unlike vault_list_notes, which returns paths only. An empty or nonexistent folder returns an empty array, not an error.
 
 Example: vault_search_by_folder({ folder: "Projects" }) or vault_search_by_folder({ folder: "${config.memoryDir}", recursive: false })
 
-When to use: Exploring a folder's contents with full context — tags, type, relationships. Useful for vault orientation and understanding folder structure.
+When to use: Exploring a folder's contents with full context for vault orientation.
 Prefer vault_list_notes when you only need paths. Prefer vault_search when you have a text query.
+
+Parameters:
+- folder is matched as a path prefix; pass it without a trailing slash ("Projects").
+- recursive (default true) includes all nested subfolders; set false to list only the folder's top level.
+- limit (default 20) caps results.
 
 Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified.`,
       inputSchema: {
@@ -783,15 +793,20 @@ Returns: Raw markdown text.`,
     TOOL_NAMES.VAULT_UPDATE_MEMORY,
     {
       title: "Update Memory",
-      description: `Append a dated entry to a section of a ${config.memoryDir}/ memory file. The server auto-prefixes today's date (format: "- **YYYY-MM-DD**: entry text"). Call vault_list_memory_files first to discover valid file and section names.
+      description: `Append a dated entry to a section of a ${config.memoryDir}/ memory file. The server prefixes the date automatically (format: "- **YYYY-MM-DD**: entry text") and inserts newest-first by default. Pass raw entry text without a date prefix.
 
 Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
 
-When to use: Recording a new preference, principle, opinion, or fact about the user. Pass raw entry text without date prefix. Always call vault_list_memory_files first to discover existing files and sections, and use matching names to keep entries organized alongside existing content.
-Auto-creates: If the file or section does not exist, it is created automatically. If the section name does not already include "(newest first)", the server appends it (e.g. "Design preferences" becomes "Design preferences (newest first)"). Use the full heading name in subsequent vault_get_memory calls, or call vault_list_memory_files to discover the actual heading names. Use existing file and section names from vault_list_memory_files when available.
-Prefer vault_write_note for creating entirely new notes (not memory entries).
+When to use: Recording a new preference, principle, opinion, or fact about the user. Call vault_list_memory_files first and reuse existing file and section names so entries stay grouped.
+Prefer vault_write_note for creating non-memory notes.
 
-Obsidian syntax: Entry text is rendered inline as Obsidian Flavored Markdown. Watch for: #word = tag, [[ = wikilink. Escape with backslash or backticks when unintentional.
+Behavior: Additive — existing entries are never overwritten, and repeat calls add duplicate entries. A missing file or section is created automatically; if the section name omits "(newest first)" the server appends it ("Design preferences" becomes "Design preferences (newest first)") — use that full name in later calls.
+
+Parameters:
+- options.date — ISO YYYY-MM-DD, defaults to today (server timezone).
+- options.position — "top" (default, newest-first) inserts above existing entries; "bottom" appends below them.
+
+Obsidian syntax: Entry text renders as Obsidian Flavored Markdown. Watch for: #word = tag, [[ = wikilink. Escape with backslash or backticks when unintentional.
 
 Returns: Confirmation message.`,
       inputSchema: {
@@ -1107,17 +1122,17 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
     TOOL_NAMES.VAULT_GET_BACKLINKS,
     {
       title: "Get Backlinks",
-      description: `Find all notes that link to a given note (incoming wikilinks and markdown links). Shows which notes reference the target — useful for understanding a note's context and importance in the vault's knowledge graph.
+      description: `Find all notes that link to a given note via incoming [[wikilinks]] or [markdown](links). Reveals what references the target — its context and importance in the knowledge graph, invisible without a graph query. Both link styles are captured; links inside code blocks are ignored, and a note that links to itself appears in its own backlinks.
 
 Example: vault_get_backlinks({ path: "Projects/vault-cortex.md" })
 
-When to use: When you need to understand what references a note, find related context, or assess a note's connectivity. Core Obsidian concept — backlinks are invisible without a database query.
-For outgoing links (what a note links TO), use vault_get_outgoing_links. For orphan detection, use vault_find_orphans.
+When to use: Understanding what references a note or assessing its connectivity.
+For outgoing links (what a note links TO), use vault_get_outgoing_links. To find notes with no backlinks at all, use vault_find_orphans.
 
-Errors:
-- No error if the note has zero backlinks — returns an empty array.
+Parameters:
+- path must be the exact vault-relative path — case-sensitive, including the .md extension. A path matching no indexed note returns an empty array (count 0), not an error, so this is not a reliable existence check.
 
-Returns: JSON with path (the queried note), backlinks (array of { path, title }), and count.`,
+Returns: JSON with path (the queried note), backlinks (array of { path, title }, sorted by title), and count.`,
       inputSchema: {
         path: z
           .string()
@@ -1152,17 +1167,17 @@ Returns: JSON with path (the queried note), backlinks (array of { path, title })
     TOOL_NAMES.VAULT_GET_OUTGOING_LINKS,
     {
       title: "Get Outgoing Links",
-      description: `Find all notes that a given note links to (outgoing wikilinks and markdown links). Each link includes an exists flag — false means the target note doesn't exist (broken link).
+      description: `Find all notes a given note links to via outgoing [[wikilinks]] or [markdown](links). Each entry has an exists flag — false marks a broken link (target not in the vault). Both link styles are captured; links inside code blocks are ignored, and a note that links to itself appears in its own outgoing links.
 
 Example: vault_get_outgoing_links({ path: "Projects/vault-cortex.md" })
 
-When to use: When you need to see what a note references, navigate the knowledge graph forward, or detect broken links in a specific note.
+When to use: Seeing what a note references, navigating the graph forward, or finding broken links in one note.
 For incoming links (what links TO a note), use vault_get_backlinks.
 
-Errors:
-- No error if the note has zero outgoing links — returns an empty array.
+Parameters:
+- path must be the exact vault-relative path — case-sensitive, including the .md extension. A path matching no indexed note returns an empty array (count 0), not an error.
 
-Returns: JSON with path (the queried note), outgoing_links (array of { path, title, exists }), and count.`,
+Returns: JSON with path (the queried note), outgoing_links (array of { path, title, exists }, sorted by target path), and count.`,
       inputSchema: {
         path: z.string().min(1).describe("Vault-relative path to the note"),
       },
@@ -1196,12 +1211,16 @@ Returns: JSON with path (the queried note), outgoing_links (array of { path, tit
     TOOL_NAMES.VAULT_FIND_ORPHANS,
     {
       title: "Find Orphans",
-      description: `Find notes with no incoming links from other notes. Orphan notes are disconnected from the vault's knowledge graph — they may be forgotten or need linking from relevant notes.
+      description: `Find notes with no incoming links from other notes — orphans are disconnected from the knowledge graph and may be forgotten or need linking. A note that only links to itself still counts as an orphan (self-links are ignored).
 
-Example: vault_find_orphans() or vault_find_orphans({ exclude_folders: ${JSON.stringify(config.orphanExcludeFolders)} })
+Example: vault_find_orphans({ exclude_folders: ${JSON.stringify(config.orphanExcludeFolders)} })
 
-When to use: Vault maintenance and organization. Helps identify notes that might be forgotten or need integration into the knowledge graph. ${config.orphanExcludeFolders.join(", ")} folders are excluded by default since those are standalone by design.
-To add links to an orphan, use vault_patch_note to mention it from a relevant note.
+When to use: Vault maintenance — surfacing notes to integrate into the graph. Link an orphan by mentioning it from a relevant note with vault_patch_note.
+Prefer vault_get_backlinks to check the connectivity of one specific note rather than scanning the whole vault.
+
+Parameters:
+- exclude_folders replaces the defaults (${JSON.stringify(config.orphanExcludeFolders)}), it does not add to them — include the defaults yourself to keep them. Matched by folder prefix, recursing into subfolders ("Projects" also excludes "Projects/Archive").
+- limit (default 50) caps results after sorting by most-recently-modified.
 
 Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified.`,
       inputSchema: {
@@ -1209,7 +1228,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
           .array(z.string())
           .optional()
           .describe(
-            `Folders to exclude (default: ${JSON.stringify(config.orphanExcludeFolders)})`,
+            `Folders to exclude — replaces the defaults (${JSON.stringify(config.orphanExcludeFolders)}), not merged`,
           ),
         limit: z.number().optional().describe("Max results (default 50)"),
       },

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -415,7 +415,7 @@ Returns: JSON array of vault-relative paths.`,
     TOOL_NAMES.VAULT_DELETE_NOTE,
     {
       title: "Delete Note",
-      description: `Permanently delete a markdown note. Deletion is irreversible — the note is removed, not moved to a trash folder, and cannot be recovered through this server. After deletion it no longer appears in search results or backlinks, and links to it from other notes become broken (detectable via vault_get_outgoing_links). Protected paths (${config.protectedPaths.map((p) => p + "/").join(", ")}) are refused to prevent accidental loss of memory or daily notes.
+      description: `Permanently delete a markdown note. The note is removed from disk directly (not moved to a trash folder), and this server has no undo — recovery depends on your own backups or sync history. After deletion it no longer appears in search results or backlinks, and links to it from other notes become broken (detectable via vault_get_outgoing_links). Protected paths (${config.protectedPaths.map((p) => p + "/").join(", ")}) are refused to prevent accidental loss of memory or daily notes.
 
 Example: vault_delete_note({ path: "Scratch/temp.md" })
 
@@ -695,7 +695,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
     TOOL_NAMES.VAULT_SEARCH_BY_FOLDER,
     {
       title: "Search by Folder",
-      description: `Browse notes in a folder with full metadata (tags, type, related, created, modified) — unlike vault_list_notes, which returns paths only. An empty or nonexistent folder returns an empty array, not an error.
+      description: `Browse notes in a folder with full metadata (tags, type, related, created, modified) — unlike vault_list_notes, which returns paths only.
 
 Example: vault_search_by_folder({ folder: "Projects" }) or vault_search_by_folder({ folder: "${config.memoryDir}", recursive: false })
 
@@ -706,6 +706,9 @@ Parameters:
 - folder is matched as a path prefix; pass it without a trailing slash ("Projects").
 - recursive (default true) includes all nested subfolders; set false to list only the folder's top level.
 - limit (default 20) caps results.
+
+Errors:
+- An empty or nonexistent folder returns an empty array, not an error.
 
 Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified.`,
       inputSchema: {
@@ -1130,7 +1133,10 @@ When to use: Understanding what references a note or assessing its connectivity.
 For outgoing links (what a note links TO), use vault_get_outgoing_links. To find notes with no backlinks at all, use vault_find_orphans.
 
 Parameters:
-- path must be the exact vault-relative path — case-sensitive, including the .md extension. A path matching no indexed note returns an empty array (count 0), not an error, so this is not a reliable existence check.
+- path must be the exact vault-relative path — case-sensitive, including the .md extension.
+
+Errors:
+- A note with no inbound links, or a path not in the index, returns an empty array (count 0), not an error — don't use this as an existence check.
 
 Returns: JSON with path (the queried note), backlinks (array of { path, title }, sorted by title), and count.`,
       inputSchema: {
@@ -1175,7 +1181,10 @@ When to use: Seeing what a note references, navigating the graph forward, or fin
 For incoming links (what links TO a note), use vault_get_backlinks.
 
 Parameters:
-- path must be the exact vault-relative path — case-sensitive, including the .md extension. A path matching no indexed note returns an empty array (count 0), not an error.
+- path must be the exact vault-relative path — case-sensitive, including the .md extension.
+
+Errors:
+- A note with no outbound links, or a path not in the index, returns an empty array (count 0), not an error.
 
 Returns: JSON with path (the queried note), outgoing_links (array of { path, title, exists }, sorted by target path), and count.`,
       inputSchema: {
@@ -1221,6 +1230,9 @@ Prefer vault_get_backlinks to check the connectivity of one specific note rather
 Parameters:
 - exclude_folders replaces the defaults (${JSON.stringify(config.orphanExcludeFolders)}), it does not add to them — include the defaults yourself to keep them. Matched by folder prefix, recursing into subfolders ("Projects" also excludes "Projects/Archive").
 - limit (default 50) caps results after sorting by most-recently-modified.
+
+Errors:
+- An empty array means no orphans were found (after exclusions), not an error.
 
 Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified.`,
       inputSchema: {


### PR DESCRIPTION
## Summary

Glama scored all 23 tools (Tool Definition Quality grade: **A**). Six tools sat below the pack, dragged by the same dimensions — **Parameters** (descriptions restated the schema instead of explaining intent) and, on several, **Behavior**. This enriches those six descriptions with non-obvious parameter semantics, behavioral consequences, and tighter usage guidance; fixes one latent bug surfaced during the audit; and tightens the description-quality conventions + test coverage off the back of review.

Targeted tools and their weak dimensions:

| Tool | Score | Targeted |
|---|---|---|
| `vault_find_orphans` | 4.2 | Parameters, Usage, Conciseness |
| `vault_delete_note` | 4.4 | Behavior, Completeness (Parameters left at baseline — single `path`) |
| `vault_get_backlinks` | 4.5 | Parameters, Behavior |
| `vault_get_outgoing_links` | 4.5 | Parameters, Behavior |
| `vault_search_by_folder` | 4.6 | Behavior, Completeness, Parameters |
| `vault_update_memory` | 4.6 | Conciseness (trimmed repetition), Behavior, Parameters |

Notable additions, all verified against the data layer (not invented):
- `find_orphans`: `exclude_folders` **replaces** the defaults rather than merging (a real footgun), and matches by recursive folder prefix.
- `delete_note`: deletion is permanent on disk (no trash) with **no server-side undo** — recovery depends on the user's own backups or sync history (claim scoped to the server; not asserted as absolutely irreversible, since synced vaults retain version history). Inbound links break on delete; added an `Errors:` section.
- `get_backlinks`/`get_outgoing_links`: `path` is exact + case-sensitive incl. `.md`; a non-matching path returns an empty array, not an error (now stated under `Errors:`); self-links and code-fence exclusion documented.
- `update_memory`: additive (never overwrites; repeat calls duplicate); trimmed the triple-repeated "call list_memory_files first" that capped Conciseness.

## Bug fix (same audit)

`vault_search_by_folder` documented "sorted by most recently modified" but its SQL omitted `ORDER BY`, returning results in arbitrary order. Added `ORDER BY mtime DESC` to match every sibling metadata tool, with a test asserting the ordering. (Declined CodeRabbit's `path ASC` tie-breaker here — `recentNotes` and `findOrphans` also sort by bare `mtime DESC`; a tie-breaker should be applied uniformly in a separate change, not piecemeal.)

## Review follow-ups (conventions + tests)

- **`Errors:` sections, where relevant.** Added the empty-result-is-not-an-error contract to `search_by_folder`, `get_backlinks`, `get_outgoing_links`, `find_orphans`; `delete_note` carries its real errors. `update_memory` is intentionally left without one (auto-creates; no failure/no-match contract — a boilerplate "Errors: none" would just cost tokens).
- **AGENTS.md reconciled** so the guideline no longer contradicts the code: `Errors:` is required where a tool has failure modes or a no-match/empty-result contract worth clarifying, optional for tools that can't meaningfully fail.
- **New test:** `tool-definitions.test.ts` now asserts every tool description includes a `Returns:` section (alongside the existing `Example:` / `When to use` checks) so a future tool can't omit it.

## Scope

Description text + one-line SQL sort fix + a doc-convention update + two tests. No tool behavior changes beyond the folder-search ordering.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — **499 passing** (incl. `searchByFolder` ordering test + `Returns:` section test)
- [ ] Downstream: scores update only after this merges, the live server redeploys, and Glama re-syncs (directional gains expected — LLM grader).

https://claude.ai/code/session_01KnvnMoDuU6QkYrCna54CqT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnvnMoDuU6QkYrCna54CqT)_


## Summary by CodeRabbit

* **New Features**
  * Folder search now returns items ordered by most-recently-modified for improved discovery.

* **Documentation**
  * Expanded vault tool docs and style guidance to clarify folder-search semantics, deletion behavior, memory update rules, backlink/outgoing-link specifics, orphan-finding options, and required tool description sections.

* **Tests**
  * Added tests verifying folder-search ordering and that tool descriptions include a "Returns:" section.



`[[Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aliasunder/vault-cortex/pull/66?utm_source=github_walkthrough&amp;utm_medium=github&amp;utm_campaign=change_stack)`