### PR TITLE
fix: publish multi-arch (amd64 + arm64) Docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,8 @@ jobs:
             echo "host=$PUBLIC_IP" >> "$GITHUB_OUTPUT"
           fi
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR (build push)
@@ -89,7 +91,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.IMAGE }}:v${{ inputs.version }}


### PR DESCRIPTION
## Problem

`deploy.yml` builds the image for `linux/amd64` only. Because the release build uses buildx/`build-push-action@v7`, the published `:latest` is a **manifest list (index)** that contains a single amd64 entry. On Apple Silicon (`linux/arm64`), `docker compose pull` then fails hard:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

Unlike a plain single-arch image (which Docker runs under emulation with a warning), a manifest list without an arm64 entry makes Docker **refuse to pull**. So the local-quickstart audience — heavily Mac, especially for the Cline Marketplace — can't pull current code at all and gets pinned to whatever stale image is cached locally. (Surfaced live: a Mac was stuck running `0.12.1` and couldn't upgrade.)

## Fix

- Add `docker/setup-qemu-action` so the amd64 runner can cross-build arm64.
- Build `linux/amd64,linux/arm64`.

The published index now carries both platforms: arm64 hosts pull natively, and amd64 (including the Lightsail deploy target) is unchanged. One-file change.

## Notes / things to watch on the next release

- **Takes effect on the next release+deploy** — `deploy.yml` is `workflow_call`'d from the release workflows, so a release must run to rebuild and repush a multi-arch `:latest`. This is a `fix:` commit, so it should auto-cut a patch release on merge.
- **Build time** — arm64 cross-build runs under QEMU and `better-sqlite3` compiles from source on Alpine/musl (the Dockerfile already carries `python3 make g++` for this). Expect a noticeably longer release build.
- **Verify after the release:** confirm `mcp-publisher` still reads the `io.modelcontextprotocol.server.name` label off the now multi-arch manifest in `publish-registry.yml`, and that `:latest` pulls natively on arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012b5S8r1yiiNwZRqrumY3Au)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment infrastructure to support additional processor architectures (ARM64), enabling the application to run on a broader range of devices and systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->