### PR TITLE
fix: build release image from the version tag so its stamp matches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,13 @@ jobs:
       SST_STAGE: ${{ secrets.SST_STAGE }}
       IMAGE: ghcr.io/${{ vars.GHCR_USER }}/vault-mcp
     steps:
+      # Build from the release tag, not the default checkout SHA. On a manual
+      # release the tag (created by bump-and-tag) points at the version-bump
+      # commit, while github.sha is the pre-bump dispatch commit — checking out
+      # the latter stamps the image one version behind the release it ships as.
       - uses: actions/checkout@v6
+        with:
+          ref: v${{ inputs.version }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Problem

The published Docker image's baked `package.json` version lags the release tag by one. The `v0.15.13` release shipped an image whose `package.json` reads `0.15.12` (confirmed: a fresh `:latest` pull on Apple Silicon ran the new multi-arch image but `node -p require('/app/package.json').version` returned `0.15.12`).

**Cause:** `deploy.yml`'s `actions/checkout` uses the default ref (`github.sha`). On a **manual release**, `manual_release.yml` runs `bump-and-tag` (bump `package.json` → commit `release: vX` → tag) and *then* calls `deploy` — but `github.sha` for the run is still the pre-bump dispatch commit. So the image is built from source where `package.json` is the previous version, yet tagged/shipped as the new one.

This is purely a version-stamp issue (the code is current), but it's misleading — the `package.json` version probe is an unreliable "which release am I on" signal, and it made diagnosing a stale-image problem murkier during testing.

## Fix

Pin `deploy.yml`'s checkout to the release tag:

```yaml
- uses: actions/checkout@v6
  with:
    ref: v${{ inputs.version }}
```

`bump-and-tag` pushes the tag before `deploy` runs (`deploy` `needs: bump-and-tag`), so the ref always resolves. The image is then built from the bumped commit and stamps the correct version.

## Safety for both callers

- **`manual_release.yml`** (the affected path) — tag exists before `deploy`; now builds the bumped commit. ✅ fixes the lag.
- **`auto_release.yml`** — triggered *by the tag push*, so its `github.sha` is already the bumped/tagged commit (it even asserts `package.json == tag`). Pinning to the same tag is a no-op. ✅ no regression.

One-line workflow change; affects future releases only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012b5S8r1yiiNwZRqrumY3Au)_