### PR TITLE
build(docker): pin base images by digest + Dependabot docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  # Keeps the digest-pinned FROM lines in the Dockerfile current when
+  # upstream node:24-alpine rebuilds (e.g. Alpine security releases).
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@
 # GOTCHA: build deps (python3/make/g++) are needed as fallback if
 # prebuilds don't exist for your arch. They stay in the build stage.
 
-FROM node:24-alpine AS deps
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS deps
 WORKDIR /app
 RUN apk add --no-cache python3 make g++
 COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev --ignore-scripts && npm rebuild better-sqlite3
 
-FROM node:24-alpine AS build
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS build
 WORKDIR /app
 RUN apk add --no-cache python3 make g++
 COPY package.json package-lock.json* ./
@@ -21,7 +21,7 @@ COPY src/ ./src/
 # Server compile only — cli/ is npm-distributed and never copied into the image.
 RUN npm run build:server
 
-FROM node:24-alpine AS runtime
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS runtime
 WORKDIR /app
 # tini: PID 1 that forwards SIGTERM so SQLite WAL closes cleanly.
 # libstdc++: required by better-sqlite3.node native addon on Alpine.


### PR DESCRIPTION
## Summary

Closes the floating-tag portion of Scorecard's three **Pinned-Dependencies** findings on the Dockerfile.

- All three `FROM node:24-alpine` stages now pin the **manifest-list (index) digest** (`docker buildx imagetools inspect node:24-alpine`) — the index rather than a platform digest because `deploy.yml` builds `linux/amd64,linux/arm64`. The tag is kept in the reference for readability.
- New `docker` ecosystem entry in `.github/dependabot.yml` (weekly): Dependabot rewrites the digest pin whenever upstream `node:24-alpine` rebuilds, so the pin can't silently go stale on Alpine security releases. Pin + refresh mechanism ship together deliberately — either one alone is a regression.

The remaining Pinned-Dependencies signal (unpinned `apk add`) is intentionally not addressed: Alpine removes superseded package versions from its repositories, so apk version pins break builds nondeterministically. That portion will be dismissed with a documented reason once this merges.

## Verification

- `docker build` succeeds against the pinned digest; `node --version` in the image returns v24.16.0
- Digest verified as the index digest (MediaType `application/vnd.oci.image.index.v1+json`)

Part of the Trivy/Scorecard findings triage (second of four PRs, after #100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)