### PR TITLE
docs: document security scanning workflows across contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,9 @@ truth. Key points:
    ```
 4. **Fill out the PR template** — the checklist mirrors CI
 5. **CI must pass** — the `CI` workflow runs prettier, lint, test, and build on
-   every PR
+   every PR. Two security scans also run on PRs: **Gitleaks** (secret
+   detection) and **Trivy** (vulnerability scan of the Docker image built from
+   your branch — findings appear in the PR's Checks tab)
 
 ## Issues
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -133,17 +133,21 @@ npx sst remove   # removes Lightsail, API Gateway, Lambda
 
 ## CI/CD
 
-GitHub Actions runs lint/test/build on every PR and push to main, and handles releases via tag push or manual dispatch. CI deploys land on the same Lightsail instance as your laptop deploys (the `SST_STAGE` repo variable pins the SST stage).
+GitHub Actions runs lint/test/build plus security scans (secret detection, image vulnerabilities) on every PR and push to main, and handles releases via tag push or manual dispatch. CI deploys land on the same Lightsail instance as your laptop deploys (the `SST_STAGE` repo variable pins the SST stage).
 
 ### Workflows
 
 | Workflow               | Trigger                          | What it does                                                                                                                                                                                                                                |
 | ---------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ci.yml`               | PR + push to main                | `prettier:check`, `lint`, `test`, `build`                                                                                                                                                                                                   |
+| `gitleaks.yml`         | PR + push to main                | Secret detection across the repo and its git history                                                                                                                                                                                        |
+| `trivy.yml`            | PR + push to main + weekly cron  | Vulnerability scan of the Docker image — PRs scan an image built from the branch; pushes and the cron scan the published GHCR `:latest`. Findings upload as SARIF to the Security tab.                                                      |
+| `scorecard.yml`        | Push to main + weekly cron       | [OpenSSF Scorecard](https://github.com/ossf/scorecard) supply-chain posture analysis; results upload to the Security tab. Also re-runs when branch protection settings change.                                                              |
 | `auto_release.yml`     | `v*` tag push (from your laptop) | Validates `package.json` version matches the tag → calls `deploy.yml` + `publish-registry.yml` → creates a GitHub Release with auto-generated notes and updates `CHANGELOG.md`                                                              |
 | `manual_release.yml`   | Actions UI (`workflow_dispatch`) | Bumps version, commits, tags, pushes, calls `deploy.yml` + `publish-registry.yml`, creates the GitHub Release — all inline. Does NOT chain through `auto_release.yml` (a workflow-pushed tag can't trigger another workflow).               |
 | `deploy.yml`           | Reusable (`workflow_call`)       | OIDC AWS auth → `sst deploy` → Docker build/push to GHCR → SSH to Lightsail → `docker compose pull && up -d` → `/healthz` gate                                                                                                              |
 | `publish-registry.yml` | Reusable (`workflow_call`)       | Publishes `server.json` to the [official MCP Registry](https://registry.modelcontextprotocol.io/) via `mcp-publisher`, authenticating with GitHub OIDC. Runs after `deploy` (so the GHCR image referenced in `server.json` already exists). |
+| `cli_release.yml`      | Actions UI (`workflow_dispatch`) | Publishes the `cli/` package to npm via Trusted Publishing — independent of server releases. See [CONTRIBUTING.md](./CONTRIBUTING.md#the-cli-package).                                                                                      |
 
 > **Why two release paths?** Tag pushes done by `GITHUB_TOKEN` from inside a workflow can't trigger other workflows (GitHub's anti-loop guard). So `manual_release.yml` has to do its own deploy + release inline instead of relying on `auto_release.yml` firing. `auto_release.yml` still exists for the laptop path — when you push a tag from your terminal, your user account is the actor and the trigger fires normally.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,24 @@ The attack surface includes:
 - **CI/CD workflows** — GitHub Actions with OIDC AWS auth, SSH to Lightsail,
   GHCR image push
 
+## Automated Scanning
+
+Several scanners already run against this repository:
+
+- **CodeQL** — static analysis on every PR and push (GitHub default setup)
+- **Gitleaks** — secret detection on every PR and push to main
+- **Trivy** — vulnerability scan of the Docker image: PR-built images on every
+  PR, the published GHCR image on pushes to main and a weekly schedule.
+  Findings report to the repository's
+  [Security tab](https://github.com/aliasunder/vault-cortex/security)
+- **OpenSSF Scorecard** — supply-chain posture analysis, weekly and on pushes
+  to main
+- **Dependabot** — weekly dependency update PRs for npm and GitHub Actions
+
+Base-image CVEs surfaced by Trivy are typically already tracked in the
+Security tab and handled through image updates. A report is still welcome if
+you've found a Vault Cortex–specific exploit path for one.
+
 ## Reporting a Vulnerability
 
 If you discover a security issue, please report it through


### PR DESCRIPTION
## Summary

The Gitleaks, Trivy, and Scorecard workflows landed (#94–#97) without updates to the docs that inventory CI — this brings the three contributor-facing docs back in sync.

- **CONTRIBUTING.md** — the PR process claimed `ci.yml` was the only PR check; added a sentence covering the two security scans contributors will actually see on their PRs (Gitleaks secret detection, Trivy image scan). Worded to stay accurate whether the Trivy scan is report-only or gating.
- **DEPLOY.md** — the CI/CD workflow table listed 5 of 9 workflows; added the missing four (`gitleaks.yml`, `trivy.yml`, `scorecard.yml`, `cli_release.yml`, the last pointing to CONTRIBUTING's CLI section) and mentioned the scans in the section intro. CONTRIBUTING already routes readers to this table "for details on each workflow," so the gaps were dead ends.
- **SECURITY.md** — new **Automated Scanning** section listing what already runs (CodeQL default setup, Gitleaks, Trivy, Scorecard, Dependabot), so reporters can check the Security tab before filing base-image CVEs that are already tracked.

Docs only — no code changes.

## Verification

- `npx prettier --check` clean on all three files
- Workflow triggers in the table verified against each workflow's `on:` block
- Dependabot ecosystems (npm + github-actions) verified against `.github/dependabot.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)