### PR TITLE
docs(readme): swap Glama score badge for card badge + 12h shields cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,19 @@
 
 <div align="center">
 
-[![CI](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/ci.yml?branch=main&logo=github&label=CI)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
-[![Gitleaks](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/gitleaks.yml?branch=main&logo=github&label=Gitleaks)](https://github.com/aliasunder/vault-cortex/actions/workflows/gitleaks.yml)
-[![GitHub Release](https://img.shields.io/github/v/release/aliasunder/vault-cortex)](https://github.com/aliasunder/vault-cortex/releases)
-[![License: MIT](https://img.shields.io/github/license/aliasunder/vault-cortex?v=1)](https://github.com/aliasunder/vault-cortex/blob/main/LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/ci.yml?branch=main&logo=github&label=CI&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
+[![Gitleaks](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/gitleaks.yml?branch=main&logo=github&label=Gitleaks&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/gitleaks.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/aliasunder/vault-cortex?cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/releases)
+[![License: MIT](https://img.shields.io/github/license/aliasunder/vault-cortex?v=1&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/blob/main/LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D24-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![MCP Server](https://badge.mcpx.dev?type=server&features=tools)](https://modelcontextprotocol.io)
-[![vault-cortex](https://glama.ai/mcp/servers/aliasunder/vault-cortex/badges/score.svg?v=2)](https://glama.ai/mcp/servers/aliasunder/vault-cortex)
+
+</div>
+
+<div align="center">
+
+[![vault-cortex MCP server](https://glama.ai/mcp/servers/aliasunder/vault-cortex/badges/card.svg)](https://glama.ai/mcp/servers/aliasunder/vault-cortex)
 
 </div>
 


### PR DESCRIPTION
## What

- **Glama card badge** — the Glama Build has earned its quality grade (A/A/A across license, quality, maintenance), so the compact score badge in the shields row is replaced by the richer card badge (`card.svg`) as a standalone centered block under the badge row. Shows grades, language, tool capabilities, and platform support.
- **12-hour shields cache** — the four GitHub-API-backed shields badges (CI, Gitleaks, GitHub Release, License) now pin `cacheSeconds=43200`, so cached copies are served for 12 hours instead of re-fetching on shields' default lifetime. Avoids the recurring "inaccessible" badge render when shields' GitHub API token pool is exhausted. The Node.js/TypeScript badges are static (no upstream fetch) and don't need the param.

## Notes

- `cacheSeconds` is shields' documented cache-control query param; values below a badge's default are ignored, so this can only lengthen the cache.
- A 12h cache means a CI status flip can take up to 12h to show on the README badge — acceptable trade-off for reliable rendering.
- The Glama score badge appeared only in the main README, so this is a clean swap (no other docs reference it).

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by CodeRabbit

* **Documentation**
  * Updated README badges for improved consistency and caching.