### PR TITLE
ci: move workflow token writes from top level to job level

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -9,10 +9,11 @@ concurrency:
   group: deploy-prod
   cancel-in-progress: false
 
+# Top-level token is read-only; each job declares the writes it needs.
+# A job-level permissions block replaces the whole set — every block
+# must re-state contents: read for checkout.
 permissions:
-  contents: write
-  id-token: write
-  packages: write
+  contents: read
 
 jobs:
   validate:
@@ -40,6 +41,11 @@ jobs:
 
   deploy:
     needs: validate
+    # Ceiling for the reusable workflow: AWS OIDC + GHCR push.
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
     uses: ./.github/workflows/deploy.yml
     with:
       version: ${{ needs.validate.outputs.version }}
@@ -47,6 +53,10 @@ jobs:
 
   publish-registry:
     needs: [validate, deploy]
+    # Ceiling for the reusable workflow: MCP Registry OIDC.
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/publish-registry.yml
     with:
       version: ${{ needs.validate.outputs.version }}
@@ -54,6 +64,10 @@ jobs:
   release:
     needs: [validate, deploy]
     runs-on: ubuntu-latest
+    # gh release create uses GITHUB_TOKEN; the CHANGELOG push to main
+    # authenticates as the release App, not this token.
+    permissions:
+      contents: write
     steps:
       - name: Generate App token
         id: app-token

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -28,13 +28,16 @@ concurrency:
   group: cli-release
   cancel-in-progress: false
 
+# Top-level token is read-only; the job declares its writes.
 permissions:
-  contents: write
-  id-token: write # npm provenance
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh release create (git pushes use the App token)
+      id-token: write # npm provenance
     steps:
       - name: Generate App token
         id: app-token

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,14 +8,18 @@ on:
         required: true
         type: string
 
+# Top-level token is read-only; the job declares its writes. Callers'
+# job-level grants are the ceiling — they must cover the same set.
 permissions:
-  id-token: write
   contents: read
-  packages: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # AWS OIDC role assumption
+      contents: read
+      packages: write # GHCR image push
     env:
       AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
       SST_STAGE: ${{ secrets.SST_STAGE }}

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -17,10 +17,12 @@ concurrency:
   group: deploy-prod
   cancel-in-progress: false
 
+# Top-level token is read-only; each job declares the writes it needs.
+# A job-level permissions block replaces the whole set — every block
+# must re-state contents: read for checkout. bump-and-tag needs no
+# block: its commit/tag/push authenticates as the release App.
 permissions:
-  id-token: write
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   bump-and-tag:
@@ -87,6 +89,11 @@ jobs:
 
   deploy:
     needs: bump-and-tag
+    # Ceiling for the reusable workflow: AWS OIDC + GHCR push.
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
     uses: ./.github/workflows/deploy.yml
     with:
       version: ${{ needs.bump-and-tag.outputs.version }}
@@ -94,6 +101,10 @@ jobs:
 
   publish-registry:
     needs: [bump-and-tag, deploy]
+    # Ceiling for the reusable workflow: MCP Registry OIDC.
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/publish-registry.yml
     with:
       version: ${{ needs.bump-and-tag.outputs.version }}
@@ -101,6 +112,10 @@ jobs:
   release:
     needs: [bump-and-tag, deploy]
     runs-on: ubuntu-latest
+    # gh release create uses GITHUB_TOKEN; the CHANGELOG push to main
+    # authenticates as the release App, not this token.
+    permissions:
+      contents: write
     steps:
       - name: Generate App token
         id: app-token

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -27,14 +27,17 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Top-level token is read-only; each job grants its own SARIF upload.
 permissions:
   contents: read
-  security-events: write # SARIF upload to the Security tab
 
 jobs:
   trivy-published:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # SARIF upload to the Security tab
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -63,6 +66,9 @@ jobs:
   trivy-pr:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # SARIF upload to the Security tab
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
## Summary

Clears the final 7 open Security-tab findings — Scorecard's **Token-Permissions** check penalizes top-level write grants (every job inherits them) and credits the read-only-top + per-job pattern that `scorecard.yml` and `publish-registry.yml` already follow (both unflagged).

| Workflow | Top level | Job-level writes |
|---|---|---|
| auto_release.yml | `contents: read` | `deploy`: id-token + packages · `publish-registry`: id-token · `release`: contents |
| manual_release.yml | `contents: read` | same as auto_release; `bump-and-tag` needs nothing (App token does its pushing) |
| deploy.yml | `contents: read` | `deploy`: id-token + packages |
| cli_release.yml | `contents: read` | `release`: contents + id-token (npm provenance) |
| trivy.yml | `contents: read` | both scan jobs: security-events (SARIF upload) |

Notes:
- Every job-level block re-states `contents: read` — a job block replaces the inherited set entirely.
- For the `uses:` jobs, the caller's job-level grant is the **ceiling** passed to the reusable workflow; caller grants mirror what `deploy.yml`/`publish-registry.yml` declare.
- Net tightening example: `validate` in auto_release previously held `contents: write` + `packages: write` it never used.

## Verification

- Prettier clean; permissions-only diff (no step/trigger changes)
- The next release exercises every changed path: GHCR push, AWS OIDC, registry publish, `gh release create`, changelog App-push — worth watching its run
- Scorecard re-runs on this merge (push to main); the 7 alerts should close

Final PR of the Trivy/Scorecard findings triage (#100, #101, #107 before it). Security tab should reach **0 open findings** after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)