### PR TITLE
fix(auth): tolerate whitespace in consent-page token submission

### DIFF
--- a/cli/src/__tests__/init.test.ts
+++ b/cli/src/__tests__/init.test.ts
@@ -233,6 +233,32 @@ describe("local connect message client routing", () => {
     // its connector dialog rejects http URLs.
     expect(connectMessage).not.toContain("OAuth clients (Claude Desktop")
   })
+
+  it("prints the generated auth token alone on its own line for clean copying", async () => {
+    const vaultDir = makeVault()
+    const targetDir = makeTargetDir()
+    const scripted = createScriptedPrompts([])
+
+    const exitCode = await runInit(
+      { yes: true, vaultPath: vaultDir, dir: targetDir },
+      {
+        prompts: scripted.prompts,
+        docker: dockerUnavailable,
+        fetchFn: fetchNever,
+      },
+    )
+
+    expect(exitCode).toBe(0)
+    const token = /MCP_AUTH_TOKEN=(.+)/.exec(
+      readFileSync(join(targetDir, ".env"), "utf8"),
+    )?.[1]
+    expect(token).toMatch(/^[0-9a-f]{64}$/)
+    const connectMessage = scripted.notes[0]
+    // The token must be on a line by itself (so a line-select grabs only it),
+    // not inline after the "Auth token:" label.
+    expect(connectMessage.split("\n")).toContain(`  ${token}`)
+    expect(connectMessage).not.toContain(`Auth token: ${token}`)
+  })
 })
 
 describe("remote connect message https routing", () => {

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -38,8 +38,11 @@ export const buildLocalConnectMessage = (params: {
     ? "The server is running."
     : startServerLine(targetDir)
 
+  // When the token was written, put it alone on its own line so selecting
+  // that line copies just the token — no "Auth token: " prefix to trim and
+  // no chance of grabbing the surrounding label.
   const tokenLine = tokenWritten
-    ? `Auth token: ${token}`
+    ? `Auth token:\n  ${token}`
     : `Auth token: use the existing MCP_AUTH_TOKEN in ${targetDir}/.env`
 
   // Flush-left on purpose: template literals keep leading whitespace, so

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -120,6 +120,27 @@ docker compose down
 docker compose down -v
 ```
 
+## Troubleshooting
+
+**`invalid_client` / "Invalid client_id" when connecting.** Your MCP client
+cached an OAuth registration from a previous server at this address. Recreating
+the server (`docker compose down -v`, or scaffolding a fresh instance) resets
+`oauth.db`, so the cached `client_id` no longer exists and `/authorize` rejects
+it. Clear the client's stored authorization for this server and reconnect so it
+registers fresh:
+
+- **Claude Code:** `claude mcp remove <name>`, then
+  `claude mcp add --transport http <name> http://localhost:8000/mcp`.
+- **Claude Desktop / mcp-remote:** delete `~/.mcp-auth` and restart the client.
+- **Other clients:** remove and re-add the server.
+
+**"Invalid token" on the consent page even with the correct token.** The
+consent form trims surrounding whitespace and line breaks from the token before
+checking it, so a value copied out of a terminal (where a long token can wrap
+across lines) still works. If you still see this error, double-check you copied
+the full `MCP_AUTH_TOKEN` from your `.env` — a missing or extra character is the
+usual cause.
+
 ## Memory
 
 On first startup, if your vault doesn't already have a memory folder (default:

--- a/src/vault-mcp/auth/__tests__/consent-page.test.ts
+++ b/src/vault-mcp/auth/__tests__/consent-page.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest"
+import { renderConsentPage } from "../consent-page.js"
+
+const baseParams = {
+  clientName: "Test Client",
+  clientId: "client-123",
+  scopes: ["vault"],
+  requestId: "req-abc",
+}
+
+describe("consent page reveal toggle", () => {
+  it("renders the token field masked by default", () => {
+    const html = renderConsentPage(baseParams)
+    // The token is a credential — it must start hidden, not in plaintext.
+    expect(html).toContain('<input type="password" id="token" name="token"')
+  })
+
+  it("wires the reveal button to the token input's id", () => {
+    const html = renderConsentPage(baseParams)
+    const tokenId = /<input type="password" id="([^"]+)" name="token"/.exec(
+      html,
+    )?.[1]
+    const onclick = /class="reveal"[^>]*onclick="([^"]+)"/.exec(html)?.[1]
+    expect(tokenId).toBe("token")
+    // The toggle must target the input by its id and flip it to a visible
+    // type — otherwise "Show" silently does nothing.
+    expect(onclick).toContain(`getElementById('${tokenId}')`)
+    expect(onclick).toContain("'text'")
+  })
+})

--- a/src/vault-mcp/auth/__tests__/oauth-routes.test.ts
+++ b/src/vault-mcp/auth/__tests__/oauth-routes.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import type { Server } from "node:http"
+import type { AddressInfo } from "node:net"
+import type { Response } from "express"
+import express from "express"
+import type { AuthorizationParams } from "@modelcontextprotocol/sdk/server/auth/provider.js"
+import { createOAuthProvider } from "../oauth-provider.js"
+import type { OAuthProvider } from "../oauth-provider.js"
+import { createOAuthRoutes } from "../oauth-routes.js"
+
+// The documented local-dev placeholder (.gitleaks.toml allowlist, also used in
+// README/CONTRIBUTING) — allowlisted by the secret scanner, never a real key.
+const AUTH_TOKEN = "local-dev-token"
+const REDIRECT_URI = "http://localhost:9999/callback"
+
+/** Pulls the hidden request_id out of the rendered consent HTML. */
+const REQUEST_ID_PATTERN = /name="request_id"\s+value="([^"]+)"/
+
+describe("OAuth consent token submission", () => {
+  let dir: string
+  let oauth: OAuthProvider
+  let server: Server
+  let baseUrl: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "oauth-routes-test-"))
+    oauth = createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      dbPath: join(dir, "oauth.db"),
+    })
+    const router = createOAuthRoutes({
+      authToken: AUTH_TOKEN,
+      serverUrl: new URL("http://localhost:8000"),
+      oauthProvider: oauth,
+      serviceDocumentationUrl: "https://example.com",
+    })
+    const app = express()
+    app.use(router)
+    server = await new Promise<Server>((resolve) => {
+      const listening = app.listen(0, () => resolve(listening))
+    })
+    const { port } = server.address() as AddressInfo
+    baseUrl = `http://localhost:${port}`
+  })
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  // Register a client and start an authorization request directly through
+  // the provider (the HTTP /register and /authorize routes are rate-limited;
+  // /oauth/decide, the route under test, is not).
+  const startPendingRequest = async (): Promise<string> => {
+    const client = await oauth.provider.clientsStore!.registerClient!({
+      client_name: "Test Client",
+      redirect_uris: [REDIRECT_URI],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    })
+    const params: AuthorizationParams = {
+      codeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      redirectUri: REDIRECT_URI,
+      scopes: ["vault"],
+      state: "test-state",
+    }
+    let capturedHtml = ""
+    const res = {
+      type: () => res,
+      send: (html: string) => {
+        capturedHtml = html
+        return res
+      },
+    }
+    await oauth.provider.authorize(client, params, res as unknown as Response)
+    const requestId = REQUEST_ID_PATTERN.exec(capturedHtml)?.[1]
+    if (!requestId) throw new Error("no request_id in consent HTML")
+    return requestId
+  }
+
+  const submitToken = async (requestId: string, token: string) =>
+    fetch(`${baseUrl}/oauth/decide`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        request_id: requestId,
+        token,
+        action: "approve",
+      }),
+      redirect: "manual",
+    })
+
+  it("approves the exact token", async () => {
+    const requestId = await startPendingRequest()
+    const response = await submitToken(requestId, AUTH_TOKEN)
+    expect(response.status).toBe(302)
+    const location = new URL(response.headers.get("location")!)
+    expect(location.searchParams.get("code")).toBeTruthy()
+    expect(location.searchParams.get("state")).toBe("test-state")
+  })
+
+  it("approves a token with leading and trailing whitespace", async () => {
+    const requestId = await startPendingRequest()
+    const response = await submitToken(requestId, `  ${AUTH_TOKEN}\n`)
+    expect(response.status).toBe(302)
+    const location = new URL(response.headers.get("location")!)
+    expect(location.searchParams.get("code")).toBeTruthy()
+    expect(location.searchParams.get("state")).toBe("test-state")
+  })
+
+  it("approves a token broken by an embedded newline (terminal wrap)", async () => {
+    const requestId = await startPendingRequest()
+    // Split mid-token so the newline is genuinely embedded, regardless of length.
+    const mid = Math.floor(AUTH_TOKEN.length / 2)
+    const wrapped = `${AUTH_TOKEN.slice(0, mid)}\n${AUTH_TOKEN.slice(mid)}`
+    const response = await submitToken(requestId, wrapped)
+    expect(response.status).toBe(302)
+    const location = new URL(response.headers.get("location")!)
+    expect(location.searchParams.get("code")).toBeTruthy()
+    expect(location.searchParams.get("state")).toBe("test-state")
+  })
+
+  it("rejects a genuinely wrong token without redirecting or issuing a code", async () => {
+    const requestId = await startPendingRequest()
+    const response = await submitToken(requestId, "not-the-token")
+    expect(response.status).toBe(200)
+    // No redirect means no authorization code was issued — the only way
+    // the rejection could "pass" spuriously is if it secretly approved.
+    expect(response.headers.get("location")).toBeNull()
+    expect(await response.text()).toContain("Invalid token. Please try again.")
+  })
+
+  it("rejects an all-whitespace token (must not normalize to an empty match)", async () => {
+    const requestId = await startPendingRequest()
+    const response = await submitToken(requestId, "   \n  ")
+    expect(response.status).toBe(200)
+    expect(response.headers.get("location")).toBeNull()
+    expect(await response.text()).toContain("Invalid token. Please try again.")
+  })
+})

--- a/src/vault-mcp/auth/consent-page.ts
+++ b/src/vault-mcp/auth/consent-page.ts
@@ -43,8 +43,11 @@ export const renderConsentPage = ({
   ul{list-style:none;padding:0}
   ul li{padding:.25rem 0;font-size:.9rem}
   ul li::before{content:"\\2022";color:#6366f1;margin-right:.5rem}
-  input[type=password]{width:100%;padding:.6rem .75rem;background:#0f1117;border:1px solid #2e2e38;border-radius:6px;color:#fafafa;font-size:.9rem;margin-top:.25rem}
-  input[type=password]:focus{outline:none;border-color:#6366f1}
+  .token-input{display:flex;gap:.5rem;margin-top:.25rem}
+  .token-input input{flex:1;min-width:0;padding:.6rem .75rem;background:#0f1117;border:1px solid #2e2e38;border-radius:6px;color:#fafafa;font-size:.9rem;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+  .token-input input:focus{outline:none;border-color:#6366f1}
+  .reveal{flex:0 0 auto;padding:0 .75rem;background:#27272a;border:1px solid #2e2e38;border-radius:6px;color:#a1a1aa;font-size:.8rem;cursor:pointer}
+  .reveal:hover{background:#2e2e38;color:#e4e4e7}
   .actions{display:flex;gap:.75rem;margin-top:1.5rem}
   button{flex:1;padding:.6rem 1rem;border:none;border-radius:6px;font-size:.9rem;cursor:pointer;font-weight:500}
   .approve{background:#6366f1;color:#fff}
@@ -74,7 +77,10 @@ export const renderConsentPage = ({
     <input type="hidden" name="request_id" value="${escapeHtml(requestId)}">
     <div class="field">
       <div class="label">Server token</div>
-      <input type="password" name="token" placeholder="Enter your MCP_AUTH_TOKEN" required autocomplete="off">
+      <div class="token-input">
+        <input type="password" id="token" name="token" placeholder="Enter your MCP_AUTH_TOKEN" required autocomplete="off">
+        <button type="button" class="reveal" aria-label="Show or hide token" onclick="var t=document.getElementById('token');var s=t.type==='password';t.type=s?'text':'password';this.textContent=s?'Hide':'Show'">Show</button>
+      </div>
     </div>
     <div class="actions">
       <button type="submit" name="action" value="deny" class="deny">Deny</button>

--- a/src/vault-mcp/auth/oauth-routes.ts
+++ b/src/vault-mcp/auth/oauth-routes.ts
@@ -79,7 +79,15 @@ export const createOAuthRoutes = ({
         return
       }
 
-      if (!token || !safeEqual(token, authToken)) {
+      // Tolerate whitespace introduced when the token is copied from a
+      // terminal: a 64-character token wraps across lines in a narrow
+      // terminal, and selecting it captures the wrap as an embedded
+      // newline (plus possible leading/trailing spaces). A valid
+      // MCP_AUTH_TOKEN never contains whitespace, so stripping it is safe
+      // and keeps the consent flow forgiving — mirroring the trim()
+      // already applied to bearer-header auth in parseBearer().
+      const submittedToken = token?.replace(/\s+/g, "") ?? ""
+      if (!submittedToken || !safeEqual(submittedToken, authToken)) {
         res.type("html").send(
           renderConsentPage({
             clientName: pending.client.client_name ?? pending.client.client_id,

--- a/src/vault-mcp/server.ts
+++ b/src/vault-mcp/server.ts
@@ -31,7 +31,10 @@ export const createErrorMiddleware =
 
 const startServer = async (): Promise<void> => {
   const config = loadConfig()
-  const authToken = env.get("MCP_AUTH_TOKEN").required().asString()
+  // Trim so a stray trailing space or newline on MCP_AUTH_TOKEN in .env
+  // can't silently break every auth attempt — a valid token has no
+  // surrounding whitespace.
+  const authToken = env.get("MCP_AUTH_TOKEN").required().asString().trim()
   const vaultPath = env.get("VAULT_PATH").required().asString()
   const publicUrl = env.get("PUBLIC_URL").required().asString()
 


### PR DESCRIPTION
## Problem

A 64-character `MCP_AUTH_TOKEN` copied out of a terminal can arrive with an embedded newline (the token wraps across lines and the copy captures the wrap) or surrounding whitespace. The OAuth consent page compared the submitted value to the configured token with no normalization, so an otherwise-correct token was rejected as **"Invalid token"**. The bearer-header path already trims via `parseBearer`; the consent path did not — an inconsistency between the two auth entry points.

## Changes

- **`oauth-routes.ts`** — strip whitespace from the submitted token in `/oauth/decide` before `safeEqual`. A valid `MCP_AUTH_TOKEN` never contains whitespace, so this is security-neutral (the constant-time compare still runs on the normalized value; token entropy is unchanged) and mirrors the existing bearer-path trim. An all-whitespace submission still normalizes to empty and is rejected.
- **`server.ts`** — `.trim()` `MCP_AUTH_TOKEN` at config load. `env-var`'s `asString()` does not trim, so a stray trailing space in `.env` would otherwise silently break every auth attempt.
- **`consent-page.ts`** — add a Show/Hide toggle on the token field (default masked) so the value can be verified before submitting.
- **`messages.ts`** — print the auth token on its own line in the CLI connect message, so a line-select copies just the token (no `Auth token: ` prefix, less likely to wrap into a padded line).
- **`deploy/local/README.md`** — troubleshooting section covering `invalid_client` (stale cached client registration after recreating the server) and the `Invalid token` copy-whitespace case.

## Tests

New, each mutation-checked (fails when the corresponding fix is reverted):

- `oauth-routes.test.ts` — approves exact / leading-trailing-whitespace / embedded-newline tokens (302 + auth code); rejects a wrong token and an all-whitespace token without redirecting or issuing a code.
- `consent-page.test.ts` — token field masked by default; reveal button wired to the input's id and flips it to a visible type.
- `init.test.ts` — generated token rendered alone on its own line, not inline with the label.

Verified locally: 614 server + 78 CLI tests pass, lint clean, both builds clean. The fix was also confirmed end-to-end against a from-source server — a newline-corrupted token submitted to `/oauth/decide` returns 302 with an auth code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a token visibility toggle button on the consent page to show/hide token input.
  * Token now displays on its own line for cleaner copying.

* **Bug Fixes**
  * Token validation now accepts tokens with extra whitespace and line breaks from copy-paste operations.

* **Documentation**
  * Added troubleshooting section with guidance for common connection issues, including invalid client and token validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->