### PR TITLE
docs: reroute localhost connect instructions for Claude's https-only connector dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,14 +107,39 @@ docker compose up -d
 
 ### Connect your MCP client
 
-Add the server URL as a remote/HTTP MCP server in any client — Claude Desktop, Claude Code, Cursor, OpenCode, or any other:
-
 | Setup      | Server URL                  |
 | ---------- | --------------------------- |
 | **Local**  | `http://localhost:8000/mcp` |
 | **Remote** | `<PUBLIC_URL>/mcp`          |
 
-OAuth clients open a consent page in your browser — approve with your token, and the client handles token renewal from then on. Clients without OAuth (MCP Inspector, scripts) send the token directly as an `Authorization: Bearer` header.
+Most clients — Claude Code, Cursor, OpenCode, MCP Inspector — accept either URL directly as a remote/HTTP MCP server. OAuth clients open a consent page in your browser — approve with your token, and the client handles token renewal from then on. Clients without OAuth (MCP Inspector, scripts) send the token directly as an `Authorization: Bearer` header.
+
+**Claude Code:**
+
+```bash
+claude mcp add --transport http vault-cortex http://localhost:8000/mcp   # local (or <PUBLIC_URL>/mcp)
+```
+
+**Claude Desktop:** the "Add custom connector" dialog only accepts `https` URLs. Remote setups (`https` `PUBLIC_URL`) connect there directly; for the local setup, register the server in `claude_desktop_config.json` through the [mcp-remote](https://github.com/geelen/mcp-remote) stdio bridge instead:
+
+```json
+{
+  "mcpServers": {
+    "vault-cortex": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "http://localhost:8000/mcp",
+        "--header",
+        "Authorization: Bearer <your MCP_AUTH_TOKEN>"
+      ]
+    }
+  }
+}
+```
+
+**claude.ai (web and mobile)** connects to the remote setup only — its connectors are fetched server-side and can never reach localhost.
 
 > "Remote MCP server" refers to the connection type (HTTP) — in the local setup the server still runs entirely on your machine.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ docker compose up -d
 | **Local**  | `http://localhost:8000/mcp` |
 | **Remote** | `<PUBLIC_URL>/mcp`          |
 
-Most clients — Claude Code, Cursor, OpenCode, MCP Inspector — accept either URL directly as a remote/HTTP MCP server. OAuth clients open a consent page in your browser — approve with your token, and the client handles token renewal from then on. Clients without OAuth (MCP Inspector, scripts) send the token directly as an `Authorization: Bearer` header.
+Add the server URL in any MCP client — Claude Code, Claude Desktop, Cursor, OpenCode, or any other. OAuth clients open a consent page in your browser — approve with your token, and the client handles token renewal from then on. Clients without OAuth (MCP Inspector, scripts) send the token directly as an `Authorization: Bearer` header.
 
 **Claude Code:**
 
@@ -120,7 +120,7 @@ Most clients — Claude Code, Cursor, OpenCode, MCP Inspector — accept either 
 claude mcp add --transport http vault-cortex http://localhost:8000/mcp   # local (or <PUBLIC_URL>/mcp)
 ```
 
-**Claude Desktop:** the "Add custom connector" dialog only accepts `https` URLs. Remote setups (`https` `PUBLIC_URL`) connect there directly; for the local setup, register the server in `claude_desktop_config.json` through the [mcp-remote](https://github.com/geelen/mcp-remote) stdio bridge instead:
+**Claude Desktop:** the "Add custom connector" dialog only accepts `https` URLs. With an `https` PUBLIC_URL, add it directly in the connector dialog; for a localhost server, register it in `claude_desktop_config.json` through the [mcp-remote](https://github.com/geelen/mcp-remote) stdio bridge instead:
 
 ```json
 {

--- a/cli/src/__tests__/init.test.ts
+++ b/cli/src/__tests__/init.test.ts
@@ -205,6 +205,36 @@ describe("runInit --yes (non-interactive local)", () => {
   })
 })
 
+describe("local connect message client routing", () => {
+  it("routes Claude Code to claude mcp add and Claude Desktop to the mcp-remote bridge", async () => {
+    const vaultDir = makeVault()
+    const targetDir = makeTargetDir()
+    const scripted = createScriptedPrompts([])
+
+    const exitCode = await runInit(
+      { yes: true, vaultPath: vaultDir, dir: targetDir },
+      {
+        prompts: scripted.prompts,
+        docker: dockerUnavailable,
+        fetchFn: fetchNever,
+      },
+    )
+
+    expect(exitCode).toBe(0)
+    const connectMessage = scripted.notes[0]
+    expect(connectMessage).toContain(
+      "claude mcp add --transport http vault-cortex http://localhost:8000/mcp",
+    )
+    expect(connectMessage).toContain(
+      '"mcp-remote", "http://localhost:8000/mcp"',
+    )
+    expect(connectMessage).toContain("only accepts https URLs")
+    // Claude Desktop must not be grouped with the add-as-remote-server flow —
+    // its connector dialog rejects http URLs.
+    expect(connectMessage).not.toContain("OAuth clients (Claude Desktop")
+  })
+})
+
 describe("runInit interactive local flow", () => {
   it("defaults the mode select to local", async () => {
     const vaultDir = makeVault()

--- a/cli/src/__tests__/init.test.ts
+++ b/cli/src/__tests__/init.test.ts
@@ -273,7 +273,7 @@ describe("remote connect message https routing", () => {
   it("omits the http warning when PUBLIC_URL is https", async () => {
     const connectMessage = await runRemoteInit("https://vault.example.com")
 
-    expect(connectMessage).not.toContain("only\naccepts https URLs")
+    expect(connectMessage).not.toContain("only accept https URLs")
     expect(connectMessage).not.toContain("claude mcp add")
   })
 })

--- a/cli/src/__tests__/init.test.ts
+++ b/cli/src/__tests__/init.test.ts
@@ -235,6 +235,49 @@ describe("local connect message client routing", () => {
   })
 })
 
+describe("remote connect message https routing", () => {
+  const runRemoteInit = async (publicUrl: string) => {
+    const scripted = createScriptedPrompts([
+      publicUrl,
+      "MyVault",
+      "", // blank sync token — fill in .env later
+      false, // no encryption
+    ])
+
+    const exitCode = await runInit(
+      { mode: "remote", dir: makeTargetDir() },
+      {
+        prompts: scripted.prompts,
+        docker: dockerUnavailable,
+        fetchFn: fetchNever,
+      },
+    )
+
+    expect(exitCode).toBe(0)
+    const connectMessage = scripted.notes.find((note) =>
+      note.includes("Connect your MCP client"),
+    )
+    expect(connectMessage).toBeDefined()
+    return connectMessage as string
+  }
+
+  it("warns and offers claude mcp add when PUBLIC_URL is http", async () => {
+    const connectMessage = await runRemoteInit("http://203.0.113.10:8000")
+
+    expect(connectMessage).toContain("only\naccepts https URLs")
+    expect(connectMessage).toContain(
+      "claude mcp add --transport http vault-cortex http://203.0.113.10:8000/mcp",
+    )
+  })
+
+  it("omits the http warning when PUBLIC_URL is https", async () => {
+    const connectMessage = await runRemoteInit("https://vault.example.com")
+
+    expect(connectMessage).not.toContain("only\naccepts https URLs")
+    expect(connectMessage).not.toContain("claude mcp add")
+  })
+})
+
 describe("runInit interactive local flow", () => {
   it("defaults the mode select to local", async () => {
     const vaultDir = makeVault()

--- a/cli/src/__tests__/init.test.ts
+++ b/cli/src/__tests__/init.test.ts
@@ -264,7 +264,7 @@ describe("remote connect message https routing", () => {
   it("warns and offers claude mcp add when PUBLIC_URL is http", async () => {
     const connectMessage = await runRemoteInit("http://203.0.113.10:8000")
 
-    expect(connectMessage).toContain("only\naccepts https URLs")
+    expect(connectMessage).toContain("only accept https URLs")
     expect(connectMessage).toContain(
       "claude mcp add --transport http vault-cortex http://203.0.113.10:8000/mcp",
     )

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -72,8 +72,8 @@ the server still runs on your machine), then approve the consent page.
 Clients without OAuth, scripts, and curl send the token directly:
   curl -H "Authorization: Bearer <token>" http://localhost:${port}/mcp
 
-Note: claude.ai (web) cannot reach localhost — use Claude Code or the
-mcp-remote bridge for a local server.
+Note: claude.ai (web) cannot reach localhost — use Claude Code for local
+access, or Claude Desktop with the mcp-remote bridge.
 
 Smoke test:
   curl http://localhost:${port}/healthz

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -50,19 +50,30 @@ Connect your MCP client:
   URL:        http://localhost:${port}/mcp
   ${tokenLine}
 
-OAuth clients (Claude Desktop, Claude Code, most MCP clients):
-  1. Add the URL above as a remote MCP server, leaving Client
-     ID/Secret empty ("remote" = HTTP — the server still runs on
-     your machine)
-  2. Approve the browser consent page with the token above
-  3. Done — the client holds auto-refreshing access tokens; the
-     token never sits in client config
+Claude Code:
+  claude mcp add --transport http vault-cortex http://localhost:${port}/mcp
+  Approve the browser consent page with the token above — the client
+  then holds auto-refreshing access tokens; the token never sits in
+  client config
+
+Claude Desktop only accepts https URLs in its connector dialog, so
+register the server in claude_desktop_config.json via the mcp-remote
+bridge instead:
+  "vault-cortex": {
+    "command": "npx",
+    "args": ["-y", "mcp-remote", "http://localhost:${port}/mcp",
+      "--header", "Authorization: Bearer <token above>"]
+  }
+
+Other OAuth clients (Cursor, most MCP clients) add the URL above as a
+remote MCP server, leaving Client ID/Secret empty ("remote" = HTTP —
+the server still runs on your machine), then approve the consent page.
 
 Clients without OAuth, scripts, and curl send the token directly:
   curl -H "Authorization: Bearer <token>" http://localhost:${port}/mcp
 
-Note: claude.ai (web) cannot reach localhost — use Claude Desktop or
-Claude Code for a local server.
+Note: claude.ai (web) cannot reach localhost — use Claude Code or the
+mcp-remote bridge for a local server.
 
 Smoke test:
   curl http://localhost:${port}/healthz

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -118,6 +118,17 @@ export const buildRemoteConnectMessage = (params: {
     ? `approve with your MCP_AUTH_TOKEN:\n  ${token}`
     : `approve with the existing MCP_AUTH_TOKEN in ${targetDir}/.env`
 
+  // Claude's connector dialog (claude.ai, Claude Desktop) rejects http URLs,
+  // so an http PUBLIC_URL needs the Claude Code route or an HTTPS front.
+  const httpUrlWarning = publicUrl.startsWith("https://")
+    ? ""
+    : `
+
+Note: Claude's connector dialog (claude.ai, Claude Desktop) only
+accepts https URLs. With this http URL, connect via Claude Code:
+  claude mcp add --transport http vault-cortex ${publicUrl}/mcp
+or front the server with HTTPS (see the options link below).`
+
   // Flush-left on purpose: template literals keep leading whitespace, so
   // indenting these lines would indent the rendered output.
   const connectMessage = `${startLine}
@@ -127,7 +138,7 @@ Connect your MCP client:
 
 OAuth clients (Claude Desktop, Claude Code, claude.ai): add a remote MCP
 server with that URL and leave Client ID/Secret empty — a consent page
-opens; ${approveLine}
+opens; ${approveLine}${httpUrlWarning}
 
 Optional settings (timezone, memory folder, port, logging, sync
 behavior) are commented out in ${targetDir}/.env — uncomment, set a

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -118,16 +118,14 @@ export const buildRemoteConnectMessage = (params: {
     ? `approve with your MCP_AUTH_TOKEN:\n  ${token}`
     : `approve with the existing MCP_AUTH_TOKEN in ${targetDir}/.env`
 
-  // Claude's connector dialog (claude.ai, Claude Desktop) rejects http URLs,
-  // so an http PUBLIC_URL needs the Claude Code route or an HTTPS front.
   const httpUrlWarning = publicUrl.startsWith("https://")
     ? ""
     : `
 
-Note: Claude's connector dialog (claude.ai, Claude Desktop) only
-accepts https URLs. With this http URL, connect via Claude Code:
-  claude mcp add --transport http vault-cortex ${publicUrl}/mcp
-or front the server with HTTPS (see the options link below).`
+Note: claude.ai and Claude Desktop only accept https URLs — set up
+HTTPS when you're ready for those clients (see the HTTPS section in
+the remote guide). Claude Code works with http:
+  claude mcp add --transport http vault-cortex ${publicUrl}/mcp`
 
   // Flush-left on purpose: template literals keep leading whitespace, so
   // indenting these lines would indent the rendered output.

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -51,10 +51,10 @@ Connect your MCP client:
   ${tokenLine}
 
 Claude Code:
-  claude mcp add --transport http vault-cortex http://localhost:${port}/mcp
-  Approve the browser consent page with the token above — the client
-  then holds auto-refreshing access tokens; the token never sits in
-  client config
+  1. claude mcp add --transport http vault-cortex http://localhost:${port}/mcp
+  2. Approve the browser consent page with the token above
+  3. Done. The client holds auto-refreshing access tokens; the
+     token never sits in client config
 
 Claude Desktop only accepts https URLs in its connector dialog, so
 register the server in claude_desktop_config.json via the mcp-remote

--- a/cli/templates/local/docker-compose.yml
+++ b/cli/templates/local/docker-compose.yml
@@ -6,6 +6,8 @@
 # 1. cp .env.example .env   (then fill in MCP_AUTH_TOKEN and VAULT_PATH)
 # 2. docker compose up
 # 3. Connect your MCP client to http://localhost:8000/mcp
+#    (Claude Desktop's connector dialog requires https — register a
+#    localhost server via the mcp-remote bridge; see the local README)
 #
 # Full docs: https://github.com/aliasunder/vault-cortex
 

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -42,13 +42,47 @@ builds the search index — this takes a few seconds depending on vault size.
 
 The server listens at `http://localhost:8000/mcp`.
 
-**OAuth clients (Claude Desktop, Claude Code, and most MCP clients):**
+**Claude Code:**
+
+```bash
+claude mcp add --transport http vault-cortex http://localhost:8000/mcp
+```
+
+First use opens a consent page in your browser — approve with your
+`MCP_AUTH_TOKEN`. The client receives auto-refreshing access tokens, so the
+token itself never sits in client config.
+
+**Claude Desktop:** the "Add custom connector" dialog only accepts `https`
+URLs, so a localhost server can't be added there. Register it in
+`claude_desktop_config.json` (Settings → Developer → Edit Config) through the
+[mcp-remote](https://github.com/geelen/mcp-remote) stdio bridge instead:
+
+```json
+{
+  "mcpServers": {
+    "vault-cortex": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "http://localhost:8000/mcp",
+        "--header",
+        "Authorization: Bearer <your MCP_AUTH_TOKEN>"
+      ]
+    }
+  }
+}
+```
+
+On Windows, spaces inside `args` can be mangled — move the header value into
+an env var instead: `"--header", "Authorization:${AUTH_HEADER}"` with
+`"env": { "AUTH_HEADER": "Bearer <your MCP_AUTH_TOKEN>" }`.
+
+**Other OAuth clients (Cursor and most MCP clients):**
 
 1. Add `http://localhost:8000/mcp` as a remote MCP server, leaving OAuth
    Client ID and Secret empty.
 2. A consent page opens in your browser — approve with your `MCP_AUTH_TOKEN`.
-3. Done. The client receives auto-refreshing access tokens, so the token
-   itself never sits in client config.
 
 - "Remote" refers to the connection type (HTTP, as opposed to a stdio process
   the client launches itself) — this server still runs entirely on your

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -44,13 +44,10 @@ The server listens at `http://localhost:8000/mcp`.
 
 **Claude Code:**
 
-```bash
-claude mcp add --transport http vault-cortex http://localhost:8000/mcp
-```
-
-First use opens a consent page in your browser — approve with your
-`MCP_AUTH_TOKEN`. The client receives auto-refreshing access tokens, so the
-token itself never sits in client config.
+1. Run `claude mcp add --transport http vault-cortex http://localhost:8000/mcp`
+2. Approve the consent page in your browser with your `MCP_AUTH_TOKEN`.
+3. Done. The client receives auto-refreshing access tokens, so the token
+   itself never sits in client config.
 
 **Claude Desktop:** the "Add custom connector" dialog only accepts `https`
 URLs, so a localhost server can't be added there. Register it in
@@ -83,6 +80,8 @@ an env var instead: `"--header", "Authorization:${AUTH_HEADER}"` with
 1. Add `http://localhost:8000/mcp` as a remote MCP server, leaving OAuth
    Client ID and Secret empty.
 2. A consent page opens in your browser — approve with your `MCP_AUTH_TOKEN`.
+3. Done. The client receives auto-refreshing access tokens, so the token
+   itself never sits in client config.
 
 - "Remote" refers to the connection type (HTTP, as opposed to a stdio process
   the client launches itself) — this server still runs entirely on your

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -6,6 +6,8 @@
 # 1. cp .env.example .env   (then fill in MCP_AUTH_TOKEN and VAULT_PATH)
 # 2. docker compose up
 # 3. Connect your MCP client to http://localhost:8000/mcp
+#    (Claude Desktop's connector dialog requires https — register a
+#    localhost server via the mcp-remote bridge; see the local README)
 #
 # Full docs: https://github.com/aliasunder/vault-cortex
 

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -137,9 +137,7 @@ Secret empty — dynamic registration handles it. A consent page opens in your
 browser; enter your `MCP_AUTH_TOKEN` to approve. The client receives a JWT
 access token (24h) with automatic refresh (60-day sliding window).
 
-Claude's "Add custom connector" dialog (claude.ai and Claude Desktop) only
-accepts `https` URLs — every [HTTPS access](#https-access) option above
-provides one. Claude Code accepts `http` URLs too:
+Claude Code also accepts `http` URLs directly:
 
 ```bash
 claude mcp add --transport http vault-cortex <PUBLIC_URL>/mcp

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -118,6 +118,12 @@ Access the server directly at `http://<your-ip>:8000`. No TLS — suitable for
 testing on a private network, not for production. Set `PUBLIC_URL` to
 `http://<your-ip>:8000`.
 
+Claude's "Add custom connector" dialog (claude.ai and Claude Desktop) only
+accepts `https` URLs, so with an `http` PUBLIC_URL connect via Claude Code
+(`claude mcp add --transport http` — see below) or the
+[mcp-remote](https://github.com/geelen/mcp-remote) stdio bridge with its
+`--allow-http` flag.
+
 > **Note:** `PUBLIC_URL` must match exactly how MCP clients reach the server.
 > OAuth discovery metadata uses this URL, so a mismatch causes authentication
 > failures.
@@ -130,6 +136,14 @@ Add a remote MCP server with URL `<PUBLIC_URL>/mcp`. Leave OAuth Client ID and
 Secret empty — dynamic registration handles it. A consent page opens in your
 browser; enter your `MCP_AUTH_TOKEN` to approve. The client receives a JWT
 access token (24h) with automatic refresh (60-day sliding window).
+
+Claude's "Add custom connector" dialog (claude.ai and Claude Desktop) only
+accepts `https` URLs — every [HTTPS access](#https-access) option above
+provides one. Claude Code accepts `http` URLs too:
+
+```bash
+claude mcp add --transport http vault-cortex <PUBLIC_URL>/mcp
+```
 
 ### Static bearer token (CLI tools, curl)
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -121,6 +121,11 @@ If the client only speaks stdio, bridge with `mcp-remote` (same token):
 }
 ```
 
+This same `mcp-remote` config is also the way to register a localhost server
+with **Claude Desktop** (`claude_desktop_config.json`) — its "Add custom
+connector" dialog only accepts `https` URLs, so the stdio bridge is required
+even though Claude Desktop speaks HTTP natively.
+
 ## Troubleshooting
 
 - **`401`, or the client reports the token "has no expiration time" / "needs a JWT."**

--- a/llms-install.md
+++ b/llms-install.md
@@ -124,7 +124,7 @@ If the client only speaks stdio, bridge with `mcp-remote` (same token):
 This same `mcp-remote` config is also the way to register a localhost server
 with **Claude Desktop** (`claude_desktop_config.json`) — its "Add custom
 connector" dialog only accepts `https` URLs, so the stdio bridge is required
-even though Claude Desktop speaks HTTP natively.
+for localhost.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Problem

Claude's "Add custom connector" dialog now rejects non-https URLs ("URL must start with 'https'"), which breaks the documented Local quickstart path of adding `http://localhost:8000/mcp` as a connector — and equally affects remote setups whose `PUBLIC_URL` is plain http (the "Direct access" testing option). (claude.ai **web** connectors never could reach localhost — they're fetched server-side — so the localhost case mainly affects the desktop-app path.)

## Fix

Route users on http URLs to connect methods that work, in every place that previously said "add the URL as a remote MCP server":

- **Claude Code** — `claude mcp add --transport http vault-cortex <url>/mcp` (accepts http and localhost; OAuth consent page on first use, so the token stays out of client config). Verified live: this writes the `{"type": "http", "url": ...}` server entry and Claude Code prompts to connect on next start.
- **Claude Desktop** — register in `claude_desktop_config.json` via the [mcp-remote](https://github.com/geelen/mcp-remote) stdio bridge with `--header "Authorization: Bearer <token>"`. Flags verified against mcp-remote's source: localhost/127.0.0.1 is exempt from its HTTPS requirement (no `--allow-http` needed); non-localhost http needs `--allow-http`. The known Windows space-mangling bug is covered with the documented `env` workaround.
- **Other OAuth clients** (Cursor, etc.) keep the existing add-as-remote-server flow — they accept localhost.

## Changes

| File | Change |
|---|---|
| `README.md` | Connect section: per-client routing (Claude Code command, Claude Desktop mcp-remote config, claude.ai = remote-only) |
| `deploy/local/README.md` | Same restructure for the local guide, incl. the Windows args workaround |
| `deploy/remote/README.md` | OAuth connect section notes the https-only dialog + `claude mcp add` alternative; Direct access option points http users at Claude Code / mcp-remote `--allow-http` |
| `cli/src/messages.ts` | Local connect message routes Claude Code → `claude mcp add`, Claude Desktop → mcp-remote bridge; remote connect message warns conditionally when the entered `PUBLIC_URL` is not https |
| `cli/src/__tests__/init.test.ts` | New routing tests: local message routing, remote http warning present, remote https warning absent |
| `deploy/local/docker-compose.yml` + `cli/templates/local/docker-compose.yml` | Header comment notes the Claude Desktop caveat (synced via `npm run sync:cli-templates`, byte-identical) |
| `llms-install.md` | Notes the existing mcp-remote snippet is also the Claude Desktop path |

## Audited, no change needed

- `server.json` — `transport.url` is programmatic registry metadata consumed by clients, not connector-dialog instructions
- `CONTRIBUTING.md`, `docker-compose.local.yml`, README dev section — `PUBLIC_URL=http://localhost:8000` is server config; MCP Inspector still accepts localhost URLs

## Verification

- `npm run prettier:check && npm run lint && npm test && npm run build` — all green, 606 tests (603 + 3 new)
- New tests mutation-checked: reverting the `messages.ts` local change fails exactly the local routing test; reverting the remote change fails exactly the remote http-warning test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced setup guides for Claude Code and Claude Desktop with client-specific configuration instructions
  * Clarified HTTPS requirements and documented HTTP support options for different deployment scenarios
  * Added detailed examples for connecting local and remote servers

* **Tests**
  * Added new test coverage for client connection message routing in local and remote modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->