### PR TITLE
feat(deploy): optional custom domain for API Gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@ MCP_AUTH_TOKEN=
 
 # Public URL — the HTTPS URL that MCP clients use to reach this server.
 # Used as the OAuth issuer URL in discovery metadata.
-# Usually your API Gateway URL (from `sst deploy` outputs).
+# Usually your API Gateway URL (from `sst deploy` outputs), or your
+# custom domain if you've configured one (CUSTOM_DOMAIN below).
 PUBLIC_URL=
 
 # Obsidian Sync credentials
@@ -62,6 +63,14 @@ TZ=UTC
 # Comma-separated CIDRs = restrict to specific IPs
 # Default (unset): 0.0.0.0/0 (open to all)
 # MCP_PORT_CIDRS=none
+
+# CUSTOM_DOMAIN — Optional. Custom domain for API Gateway, replacing the
+# auto-generated execute-api URL for clients. Only used by SST deploys;
+# requires CUSTOM_DOMAIN_CERT_ARN (an ISSUED ACM cert in the API's region
+# covering the domain). DNS stays with your provider — after deploy, point
+# a CNAME at the `customDomainTarget` output. See DEPLOY.md § Custom Domain.
+# CUSTOM_DOMAIN=mcp.example.com
+# CUSTOM_DOMAIN_CERT_ARN=arn:aws:acm:us-east-1:<account>:certificate/<id>
 
 # vault-cortex configuration
 # Memory folder name in your vault (default: "About Me")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,8 @@ jobs:
           SSH_CIDRS: ${{ secrets.SSH_CIDRS }}
           ORIGIN_URL: ${{ secrets.ORIGIN_URL }}
           MCP_PORT_CIDRS: ${{ secrets.MCP_PORT_CIDRS }}
+          CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
+          CUSTOM_DOMAIN_CERT_ARN: ${{ secrets.CUSTOM_DOMAIN_CERT_ARN }}
         run: npx sst deploy --stage "$SST_STAGE"
 
       - name: Connect to Tailscale

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -319,6 +319,12 @@ a tunnel or reverse proxy (e.g., Cloudflare Tunnel), then set
 tokens never travel in plaintext on any network segment — all traffic is
 HTTPS end-to-end. See [`DEPLOY.md`](./DEPLOY.md#port-8000-hardening-optional).
 
+**Optional: custom domain.** Set `CUSTOM_DOMAIN` + `CUSTOM_DOMAIN_CERT_ARN`
+to serve the API Gateway on your own hostname instead of the auto-generated
+execute-api URL (which stays active alongside it). The ACM cert and DNS
+records are managed outside SST — any DNS provider works. See
+[`DEPLOY.md`](./DEPLOY.md#custom-domain-optional).
+
 **Rotation:** Update the SST secret AND the Lightsail `.env`, then redeploy
 both. Existing JWTs signed with the old key become invalid immediately.
 Refresh tokens in SQLite are unaffected — clients silently get new JWTs

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -50,14 +50,14 @@ sed -i '' "s/^MCP_AUTH_TOKEN=.*/MCP_AUTH_TOKEN=$MCP_AUTH_TOKEN/" ~/.config/vault
 
 Then open `~/.config/vault-cortex/.env` and fill in the remaining values:
 
-| Variable              | Value                                                                    |
-| --------------------- | ------------------------------------------------------------------------ |
-| `PUBLIC_URL`          | API Gateway URL (from `sst deploy` output, available after first deploy) |
-| `GHCR_USER`           | Your GitHub username                                                     |
-| `GHCR_TOKEN`          | The GitHub PAT from prerequisites                                        |
-| `VAULT_NAME`          | Your Obsidian vault name (exact, case-sensitive)                         |
-| `VAULT_PASSWORD`      | Only if vault has E2E encryption                                         |
-| `OBSIDIAN_AUTH_TOKEN` | Generate with the command below                                          |
+| Variable              | Value                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------- |
+| `PUBLIC_URL`          | API Gateway URL (from `sst deploy` output) — or your [custom domain](#custom-domain-optional) |
+| `GHCR_USER`           | Your GitHub username                                                                          |
+| `GHCR_TOKEN`          | The GitHub PAT from prerequisites                                                             |
+| `VAULT_NAME`          | Your Obsidian vault name (exact, case-sensitive)                                              |
+| `VAULT_PASSWORD`      | Only if vault has E2E encryption                                                              |
+| `OBSIDIAN_AUTH_TOKEN` | Generate with the command below                                                               |
 
 The [`.env.example`](./.env.example) file also includes optional configuration for the memory system (`MEMORY_DIR`, `PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`), timezone (`TZ`), and OAuth metadata (`SERVICE_DOCUMENTATION_URL`). All have sensible defaults — see the [Configuration](./README.md#configuration) section in the README.
 
@@ -203,30 +203,32 @@ To find your stage: `cat .sst/stage` (after your first deploy).
 
 **Variables** (Settings → Secrets and variables → Actions → Variables tab) — non-sensitive identifiers and config:
 
-| Variable                    | Purpose                                                                                                                                                                                   |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AWS_DEPLOY_ROLE_ARN`       | IAM role ARN from the [OIDC setup](#github-oidc-setup-for-forkers) above. An identifier, not a credential — use a repo variable, not a secret.                                            |
-| `AWS_REGION`                | AWS region for SST deployment (default: `us-east-1`). Must match the region in `sst.config.ts`.                                                                                           |
-| `GHCR_USER`                 | GitHub username. Used in image tags and instance `.env`.                                                                                                                                  |
-| `PUBLIC_URL`                | API Gateway URL (e.g. `https://<id>.execute-api.<region>.amazonaws.com`). Used for the healthcheck and written into the instance `.env` as the OAuth issuer URL.                          |
-| `SST_STAGE`                 | SST stage name — see [SST stage](#sst-stage) above. Must match your local `.sst/stage` so CI and laptop deploys target the same infrastructure.                                           |
-| `VAULT_NAME`                | Exact (case-sensitive) Obsidian vault name.                                                                                                                                               |
-| `MEMORY_DIR`                | Optional. Memory folder name in the vault (default: `About Me`). See the [Configuration](./README.md#configuration) section.                                                              |
-| `PROTECTED_PATHS`           | Optional. Comma-separated folders protected from deletion (default: `MEMORY_DIR, Daily Notes`). Overrides the default entirely when set.                                                  |
-| `ORPHAN_EXCLUDE_FOLDERS`    | Optional. Comma-separated folders excluded from orphan detection (default: `Daily Notes, Templates, MEMORY_DIR`). Overrides the default entirely when set.                                |
-| `SERVICE_DOCUMENTATION_URL` | Optional. URL in OAuth discovery metadata (default: `https://github.com/aliasunder/vault-cortex`). Set to your fork's URL.                                                                |
-| `TZ`                        | Optional. Container timezone (default: `UTC`). Affects `vault_update_memory` date stamps and `vault_get_daily_note` date resolution. Set to your IANA timezone (e.g. `America/New_York`). |
+| Variable                    | Purpose                                                                                                                                                                                                           |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AWS_DEPLOY_ROLE_ARN`       | IAM role ARN from the [OIDC setup](#github-oidc-setup-for-forkers) above. An identifier, not a credential — use a repo variable, not a secret.                                                                    |
+| `AWS_REGION`                | AWS region for SST deployment (default: `us-east-1`). Must match the region in `sst.config.ts`.                                                                                                                   |
+| `GHCR_USER`                 | GitHub username. Used in image tags and instance `.env`.                                                                                                                                                          |
+| `PUBLIC_URL`                | API Gateway URL (e.g. `https://<id>.execute-api.<region>.amazonaws.com`) or your [custom domain](#custom-domain-optional). Used for the healthcheck and written into the instance `.env` as the OAuth issuer URL. |
+| `SST_STAGE`                 | SST stage name — see [SST stage](#sst-stage) above. Must match your local `.sst/stage` so CI and laptop deploys target the same infrastructure.                                                                   |
+| `VAULT_NAME`                | Exact (case-sensitive) Obsidian vault name.                                                                                                                                                                       |
+| `MEMORY_DIR`                | Optional. Memory folder name in the vault (default: `About Me`). See the [Configuration](./README.md#configuration) section.                                                                                      |
+| `PROTECTED_PATHS`           | Optional. Comma-separated folders protected from deletion (default: `MEMORY_DIR, Daily Notes`). Overrides the default entirely when set.                                                                          |
+| `ORPHAN_EXCLUDE_FOLDERS`    | Optional. Comma-separated folders excluded from orphan detection (default: `Daily Notes, Templates, MEMORY_DIR`). Overrides the default entirely when set.                                                        |
+| `SERVICE_DOCUMENTATION_URL` | Optional. URL in OAuth discovery metadata (default: `https://github.com/aliasunder/vault-cortex`). Set to your fork's URL.                                                                                        |
+| `TZ`                        | Optional. Container timezone (default: `UTC`). Affects `vault_update_memory` date stamps and `vault_get_daily_note` date resolution. Set to your IANA timezone (e.g. `America/New_York`).                         |
 
 **Secrets** (Settings → Secrets and variables → Actions → Secrets tab) — sensitive credentials:
 
-| Secret                | Purpose                                                                                                                                                                           |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GHCR_TOKEN`          | Personal access token (classic) with `write:packages` + `read:packages`. Used by `docker login` both at build-push and on-instance pull. Persists across runs; rotate when stale. |
-| `MCP_AUTH_TOKEN`      | Same value as the SST secret of the same name. Written into the instance `.env` for the Express auth layer.                                                                       |
-| `OBSIDIAN_AUTH_TOKEN` | Output of `docker run --rm -it --entrypoint get-token ghcr.io/belphemur/obsidian-headless-sync-docker:latest`.                                                                    |
-| `VAULT_PASSWORD`      | Optional — only set if your vault uses end-to-end encryption. Empty value is fine and ships through to `.env` as `VAULT_PASSWORD=`.                                               |
-| `SSH_PUBKEY`          | Public key contents of your `~/.ssh/vault-cortex.pub` (literal, single line). Same key local dev and CI use — see [Prerequisites](#prerequisites).                                |
-| `SSH_PRIVATE_KEY`     | Private half (`~/.ssh/vault-cortex`, full multi-line block including BEGIN/END markers). Loaded by `webfactory/ssh-agent` for SCP/SSH to the instance.                            |
+| Secret                   | Purpose                                                                                                                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GHCR_TOKEN`             | Personal access token (classic) with `write:packages` + `read:packages`. Used by `docker login` both at build-push and on-instance pull. Persists across runs; rotate when stale. |
+| `MCP_AUTH_TOKEN`         | Same value as the SST secret of the same name. Written into the instance `.env` for the Express auth layer.                                                                       |
+| `OBSIDIAN_AUTH_TOKEN`    | Output of `docker run --rm -it --entrypoint get-token ghcr.io/belphemur/obsidian-headless-sync-docker:latest`.                                                                    |
+| `VAULT_PASSWORD`         | Optional — only set if your vault uses end-to-end encryption. Empty value is fine and ships through to `.env` as `VAULT_PASSWORD=`.                                               |
+| `SSH_PUBKEY`             | Public key contents of your `~/.ssh/vault-cortex.pub` (literal, single line). Same key local dev and CI use — see [Prerequisites](#prerequisites).                                |
+| `SSH_PRIVATE_KEY`        | Private half (`~/.ssh/vault-cortex`, full multi-line block including BEGIN/END markers). Loaded by `webfactory/ssh-agent` for SCP/SSH to the instance.                            |
+| `CUSTOM_DOMAIN`          | Optional. Custom domain for API Gateway (e.g. `mcp.example.com`) — see [Custom Domain](#custom-domain-optional). Set together with `CUSTOM_DOMAIN_CERT_ARN`.                      |
+| `CUSTOM_DOMAIN_CERT_ARN` | Optional. ARN of an **Issued** ACM certificate (same region as the API) covering `CUSTOM_DOMAIN`.                                                                                 |
 
 Both halves come from the dedicated deploy keypair set up in [Prerequisites](#prerequisites). Generating a new keypair just for CI would cause SST to replace the Lightsail VM on the next deploy — that's why local and CI share the same key.
 
@@ -578,6 +580,35 @@ aws lightsail put-instance-public-ports \
   --instance-name vault-cortex-<stage> \
   --port-infos '[{"protocol":"tcp","fromPort":22,"toPort":22,"cidrs":["0.0.0.0/0"]},{"protocol":"tcp","fromPort":8000,"toPort":8000,"cidrs":["0.0.0.0/0"]}]'
 ```
+
+---
+
+## Custom Domain (Optional)
+
+By default, clients reach the server at the auto-generated API Gateway URL (`https://<id>.execute-api.<region>.amazonaws.com`). A custom domain (e.g. `mcp.example.com`) replaces that with your own hostname — nicer connect URLs, and MCP clients that derive a connector icon from the URL's domain show your site's favicon instead of the AWS one.
+
+DNS stays with your provider (Cloudflare, Route 53, anything) — SST only creates the API Gateway domain and stage mapping from a certificate you already hold. The default execute-api URL keeps working alongside the custom domain, so existing OAuth clients are not cut off.
+
+**1. Get an ACM certificate** in the same region as the API, covering the domain (exact name or a wildcard like `*.example.com`). Request it in the ACM console (or any IaC), add the DNS validation record at your DNS provider, and wait for status **Issued**. The cert is referenced by ARN — it can live in your account already.
+
+**2. Deploy with the domain configured:**
+
+```bash
+CUSTOM_DOMAIN=mcp.example.com \
+CUSTOM_DOMAIN_CERT_ARN=arn:aws:acm:us-east-1:<account>:certificate/<id> \
+npx sst deploy
+```
+
+For CI deploys, set both as repo secrets — `deploy.yml` passes them through. Both must be set together; `CUSTOM_DOMAIN` without the cert ARN fails fast with an error.
+
+**3. Point DNS at the gateway** — the deploy prints a `customDomainTarget` output (a `d-xxxx.execute-api.<region>.amazonaws.com` hostname). Create a CNAME from your domain to that target at your DNS provider. Verify:
+
+```bash
+curl https://mcp.example.com/healthz
+# → {"ok":true}
+```
+
+**4. Update `PUBLIC_URL`** to `https://mcp.example.com` (instance `.env` + the repo secret for CI) and redeploy or restart, so OAuth discovery metadata advertises the custom domain. Existing OAuth clients connected via the execute-api URL keep working; new connections should use the custom domain.
 
 ---
 

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -42,6 +42,21 @@ export default $config({
     // reverse proxy, or any HTTPS frontend that proxies to localhost:8000.
     const originUrl = env("ORIGIN_URL").asString()
 
+    // Optional custom domain on API Gateway (e.g. mcp.example.com), replacing
+    // the auto-generated execute-api URL. DNS stays external (any provider):
+    // SST only creates the API Gateway domain + mapping from an existing
+    // ACM cert — after deploy, point a CNAME from the domain to the
+    // `customDomainTarget` output. CUSTOM_DOMAIN_CERT_ARN must be an ISSUED
+    // certificate in the API's region covering the name (wildcard or exact).
+    const customDomain = env("CUSTOM_DOMAIN").asString()
+    const customDomainCertArn = env("CUSTOM_DOMAIN_CERT_ARN").asString()
+    if (customDomain && !customDomainCertArn) {
+      throw new Error(
+        "CUSTOM_DOMAIN requires CUSTOM_DOMAIN_CERT_ARN — the ARN of an " +
+          "ISSUED ACM certificate (in this API's region) covering that domain.",
+      )
+    }
+
     const expandHome = (p: string): string =>
       p.startsWith("~/") ? `${homedir()}${p.slice(1)}` : p
 
@@ -229,6 +244,16 @@ export default $config({
     // and throttlingBurstLimit must BOTH be set — partial config is
     // interpreted as 0 and rejects all traffic (pulumi/pulumi-aws#2363).
     const api = new sst.aws.ApiGatewayV2("VaultCortexApi", {
+      // dns: false — SST skips DNS record creation (records live with the
+      // external DNS provider) and requires the pre-issued cert instead of
+      // provisioning one. The default execute-api endpoint stays active.
+      ...(customDomain && {
+        domain: {
+          name: customDomain,
+          dns: false,
+          cert: customDomainCertArn as string,
+        },
+      }),
       transform: {
         stage: {
           defaultRouteSettings: {
@@ -280,6 +305,12 @@ export default $config({
     return {
       apiUrl: api.url,
       lightsailIp: staticIp.ipAddress,
+      // CNAME target for the custom domain: point CUSTOM_DOMAIN at this
+      // hostname with your DNS provider. Only present when configured.
+      ...(customDomain && {
+        customDomainTarget:
+          api.nodes.domainName.domainNameConfiguration.targetDomainName,
+      }),
     }
   },
 })

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -247,13 +247,14 @@ export default $config({
       // dns: false — SST skips DNS record creation (records live with the
       // external DNS provider) and requires the pre-issued cert instead of
       // provisioning one. The default execute-api endpoint stays active.
-      ...(customDomain && {
-        domain: {
-          name: customDomain,
-          dns: false,
-          cert: customDomainCertArn as string,
-        },
-      }),
+      ...(customDomain &&
+        customDomainCertArn && {
+          domain: {
+            name: customDomain,
+            dns: false,
+            cert: customDomainCertArn,
+          },
+        }),
       transform: {
         stage: {
           defaultRouteSettings: {
@@ -307,6 +308,10 @@ export default $config({
       lightsailIp: staticIp.ipAddress,
       // CNAME target for the custom domain: point CUSTOM_DOMAIN at this
       // hostname with your DNS provider. Only present when configured.
+      // nodes.domainName is the component's documented accessor for the
+      // underlying aws.apigatewayv2.DomainName resource, and targetDomainName
+      // is the same output SST feeds its own DNS alias records from — verify
+      // both still hold when upgrading SST.
       ...(customDomain && {
         customDomainTarget:
           api.nodes.domainName.domainNameConfiguration.targetDomainName,


### PR DESCRIPTION
## Summary

Adds optional custom-domain support to the API Gateway, following the existing `ORIGIN_URL`/`SSH_CIDRS` optional-env-var pattern:

- **`sst.config.ts`** — `CUSTOM_DOMAIN` + `CUSTOM_DOMAIN_CERT_ARN` attach a `domain` to the `VaultCortexApi` construct with `dns: false`: SST creates only the API Gateway domain (REGIONAL, TLS 1.2) and stage mapping from a pre-issued ACM cert; DNS records stay with any external provider. Setting `CUSTOM_DOMAIN` without the cert ARN fails fast with a clear error. A new `customDomainTarget` output exposes the `d-xxxx.execute-api` hostname to point a CNAME at.
- **`deploy.yml`** — passes both values through from repo secrets into the SST deploy step.
- **`DEPLOY.md`** — new "Custom Domain (Optional)" walkthrough (cert → deploy → CNAME → `PUBLIC_URL` switch), secrets-table rows, and `PUBLIC_URL` rows updated to mention the custom domain. (Table realignment in the diff is `prettier --write`.)

The default execute-api endpoint stays active alongside the custom domain, so existing OAuth clients keep working until `PUBLIC_URL` is switched and they reconnect.

Host-agnostic by design: nothing Cloudflare- or deployment-specific is committed — any forker with any DNS provider can use it, or ignore it entirely.

Verified against the SST v4.15.2 `ApiGatewayV2` source (`dns: false` requires `cert`, skips DNS record creation, leaves the default endpoint enabled; `nodes.domainName` only resolves when a domain is configured). 603 tests, lint, build, prettier all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCckC6tPukPynnFE55r8xK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional custom domain support for the API endpoint with user-supplied ACM certificate and deployment-time inputs.

* **Documentation**
  * Updated deployment guide, environment template, and architecture notes with clearer PUBLIC_URL behavior, secret/variable tables, DNS steps, and OAuth discovery guidance.
  * Added instructions for providing custom domain and certificate values and updating DNS post-deploy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->