### PR TITLE
fix: server image build broken by cli build coupling + release-notes tag filter

### DIFF
--- a/.github/scripts/generate-notes.sh
+++ b/.github/scripts/generate-notes.sh
@@ -6,7 +6,9 @@
 set -euo pipefail
 
 NEW_TAG="${1:?Usage: generate-notes.sh <new-tag> [previous-tag]}"
-PREV_TAG="${2:-$(git describe --tags --abbrev=0 "$NEW_TAG"^ 2>/dev/null || echo "")}"
+# --match restricts to server tags (v0.16.0) — without it, git describe
+# would pick up cli-v* tags from CLI releases and truncate the range.
+PREV_TAG="${2:-$(git describe --tags --abbrev=0 --match "v[0-9]*" "$NEW_TAG"^ 2>/dev/null || echo "")}"
 
 if [ -n "$PREV_TAG" ]; then
   RANGE="${PREV_TAG}..${NEW_TAG}"
@@ -14,8 +16,9 @@ else
   RANGE="$NEW_TAG"
 fi
 
-# Collect commits (skip release commits and merge commits)
-COMMITS=$(git log --oneline --no-merges "$RANGE" | grep -v '^[a-f0-9]* release:' || true)
+# Collect commits (skip release commits — server "release:" and CLI
+# "release(cli):" bumps — and merge commits)
+COMMITS=$(git log --oneline --no-merges "$RANGE" | grep -vE '^[a-f0-9]+ release(\(cli\))?:' || true)
 
 if [ -z "$COMMITS" ]; then
   echo "No notable changes."

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY package.json package-lock.json* ./
 RUN npm ci
 COPY tsconfig.json sst-env.d.ts ./
 COPY src/ ./src/
-RUN npm run build
+# Server compile only — cli/ is npm-distributed and never copied into the image.
+RUN npm run build:server
 
 FROM node:24-alpine AS runtime
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "node": ">=24.0.0 <25.0.0"
   },
   "scripts": {
-    "build": "tsc && tsc -p cli/tsconfig.json && tsc -p cli/tsconfig.test.json",
+    "build": "npm run build:server && npm run build:cli",
+    "build:server": "tsc",
+    "build:cli": "tsc -p cli/tsconfig.json && tsc -p cli/tsconfig.test.json",
     "sync:cli-templates": "tsx scripts/sync-cli-templates.ts",
     "dev:mcp": "tsx watch src/vault-mcp/server.ts",
     "dev:docker": "docker compose -f docker-compose.local.yml up --build",


### PR DESCRIPTION
## Why

The v0.16.0 release failed at deploy: the Docker build stage runs the root build script, but PR #89 extended `npm run build` to also compile `cli/tsconfig.json` — which is never COPYed into the image. `TS5058: The specified path does not exist: 'cli/tsconfig.json'` killed the image build, so deploy failed and the release/registry jobs were skipped.

This PR also re-lands the `generate-notes.sh` fix that was orphaned when #90 merged before its second commit was pushed.

## What

- **Split build scripts**: `build:server` (`tsc`, used by the Dockerfile) and `build:cli`; root `build` runs both, so CI and local dev behavior are unchanged. The Dockerfile build stage now runs `build:server` — the server image has no business compiling the npm-distributed CLI.
- **Release notes cross-stream fix**: previous-tag detection in `generate-notes.sh` restricted to `--match "v[0-9]*"` (without it, `cli-v0.2.0` becomes the previous tag for the next server release, truncating its notes to nearly nothing — the entire CLI feature would have been missing). `release(cli):` bump commits are filtered from notes alongside server `release:` commits.

## Verification

- `npm run build` (both halves) + 603 tests green
- `docker build --target build .` — the exact stage that failed in the release — now succeeds; full image build also verified locally
- Simulated next server release notes with the fixed script: previous tag resolves to v0.15.23 and the notes correctly include `feat: add npx vault-cortex init (#89)`

## After merging

v0.16.0 is currently tagged but undeployed/unreleased (broken tree). Recommended rescue: delete the remote `v0.16.0` tag and re-tag this branch's merge commit as `v0.16.0` — package.json/server.json already say 0.16.0, and the tag push triggers Auto Release, which deploys the fixed tree and generates correct notes (range v0.15.23..v0.16.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)