### PR TITLE
Lift Glama TDQS on the three lowest-scoring tools

### DIFF
--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -29,8 +29,14 @@ const READ_ONLY_TOOLS = [
 const DESTRUCTIVE_TOOLS = [
   TOOL_NAMES.VAULT_WRITE_NOTE,
   TOOL_NAMES.VAULT_DELETE_NOTE,
-  TOOL_NAMES.VAULT_UPDATE_MEMORY,
   TOOL_NAMES.VAULT_DELETE_MEMORY,
+] as const
+
+// Writers that only add to the vault — never overwrite or delete existing
+// content — so destructiveHint must be false even though readOnlyHint is too.
+const ADDITIVE_WRITE_TOOLS = [
+  TOOL_NAMES.VAULT_UPDATE_MEMORY,
+  TOOL_NAMES.VAULT_UPDATE_PROPERTIES,
 ] as const
 
 const WRITE_TOOLS = [
@@ -151,6 +157,12 @@ describe("annotations", () => {
     const call = findCall(name)!
     expect(call[1].annotations?.destructiveHint).toBe(true)
     expect(call[1].annotations?.readOnlyHint).toBe(false)
+  })
+
+  it.each(ADDITIVE_WRITE_TOOLS)("%s is a non-destructive write", (name) => {
+    const call = findCall(name)!
+    expect(call[1].annotations?.readOnlyHint).toBe(false)
+    expect(call[1].annotations?.destructiveHint).toBe(false)
   })
 
   it("all tools have openWorldHint: false", () => {

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -588,7 +588,14 @@ Example: vault_search_by_tag({ tag: "project" }) returns all notes tagged projec
 When to use: Exploring tag hierarchies or finding all notes with a specific tag, without needing a text query.
 Prefer vault_search when you also need text-based relevance ranking. Use vault_list_tags first to discover available tags.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified. Promoted keys are in top-level fields; additional_properties contains only unpromoted keys.`,
+Parameters:
+- tag is the bare tag name without a leading "#" ("project", not "#project").
+- exact (default false) does hierarchical prefix matching — the tag and all its children. Set true to match the exact tag only, excluding children.
+
+Errors:
+- An unknown tag or no matches returns an empty array, not an error — don't use as an existence check.
+
+Returns: JSON array of up to 20 notes' metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified. Promoted keys are in top-level fields; additional_properties contains only unpromoted keys.`,
       inputSchema: {
         tag: z.string().describe("Tag to search for"),
         exact: z
@@ -1010,7 +1017,10 @@ Example: vault_list_property_keys() returns [{ key: "tags", count: 342, sample_v
 When to use: Discovering what properties exist before searching by property. Good first step for vault orientation alongside vault_list_tags.
 Prefer vault_list_property_values when you need the full list of values for a specific key. Prefer vault_search_by_property to find notes matching a specific key-value pair.
 
-Returns: JSON array of { key, count, sample_values } sorted by count descending. sample_values shows the top 3 most common values for quick orientation.`,
+Parameters:
+- folder is matched as a path prefix and recurses into subfolders ("Projects" also covers "Projects/Archive"); omit it to scan the entire vault.
+
+Returns: JSON array of { key, count, sample_values } sorted by count descending. sample_values shows the top 3 most common values per key for quick orientation.`,
       inputSchema: {
         folder: z
           .string()

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -838,7 +838,10 @@ Returns: Confirmation message.`,
       },
       annotations: {
         readOnlyHint: false,
-        destructiveHint: true,
+        // Append-only: entries are inserted, never overwritten or deleted
+        // (see memoryStore.updateMemory) — additive, not destructive.
+        destructiveHint: false,
+        // Repeat calls add a duplicate dated entry, so not idempotent.
         idempotentHint: false,
         openWorldHint: false,
       },


### PR DESCRIPTION
Targets the three current lowest scorers in Glama's TDQS breakdown. TDQS weighting (reverse-engineered + confirmed in #66): `0.25·Purpose + 0.20·Usage + 0.20·Behavior + 0.15·Parameters + 0.10·Conciseness + 0.10·Completeness`.

| Tool | Score | Weak dimension | Fix |
|---|---|---|---|
| `vault_update_memory` | 4.0 | **Behavior 1/5** | flip `destructiveHint` → `false` |
| `vault_list_property_keys` | 4.4 | **Parameters 3/5** | document `folder` semantics |
| `vault_search_by_tag` | 4.5 | broad 4/5 | Parameters + empty-result contract + disclose the 20-cap |

### `vault_update_memory` — the headline fix (a self-inflicted regression)

#66 rewrote this description to emphasize "Additive — never overwrites," but left the annotation `destructiveHint: true` untouched. Glama reads that prose-vs-annotation contradiction and hard-floors **Behavior to 1/5**, dropping the tool 4.6 → 4.0.

The annotation was simply wrong. `memoryStore.updateMemory` is append-only across all three branches — new file, new section appended at EOF, and an in-section splice-insert `[...slice(0, i), bullet, ...slice(i)]` that provably preserves every existing line; frontmatter round-trips via `matter.stringify(content, parsed.data)`. No `unlink`, no truncation, no in-place replacement. Per the MCP spec, an additive tool must set `destructiveHint: false`. `idempotentHint` stays `false` — repeat calls add a duplicate dated entry. The description is left as-is (it already discloses the duplicate-on-repeat side effect — now consistent with the annotation).

Expected: Behavior 1 → ~5 (~4.0 → ~4.75).

### `vault_list_property_keys` — Parameters 3/5

Added a `Parameters:` section: `folder` is a path prefix that recurses into subfolders (`"Projects"` covers `"Projects/Archive"`), optional (omit to scan the whole vault) — semantics the schema alone doesn't convey. Verified against `n.path LIKE @folder || '/%'` in `search-index.ts`.

### `vault_search_by_tag` — broad 4/5

- `Parameters:` — `tag` is the bare name (no leading `#`); `exact` defaults to false (hierarchical prefix matching).
- `Errors:` — unknown tag / no match returns an empty array, not an error.
- `Returns:` — discloses the fixed **20-result cap**. The handler doesn't expose `limit`, so `searchByTag` falls to its `params.limit ?? 20` default; results are always the 20 most-recently-modified. (Not documented as a settable param, since it isn't one.)

### Tests

Moved `vault_update_memory` out of `DESTRUCTIVE_TOOLS` and added an `ADDITIVE_WRITE_TOOLS` bucket asserting `readOnlyHint:false` + `destructiveHint:false` — also covering `vault_update_properties`, whose non-destructive annotation was previously unasserted. Full suite green (500 tests), `tsc` + `eslint` clean.

### Note

Gains are directional (LLM grader) and only re-score after the live server redeploys with these descriptions and Glama re-syncs — same downstream-ops pattern as #66.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdpbH9inBYaxSKsaD9mEFF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced vault_search_by_tag documentation with detailed parameter guidance, error handling, and return value descriptions.
  * Clarified vault_list_property_keys behavior regarding folder prefix matching and vault-wide scanning.

* **Bug Fixes**
  * Fixed vault_update_memory annotation to correctly reflect its non-destructive, append-only nature; noted that repeated calls may result in duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->