### PR TITLE
build: add OCI image metadata so the GHCR package shows a description

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,14 @@ jobs:
             ${{ env.IMAGE }}:v${{ inputs.version }}
             ${{ env.IMAGE }}:${{ inputs.version }}
             ${{ env.IMAGE }}:latest
+          # GHCR shows a multi-arch package's description from the image *index*
+          # annotation (a Dockerfile LABEL alone doesn't surface on the package
+          # page). Mirror the server.json / Dockerfile description here.
+          annotations: |
+            index:org.opencontainers.image.title=vault-cortex
+            index:org.opencontainers.image.description=MCP server for Obsidian vaults — search, memory, link graph, 23 tools, OAuth-protected.
+            index:org.opencontainers.image.source=https://github.com/aliasunder/vault-cortex
+            index:org.opencontainers.image.licenses=MIT
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,16 @@ WORKDIR /app
 # PUID so both containers can read/write the shared /vault volume.
 RUN apk add --no-cache tini libstdc++
 ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0 VAULT_PATH=/vault INDEX_DB_PATH=/data/index.db
-# OCI ownership marker for the MCP Registry — must match `name` in
-# server.json. mcp-publisher reads this label off the image manifest.
-LABEL io.modelcontextprotocol.server.name="io.github.aliasunder/vault-cortex"
+# OCI image metadata. The ownership marker must match `name` in server.json
+# (mcp-publisher reads it off the manifest). title/description/source/licenses
+# show via `docker inspect` and on the GHCR package page; for the multi-arch
+# manifest list GHCR takes the displayed description from the *index* annotation
+# set in deploy.yml — keep that description and the one here in sync.
+LABEL io.modelcontextprotocol.server.name="io.github.aliasunder/vault-cortex" \
+      org.opencontainers.image.title="vault-cortex" \
+      org.opencontainers.image.description="MCP server for Obsidian vaults — search, memory, link graph, 23 tools, OAuth-protected." \
+      org.opencontainers.image.source="https://github.com/aliasunder/vault-cortex" \
+      org.opencontainers.image.licenses="MIT"
 COPY --from=deps  /app/node_modules ./node_modules
 COPY --from=build /app/dist/src ./dist/src
 COPY package.json ./


### PR DESCRIPTION
## Problem

The GHCR package page (`ghcr.io/aliasunder/vault-mcp`) shows **"No description provided."** GitHub's own hint on that page notes that for **multi-arch images** the description must be set as the `org.opencontainers.image.description` **annotation on the manifest index** — a Dockerfile `LABEL` alone won't surface, because GHCR reads the index annotation, not the per-platform image config, for a manifest list.

## Change

Add standard `org.opencontainers.image.*` metadata (title, description, source, licenses) in two places:

- **`Dockerfile` LABELs** — config-level metadata: shows via `docker inspect`, covers single-arch / local source builds, and `org.opencontainers.image.source` links the GHCR package to this repo.
- **`deploy.yml` index annotations** (`docker/build-push-action` `annotations: index:…`) — this is what GHCR actually reads for the multi-arch package's displayed description.

The description text mirrors `server.json` (`"MCP server for Obsidian vaults — search, memory, link graph, 23 tools, OAuth-protected."`) for consistency across the registry, package page, and `docker inspect`.

## Notes

- **Applies on the next release build** — the current `:latest` (0.15.15) won't gain a description retroactively; cut a release to publish it.
- Description is intentionally duplicated across `Dockerfile` and `deploy.yml` (config label vs. index annotation are different surfaces); a comment in each flags keeping them in sync. A future `docker/metadata-action` could centralize this if desired.
- Prettier-checked locally (`checks` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012b5S8r1yiiNwZRqrumY3Au)_