### PR TITLE
ci: create GitHub releases for CLI versions

### DIFF
--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -133,3 +133,33 @@ jobs:
 
       - name: Publish to npm (Trusted Publishing / OIDC)
         run: npm publish ./cli --provenance --access public
+
+      # --latest=false keeps the "Latest" badge on server releases. Notes
+      # list only cli/ commits — server commits interleave on main, so
+      # range-wide auto-notes would include unrelated work. If this step
+      # fails after a successful publish, create the release manually
+      # (re-running the workflow would refuse to republish the version).
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT: ${{ steps.next.outputs.version }}
+        run: |
+          if gh release view "cli-v$NEXT" > /dev/null 2>&1; then
+            echo "Release cli-v$NEXT already exists; skipping"
+            exit 0
+          fi
+          PREV=$(git describe --tags --match "cli-v*" --abbrev=0 "cli-v$NEXT"^ 2> /dev/null || true)
+          if [ -n "$PREV" ]; then
+            RANGE="$PREV..cli-v$NEXT"
+          else
+            RANGE="cli-v$NEXT"
+          fi
+          {
+            git log "$RANGE" --pretty="- %s" -- cli/
+            echo ""
+            echo "Published to npm: https://www.npmjs.com/package/vault-cortex/v/$NEXT"
+          } > /tmp/release-notes.md
+          gh release create "cli-v$NEXT" \
+            --title "cli-v$NEXT" \
+            --notes-file /tmp/release-notes.md \
+            --latest=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,11 @@ otherwise.
 nothing publishes to npm as a side effect of a server release. The maintainer
 runs the **"Release CLI"** workflow (Actions tab), choosing a
 `patch`/`minor`/`major` bump (or `none` to publish the current version); it
-bumps `cli/package.json` on `main`, tags `cli-v<version>`, and publishes to
-npm via [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC)
-— no npm token secret is stored in the repo. The trusted publisher is
+bumps `cli/package.json` on `main`, tags `cli-v<version>`, publishes to npm
+via [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) —
+no npm token secret is stored in the repo — and creates a `cli-v<version>`
+GitHub release (marked non-latest so server releases keep the "Latest"
+badge). The trusted publisher is
 configured in the npm package settings for this repo + `cli_release.yml`. PRs
 that change `cli/` should **not** bump the version — the release workflow owns
 it. The npm package is deliberately absent from `server.json` — it's a


### PR DESCRIPTION
## Why

`cli-v*` tags don't surface anywhere humans look: watchers are notified of releases (not tags), the Releases page and its feed skip them, and npm shows versions without changelogs. `cli-v0.2.0` is currently invisible on the repo.

## What

- The **Release CLI** workflow now ends by creating a `cli-v<version>` GitHub release:
  - Notes are `git log` filtered to `cli/` commits since the previous `cli-v*` tag (server commits interleave on main, so range-wide auto-notes would include unrelated work), plus a link to the npm version page.
  - `--latest=false` keeps the "Latest" badge on server releases.
  - Skips when the release already exists (safe re-runs); a comment documents the manual-create remediation if the step fails after a successful publish.
- CONTRIBUTING's publishing section updated to match.

Deliberately **not** wiring CLI releases into `CHANGELOG.md` — that file and its scripts are server-release machinery; the GH release + npm page cover the CLI.

`cli-v0.2.0`'s release will be backfilled manually once this merges, so all published versions are represented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CLI release automation to automatically generate GitHub releases when publishing new versions to npm.
  * Updated release process documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->