### PR TITLE
ci(deploy): mask instance identifiers before SST runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,32 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
+      # Best-effort masking BEFORE SST runs: the checked-out release tag's
+      # sst.config.ts may predate the removal of identifier outputs
+      # (v0.17.0 and earlier), in which case `sst deploy` prints the
+      # Lightsail IP and custom-domain target. Both lookups tolerate
+      # absence — on a first-ever deploy the resources don't exist yet,
+      # and the post-deploy fetch below is the authoritative one.
+      - name: Pre-mask instance identifiers
+        env:
+          CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
+        run: |
+          ip=$(aws lightsail get-static-ip \
+            --static-ip-name "vault-cortex-ip-${SST_STAGE}" \
+            --query staticIp.ipAddress --output text 2>/dev/null || true)
+          if [ -n "$ip" ] && [ "$ip" != "None" ]; then
+            echo "::add-mask::$ip"
+          fi
+          if [ -n "$CUSTOM_DOMAIN" ]; then
+            target=$(aws apigatewayv2 get-domain-name \
+              --domain-name "$CUSTOM_DOMAIN" \
+              --query 'DomainNameConfigurations[0].ApiGatewayDomainName' \
+              --output text 2>/dev/null || true)
+            if [ -n "$target" ] && [ "$target" != "None" ]; then
+              echo "::add-mask::$target"
+            fi
+          fi
+
       - name: SST deploy
         env:
           SSH_PUBKEY: ${{ secrets.SSH_PUBKEY }}


### PR DESCRIPTION
## Summary

The first Force Deploy run exposed a gap in #118: Force Deploy checks out the **latest release tag**, and tags at or before v0.17.0 carry an `sst.config.ts` that still emits `lightsailIp` and `customDomainTarget` as outputs — so `sst deploy` printed both identifiers in the public log even though the workflow itself came from main.

Fix: a `Pre-mask instance identifiers` step runs **before** `SST deploy`, looking up the static IP (`aws lightsail get-static-ip`) and, when `CUSTOM_DOMAIN` is set, the gateway target (`aws apigatewayv2 get-domain-name`), and registering `::add-mask::` for each. Whatever the checked-out tag's config prints, the runner redacts it.

- Both lookups are best-effort (`|| true`, `None` guard): on a first-ever deploy the resources don't exist yet and the step is a silent no-op — the existing post-deploy fetch remains the authoritative source for the SSH target.
- Values become moot for tags cut from current main (no outputs to print), but this keeps every historical tag safe to force-deploy.

Note: the exposed Force Deploy run's logs (and the v0.17.0 release run's) still contain the values until deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCckC6tPukPynnFE55r8xK)_