### PR TITLE
ci: tool-prefixed job IDs for scan jobs (gitleaks, trivy-pr, trivy-published)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,7 +13,9 @@ permissions:
   contents: read
 
 jobs:
-  scan:
+  # Job ID doubles as the required-status-check context in the branch
+  # ruleset — tool-prefixed so it's unambiguous in that flat namespace.
+  gitleaks:
     runs-on: ubuntu-latest
     env:
       GITLEAKS_VERSION: 8.21.2

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -5,17 +5,19 @@ name: Trivy
 # post-release CVE drift live only in the published image.
 #
 # Two targets:
-#   - scan-published (cron + merges to main + dispatch): the GHCR :latest
+#   - trivy-published (cron + merges to main + dispatch): the GHCR :latest
 #     image users pull today, so a CVE disclosed after a release still
 #     surfaces — merges also keep the README status badge current.
-#   - scan-pr (pull_request): an image built from the branch, so a CVE
+#   - trivy-pr (pull_request): an image built from the branch, so a CVE
 #     entering via Dockerfile/base-image changes surfaces before merge.
+#     Its job ID is the required-status-check context in the branch
+#     ruleset — tool-prefixed so it's unambiguous in that flat namespace.
 #
 # Scope is vulnerability scanning only — secrets are gitleaks' job, and
 # the IaC here is Pulumi TypeScript, which Trivy doesn't parse.
 #
 # Both jobs are report-only (exit-code: 0) while gauging noise; flip the
-# scan-pr exit-code to "1" to gate merges on CRITICAL/HIGH findings.
+# trivy-pr exit-code to "1" to gate merges on CRITICAL/HIGH findings.
 
 on:
   schedule:
@@ -30,7 +32,7 @@ permissions:
   security-events: write # SARIF upload to the Security tab
 
 jobs:
-  scan-published:
+  trivy-published:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +60,7 @@ jobs:
           sarif_file: trivy-results.sarif
           category: trivy-published-image
 
-  scan-pr:
+  trivy-pr:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Job IDs double as status-check contexts in the branch ruleset's required-checks picker — a flat namespace where `scan` (Gitleaks) and `scan-pr` (Trivy) look like siblings of each other instead of belonging to different workflows.

| Workflow | Old job ID | New job ID |
|---|---|---|
| gitleaks.yml | `scan` | `gitleaks` |
| trivy.yml | `scan-pr` | `trivy-pr` |
| trivy.yml | `scan-published` | `trivy-published` |

- **SARIF categories are unchanged** (`trivy-pr-image`, `trivy-published-image` are explicit inputs) — Security-tab alert history is unaffected.
- No other references to the old job IDs exist in the repo (grep-verified; README badges key off workflow file names, not job IDs).

## ⚠️ Merge coordination

The ruleset currently requires the `scan` context. **The moment this merges, `scan` stops reporting** and every subsequent PR would wait on it forever. The ruleset update (swap `scan` → `gitleaks`, add `trivy-pr`) must happen immediately after merge — I'll apply it via the API right away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)