### PR TITLE
build(docker): harden runtime image (apk security upgrades, drop npm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,15 @@ WORKDIR /app
 # libstdc++: required by better-sqlite3.node native addon on Alpine.
 # node:24-alpine ships a `node` user at UID 1000 — matches obsidian-sync's
 # PUID so both containers can read/write the shared /vault volume.
-RUN apk add --no-cache tini libstdc++
+# apk upgrade: applies Alpine security fixes (openssl et al.) at build
+# time, covering the window between an Alpine security release and the
+# next upstream node:24-alpine rebuild + digest-pin refresh.
+RUN apk upgrade --no-cache && apk add --no-cache tini libstdc++
+# The runtime is `node dist/...` only — npm, npx, corepack, and yarn are
+# never invoked in this image. Removing them drops their bundled
+# dependencies' CVE surface and shrinks the attack surface.
+RUN rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx \
+    /usr/local/bin/corepack /opt/yarn* /usr/local/bin/yarn /usr/local/bin/yarnpkg
 ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0 VAULT_PATH=/vault INDEX_DB_PATH=/data/index.db
 # OCI image metadata. The ownership marker must match `name` in server.json
 # (mcp-publisher reads it off the manifest). title/description/source/licenses


### PR DESCRIPTION
## Summary

Clears the two remaining Trivy clusters — the openssl CVEs (~15 unique, including the last HIGH: CVE-2026-45447 PKCS7_verify use-after-free) and the npm-bundled-dependency CVEs (ip-address, brace-expansion).

- **`apk upgrade --no-cache` in the runtime stage**: applies Alpine security fixes at build time, independent of upstream `node:24-alpine` rebuild lag. Verified locally: libssl3/libcrypto3 go from 3.5.6-r0 (current pinned base) to **3.5.7-r0** (the patched openssl). Runtime stage only — deps/build stages never ship.
- **Remove npm/npx/corepack/yarn from the runtime image**: the container's entire runtime is `tini → node dist/src/vault-mcp/server.js`; no compose file, healthcheck, or script invokes a package manager in the image. npm's bundled deps are a recurring CVE source that would keep tripping the scan gate after it flips to blocking, and npm itself is unnecessary attack surface in a network-exposed container.

## Verification

- `docker build` succeeds; `node --version` → v24.16.0
- `command -v npm npx corepack yarn` → all absent
- `apk list --installed` confirms upgraded openssl vs the base image
- This PR's `scan-pr` run should report no openssl or npm-path CVEs

Part of the Trivy/Scorecard findings triage (third of four PRs, after #100 and #101). Published-image alerts close after the next release rebuilds `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)