### PR TITLE
fix(cli): expand ~ in config dir and suggest user-scoped mcp add

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,10 @@ Add the server URL in any MCP client — Claude Code, Claude Desktop, Cursor, Op
 **Claude Code:**
 
 ```bash
-claude mcp add --transport http vault-cortex http://localhost:8000/mcp   # local (or <PUBLIC_URL>/mcp)
+claude mcp add --scope user --transport http vault-cortex http://localhost:8000/mcp   # local (or <PUBLIC_URL>/mcp)
 ```
+
+`--scope user` registers the server for every project; omit it to scope it to the current directory only.
 
 **Claude Desktop:** the "Add custom connector" dialog only accepts `https` URLs. With an `https` PUBLIC_URL, add it directly in the connector dialog; for a localhost server, register it in `claude_desktop_config.json` through the [mcp-remote](https://github.com/geelen/mcp-remote) stdio bridge instead:
 

--- a/cli/src/__tests__/init.test.ts
+++ b/cli/src/__tests__/init.test.ts
@@ -1,7 +1,13 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, onTestFinished } from "vitest"
 
 import { runInit } from "../init.js"
 import { readComposeTemplate } from "../scaffold.js"
@@ -223,7 +229,7 @@ describe("local connect message client routing", () => {
     expect(exitCode).toBe(0)
     const connectMessage = scripted.notes[0]
     expect(connectMessage).toContain(
-      "claude mcp add --transport http vault-cortex http://localhost:8000/mcp",
+      "claude mcp add --scope user --transport http vault-cortex http://localhost:8000/mcp",
     )
     expect(connectMessage).toContain(
       '"mcp-remote", "http://localhost:8000/mcp"',
@@ -261,6 +267,33 @@ describe("local connect message client routing", () => {
   })
 })
 
+describe("target directory tilde expansion", () => {
+  it("expands a leading ~ in --dir to the home directory instead of a literal ~ folder", async () => {
+    const vaultDir = makeVault()
+    const fakeHome = mkdtempSync(join(tmpdir(), "vault-cli-home-"))
+    const originalHome = process.env.HOME
+    process.env.HOME = fakeHome
+    onTestFinished(() => {
+      process.env.HOME = originalHome
+    })
+    const scripted = createScriptedPrompts([])
+
+    const exitCode = await runInit(
+      { yes: true, vaultPath: vaultDir, dir: "~/vault-cortex" },
+      {
+        prompts: scripted.prompts,
+        docker: dockerUnavailable,
+        fetchFn: fetchNever,
+      },
+    )
+
+    expect(exitCode).toBe(0)
+    // Files land under the expanded home, not a literal "~" directory.
+    expect(existsSync(join(fakeHome, "vault-cortex", ".env"))).toBe(true)
+    expect(existsSync(join(process.cwd(), "~"))).toBe(false)
+  })
+})
+
 describe("remote connect message https routing", () => {
   const runRemoteInit = async (publicUrl: string) => {
     const scripted = createScriptedPrompts([
@@ -292,7 +325,7 @@ describe("remote connect message https routing", () => {
 
     expect(connectMessage).toContain("only accept https URLs")
     expect(connectMessage).toContain(
-      "claude mcp add --transport http vault-cortex http://203.0.113.10:8000/mcp",
+      "claude mcp add --scope user --transport http vault-cortex http://203.0.113.10:8000/mcp",
     )
   })
 

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -14,7 +14,7 @@ import {
   type Mode,
 } from "./scaffold.js"
 import { generateToken } from "./token.js"
-import { validateVaultPath } from "./vault.js"
+import { expandTilde, validateVaultPath } from "./vault.js"
 import type { Prompts } from "./prompts.js"
 
 export type InitFlags = {
@@ -257,14 +257,18 @@ const runLocalInit = async (
       ? vaultPathResult.path
       : await askVaultPath(prompts)
 
+  // expandTilde before resolve: resolve() treats a leading `~` as a literal
+  // path segment, so a quoted "~/path" would create a directory named "~".
   const targetDir = resolve(
-    flags.dir ??
-      (flags.yes
-        ? DEFAULT_TARGET_DIR
-        : await prompts.text("Where should I put the config files?", {
-            defaultValue: DEFAULT_TARGET_DIR,
-            placeholder: DEFAULT_TARGET_DIR,
-          })),
+    expandTilde(
+      flags.dir ??
+        (flags.yes
+          ? DEFAULT_TARGET_DIR
+          : await prompts.text("Where should I put the config files?", {
+              defaultValue: DEFAULT_TARGET_DIR,
+              placeholder: DEFAULT_TARGET_DIR,
+            })),
+    ),
   )
 
   const token = generateToken()
@@ -319,12 +323,16 @@ const runRemoteInit = async (
 ): Promise<number> => {
   const { prompts, docker } = deps
 
+  // expandTilde before resolve: resolve() treats a leading `~` as a literal
+  // path segment, so a quoted "~/path" would create a directory named "~".
   const targetDir = resolve(
-    flags.dir ??
-      (await prompts.text("Where should I put the config files?", {
-        defaultValue: DEFAULT_TARGET_DIR,
-        placeholder: DEFAULT_TARGET_DIR,
-      })),
+    expandTilde(
+      flags.dir ??
+        (await prompts.text("Where should I put the config files?", {
+          defaultValue: DEFAULT_TARGET_DIR,
+          placeholder: DEFAULT_TARGET_DIR,
+        })),
+    ),
   )
 
   const publicUrl = await askPublicUrl(prompts)

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -54,7 +54,9 @@ Connect your MCP client:
   ${tokenLine}
 
 Claude Code:
-  1. claude mcp add --transport http vault-cortex http://localhost:${port}/mcp
+  1. claude mcp add --scope user --transport http vault-cortex http://localhost:${port}/mcp
+     (--scope user registers it for every project; drop it to scope
+     the server to the current directory only)
   2. Approve the browser consent page with the token above
   3. Done. The client holds auto-refreshing access tokens; the
      token never sits in client config
@@ -128,7 +130,7 @@ export const buildRemoteConnectMessage = (params: {
 Note: claude.ai and Claude Desktop only accept https URLs — set up
 HTTPS when you're ready for those clients (see the HTTPS section in
 the remote guide). Claude Code works with http:
-  claude mcp add --transport http vault-cortex ${publicUrl}/mcp`
+  claude mcp add --scope user --transport http vault-cortex ${publicUrl}/mcp`
 
   // Flush-left on purpose: template literals keep leading whitespace, so
   // indenting these lines would indent the rendered output.

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -44,7 +44,9 @@ The server listens at `http://localhost:8000/mcp`.
 
 **Claude Code:**
 
-1. Run `claude mcp add --transport http vault-cortex http://localhost:8000/mcp`
+1. Run `claude mcp add --scope user --transport http vault-cortex http://localhost:8000/mcp`
+   (`--scope user` registers it for every project; drop it to scope the server
+   to the current directory only)
 2. Approve the consent page in your browser with your `MCP_AUTH_TOKEN`.
 3. Done. The client receives auto-refreshing access tokens, so the token
    itself never sits in client config.
@@ -130,7 +132,7 @@ it. Clear the client's stored authorization for this server and reconnect so it
 registers fresh:
 
 - **Claude Code:** `claude mcp remove <name>`, then
-  `claude mcp add --transport http <name> http://localhost:8000/mcp`.
+  `claude mcp add --scope user --transport http <name> http://localhost:8000/mcp`.
 - **Claude Desktop / mcp-remote:** delete `~/.mcp-auth` and restart the client.
 - **Other clients:** remove and re-add the server.
 

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -140,8 +140,10 @@ access token (24h) with automatic refresh (60-day sliding window).
 Claude Code also accepts `http` URLs directly:
 
 ```bash
-claude mcp add --transport http vault-cortex <PUBLIC_URL>/mcp
+claude mcp add --scope user --transport http vault-cortex <PUBLIC_URL>/mcp
 ```
+
+`--scope user` registers the server for every project; omit it to scope it to the current directory only.
 
 ### Static bearer token (CLI tools, curl)
 


### PR DESCRIPTION
## Summary

Two CLI UX fixes surfaced while connecting a local server with `npx vault-cortex init`:

- **`claude mcp add` scope.** The suggested connect command defaulted to *local* scope, registering the server only for the directory `init` happened to run in. The suggested command now uses `--scope user` so a personal vault MCP is available across every project, with a one-line note that dropping the flag scopes it to the current directory. Applied to the CLI connect messages (local + remote http fallback) and the README / `deploy/{local,remote}` docs.

- **Tilde in the config dir.** The "Where should I put the config files?" target-dir prompt passed input straight to `resolve()`, which treats a leading `~` as a literal path segment — a quoted `~/path` created a directory literally named `~`. The target dir now runs through the existing `expandTilde` helper (already used for the vault path) before resolving, in both the local and remote flows.

## Tests

- New regression test: a `~`-prefixed `--dir` expands to the home directory instead of a literal `~` folder (mutation-verified — fails without the `expandTilde` wrapping).
- Updated two connect-message assertions to expect `--scope user`.
- Full CLI suite green: 79 passed. Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)