### PR TITLE
ci(deploy): stop emitting instance identifiers as SST outputs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,7 +68,8 @@ TZ=UTC
 # auto-generated execute-api URL for clients. Only used by SST deploys;
 # requires CUSTOM_DOMAIN_CERT_ARN (an ISSUED ACM cert in the API's region
 # covering the domain). DNS stays with your provider — after deploy, point
-# a CNAME at the `customDomainTarget` output. See DEPLOY.md § Custom Domain.
+# a CNAME at the gateway's target hostname (DEPLOY.md § Custom Domain has
+# the aws CLI command to fetch it).
 # CUSTOM_DOMAIN=mcp.example.com
 # CUSTOM_DOMAIN_CERT_ARN=arn:aws:acm:us-east-1:<account>:certificate/<id>
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,14 +66,23 @@ jobs:
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           tags: tag:ci
 
-      - name: Read Lightsail IP from SST outputs
+      # The IP is fetched from AWS rather than exposed as an SST output —
+      # SST prints outputs at the end of every deploy, which on a public
+      # repo means public Actions logs. The static-ip name matches
+      # sst.config.ts (`vault-cortex-ip-${stage}`).
+      - name: Fetch Lightsail IP from AWS
         id: sst
         run: |
-          if [ ! -f .sst/outputs.json ]; then
-            echo "::error::.sst/outputs.json missing after sst deploy"
+          ip=$(aws lightsail get-static-ip \
+            --static-ip-name "vault-cortex-ip-${SST_STAGE}" \
+            --query staticIp.ipAddress --output text)
+          if [ -z "$ip" ] || [ "$ip" = "None" ]; then
+            echo "::error::could not resolve the Lightsail static IP from AWS"
             exit 1
           fi
-          ip=$(jq -er '.lightsailIp' .sst/outputs.json)
+          # Forward-only mask: keeps the IP out of later steps' env headers
+          # and echoes in the public job log.
+          echo "::add-mask::$ip"
           echo "ip=$ip" >> "$GITHUB_OUTPUT"
 
       - name: Resolve SSH target

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -99,7 +99,12 @@ curl http://<lightsailIp>:8000/healthz
 curl <ORIGIN_URL>/healthz
 ```
 
-`<lightsailIp>` and `<apiUrl>` come from the `sst deploy` output (also in `.sst/outputs.json`).
+`<apiUrl>` comes from the `sst deploy` output (also in `.sst/outputs.json`). The Lightsail IP is deliberately **not** an SST output — outputs print on every deploy, and on a public repo that means public Actions logs. Fetch it from AWS instead:
+
+```bash
+aws lightsail get-static-ip --static-ip-name vault-cortex-ip-<stage> \
+  --query staticIp.ipAddress --output text
+```
 
 ## Command reference
 
@@ -288,7 +293,7 @@ Forks don't inherit GitHub Actions variables or secrets, and the OIDC role is sc
 ssh -i ~/.ssh/vault-cortex ubuntu@<lightsailIp>
 ```
 
-`<lightsailIp>` comes from `sst deploy` output (also in `.sst/outputs.json`). Uses the dedicated deploy key (`~/.ssh/vault-cortex`). To also SSH with your personal key, add it post-provision: `ssh -i ~/.ssh/vault-cortex ubuntu@<IP> "cat >> ~/.ssh/authorized_keys" < ~/.ssh/id_ed25519.pub`.
+`<lightsailIp>` comes from `aws lightsail get-static-ip` (see [Verify](#verify) — it is deliberately not an SST output). Uses the dedicated deploy key (`~/.ssh/vault-cortex`). To also SSH with your personal key, add it post-provision: `ssh -i ~/.ssh/vault-cortex ubuntu@<IP> "cat >> ~/.ssh/authorized_keys" < ~/.ssh/id_ed25519.pub`.
 
 ### Tailing logs
 
@@ -601,7 +606,14 @@ npx sst deploy
 
 For CI deploys, set both as repo secrets — `deploy.yml` passes them through. Both must be set together; `CUSTOM_DOMAIN` without the cert ARN fails fast with an error.
 
-**3. Point DNS at the gateway** — the deploy prints a `customDomainTarget` output (a `d-xxxx.execute-api.<region>.amazonaws.com` hostname). Create a CNAME from your domain to that target at your DNS provider. Verify:
+**3. Point DNS at the gateway** — fetch the gateway's target hostname (a `d-xxxx.execute-api.<region>.amazonaws.com` name; deliberately not a deploy output, so it stays out of public CI logs):
+
+```bash
+aws apigatewayv2 get-domain-name --domain-name mcp.example.com \
+  --query 'DomainNameConfigurations[0].ApiGatewayDomainName' --output text
+```
+
+Create a CNAME from your domain to that target at your DNS provider. Verify:
 
 ```bash
 curl https://mcp.example.com/healthz

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -10,16 +10,15 @@
  *                   to the VM, then `docker compose pull && up -d` over SSH
  *
  * The image is always `ghcr.io/${GHCR_USER}/vault-mcp:latest`. The
- * Lightsail IP is read from `.sst/outputs.json`, which SST writes
- * after a successful `sst deploy` (or `sst dev`).
+ * Lightsail IP is fetched from AWS (`aws lightsail get-static-ip`)
+ * using the stage in `.sst/stage` — it's deliberately not an SST
+ * output, so deploys never print it (CI logs are public).
  */
 
 import { execSync } from "node:child_process"
 import { existsSync, readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
-
-type SstOutputs = { lightsailIp?: string; apiUrl?: string }
 
 const ENV_PATH = join(homedir(), ".config", "vault-cortex", ".env")
 
@@ -79,18 +78,28 @@ const waitForDocker = (ip: string, id: string, timeoutSec = 120): void => {
 const sshHost = (): string => {
   if (env.LIGHTSAIL_SSH_HOST) return env.LIGHTSAIL_SSH_HOST
 
-  if (!existsSync(".sst/outputs.json")) {
-    console.error("✕  .sst/outputs.json not found. Run `npx sst deploy` first.")
+  if (!existsSync(".sst/stage")) {
+    console.error("✕  .sst/stage not found. Run `npx sst deploy` first.")
     process.exit(1)
   }
-  const outs = JSON.parse(
-    readFileSync(".sst/outputs.json", "utf8"),
-  ) as SstOutputs
-  if (!outs.lightsailIp) {
-    console.error("✕  lightsailIp missing from SST outputs.")
+  const stage = readFileSync(".sst/stage", "utf8").trim()
+  // Fetched from AWS rather than read from SST outputs — the IP is
+  // deliberately not an output, so deploys never print it (CI logs are
+  // public). The static-ip name matches sst.config.ts
+  // (`vault-cortex-ip-${stage}`).
+  const staticIpName = `vault-cortex-ip-${stage}`
+  const ip = execSync(
+    `aws lightsail get-static-ip --static-ip-name ${staticIpName} ` +
+      `--query staticIp.ipAddress --output text`,
+    { env },
+  )
+    .toString()
+    .trim()
+  if (!ip || ip === "None") {
+    console.error(`✕  Could not resolve ${staticIpName} from AWS.`)
     process.exit(1)
   }
-  return outs.lightsailIp
+  return ip
 }
 
 // Returns `-i <path>` for the SSH identity to use.

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -46,7 +46,8 @@ export default $config({
     // the auto-generated execute-api URL. DNS stays external (any provider):
     // SST only creates the API Gateway domain + mapping from an existing
     // ACM cert — after deploy, point a CNAME from the domain to the
-    // `customDomainTarget` output. CUSTOM_DOMAIN_CERT_ARN must be an ISSUED
+    // gateway's target hostname (see DEPLOY.md § Custom Domain for the
+    // aws CLI command). CUSTOM_DOMAIN_CERT_ARN must be an ISSUED
     // certificate in the API's region covering the name (wildcard or exact).
     const customDomain = env("CUSTOM_DOMAIN").asString()
     const customDomainCertArn = env("CUSTOM_DOMAIN_CERT_ARN").asString()
@@ -303,19 +304,15 @@ export default $config({
       auth: { lambda: authorizer.id },
     })
 
+    // Deliberately NOT outputs: the Lightsail IP and the custom domain's
+    // CNAME target. SST prints outputs at the end of every deploy — in CI
+    // that means public Actions logs. Fetch them from AWS instead:
+    //   aws lightsail get-static-ip --static-ip-name vault-cortex-ip-<stage> \
+    //     --query staticIp.ipAddress --output text
+    //   aws apigatewayv2 get-domain-name --domain-name <CUSTOM_DOMAIN> \
+    //     --query 'DomainNameConfigurations[0].ApiGatewayDomainName' --output text
     return {
       apiUrl: api.url,
-      lightsailIp: staticIp.ipAddress,
-      // CNAME target for the custom domain: point CUSTOM_DOMAIN at this
-      // hostname with your DNS provider. Only present when configured.
-      // nodes.domainName is the component's documented accessor for the
-      // underlying aws.apigatewayv2.DomainName resource, and targetDomainName
-      // is the same output SST feeds its own DNS alias records from — verify
-      // both still hold when upgrading SST.
-      ...(customDomain && {
-        customDomainTarget:
-          api.nodes.domainName.domainNameConfiguration.targetDomainName,
-      }),
     }
   },
 })


### PR DESCRIPTION
## Summary

SST prints its outputs at the end of every deploy — on a public repo that means the Lightsail IP and the custom domain's CNAME target land in public Actions logs. Rather than masking them after the fact, they're now **deliberately not SST outputs**; consumers fetch them from AWS directly:

- **`sst.config.ts`** — `lightsailIp` and `customDomainTarget` removed from the deploy outputs (`apiUrl` stays — it's the public client URL). A comment documents the omission and the `aws` CLI equivalents.
- **`.github/workflows/deploy.yml`** — the "Read Lightsail IP from SST outputs" step becomes "Fetch Lightsail IP from AWS" (`aws lightsail get-static-ip`, deterministic name `vault-cortex-ip-<stage>`, OIDC credentials already configured), with a forward-only `::add-mask::` so later steps' env headers don't print it either.
- **`scripts/dev.ts`** — laptop deploys resolve the IP the same way (stage from `.sst/stage`); the `LIGHTSAIL_SSH_HOST` override is unchanged, and the existing CI-aware `mask()` still applies.
- **`DEPLOY.md` / `.env.example`** — Verify section and the Custom Domain walkthrough now show the `aws lightsail get-static-ip` / `aws apigatewayv2 get-domain-name` commands instead of pointing at deploy outputs.

603 tests, lint, build, prettier all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)