### PR TITLE
feat: surface server icon and website URL in MCP serverInfo (SEP-973)

### DIFF
--- a/src/vault-mcp/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/__tests__/mcp-router.test.ts
@@ -58,6 +58,14 @@ const SERVER_INFO = {
   title: "Vault Cortex",
   version: "1.0.0",
   description: `Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (${DEFAULT_CONFIG.memoryDir}/) for personalization across conversations.`,
+  icons: [
+    {
+      src: "https://raw.githubusercontent.com/aliasunder/vault-cortex/main/assets/icon-400.png",
+      mimeType: "image/png",
+      sizes: ["400x400"],
+    },
+  ],
+  websiteUrl: "https://github.com/aliasunder/vault-cortex",
 }
 
 const SERVER_OPTIONS = {

--- a/src/vault-mcp/mcp-router.ts
+++ b/src/vault-mcp/mcp-router.ts
@@ -20,6 +20,22 @@ export type McpRouterOptions = {
   config: VaultConfig
 }
 
+/**
+ * Server icon for MCP clients (spec 2025-11-25, SEP-973). Clients that
+ * support serverInfo.icons render this beside the connection instead of a
+ * generic or domain-derived icon. Served from the repo so it stays valid
+ * regardless of the deployment domain.
+ */
+const SERVER_ICONS = [
+  {
+    src: "https://raw.githubusercontent.com/aliasunder/vault-cortex/main/assets/icon-400.png",
+    mimeType: "image/png",
+    sizes: ["400x400"],
+  },
+]
+
+const SERVER_WEBSITE_URL = "https://github.com/aliasunder/vault-cortex"
+
 export const createMcpRouter = ({
   vaultPath,
   search,
@@ -66,6 +82,8 @@ export const createMcpRouter = ({
             title: "Vault Cortex",
             version: "1.0.0",
             description: `Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (${config.memoryDir}/) for personalization across conversations.`,
+            icons: SERVER_ICONS,
+            websiteUrl: SERVER_WEBSITE_URL,
           },
           {
             instructions: `Read, write, and search an Obsidian vault. Use vault_search and vault_read_note to find and read notes. Use vault_get_memory to retrieve user preferences and context from ${config.memoryDir}/ files. Use vault_write_note and vault_update_memory for writes.


### PR DESCRIPTION
## Summary

Adds `icons` and `websiteUrl` to the `Implementation` metadata returned during `initialize` (MCP spec 2025-11-25, [SEP-973](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1040)). Clients that support server icons render the project mark beside the connection instead of a generic or domain-derived favicon.

## Why

MCP clients that don't implement SEP-973 fall back to deriving a connection icon from the server URL's domain — for an API Gateway deployment that resolves to the AWS favicon rather than anything project-related. Publishing the icon in `serverInfo` is the spec-correct, domain-independent fix: compliant clients pick it up immediately, and clients that currently ignore the field (tracked upstream in [anthropics/claude-ai-mcp#152](https://github.com/anthropics/claude-ai-mcp/issues/152)) inherit it the moment they add support, with no further server change.

## Changes

- `src/vault-mcp/mcp-router.ts` — `SERVER_ICONS` (the existing `assets/icon-400.png`, referenced via its raw GitHub URL so it stays valid regardless of deployment domain) and `SERVER_WEBSITE_URL` constants, passed to the `McpServer` constructor alongside the existing `name`/`title`/`version`/`description`.
- `src/vault-mcp/__tests__/mcp-router.test.ts` — `SERVER_INFO` expectation extended to the new fields (exact-match assertion; fails if the metadata is removed).

## Verification

- 520/520 tests pass; `tsc` and `eslint` clean.
- Mutation-audited: reverting the source change fails exactly the serverInfo metadata test.
- Field support verified against the pinned `@modelcontextprotocol/sdk` 1.29.0 `ImplementationSchema` (`icons`, `websiteUrl` both present).

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjXWskJGCELMcdhberwPRw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added icons array and website URL metadata to MCP server configuration in both test and production implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->