### PR TITLE
docs: lead README with banner, center badges; add banner border

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <img src="./assets/banner.svg" width="720" alt="vault-cortex">
+</p>
+
+<div align="center">
+
 [![CI](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/ci.yml?branch=main&logo=github&label=CI)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
 [![Gitleaks](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/gitleaks.yml?branch=main&logo=github&label=Gitleaks)](https://github.com/aliasunder/vault-cortex/actions/workflows/gitleaks.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/aliasunder/vault-cortex)](https://github.com/aliasunder/vault-cortex/releases)
@@ -7,9 +13,7 @@
 [![MCP Server](https://badge.mcpx.dev?type=server&features=tools)](https://modelcontextprotocol.io)
 [![vault-cortex](https://glama.ai/mcp/servers/aliasunder/vault-cortex/badges/score.svg?v=2)](https://glama.ai/mcp/servers/aliasunder/vault-cortex)
 
-<p align="center">
-  <img src="./assets/banner.svg" width="720" alt="vault-cortex">
-</p>
+</div>
 
 <!-- TODO: Uncomment when demo GIF is recorded (see ^demo-gif task)
 <p align="center">

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -19,6 +19,8 @@
 
   <!-- Self-contained dark strip (works in both light and dark mode) -->
   <rect x="0" y="0" width="720" height="184" rx="28" fill="url(#bgGrad)"/>
+  <!-- Faint cyan border so the strip stays defined on dark-mode README backgrounds -->
+  <rect x="1.5" y="1.5" width="717" height="181" rx="26.5" fill="none" stroke="#00e5ff" stroke-width="2" opacity="0.4"/>
 
   <!-- Icon (same mark as assets/icon-400.svg), drawn as vector, scaled into the left -->
   <g transform="translate(24,24) scale(0.34)">


### PR DESCRIPTION
## Summary

Improves the README header hierarchy so the brand banner stands out, and keeps the banner defined in dark mode.

- **Hero-first ordering** — moves the banner above the badge row and centers the badges beneath it. Previously the 8 colorful badges came first and the banner read as secondary; now the brand mark is the first thing a visitor sees, with badges as a supporting block.
- **Banner border** — adds a faint cyan border to `assets/banner.svg` so the always-dark strip stays visually defined on dark-mode README backgrounds (where it previously blended into the page). Stays subtle on light backgrounds.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README header banner markup structure for improved formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->