### PR TITLE
ci: bump mcp-publisher to v1.7.9 to fix OIDC audience 401

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -14,8 +14,13 @@ permissions:
 
 env:
   # Pinned deliberately (latest release; see https://github.com/modelcontextprotocol/registry/releases).
-  # Must be recent enough to accept server.json's $schema (2025-12-11); older builds reject it. Bump intentionally.
-  MCP_PUBLISHER_VERSION: "1.7.0"
+  # Floor is v1.7.6: that release binds the GitHub OIDC token exchange to a
+  # per-deployment audience (CVE-2026-44428). The hosted registry now rejects
+  # the old shared "mcp-registry" audience with a 401, so older publishers fail
+  # at `login github-oidc` ("invalid audience: expected
+  # https://registry.modelcontextprotocol.io"). Must also be recent enough to
+  # accept server.json's $schema (2025-12-11); older builds reject it. Bump intentionally.
+  MCP_PUBLISHER_VERSION: "1.7.9"
 
 jobs:
   publish:


### PR DESCRIPTION
## What

Bump the pinned `mcp-publisher` version in `.github/workflows/publish-registry.yml` from **v1.7.0** to **v1.7.9**.

## Why

The MCP Registry publish job started failing at the `login github-oidc` step:

```
Error: failed to get token: failed to exchange OIDC token: token exchange failed with status 401:
{"title":"Unauthorized","status":401,"detail":"Token exchange failed",
"errors":[{"message":"failed to validate OIDC token: invalid audience:
expected https://registry.modelcontextprotocol.io, got [mcp-registry]"}]}
```

The hosted registry was patched server-side for **CVE-2026-44428** (GitHub OIDC tokens were replayable across registry deployments due to a shared audience). It now requires the OIDC token's audience to be the per-deployment registry URL `https://registry.modelcontextprotocol.io`, and rejects the old shared `mcp-registry` audience with a 401.

The matching client fix — *"auth: bind GitHub OIDC token exchange to a per-deployment audience"* — landed in **mcp-publisher v1.7.6**. Our pin (v1.7.0) predates it, so the publisher still requests the old audience and gets rejected.

## Change

- Pin `MCP_PUBLISHER_VERSION` to `1.7.9` (latest patch as of writing; floor is v1.7.6).
- Document the v1.7.6 floor + CVE in the workflow comment so the pin can't silently regress below it.

No workflow-shape change needed: `login github-oidc` takes no new flags; v1.7.6+ derives the audience from the registry automatically.

## Note on rollout

A bare re-run of the previously failed release won't pick this up — workflow re-runs use the workflow file from the release commit, which still pins v1.7.0. After this merges to `main`, a **new release** (or re-tag) is needed for the publish job to run with v1.7.9.

## References

- [CVE-2026-44428 — shared-audience OIDC advisory](https://advisories.gitlab.com/golang/github.com/modelcontextprotocol/registry/CVE-2026-44428/)
- [modelcontextprotocol/registry releases](https://github.com/modelcontextprotocol/registry/releases) (v1.7.6 release notes)
- [MCP Registry GitHub Actions docs](https://modelcontextprotocol.io/registry/github-actions)

https://claude.ai/code/session_01WkYCgRpXKdxHU9QKJPuF2w

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkYCgRpXKdxHU9QKJPuF2w)_