### PR TITLE
ci: add Force Deploy dispatch workflow (redeploy current release)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,15 @@ on:
         description: Version being deployed (used as Docker image tag)
         required: true
         type: string
+      skip_build:
+        description: >-
+          Skip the image build/push and redeploy the already-published image.
+          A rebuild at an old tag would overwrite the release artifact with
+          different bits (base-image patches land at build time) — forced
+          redeploys must reuse what the release published.
+        required: false
+        default: false
+        type: boolean
 
 # Top-level token is read-only; the job declares its writes. Callers'
 # job-level grants are the ceiling — they must cover the same set.
@@ -98,10 +107,13 @@ jobs:
           fi
 
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        if: ${{ !inputs.skip_build }}
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        if: ${{ !inputs.skip_build }}
 
       - name: Log in to GHCR (build push)
+        if: ${{ !inputs.skip_build }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
@@ -109,6 +121,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push image
+        if: ${{ !inputs.skip_build }}
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .

--- a/.github/workflows/force_deploy.yml
+++ b/.github/workflows/force_deploy.yml
@@ -1,19 +1,13 @@
 name: Force Deploy
 
-# Redeploys an existing release without cutting a new one — rebuilds the
-# image at the release tag, re-runs SST (incremental no-op when infra is
-# unchanged), rewrites the instance .env from current secrets/vars, and
-# restarts the compose stack. Use after rotating a secret (e.g. PUBLIC_URL)
-# or to recover from a failed deploy. Re-running an old release run also
-# picks up fresh secrets, but executes the workflow as of that run's
-# commit — this dispatch always uses the current workflow from main.
+# Redeploys the current release with fresh configuration — no new release,
+# no image rebuild. Use after rotating a secret or repo variable (e.g.
+# PUBLIC_URL): re-runs SST (incremental no-op when infra is unchanged),
+# rewrites the instance .env from current secrets/vars, and restarts the
+# compose stack, which pulls the already-published image. The release
+# artifact is never rebuilt or overwritten.
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: Release version to deploy (e.g. 0.17.0). Blank = latest release.
-        required: false
-        type: string
 
 # Top-level token is read-only; jobs declare their writes.
 permissions:
@@ -32,28 +26,18 @@ jobs:
           # Only local git reads happen here — don't leave the token behind.
           persist-credentials: false
 
-      - name: Resolve version
+      - name: Resolve current release version
         id: version
-        env:
-          REQUESTED: ${{ inputs.version }}
         run: |
-          if [ -n "$REQUESTED" ]; then
-            version="${REQUESTED#v}"
-          else
-            # Latest server release tag. --match "v[0-9]*" keeps cli-v* tags
-            # out of the candidate set (same filter as generate-notes.sh).
-            version=$(git describe --tags --abbrev=0 --match "v[0-9]*")
-            version="${version#v}"
-          fi
-          if ! git rev-parse --verify --quiet "refs/tags/v$version" > /dev/null; then
-            echo "::error::tag v$version not found — pass an existing release version"
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          # Latest server release tag. --match "v[0-9]*" keeps cli-v* tags
+          # out of the candidate set (same filter as generate-notes.sh).
+          version=$(git describe --tags --abbrev=0 --match "v[0-9]*")
+          echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
   deploy:
     needs: resolve-version
-    # Ceiling for the reusable workflow: AWS OIDC + GHCR push.
+    # Ceiling for the reusable workflow: AWS OIDC. packages:write is part
+    # of deploy.yml's declared set even though skip_build pushes nothing.
     permissions:
       id-token: write
       contents: read
@@ -61,4 +45,5 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       version: ${{ needs.resolve-version.outputs.version }}
+      skip_build: true
     secrets: inherit

--- a/.github/workflows/force_deploy.yml
+++ b/.github/workflows/force_deploy.yml
@@ -36,8 +36,11 @@ jobs:
 
   deploy:
     needs: resolve-version
-    # Ceiling for the reusable workflow: AWS OIDC. packages:write is part
-    # of deploy.yml's declared set even though skip_build pushes nothing.
+    # GitHub caps a reusable workflow's token at what the calling job grants,
+    # and the call fails unless that covers everything the called job
+    # declares. deploy.yml declares exactly this set: id-token (AWS OIDC
+    # role assumption), contents, and packages — required here even though
+    # skip_build never pushes to GHCR.
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/force_deploy.yml
+++ b/.github/workflows/force_deploy.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           # git describe needs the tag history.
           fetch-depth: 0
+          # Only local git reads happen here — don't leave the token behind.
+          persist-credentials: false
 
       - name: Resolve version
         id: version

--- a/.github/workflows/force_deploy.yml
+++ b/.github/workflows/force_deploy.yml
@@ -1,0 +1,62 @@
+name: Force Deploy
+
+# Redeploys an existing release without cutting a new one — rebuilds the
+# image at the release tag, re-runs SST (incremental no-op when infra is
+# unchanged), rewrites the instance .env from current secrets/vars, and
+# restarts the compose stack. Use after rotating a secret (e.g. PUBLIC_URL)
+# or to recover from a failed deploy. Re-running an old release run also
+# picks up fresh secrets, but executes the workflow as of that run's
+# commit — this dispatch always uses the current workflow from main.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version to deploy (e.g. 0.17.0). Blank = latest release.
+        required: false
+        type: string
+
+# Top-level token is read-only; jobs declare their writes.
+permissions:
+  contents: read
+
+jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # git describe needs the tag history.
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: version
+        env:
+          REQUESTED: ${{ inputs.version }}
+        run: |
+          if [ -n "$REQUESTED" ]; then
+            version="${REQUESTED#v}"
+          else
+            # Latest server release tag. --match "v[0-9]*" keeps cli-v* tags
+            # out of the candidate set (same filter as generate-notes.sh).
+            version=$(git describe --tags --abbrev=0 --match "v[0-9]*")
+            version="${version#v}"
+          fi
+          if ! git rev-parse --verify --quiet "refs/tags/v$version" > /dev/null; then
+            echo "::error::tag v$version not found — pass an existing release version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: resolve-version
+    # Ceiling for the reusable workflow: AWS OIDC + GHCR push.
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    uses: ./.github/workflows/deploy.yml
+    with:
+      version: ${{ needs.resolve-version.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a `Force Deploy` workflow (Actions → Force Deploy → Run workflow, **no inputs**) that redeploys the **current release with fresh configuration** — no new release, no image rebuild:

- `resolve-version` resolves the latest server release tag (`git describe --match "v[0-9]*"`, the same `cli-v*`-excluding filter as `generate-notes.sh`) — always the code that is actually deployed.
- `deploy` calls the reusable `deploy.yml` with a new **`skip_build`** input: the four runner-side build steps (qemu, buildx, GHCR build login, build-push) are skipped, so the release artifact is never rebuilt or overwritten — the instance `compose pull` fetches the already-published image. SST still runs (incremental no-op on unchanged infra), the instance `.env` is rewritten from **current** secrets/vars, and the stack restarts with a healthcheck.

Design notes:
- No version input on purpose: a version picker plus rebuild-at-tag would allow publishing different bits under an existing release tag (base-image patches land at build time) — misleading at best. Force Deploy is strictly "redeploy what's released, with today's config."
- Why not re-run an old release run: re-runs read secrets fresh but execute the workflow as of the original run's commit, and expire after ~30 days.
- First use case: applying a rotated `PUBLIC_URL` without bumping a version.

Actions SHA-pinned, `persist-credentials: false` on the read-only checkout, token permissions follow the existing release-workflow pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)