### PR TITLE
ci: add Trivy image scanning + README badge

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,87 @@
+name: Trivy
+
+# Scans the Docker image for OS-layer and dependency CVEs — the one gap
+# gitleaks/CodeQL/Dependabot leave open: alpine base-image packages and
+# post-release CVE drift live only in the published image.
+#
+# Two targets:
+#   - scan-published (cron + dispatch): the GHCR :latest image users pull
+#     today, so a CVE disclosed after a release still surfaces.
+#   - scan-pr (pull_request): an image built from the branch, so a CVE
+#     entering via Dockerfile/base-image changes surfaces before merge.
+#
+# Scope is vulnerability scanning only — secrets are gitleaks' job, and
+# the IaC here is Pulumi TypeScript, which Trivy doesn't parse.
+#
+# Both jobs are report-only (exit-code: 0) while gauging noise; flip the
+# scan-pr exit-code to "1" to gate merges on CRITICAL/HIGH findings.
+
+on:
+  schedule:
+    - cron: "23 9 * * 1" # weekly, Monday 09:23 UTC
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write # SARIF upload to the Security tab
+
+jobs:
+  scan-published:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Scan published image
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          # Manifest list resolves per-runner (amd64 here); the alpine OS
+          # package set is identical across arches, so amd64-only is fine.
+          image-ref: ghcr.io/${{ vars.GHCR_USER }}/vault-mcp:latest
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: "0"
+
+      - name: Upload SARIF to the Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-published-image
+
+  scan-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Build image from branch
+        run: docker build -t vault-mcp:pr-scan .
+
+      - name: Scan branch image
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: vault-mcp:pr-scan
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: "0" # report-only phase; set to "1" to gate on findings
+
+      # Fork PRs don't get security-events write access, so the upload
+      # would 403 — scan results still show in the job log for forks.
+      - name: Upload SARIF to the Security tab
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-pr-image

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -63,8 +63,19 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
       - name: Build image from branch
-        run: docker build -t vault-mcp:pr-scan .
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          # Make the built image visible to the local Docker daemon so the
+          # scan step can reference it by tag.
+          load: true
+          tags: vault-mcp:pr-scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Scan branch image
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/ci.yml?branch=main&logo=github&label=CI&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
 [![Gitleaks](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/gitleaks.yml?branch=main&logo=github&label=Gitleaks&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/gitleaks.yml)
+[![Trivy](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/trivy.yml?branch=main&logo=github&label=Trivy&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/trivy.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/aliasunder/vault-cortex?cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/releases)
 [![License: MIT](https://img.shields.io/github/license/aliasunder/vault-cortex?v=1&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/blob/main/LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D24-339933?logo=node.js&logoColor=white)](https://nodejs.org/)


### PR DESCRIPTION
## What

Closes the one gap in the security stack: nothing scanned the published Docker image, so alpine OS-layer packages and post-release CVE drift were invisible to gitleaks/CodeQL/Dependabot.

New `trivy.yml` with two jobs:

| Job | Trigger | Target | Mode |
|---|---|---|---|
| `scan-published` | weekly cron (Mon 09:23 UTC) + manual dispatch | `ghcr.io/<GHCR_USER>/vault-mcp:latest` — the image users pull today | report-only, SARIF → Security tab |
| `scan-pr` | every PR | image built from the branch | report-only, SARIF → Security tab |

Plus a Trivy workflow-status badge in the README row next to Gitleaks (with the same 12h `cacheSeconds`).

## Design decisions

- **Vuln scanning only** (`scanners: vuln`) — secrets stay with gitleaks; the IaC is Pulumi TypeScript, which Trivy doesn't parse.
- **Report-only first** (`exit-code: "0"`) — flip `scan-pr`'s exit-code to `"1"` to gate merges on CRITICAL/HIGH once a week or so of runs has shown the noise level. The flip point is commented in the workflow.
- **`ignore-unfixed: true`** — alpine CVEs without an upstream fix are unactionable noise; they reappear automatically once a fixed package version exists.
- **amd64-only scan** — the manifest list resolves per-runner; the alpine package set is identical across arches.
- **SARIF categories** (`trivy-published-image` / `trivy-pr-image`) keep the two streams separate in the Security tab; `if: always()` so findings upload even if a future gate fails the build.
- **Fork PRs skip the SARIF upload** — fork tokens don't get `security-events: write`, so the upload would 403; findings still print in the job log.
- **Born SHA-pinned** — all three actions (`checkout` v6.0.3, `trivy-action` 0.35.0, `codeql-action/upload-sarif` v4.36.2) pinned to full commit SHAs with version comments, covered by the existing weekly Dependabot `github-actions` config. This is why the task was sequenced after #94.
- **Deploy-time gating deliberately out of scope** — the weekly scan covers post-release drift; wiring Trivy into `deploy.yml` as a release gate is a separate decision for after the report-only phase.

## Notes

- The badge renders after the workflow's first run on `main` — kick `workflow_dispatch` once after merge to populate it and get the first baseline scan into the Security tab.
- `vars.GHCR_USER` is reused from `deploy.yml` for the published-image ref.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated vulnerability scanning for container images to identify and report security issues.
  * Added security workflow status badge to project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->