### PR TITLE
ci: migrate release workflows to app client-id

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -59,7 +59,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -33,7 +33,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
@@ -106,7 +106,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What

`actions/create-github-app-token@v3` deprecated the `app-id` input in favor of `client-id`. This swaps `app-id: ${{ secrets.RELEASE_APP_ID }}` → `client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}` across both release workflows, clearing the deprecation notices in CI.

- `manual_release.yml` — both app-token steps (`bump-and-tag` + `release`)
- `auto_release.yml` — `release` step

`private-key` is unchanged.

## Why

Verified against the action's own `action.yml`: `app-id` carries a deprecation notice ("Use 'client-id' instead"); `client-id` is the current preferred input. Migrating now clears the recurring deprecation annotations on every release run.

## Prerequisite (done)

A new `RELEASE_APP_CLIENT_ID` repo secret (the `vault-cortex-release` GitHub App's Client ID) must exist before a release runs, or the token step receives an empty `client-id` and fails. **The secret has been added.** The old `RELEASE_APP_ID` secret is now unused.

## Verification

- Both workflow YAMLs parse cleanly.
- No other references to `app-id` / `RELEASE_APP_ID` remain in `.github/workflows/`.
- No docs reference the old secret (only historical CHANGELOG entries).
- End-to-end auth confirmation comes on the next release cut.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq8MRgZeLzWGhd1CxiYhRP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub App authentication configuration in release workflows to improve token generation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->