### PR TITLE
docs: update obsidian-vault skill section after repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,15 @@ npx @modelcontextprotocol/inspector
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development setup.
 
-## Tips
+## Companion: obsidian-vault skill
 
-### For Claude users
+The MCP server works on its own with any client. For agents that support [skills](https://github.com/vercel-labs/skills) (Claude Code, Cursor, Windsurf, Cline, and [70+ others](https://github.com/vercel-labs/skills#supported-agents)), the **obsidian-vault** skill adds deeper knowledge of Obsidian-flavored markdown — frontmatter conventions, callout syntax, and plugin-specific formats like Dataview, Tasks, and Kanban.
 
-The [obsidian-vault](https://github.com/aliasunder/cowork-plugins) skill teaches Claude how to write Obsidian-compatible content — frontmatter, wikilinks, tags, callouts, and plugin-specific syntax. Vault Cortex delivers the content; obsidian-vault ensures it renders correctly in Obsidian. Available for Claude Code and Claude Desktop.
+```bash
+npx skills add aliasunder/agent-skills --skill obsidian-vault
+```
+
+[Skill source →](https://github.com/aliasunder/agent-skills/tree/main/skills/obsidian-vault)
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

- Replaces the "Tips > For Claude users" subsection with a standalone "Companion: obsidian-vault skill" section
- Leads with "the MCP server works on its own" — the skill is an optional add-on, not a requirement
- Adds `npx skills add` install command and deep-links the [skill source](https://github.com/aliasunder/agent-skills/tree/main/skills/obsidian-vault)
- Fixes the stale `cowork-plugins` link (repo was renamed to `agent-skills`)
- Lists the 70+ supported agents (Claude Code, Cursor, Windsurf, Cline, etc.) — not just Claude

## Test plan

- [x] Verify README renders correctly on GitHub (section heading, code block, links)
- [x] Confirm both links resolve: [skills repo](https://github.com/vercel-labs/skills), [skill source](https://github.com/aliasunder/agent-skills/tree/main/skills/obsidian-vault)

🤖 Generated with [Claude Code](https://claude.com/claude-code)