### PR TITLE
docs(readme): restructure quick start — CLI-first remote, shared connect section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ npx vault-cortex@latest init --mode remote
 
 The CLI walks through the full setup interactively — public URL, Obsidian Sync token (it can run the token generator for you), auth token, and config files — then starts the server.
 
-Connect via OAuth — add a remote MCP server with `<PUBLIC_URL>/mcp`. A consent page opens; enter your token to approve. JWT access tokens refresh automatically.
+Connect via OAuth — add a remote MCP server with `<PUBLIC_URL>/mcp`. A consent page opens; enter your token to approve. Your client renews expiring access tokens automatically via its refresh token (60-day sliding expiry).
 
 <details>
 <summary><strong>Manual setup</strong> (no Node.js needed)</summary>

--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ docker compose up
 
 ### Remote (access from anywhere — Docker + Obsidian Sync)
 
-Run Vault Cortex on a VPS with [Obsidian Sync](https://obsidian.md/sync) for remote access from any device.
-
 **Prerequisites:** a VPS with [Docker](https://docs.docker.com/engine/install/), an [Obsidian Sync](https://obsidian.md/sync) subscription, and Node.js >= 20.12 (only for the CLI — the server itself runs in Docker).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The typical Obsidian + MCP setup requires three moving parts running simultaneou
 
 ### Local (2 minutes — Docker + your vault folder)
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and an Obsidian vault (or any folder of `.md` files).
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/), Node.js >= 20.12 (only for the CLI — the server itself runs in Docker), and an Obsidian vault (or any folder of `.md` files).
 
 ```bash
 npx vault-cortex@latest init

--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ docker compose up
 
 Run Vault Cortex on a VPS with [Obsidian Sync](https://obsidian.md/sync) for remote access from any device.
 
+**Prerequisites:** a VPS with [Docker](https://docs.docker.com/engine/install/), an [Obsidian Sync](https://obsidian.md/sync) subscription, and Node.js >= 20.12 (only for the CLI — the server itself runs in Docker).
+
+```bash
+# On your VPS:
+npx vault-cortex@latest init --mode remote
+```
+
+The CLI walks through the full setup interactively — public URL, Obsidian Sync token (it can run the token generator for you), auth token, and config files — then starts the server.
+
+Connect via OAuth — add a remote MCP server with `<PUBLIC_URL>/mcp`. A consent page opens; enter your token to approve. JWT access tokens refresh automatically.
+
+<details>
+<summary><strong>Manual setup</strong> (no Node.js needed)</summary>
+
 ```bash
 # On your VPS:
 mkdir -p /opt/vault-cortex && cd /opt/vault-cortex
@@ -93,9 +107,7 @@ cp .env.example .env
 docker compose up -d
 ```
 
-Connect via OAuth — add a remote MCP server with `<PUBLIC_URL>/mcp`. A consent page opens; enter your token to approve. JWT access tokens refresh automatically.
-
-If your VPS has Node.js >= 20.12, `npx vault-cortex@latest init --mode remote` walks through the same setup interactively (including the Obsidian Sync token step).
+</details>
 
 **[Full remote guide →](./deploy/remote/)**
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ npx vault-cortex@latest init
 
 That's it — the CLI asks for your vault path, generates the auth token and config files, starts the server, and prints the connection details for your MCP client.
 
-Connect your MCP client — Claude Desktop, Claude Code, Cursor, OpenCode, or any other — by adding `http://localhost:8000/mcp` as a remote/HTTP MCP server (the server itself runs on your machine). OAuth-capable clients open a consent page in your browser — approve with your token and the client handles the rest. Clients without OAuth can send the token directly as an `Authorization: Bearer` header.
-
 <details>
 <summary><strong>Manual setup</strong> (no Node.js needed)</summary>
 
@@ -88,9 +86,7 @@ docker compose up
 npx vault-cortex@latest init --mode remote
 ```
 
-The CLI walks through the full setup interactively — public URL, Obsidian Sync token (it can run the token generator for you), auth token, and config files — then starts the server.
-
-Connect via OAuth — add a remote MCP server with `<PUBLIC_URL>/mcp`. A consent page opens; enter your token to approve. Your client renews expiring access tokens automatically via its refresh token (60-day sliding expiry).
+That's it — the CLI walks through the public URL, Obsidian Sync token (it can run the token generator for you), and auth config, then starts the server.
 
 <details>
 <summary><strong>Manual setup</strong> (no Node.js needed)</summary>
@@ -108,6 +104,21 @@ docker compose up -d
 </details>
 
 **[Full remote guide →](./deploy/remote/)**
+
+### Connect your MCP client
+
+Add the server URL as a remote/HTTP MCP server in any client — Claude Desktop, Claude Code, Cursor, OpenCode, or any other:
+
+| Setup      | Server URL                  |
+| ---------- | --------------------------- |
+| **Local**  | `http://localhost:8000/mcp` |
+| **Remote** | `<PUBLIC_URL>/mcp`          |
+
+OAuth clients open a consent page in your browser — approve with your token, and the client handles token renewal from then on. Clients without OAuth (MCP Inspector, scripts) send the token directly as an `Authorization: Bearer` header.
+
+> "Remote MCP server" refers to the connection type (HTTP) — in the local setup the server still runs entirely on your machine.
+
+See [Authentication](#authentication) for both methods and token lifetimes.
 
 ## Tools (23)
 


### PR DESCRIPTION
## Summary

The Quick Start's Local and Remote sections had drifted apart in ways that didn't map to real differences. This restructures them into true structural mirrors and extracts the shared parts:

- **Remote leads with the CLI.** `npx vault-cortex@latest init --mode remote` is now the section's first code block (it previously trailed the manual curl steps as a prose sentence); the manual steps fold into a collapsed **Manual setup (no Node.js needed)** `<details>` block, same as Local.
- **Prerequisites stated symmetrically.** Both sections declare Node.js >= 20.12 with the same clarifier (only for the CLI — the server itself runs in Docker), resolving the apparent conflict with the `Node.js >= 24` badge. Remote also lists the VPS + Obsidian Sync requirements, replacing its redundant intro line.
- **New shared `### Connect your MCP client` subsection.** Connection mechanics are identical in both modes except the URL, but the per-section connect paragraphs had drifted (client list and bearer fallback only in Local, token renewal only in Remote). One subsection now covers both with a URL table (`http://localhost:8000/mcp` / `<PUBLIC_URL>/mcp`), the OAuth consent flow, the bearer fallback, and a link to Authentication for token lifetimes — mirroring the structure of the `deploy/` guides.
- **Token wording corrected.** "JWT access tokens refresh automatically" implied tokens self-refresh; the renewal detail now lives only in the Authentication section's accurate form (client renews via refresh token, 60-day sliding expiry).

Both sections now read: prerequisites → npx → what-the-CLI-does → collapsed manual setup → guide link.

No code changes — README only. Prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)