### PR TITLE
chore(deps): ignore major bumps for commander and the node base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
         dependency-type: production
       development:
         dependency-type: development
+    ignore:
+      # commander is version-synced with cli/package.json (a test enforces
+      # it), and the cli supports Node >=20.12 while commander 15 requires
+      # Node >=22.12. Major bumps are a deliberate cli decision.
+      - dependency-name: commander
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /
@@ -21,3 +27,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # A base-image major is a Node.js major — the server pins
+      # engines >=24 <25 (.nvmrc, Lambda runtime nodejs24.x). Node
+      # version upgrades are deliberate, not dependency churn.
+      - dependency-name: node
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Two Dependabot ignore rules for majors that are deliberate decisions rather than routine updates — prompted by today's first weekly run:

- **`commander` (npm, majors only)**: it's version-synced with `cli/package.json` (byte-equality test enforces it), and the cli supports **Node ≥20.12** while commander 15 requires **Node ≥22.12**. Dependabot can't see the cli pin, so its major bump (#106) failed the sync test — and taking it would drop Node 20 support for `npx vault-cortex init` users. commander 14 receives security updates through May 2027. Minors/patches still flow.
- **`node` (docker, majors only)**: the base-image tag is the runtime's Node major; the server pins `engines >=24 <25` (plus `.nvmrc` and the Lambda's `nodejs24.x`). #102 proposed `26-alpine` — closed via ignore command; this makes the policy durable and visible. **Digest refreshes within `24-alpine` still flow** — the reason the docker ecosystem exists.

After this merges, #106 gets recreated without commander (the four remaining dev-group bumps were fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to restrict automatic major version updates for specific packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->