### PR TITLE
chore(cli): expand npm keywords for discoverability

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -26,10 +26,17 @@
   },
   "keywords": [
     "mcp",
+    "mcp-server",
     "model-context-protocol",
     "obsidian",
-    "vault",
-    "scaffold",
+    "obsidian-mcp",
+    "obsidian-vault",
+    "ai-memory",
+    "memory",
+    "knowledge-base",
+    "note-taking",
+    "second-brain",
+    "full-text-search",
     "cli"
   ],
   "dependencies": {


### PR DESCRIPTION
## What

Expands the npm `keywords` in `cli/package.json` from 6 to 13 so the package surfaces in the searches people actually run for Obsidian MCP tooling.

**Added:**
- `mcp-server`, `obsidian-mcp`, `obsidian-vault` — direct search-term matches
- `ai-memory`, `memory`, `knowledge-base`, `note-taking`, `second-brain` — the memory layer's vocabulary
- `full-text-search` — FTS5/BM25 capability

**Dropped:**
- `scaffold` — no search value
- bare `vault` — collides with HashiCorp Vault traffic (wrong audience)

`knowledge-graph` deliberately omitted until Phase 2 (LightRAG) ships semantic graph queries.

## Notes

- Keywords only take effect on npm with the next CLI publish (Release CLI workflow, `patch` bump).
- No code change; nothing in the CLI test suite asserts on `keywords`.

Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017FhJLj9U5C2m3udSgDRwK3)_