### PR TITLE
ci: flip trivy-pr scan from report-only to gating

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -16,8 +16,10 @@ name: Trivy
 # Scope is vulnerability scanning only — secrets are gitleaks' job, and
 # the IaC here is Pulumi TypeScript, which Trivy doesn't parse.
 #
-# Both jobs are report-only (exit-code: 0) while gauging noise; flip the
-# trivy-pr exit-code to "1" to gate merges on CRITICAL/HIGH findings.
+# trivy-pr gates merges: it exits non-zero on CRITICAL/HIGH findings,
+# and is a required status check in the branch ruleset. trivy-published
+# stays report-only — its findings land in the Security tab; there is
+# no merge to block.
 
 on:
   schedule:
@@ -97,7 +99,7 @@ jobs:
           ignore-unfixed: true
           format: sarif
           output: trivy-results.sarif
-          exit-code: "0" # report-only phase; set to "1" to gate on findings
+          exit-code: "1" # gate: fail the PR on CRITICAL/HIGH findings
 
       # Fork PRs don't get security-events write access, so the upload
       # would 403 — scan results still show in the job log for forks.


### PR DESCRIPTION
## Summary

Flips `trivy-pr`'s `exit-code` from `"0"` to `"1"` — the PR image scan now **fails on CRITICAL/HIGH findings**, and since `trivy-pr` is a required status check in the branch ruleset, that failure blocks the merge. A CVE entering via a Dockerfile or base-image change now stops at the PR instead of landing in the Security tab after merge.

- Flipped against a clean baseline: 0 open image CVEs (after #100 sst removal, #107 apk upgrades + npm removal, v0.16.2 rescan)
- `trivy-published` stays report-only: its cron/push scans have no merge to block; findings surface in the Security tab
- This PR's own `trivy-pr` run is the first gated scan — it passing green is the live verification

Closes the `^trivy-gate-flip` milestone, a week ahead of schedule thanks to the triage finishing today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)