### PR TITLE
fix: prevent FTS5 syntax errors on punctuated vault_search terms

### DIFF
--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -288,6 +288,31 @@ describe("fullTextSearch", () => {
     expect(results).toHaveLength(1)
     expect(results[0].path).toBe("project.md")
   })
+
+  it("dotted query matches content containing the dotted term", () => {
+    index.upsertNote(
+      "directories.md",
+      "Submitted the listing to mcpservers.org yesterday\n",
+      6001,
+    )
+    index.upsertNote(
+      "unrelated.md",
+      "The mcpservers registry has no org field\n",
+      6002,
+    )
+    const results = index.fullTextSearch({ query: "mcpservers.org" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("directories.md")
+  })
+
+  it("query with stray punctuation does not throw", () => {
+    expect(() =>
+      index.fullTextSearch(
+        { query: "what's new in deploy/local, server.json & .env?" },
+        logger,
+      ),
+    ).not.toThrow()
+  })
 })
 
 describe("sanitizeFtsQuery", () => {
@@ -371,6 +396,76 @@ describe("sanitizeFtsQuery", () => {
       name: "mixed: quoted phrase + hyphenated + bare",
       input: 'search "exact-match" vault-cortex',
       expected: '"exact-match" "vault cortex" search',
+    },
+    {
+      name: "dotted domain → quoted phrase",
+      input: "mcpservers.org",
+      expected: '"mcpservers org"',
+    },
+    {
+      name: "dotted domain + bare terms (live failure 2026-06-09)",
+      input: "mcpservers.org submission email",
+      expected: '"mcpservers org" submission email',
+    },
+    {
+      name: "dotted filename → quoted phrase",
+      input: "server.json",
+      expected: '"server json"',
+    },
+    {
+      name: "slash path → quoted phrase",
+      input: "deploy/local",
+      expected: '"deploy local"',
+    },
+    {
+      name: "email address → quoted phrase",
+      input: "user@example.com",
+      expected: '"user example com"',
+    },
+    {
+      name: "comma-joined terms → quoted phrase",
+      input: "foo,bar",
+      expected: '"foo bar"',
+    },
+    {
+      name: "apostrophe contraction → quoted phrase",
+      input: "don't",
+      expected: '"don t"',
+    },
+    {
+      name: "mixed dot + hyphen compound → quoted phrase",
+      input: "vault-cortex.test",
+      expected: '"vault cortex test"',
+    },
+    {
+      name: "word-edge punctuation stripped, term left bare",
+      input: "email. really?!",
+      expected: "email really",
+    },
+    {
+      name: "punctuation-only input: empty result",
+      input: "?!.,",
+      expected: '""',
+    },
+    {
+      name: "metachar adjoining compound: not a joiner",
+      input: "vault-cortex: search",
+      expected: '"vault cortex" search',
+    },
+    {
+      name: "underscore is a bareword character, term left bare",
+      input: "snake_case_name",
+      expected: "snake_case_name",
+    },
+    {
+      name: "non-ASCII term left bare",
+      input: "café",
+      expected: "café",
+    },
+    {
+      name: "dot inside quoted phrase preserved",
+      input: '"mcpservers.org"',
+      expected: '"mcpservers.org"',
     },
   ]
 

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -36,38 +36,71 @@ const coerceToArray = (value: unknown): string[] =>
 
 const FTS5_RESERVED = new Set(["AND", "OR", "NOT", "NEAR"])
 
-/** Matches hyphenated compound terms (e.g. vault-cortex, self-hosted-app)
- *  where at least two word segments are joined by hyphens. */
-const HYPHENATED_COMPOUND_REGEX = /\b(\w+(?:-\w+)+)\b/g
+/** One FTS5 bareword character: anything except whitespace and ASCII
+ *  punctuation. Covers letters, digits, underscore, and all non-ASCII
+ *  characters (FTS5 treats code points ≥ 0x80 as bareword characters). */
+const BAREWORD_CHARACTER = "[^\\s!-/:-@[-^`{-~]"
+
+/** One compound-joiner character: ASCII punctuation that glues segments of a
+ *  single term together (the dot in mcpservers.org, the hyphen in
+ *  vault-cortex, the slash in deploy/local). Excludes the FTS5 metacharacters
+ *  " * ^ ( ) : (stripped outright, never joiners) and underscore (a bareword
+ *  character). */
+const COMPOUND_JOINER_CHARACTER = "[!#-'+-/;-@[-\\]`{-~]"
+
+/** Matches compound terms — two or more bareword segments joined by
+ *  punctuation — which FTS5 would otherwise reject as a syntax error
+ *  (e.g. "fts5: syntax error near '.'" for mcpservers.org). */
+const COMPOUND_TERM_REGEX = new RegExp(
+  `${BAREWORD_CHARACTER}+(?:${COMPOUND_JOINER_CHARACTER}+${BAREWORD_CHARACTER}+)+`,
+  "g",
+)
+
+/** Matches a run of joiner punctuation inside a compound term, for
+ *  replacement with a single space when the compound becomes a phrase. */
+const COMPOUND_JOINER_RUN_REGEX = new RegExp(
+  `${COMPOUND_JOINER_CHARACTER}+`,
+  "g",
+)
+
+/** Matches every ASCII punctuation character except underscore. Used as the
+ *  final sweep that turns stray punctuation (word-edge dots, unbalanced
+ *  quotes, lone operators) into token separators so it never reaches FTS5. */
+const ASCII_PUNCTUATION_REGEX = /[!-/:-@[-^`{-~]/g
 
 /** Sanitizes user input for safe FTS5 querying. Quoted phrases are preserved
- *  for exact-phrase matching. Hyphenated compound terms (e.g. vault-cortex)
- *  are converted to quoted phrases for adjacent-token matching. Remaining
- *  unquoted terms are left bare to preserve porter stemming. FTS5
- *  metacharacters and reserved words are stripped. */
+ *  for exact-phrase matching. Punctuated compound terms (vault-cortex,
+ *  mcpservers.org, deploy/local) are converted to quoted phrases for
+ *  adjacent-token matching — the unicode61 tokenizer splits the indexed text
+ *  at the same punctuation, so the phrase matches the original term exactly.
+ *  Remaining unquoted terms are left bare to preserve porter stemming. FTS5
+ *  metacharacters, stray punctuation, and reserved words are stripped, so
+ *  literal text can never produce an FTS5 syntax error. */
 export const sanitizeFtsQuery = (raw: string): string => {
   const phrases: string[] = []
 
   // Extract "quoted phrases", strip FTS5 metacharacters inside them,
-  // and collect into phrases[]. Hyphens inside quotes are left alone —
-  // the unicode61 tokenizer splits them correctly in phrase queries.
+  // and collect into phrases[]. Other punctuation inside quotes is left
+  // alone — the unicode61 tokenizer splits it correctly in phrase queries.
   const remaining = raw.replace(/"([^"]+)"/g, (_, phrase: string) => {
     const cleaned = phrase.replace(/[*^():]/g, "").trim()
     if (cleaned.length > 0) phrases.push(`"${cleaned}"`)
     return " "
   })
 
-  // Convert bare hyphenated compounds (vault-cortex → "vault cortex")
-  // so FTS5 doesn't interpret the hyphen as the NOT operator.
-  const afterHyphens = remaining.replace(HYPHENATED_COMPOUND_REGEX, (match) => {
-    phrases.push(`"${match.replace(/-/g, " ")}"`)
+  // Convert bare punctuated compounds (vault-cortex → "vault cortex",
+  // mcpservers.org → "mcpservers org") so FTS5 doesn't interpret the
+  // punctuation as an operator or reject it as a syntax error.
+  const afterCompounds = remaining.replace(COMPOUND_TERM_REGEX, (match) => {
+    phrases.push(`"${match.replace(COMPOUND_JOINER_RUN_REGEX, " ")}"`)
     return " "
   })
 
-  // Strip remaining FTS5 metacharacters (including stray/leading hyphens),
-  // split into tokens, and drop reserved words (AND, OR, NOT, NEAR).
-  const tokens = afterHyphens
-    .replace(/["*^():-]/g, " ")
+  // Strip all remaining ASCII punctuation (metacharacters, word-edge dots,
+  // stray/leading hyphens), split into tokens, and drop reserved words
+  // (AND, OR, NOT, NEAR).
+  const tokens = afterCompounds
+    .replace(ASCII_PUNCTUATION_REGEX, " ")
     .split(/\s+/)
     .filter((t) => t.length > 0 && !FTS5_RESERVED.has(t.toUpperCase()))
 

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -515,7 +515,7 @@ Returns: Confirmation message.`,
     TOOL_NAMES.VAULT_SEARCH,
     {
       title: "Search Notes",
-      description: `Full-text search across all vault notes, ranked by relevance. Supports filtering by folder, tags, type, and properties. Wrap terms in double quotes for exact phrase matching (e.g. '"machine learning"'); unquoted terms use implicit AND with porter stemming.
+      description: `Full-text search across all vault notes, ranked by relevance. Supports filtering by folder, tags, type, and properties. Wrap terms in double quotes for exact phrase matching (e.g. '"machine learning"'); unquoted terms use implicit AND with porter stemming. Punctuated terms (vault-cortex, mcpservers.org, deploy/local) are matched as exact adjacent-word phrases automatically — no quoting needed.
 
 Example: vault_search({ query: "kubernetes networking", filters: { tags: ["reference"] } })
 


### PR DESCRIPTION
## Problem

`vault_search` passes sanitized user input to FTS5, but `sanitizeFtsQuery` only handled hyphens (#18) and a short metacharacter list (`" * ^ ( ) :`). Every other ASCII punctuation character reached FTS5 raw, where it is invalid bareword syntax — so natural queries containing domains, filenames, paths, emails, or contractions threw instead of searching.

Hit live on 2026-06-09: `vault_search({ query: "mcpservers.org submission email" })` → `fts5: syntax error near "."`.

## Fix

Generalize the existing hyphen-compound treatment to all ASCII punctuation, in `sanitizeFtsQuery` (`search-index.ts`):

- **Compound terms** — two or more bareword segments joined by punctuation (`mcpservers.org`, `server.json`, `deploy/local`, `user@example.com`, `don't`) become quoted phrases with the punctuation replaced by spaces. The unicode61 tokenizer splits indexed text at the same punctuation, so the phrase matches the original term exactly — same semantics the hyphen fix established.
- **Stray punctuation** — word-edge dots, unbalanced quotes, lone operators — is swept to token separators in a final pass, so literal text can never produce an FTS5 syntax error.
- The previously stripped metacharacters (`" * ^ ( ) :`) are deliberately **not** compound joiners, preserving existing behavior exactly (`field:value` → `field value`, all 16 prior sanitizer scenarios unchanged). Underscore and non-ASCII characters remain bareword characters and are untouched.

Also documents the behavior in the `vault_search` tool description (punctuated terms match as adjacent-word phrases automatically — no quoting needed).

## Tests

- 14 new table-driven sanitizer scenarios (dots, slashes, emails, commas, apostrophes, mixed joiners, edge punctuation, punctuation-only input, underscore/non-ASCII preservation, dots inside quoted phrases)
- 2 new integration tests: dotted query matches the dotted term (with adjacent-but-separate negative data) and a punctuation-heavy query does not throw
- Mutation-audited: 11 of the new tests fail against the old sanitizer
- 520/520 tests, lint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)