### PR TITLE
fix: vault_update_properties treats null as property deletion

### DIFF
--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -30,14 +30,12 @@ const DESTRUCTIVE_TOOLS = [
   TOOL_NAMES.VAULT_WRITE_NOTE,
   TOOL_NAMES.VAULT_DELETE_NOTE,
   TOOL_NAMES.VAULT_DELETE_MEMORY,
+  TOOL_NAMES.VAULT_UPDATE_PROPERTIES,
 ] as const
 
 // Writers that only add to the vault — never overwrite or delete existing
 // content — so destructiveHint must be false even though readOnlyHint is too.
-const ADDITIVE_WRITE_TOOLS = [
-  TOOL_NAMES.VAULT_UPDATE_MEMORY,
-  TOOL_NAMES.VAULT_UPDATE_PROPERTIES,
-] as const
+const ADDITIVE_WRITE_TOOLS = [TOOL_NAMES.VAULT_UPDATE_MEMORY] as const
 
 const WRITE_TOOLS = [
   TOOL_NAMES.VAULT_WRITE_NOTE,
@@ -133,6 +131,16 @@ describe("registerTools", () => {
   it("vault_patch_note description includes cross-section move guidance", () => {
     const call = findCall(TOOL_NAMES.VAULT_PATCH_NOTE)!
     expect(call[1].description).toContain("Cross-section move")
+  })
+
+  it("vault_update_properties description documents null-deletes-key contract", () => {
+    const call = findCall(TOOL_NAMES.VAULT_UPDATE_PROPERTIES)!
+    expect(call[1].description).toContain("null as a value to delete")
+  })
+
+  it("vault_write_note description documents null-deletes-key contract", () => {
+    const call = findCall(TOOL_NAMES.VAULT_WRITE_NOTE)!
+    expect(call[1].description).toContain("keys set to null removed")
   })
 
   it("every tool has all 4 annotation hints", () => {

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -161,7 +161,7 @@ Returns: Raw markdown string (default), or JSON object of properties (when prope
     TOOL_NAMES.VAULT_WRITE_NOTE,
     {
       title: "Write Note",
-      description: `Create or update a markdown note. Body replaces the entire note content — this is a full overwrite, not a partial edit. Properties are passed separately and merged with any existing properties (new keys added, matching keys overwritten, unmentioned keys preserved).
+      description: `Create or update a markdown note. Body replaces the entire note content — this is a full overwrite, not a partial edit. Properties are passed separately and merged with any existing properties (new keys added, matching keys overwritten, keys set to null removed, unmentioned keys preserved).
 
 Example: vault_write_note({ path: "Projects/notes.md", body: "# Notes\\n\\nProject notes here.", properties: { tags: ["project"], type: "project" } })
 
@@ -187,7 +187,7 @@ Returns: Confirmation message.`,
           .record(z.string().min(1), z.unknown())
           .optional()
           .describe(
-            "Optional properties to merge. New keys are added; existing keys with matching names are overwritten; unmentioned keys are preserved from the existing file.",
+            "Optional properties to merge. New keys are added; existing keys with matching names are overwritten; a null value deletes that key; unmentioned keys are preserved from the existing file.",
           ),
       },
       annotations: {
@@ -463,11 +463,11 @@ Returns: Confirmation message.`,
     TOOL_NAMES.VAULT_UPDATE_PROPERTIES,
     {
       title: "Update Properties",
-      description: `Update properties on a single note. Merges with existing properties — new keys are added, matching keys are overwritten, unmentioned keys are preserved. Body content is never modified.
+      description: `Update properties on a single note. Merges with existing properties — new keys are added, matching keys are overwritten, unmentioned keys are preserved. Pass null as a value to delete that key. Body content is never modified.
 
-Example: vault_update_properties({ path: "Projects/todo.md", properties: { status: "active", priority: 1 } })
+Example: vault_update_properties({ path: "Projects/todo.md", properties: { status: "active", draft: null } }) — sets status and deletes the draft key.
 
-Read current properties first with vault_read_note({ properties_only: true }) — merge overwrites each key entirely (arrays are replaced, not appended to).
+Read current properties first with vault_read_note({ properties_only: true }) — merge overwrites each key entirely (arrays are replaced, not appended to). Deleting the last remaining property removes the frontmatter block entirely.
 
 When to use: Changing tags, status, type, or any property without reading/rewriting the full note body. Saves tokens on large notes.
 Prefer vault_write_note when creating a new note or replacing the body.
@@ -484,12 +484,12 @@ Returns: Confirmation message.`,
         properties: z
           .record(z.string().min(1), z.unknown())
           .describe(
-            "Properties to merge. New keys are added; existing keys are overwritten; unmentioned keys are preserved.",
+            "Properties to merge. New keys are added; existing keys are overwritten; a null value deletes that key; unmentioned keys are preserved.",
           ),
       },
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -141,6 +141,39 @@ describe("writeNote", () => {
     expect(content).toContain("title: Keep")
     expect(content).toContain("status: active")
   })
+
+  it("removes keys set to null when merging into an existing note", async () => {
+    await writeFile(
+      join(vault, "merge.md"),
+      "---\ntitle: Keep\ndraft: true\n---\nold body\n",
+      "utf8",
+    )
+    await writeNote(
+      {
+        vaultPath: vault,
+        path: "merge.md",
+        body: "new body\n",
+        properties: { draft: null },
+      },
+      logger,
+    )
+    const content = await readFile(join(vault, "merge.md"), "utf8")
+    expect(content).toBe("---\ntitle: Keep\n---\nnew body\n")
+  })
+
+  it("does not serialize null properties when creating a new file", async () => {
+    await writeNote(
+      {
+        vaultPath: vault,
+        path: "fresh.md",
+        body: "body\n",
+        properties: { title: "Fresh", draft: null },
+      },
+      logger,
+    )
+    const content = await readFile(join(vault, "fresh.md"), "utf8")
+    expect(content).toBe("---\ntitle: Fresh\n---\nbody\n")
+  })
 })
 
 const DEFAULT_PROTECTED = ["About Me", "Daily Notes"]
@@ -403,6 +436,93 @@ describe("updateProperties", () => {
     expect(content).toBe(
       "---\ntitle: Stamped\ncreated: 2026-05-13T20:00:00-04:00\nstatus: active\n---\nbody\n",
     )
+  })
+
+  it("deletes a key set to null", async () => {
+    await writeFile(
+      join(vault, "test.md"),
+      "---\ntitle: Keep\nstatus: draft\n---\nbody\n",
+      "utf8",
+    )
+    await updateProperties(
+      {
+        vaultPath: vault,
+        path: "test.md",
+        properties: { status: null },
+      },
+      logger,
+    )
+    const content = await readFile(join(vault, "test.md"), "utf8")
+    expect(content).toBe("---\ntitle: Keep\n---\nbody\n")
+  })
+
+  it("treats null for a non-existent key as a no-op", async () => {
+    const original = "---\ntitle: Keep\n---\nbody\n"
+    await writeFile(join(vault, "test.md"), original, "utf8")
+    await updateProperties(
+      {
+        vaultPath: vault,
+        path: "test.md",
+        properties: { ghost: null },
+      },
+      logger,
+    )
+    const content = await readFile(join(vault, "test.md"), "utf8")
+    expect(content).toBe(original)
+  })
+
+  it("deletes and sets keys in the same call", async () => {
+    await writeFile(
+      join(vault, "test.md"),
+      "---\nstatus: draft\ntitle: Keep\n---\nbody\n",
+      "utf8",
+    )
+    await updateProperties(
+      {
+        vaultPath: vault,
+        path: "test.md",
+        properties: { status: null, priority: 1 },
+      },
+      logger,
+    )
+    const content = await readFile(join(vault, "test.md"), "utf8")
+    expect(content).toBe("---\ntitle: Keep\npriority: 1\n---\nbody\n")
+  })
+
+  it("removes the frontmatter block entirely when the last key is deleted", async () => {
+    await writeFile(
+      join(vault, "test.md"),
+      "---\nstatus: draft\n---\nbody\n",
+      "utf8",
+    )
+    await updateProperties(
+      {
+        vaultPath: vault,
+        path: "test.md",
+        properties: { status: null },
+      },
+      logger,
+    )
+    const content = await readFile(join(vault, "test.md"), "utf8")
+    expect(content).toBe("body\n")
+  })
+
+  it("preserves an unmentioned pre-existing empty property", async () => {
+    await writeFile(
+      join(vault, "test.md"),
+      "---\ndue:\ntitle: Keep\n---\nbody\n",
+      "utf8",
+    )
+    await updateProperties(
+      {
+        vaultPath: vault,
+        path: "test.md",
+        properties: { status: "active" },
+      },
+      logger,
+    )
+    const content = await readFile(join(vault, "test.md"), "utf8")
+    expect(content).toBe("---\ndue:\ntitle: Keep\nstatus: active\n---\nbody\n")
   })
 
   it("throws on non-existent file", async () => {

--- a/src/vault-mcp/vault-operations/frontmatter.ts
+++ b/src/vault-mcp/vault-operations/frontmatter.ts
@@ -10,6 +10,8 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml"
  * dump back unquoted — frontmatter values round-trip verbatim.
  *
  * `lineWidth: 0` disables the dumper's 80-column folding of long values.
+ * `nullStr: ""` dumps null values as empty properties (`due:`), matching
+ * how Obsidian writes them, instead of a literal `due: null`.
  */
 const MATTER_OPTIONS = {
   engines: {
@@ -21,7 +23,7 @@ const MATTER_OPTIONS = {
         return (parsed ?? {}) as Record<string, unknown>
       },
       stringify: (data: object): string =>
-        stringifyYaml(data, { lineWidth: 0 }),
+        stringifyYaml(data, { lineWidth: 0, nullStr: "" }),
     },
   },
 }
@@ -47,3 +49,26 @@ export const parseNote = (content: string): matter.GrayMatterFile<string> =>
  */
 export const stringifyNote = (body: string, data: object): string =>
   matter.stringify(body, data, MATTER_OPTIONS)
+
+/**
+ * Merges `updates` into `existing` frontmatter. A key explicitly set to
+ * null in `updates` is removed. Nulls already present in `existing`
+ * (e.g. Obsidian empty properties like `due:`) are preserved — only the
+ * caller's nulls are deletions.
+ */
+export const mergeFrontmatter = (
+  existing: Record<string, unknown>,
+  updates: Record<string, unknown>,
+): Record<string, unknown> => {
+  // Keys the caller explicitly nulled are deletions, not values
+  const deletedKeys = new Set(
+    Object.entries(updates)
+      .filter(([, updateValue]) => updateValue === null)
+      .map(([updateKey]) => updateKey),
+  )
+  return Object.fromEntries(
+    Object.entries({ ...existing, ...updates }).filter(
+      ([mergedKey]) => !deletedKeys.has(mergedKey),
+    ),
+  )
+}

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, readdir, mkdir, unlink } from "node:fs/promises"
 import { join, dirname, relative, resolve } from "node:path"
 import type { Dirent } from "node:fs"
 import picomatch from "picomatch"
-import { parseNote, stringifyNote } from "./frontmatter.js"
+import { parseNote, stringifyNote, mergeFrontmatter } from "./frontmatter.js"
 import type { Logger } from "../../logger.js"
 
 /** Resolves a note path within the vault, throwing on traversal attempts. */
@@ -38,17 +38,18 @@ const readdirOrNull = async (path: string): Promise<Dirent[] | null> => {
   }
 }
 
-/** Combines body + frontmatter into a gray-matter serialized string. Merges with existing frontmatter if file already exists. */
+/** Combines body + frontmatter into a gray-matter serialized string. Merges with existing frontmatter if file already exists; keys set to null are removed. */
 const serializeNote = (
   existing: string | null,
   body: string,
   frontmatter?: Record<string, unknown>,
 ): string => {
-  if (!existing) return stringifyNote(body, frontmatter ?? {})
+  if (!existing)
+    return stringifyNote(body, mergeFrontmatter({}, frontmatter ?? {}))
 
   const parsed = parseNote(existing)
   const mergedData = frontmatter
-    ? { ...parsed.data, ...frontmatter }
+    ? mergeFrontmatter(parsed.data, frontmatter)
     : parsed.data
   return stringifyNote(body, mergedData)
 }
@@ -102,7 +103,7 @@ const writeNote = async (
   logger.info("wrote note", { path: params.path })
 }
 
-/** Merges properties into an existing note's YAML frontmatter without touching the body. */
+/** Merges properties into an existing note's YAML frontmatter without touching the body. Keys set to null are removed. */
 const updateProperties = async (
   params: {
     vaultPath: string
@@ -117,7 +118,7 @@ const updateProperties = async (
     throw new Error(`note not found: "${params.path}"`)
   }
   const parsed = parseNote(existing)
-  const mergedProperties = { ...parsed.data, ...params.properties }
+  const mergedProperties = mergeFrontmatter(parsed.data, params.properties)
   await writeFile(
     fullPath,
     stringifyNote(parsed.content, mergedProperties),


### PR DESCRIPTION
## Problem

`vault_update_properties` was merge-only with no property-removal path. Passing `{ "key": null }` carried the null straight through the spread merge into the YAML serializer, which wrote a literal `key: null` into frontmatter. Hit live 2026-06-10 cleaning a stray property off a note — recovery required a manual file edit.

## Fix

**Contract: null means delete.** A key explicitly set to `null` in the update is removed from frontmatter.

- New `mergeFrontmatter` helper in `frontmatter.ts` — used by both merge paths (`updateProperties` and `vault_write_note`'s `serializeNote`, including its new-file branch) so the contract is consistent everywhere.
- **Only the caller's nulls delete.** Nulls already present in existing frontmatter — Obsidian empty properties like `due:` parse as null — are preserved when unmentioned; filtering all nulls would silently strip empty template properties on every update.
- `nullStr: ""` added to the YAML stringify options so preserved nulls round-trip Obsidian-style as `due:` instead of `due: null`.
- Deleting the last remaining property removes the frontmatter block entirely (no empty `---` stub).
- Tool descriptions + Zod `describe()` document the contract on both tools.

## ⚠️ destructiveHint flip

`vault_update_properties` annotations change `destructiveHint: false → true` — the tool can now irreversibly remove data (and already overwrote values). Some MCP clients may start gating it behind a confirmation prompt; this is intended. Moved from `ADDITIVE_WRITE_TOOLS` to `DESTRUCTIVE_TOOLS` in the annotation tests (`vault_update_memory` remains the only genuinely additive writer).

## Tests

9 new tests, all byte-exact content assertions. Mutation-audited:
- Plain-spread revert at both call sites → exactly the 6 delete-behavior tests fail
- Helper mutated to filter *all* nulls → exactly the preserve-empty-property guard fails

529 tests pass; lint, build, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented proper null semantics for property handling—setting a property to `null` now correctly deletes that key from notes while preserving unmodified properties.

* **Documentation**
  * Expanded tool descriptions with examples demonstrating null-deletes-key behavior.
  * Reclassified property update tool as destructive, accurately reflecting its capability to remove data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->