### PR TITLE
ci: run Trivy published-image scan on pushes to main

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -5,8 +5,9 @@ name: Trivy
 # post-release CVE drift live only in the published image.
 #
 # Two targets:
-#   - scan-published (cron + dispatch): the GHCR :latest image users pull
-#     today, so a CVE disclosed after a release still surfaces.
+#   - scan-published (cron + merges to main + dispatch): the GHCR :latest
+#     image users pull today, so a CVE disclosed after a release still
+#     surfaces — merges also keep the README status badge current.
 #   - scan-pr (pull_request): an image built from the branch, so a CVE
 #     entering via Dockerfile/base-image changes surfaces before merge.
 #
@@ -19,6 +20,8 @@ name: Trivy
 on:
   schedule:
     - cron: "23 9 * * 1" # weekly, Monday 09:23 UTC
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/ci.yml?branch=main&logo=github&label=CI&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
 [![Gitleaks](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/gitleaks.yml?branch=main&logo=github&label=Gitleaks&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/gitleaks.yml)
-[![Trivy](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/trivy.yml?branch=main&logo=github&label=Trivy&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/trivy.yml)
+[![Trivy](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/trivy.yml?branch=main&logo=github&label=Trivy&cacheSeconds=43200&v=1)](https://github.com/aliasunder/vault-cortex/actions/workflows/trivy.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/aliasunder/vault-cortex?cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/releases)
 [![License: MIT](https://img.shields.io/github/license/aliasunder/vault-cortex?v=1&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/blob/main/LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D24-339933?logo=node.js&logoColor=white)](https://nodejs.org/)


### PR DESCRIPTION
## What

Adds `push: branches: [main]` to `trivy.yml` — the trigger shape CI and Gitleaks already have. On every merge, the `scan-published` job re-scans the GHCR `:latest` image.

Three wins:

- **CVE pickup at merge time** — disclosures against the published image surface at the next merge instead of waiting for the Monday cron
- **Self-maintaining badge** — the README status badge filters `branch=main`, and a workflow with no main-branch runs renders "no status" (hit live today; bootstrapped with a manual dispatch)
- **Consistency** — Trivy now behaves like its sibling security workflows

The weekly cron stays: it's the only coverage during commit-quiet stretches, when the CVE database moves but no triggers fire. The header comment is updated to keep the trigger description accurate.

Also cache-busts the Trivy README badge (`&v=1`): the "no status" response was cached before the workflow's first main-branch run existed and could otherwise persist up to the 12h `cacheSeconds` window.

Generated with [Claude Code](https://claude.com/claude-code)