### PR TITLE
docs: remove mcpx feature badge from README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![License: MIT](https://img.shields.io/github/license/aliasunder/vault-cortex?v=1&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/blob/main/LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D24-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![MCP Server](https://badge.mcpx.dev?type=server&features=tools)](https://modelcontextprotocol.io)
 
 </div>
 


### PR DESCRIPTION
## Summary

Removes the `badge.mcpx.dev` feature badge (`Server Rx·Px·T✓·Sx`) from the README badge row.

- The glyphs are cryptic to first-time visitors, and two of the four are ✗ marks — it advertised unsupported MCP features (resources, prompts, sampling) more loudly than the supported one.
- The Glama card directly below carries the third-party MCP credibility signal far more legibly (A/A/A ratings, tool count, platforms).
- It was the badge that wrapped alone onto a second row at common desktop widths; the remaining seven now sit on one line.

No other references to the badge exist in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed MCP Server badge from project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->