### PR TITLE
docs: release flows reflect PR-only main (branch ruleset)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,11 @@ Releases are cut by the maintainer. Two paths:
 
 - **Manual Release:** Actions tab → "Manual Release" → choose
   `patch`/`minor`/`major`. Bumps version, deploys, creates GitHub Release.
-- **Tag push:** bump `package.json`, commit on `main`, then
+- **Tag push:** merge a version-bump PR into `main`, then
   `git tag v<version> && git push --tags`
+
+Direct commits to `main` are blocked by a branch ruleset — all changes,
+version bumps included, land via PR.
 
 The CLI releases separately: Actions tab → "Release CLI" (see
 [The `cli/` Package](#the-cli-package)).

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -232,9 +232,11 @@ Both halves come from the dedicated deploy keypair set up in [Prerequisites](#pr
 
 ### Cutting a release
 
-**Manual** — Actions tab → "Manual Release" → Run workflow → choose `patch`/`minor`/`major`. The job bumps `package.json`, commits, tags, and pushes. The tag push triggers `auto_release.yml` which deploys and creates the release.
+**Manual** — Actions tab → "Manual Release" → Run workflow → choose `patch`/`minor`/`major`. The job bumps `package.json`, commits, tags, deploys, and creates the GitHub Release — all inline (a workflow-pushed tag can't trigger `auto_release.yml`; see [Workflows](#workflows)).
 
-**Tag push** — Bump `package.json` locally, commit on `main`, then `git tag v<version> && git push --tags`. Same auto-release flow runs.
+**Tag push** — merge a version-bump PR into `main`, then tag the merge commit: `git tag v<version> && git push --tags`. The tag push triggers `auto_release.yml`, which deploys and creates the release.
+
+Direct commits to `main` are blocked by a branch ruleset — every change, version bumps included, lands via PR. Release automation is the only actor that pushes to `main` directly (the changelog and version-bump commits in the workflows above).
 
 ### Rotating SSH keys
 


### PR DESCRIPTION
## Summary

`main` is protected by a branch ruleset (PRs required, force-pushes/deletions blocked, required status checks; release automation is the only direct-push bypass actor). Two release-doc spots still described committing version bumps directly on `main` — updated both to the PR-based flow:

- **CONTRIBUTING.md**: tag-push path is now "merge a version-bump PR, then tag"; added a one-line note that direct commits to `main` are blocked.
- **DEPLOY.md "Cutting a release"**: same tag-push rewording, plus fixes a **pre-existing factual error** — the Manual path claimed "the tag push triggers `auto_release.yml`", but a workflow-pushed tag can't trigger another workflow (GitHub's anti-loop guard); Manual Release deploys and creates the GitHub Release inline, exactly as the "Why two release paths?" note and the workflows table already said.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)