### PR TITLE
fix(deploy): return 401 for tokenless requests to enable MCP connect flow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,7 +62,7 @@ graph TB
 
     subgraph apigw_grp ["AWS — API Gateway"]
         APIGW["API Gateway HTTP API<br/>HTTPS + auto URL"]
-        AUTH_FN["Lambda Authorizer<br/>path-aware: OAuth pass-through,<br/>/mcp validates static + JWT"]
+        AUTH_FN["Lambda Authorizer<br/>protected routes only:<br/>validates static + JWT"]
         APIGW -->|validate| AUTH_FN
     end
 
@@ -113,9 +113,11 @@ sequenceDiagram
     participant DB as SQLite (oauth.db)
 
     Note over C,E: First-time OAuth Authorization
+    C->>AG: POST /mcp (no token — initial probe)
+    AG-->>C: 401 Unauthorized (identity source missing — Lambda not invoked)
+    Note over C: 401 → client enters OAuth flow,<br/>falls back to default discovery location
     C->>AG: GET /.well-known/oauth-protected-resource
-    AG->>L: Authorize request
-    L-->>AG: isAuthorized: true (open path)
+    Note over AG: Open route — no authorizer
     AG->>E: Forward
     E-->>C: {authorization_servers: [...]}
 
@@ -258,11 +260,19 @@ Two authentication methods, both validated at two layers:
 | Static bearer token                   | Claude Code, MCP Inspector, curl                             | Raw string (MCP_AUTH_TOKEN) | No expiry                                   |
 
 **Layer 1 — API Gateway Lambda authorizer** (`src/functions/authorizer.ts`):
-Path-aware. OAuth discovery paths (`/.well-known/*`, `/authorize`, `/token`,
-`/register`, `/oauth/decide`, `/healthz`) pass through unauthenticated
-(required by the OAuth/MCP spec). `/mcp` validates the bearer token —
-accepts both the static `MCP_AUTH_TOKEN` (via `safeEqual`) and JWT access
-tokens signed with it (via `verifyJwt`).
+Attached to protected routes only. OAuth discovery paths (`/.well-known/*`,
+`/authorize`, `/token`, `/register`, `/revoke`, `/oauth/*`, `/healthz`) are
+separate unauthenticated routes in `sst.config.ts` (required by the
+OAuth/MCP spec) and never invoke the Lambda. On protected routes the
+authorizer validates the bearer token — accepts both the static
+`MCP_AUTH_TOKEN` (via `safeEqual`) and JWT access tokens signed with it
+(via `verifyJwt`). The Authorization header is the route's identity
+source, so a tokenless request gets an automatic **401** from API Gateway
+without invoking the Lambda — this is what lets MCP clients (Claude
+Desktop/web, etc.) enter the OAuth connect flow on their first
+unauthenticated probe. A Lambda deny is a fixed, uncustomizable **403**
+on HTTP APIs, which MCP clients treat as a broken server rather than a
+sign-in prompt.
 
 **Layer 2 — Express middleware** (MCP SDK's `requireBearerAuth` in `server.ts`):
 The OAuth provider's `verifyAccessToken()` accepts both static tokens and

--- a/src/functions/authorizer.ts
+++ b/src/functions/authorizer.ts
@@ -12,9 +12,12 @@
  * 401 BEFORE invoking this Lambda — that 401 is what lets MCP clients
  * enter the OAuth connect flow (a Lambda deny is a fixed 403 that HTTP
  * APIs cannot customize, which clients treat as a broken server).
- * The open-path and missing-token branches below are therefore dead
- * code in the current wiring — kept as defense in depth in case the
- * authorizer is ever reattached to other routes.
+ * The open-path branch below is therefore dead code in the current
+ * wiring (open routes never invoke this Lambda). The parse-failure
+ * branch stays reachable: the identity source only requires the header
+ * to be present, so a malformed Authorization header (e.g. "Basic …")
+ * still reaches parseBearer and is denied there. Both are kept as
+ * defense in depth in case the wiring ever changes.
  *
  * Key facts:
  *   - API Gateway HTTP API v2 LOWERCASES all header names.

--- a/src/functions/authorizer.ts
+++ b/src/functions/authorizer.ts
@@ -1,10 +1,20 @@
 /**
- * Smart Lambda authorizer for API Gateway HTTP API (payload format 2.0).
+ * Lambda authorizer for API Gateway HTTP API (payload format 2.0).
  *
- * Path-aware: OAuth discovery endpoints pass through unauthenticated
- * (required by the MCP/OAuth spec). All other paths validate the
- * bearer token — accepts both the static McpAuthToken and JWT access
- * tokens signed with it (defense in depth with Express).
+ * Attached only to protected routes (see sst.config.ts) — the OAuth
+ * discovery endpoints are separate unauthenticated routes that never
+ * invoke this Lambda. Validates the bearer token: accepts both the
+ * static McpAuthToken and JWT access tokens signed with it (defense
+ * in depth with Express).
+ *
+ * The route config registers the Authorization header as the identity
+ * source, so API Gateway answers tokenless requests with an automatic
+ * 401 BEFORE invoking this Lambda — that 401 is what lets MCP clients
+ * enter the OAuth connect flow (a Lambda deny is a fixed 403 that HTTP
+ * APIs cannot customize, which clients treat as a broken server).
+ * The open-path and missing-token branches below are therefore dead
+ * code in the current wiring — kept as defense in depth in case the
+ * authorizer is ever reattached to other routes.
  *
  * Key facts:
  *   - API Gateway HTTP API v2 LOWERCASES all header names.

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -266,10 +266,21 @@ export default $config({
       },
     })
 
-    // Smart Lambda authorizer — path-aware, defense in depth:
-    //   - OAuth paths (/.well-known/*, /authorize, /token, etc.) → pass through
-    //   - /mcp → validates Bearer token (static MCP_AUTH_TOKEN or JWT)
-    // Express also validates in-process via requireBearerAuth (second layer).
+    // Lambda authorizer — validates Bearer tokens (static MCP_AUTH_TOKEN
+    // or JWT) on protected routes only. OAuth discovery paths are wired as
+    // separate unauthenticated routes below, so the authorizer no longer
+    // needs to pass them through (it keeps the path check as defense in
+    // depth). Express also validates in-process via requireBearerAuth.
+    //
+    // identitySources is the load-bearing detail: with the Authorization
+    // header registered as the identity source, API Gateway answers
+    // tokenless requests with an automatic 401 Unauthorized — without
+    // invoking the Lambda. MCP clients (Claude, etc.) require a 401 on the
+    // initial unauthenticated probe to enter the OAuth connect flow; they
+    // fall back to /.well-known/oauth-protected-resource discovery when no
+    // WWW-Authenticate header is present (RFC 9728 default location).
+    // A Lambda-authorizer deny, by contrast, is a fixed 403 Forbidden that
+    // HTTP APIs cannot customize — clients treat it as a broken server.
     const authorizer = api.addAuthorizer({
       name: "bearer-auth",
       lambda: {
@@ -280,27 +291,43 @@ export default $config({
           timeout: "5 seconds",
           memory: "128 MB",
         },
-        identitySources: [],
+        identitySources: ["$request.header.Authorization"],
       },
     })
 
-    // GOTCHA: {proxy+} matches one-or-more path segments but NOT
-    // the bare root "/". You need both routes.
-    //
     // ORIGIN_URL: when set, API GW routes through a tunnel/proxy (HTTPS)
     // instead of directly to the Lightsail IP (plaintext HTTP). Pair with
     // MCP_PORT_CIDRS=none to close port 8000 on the firewall.
-    const proxyTarget = originUrl
-      ? `${originUrl}/{proxy}`
-      : $interpolate`http://${staticIp.ipAddress}:8000/{proxy}`
-    const rootTarget = originUrl
-      ? originUrl
-      : $interpolate`http://${staticIp.ipAddress}:8000`
+    const target = (path: string) =>
+      originUrl
+        ? `${originUrl}${path}`
+        : $interpolate`http://${staticIp.ipAddress}:8000${path}`
 
-    api.routeUrl("ANY /{proxy+}", proxyTarget, {
+    // ── Open routes — no authorizer ──────────────────────────────
+    // OAuth discovery/flow endpoints must be reachable unauthenticated
+    // (MCP/OAuth spec). Express owns their logic — DCR, consent, token
+    // validation, and 5 req/min rate limiting. API Gateway always picks
+    // the most specific matching route, so these win over the protected
+    // catch-alls below regardless of declaration order.
+    for (const path of [
+      "/authorize",
+      "/token",
+      "/register",
+      "/revoke",
+      "/healthz",
+    ]) {
+      api.routeUrl(`ANY ${path}`, target(path))
+    }
+    api.routeUrl("ANY /.well-known/{proxy+}", target("/.well-known/{proxy}"))
+    api.routeUrl("ANY /oauth/{proxy+}", target("/oauth/{proxy}"))
+
+    // ── Protected routes — Lambda authorizer ─────────────────────
+    // GOTCHA: {proxy+} matches one-or-more path segments but NOT
+    // the bare root "/". You need both routes.
+    api.routeUrl("ANY /{proxy+}", target("/{proxy}"), {
       auth: { lambda: authorizer.id },
     })
-    api.routeUrl("ANY /", rootTarget, {
+    api.routeUrl("ANY /", target(""), {
       auth: { lambda: authorizer.id },
     })
 


### PR DESCRIPTION
## Problem

Adding the server as a claude.ai custom connector fails with **"Connection issue — Couldn't connect to the server"** instead of showing the Connect button.

Root cause: the Lambda authorizer denies tokenless `POST /mcp` probes, and an HTTP API converts a Lambda deny into a fixed `403 {"message":"Forbidden"}` with no `WWW-Authenticate` header (Gateway Responses are REST-API-only, so this response cannot be customized). Per [Claude's connector docs](https://claude.com/docs/connectors/building/authentication), "the 401 status is required" to start OAuth discovery — a 403 is treated as a broken server. ([Claude Code](https://code.claude.com/docs/en/mcp) tolerates 401 *or* 403, which is why this never surfaced on existing/CLI connections.)

Verified on both the custom domain and the direct execute-api URL (identical behavior — Cloudflare is not involved; the 403 reproduces against the API Gateway origin directly):

```
POST /mcp (no token)                        → 403 {"message":"Forbidden"}  (apigw, never reaches Express)
GET /.well-known/oauth-protected-resource   → 200
GET /.well-known/oauth-authorization-server → 200
```

## Change

- **`identitySources: ["$request.header.Authorization"]`** on the authorizer: API Gateway now answers tokenless requests with an automatic **401** without invoking the Lambda. Claude then falls back to RFC 9728 default discovery at `/.well-known/oauth-protected-resource` (already served) and enters the OAuth flow.
- **Explicit unauthenticated routes** for `/authorize`, `/token`, `/register`, `/revoke`, `/healthz`, `/.well-known/*`, `/oauth/*` — this is what makes the identity source safe to restore. The May 8 removal of `identitySources` (`fix: remove authorizer identity source so OAuth paths aren't auto-rejected`) fixed the auto-rejection but silently turned tokenless `/mcp` probes into 403s. Splitting the routes addresses the original problem at the routing layer instead. More-specific routes always win over `{proxy+}`, so declaration order doesn't matter.
- **Authorizer Lambda unchanged in behavior** — still validates static token + JWT on protected routes. Its open-path and missing-token branches are now dead code in this wiring; kept as defense in depth (documented in the header comment).
- ARCHITECTURE.md auth-flow diagram and Layer 1 description updated to match.

Established connections are unaffected: refresh flows through `/token` (open path) and clients refresh proactively, so valid-token traffic behaves exactly as before. The 401 path only fires on cold tokenless probes: new connector adds, re-auth after refresh-token expiry (60-day dormancy), or `MCP_AUTH_TOKEN` rotation.

## Testing

- [x] `npm test` — 603 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [ ] Post-deploy: `curl -i -X POST URL/mcp -H 'Content-Type: application/json' -d '{}'` → expect **401** `{"message":"Unauthorized"}`
- [ ] Post-deploy: well-known endpoints still 200; `POST /mcp` with valid bearer still 200
- [ ] Re-add `URL/mcp` as a claude.ai custom connector → expect Connect button / OAuth consent page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture and authentication flow documentation to clarify how unauthenticated OAuth discovery routes are separated from protected API endpoints.

* **Refactor**
  * Improved API Gateway routing configuration to explicitly define unauthenticated OAuth paths while applying token validation only to protected routes. Authentication error responses now properly distinguish between missing credentials (401) and authorization failures (403).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->