### PR TITLE
feat: switch obsidian-sync to the forked image, drop init-config-perms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ PUBLIC_URL=
 # Obsidian Sync credentials
 # Generate OBSIDIAN_AUTH_TOKEN once with:
 #   docker run --rm -it --entrypoint get-token \
-#     ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+#     ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
 OBSIDIAN_AUTH_TOKEN=
 VAULT_NAME=
 VAULT_PASSWORD=              # only if vault has E2E encryption
@@ -40,7 +40,7 @@ GHCR_USER=
 PUID=1000
 PGID=1000
 DEVICE_NAME=vault-cortex-lightsail
-CONFLICT_STRATEGY=merge
+CONFLICT_STRATEGY=conflict
 SYNC_MODE=bidirectional
 LOG_LEVEL=info
 # Days to retain persistent log files before cleanup (default: 30).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,7 +199,7 @@ jobs:
           PUID=1000
           PGID=1000
           DEVICE_NAME=vault-cortex-lightsail
-          CONFLICT_STRATEGY=merge
+          CONFLICT_STRATEGY=conflict
           SYNC_MODE=bidirectional
           LOG_LEVEL=info
           TZ=${TZ:-UTC}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,12 @@ Project conventions for AI-assisted development on vault-cortex — for Claude C
 
 ## What this project is
 
-Remote MCP server exposing an Obsidian vault over HTTPS. Three services on
-Lightsail via Docker Compose: init-config-perms (one-shot volume fix),
-obsidian-sync (bidirectional Obsidian Sync), vault-mcp (MCP server, UID 1000).
+Remote MCP server exposing an Obsidian vault over HTTPS. Two services on
+Lightsail via Docker Compose: obsidian-sync (bidirectional Obsidian Sync),
+vault-mcp (MCP server, UID 1000). The obsidian-sync image is a fork of
+Belphemur/obsidian-headless-sync-docker that chowns its config dir at build
+time (so no init container is needed) and registers the initial Sync device
+under DEVICE_NAME.
 Fronted by API Gateway with a smart Lambda authorizer (path-aware: OAuth
 endpoints pass through, /mcp validates static token or JWT). IaC via SST v4.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,13 +154,11 @@ sequenceDiagram
 
 ```mermaid
 graph LR
-    A["init-config-perms<br/>(Alpine one-shot)<br/>chown config volume"] --> B["obsidian-sync<br/>(UID 1000)<br/>Obsidian Sync → /vault"]
-    B --> C["vault-mcp<br/>(UID 1000)<br/>MCP server :8000"]
+    B["obsidian-sync<br/>(UID 1000)<br/>Obsidian Sync → /vault"] --> C["vault-mcp<br/>(UID 1000)<br/>MCP server :8000"]
     B -.->|shared volume| D[("/vault<br/>source of truth")]
     C -.->|shared volume| D
     C -.->|index + OAuth| E[("/data<br/>index.db + oauth.db")]
-    A -.->|fixes perms| F[("config volume<br/>/home/obsidian/.config")]
-    B -.->|sync state| F
+    B -.->|sync state| F[("config volume<br/>/home/obsidian/.config<br/>owned obsidian:obsidian at build time")]
 ```
 
 ## Data Flow
@@ -342,16 +340,15 @@ signed with the new key on their next token refresh.
 
 ### Docker Compose: startup sequence
 
-Three services run in order via `depends_on`:
+Two services run in order via `depends_on`:
 
-1. **`init-config-perms`** (Alpine, one-shot) — chowns the obsidian config
-   volume to `PUID:PGID`. Workaround for an upstream bug: the
-   obsidian-headless Dockerfile creates `/home/obsidian/.config` as root,
-   so Docker named volumes inherit root ownership.
-2. **`obsidian-sync`** — bidirectional Obsidian Sync. Stores sync state in
+1. **`obsidian-sync`** — bidirectional Obsidian Sync. Stores sync state in
    the config volume at `/home/obsidian/.config` (persists across restarts
-   for incremental sync — critical for Phase 2 LightRAG ingestion).
-3. **`vault-mcp`** — MCP server. Runs as the `node` user (UID 1000),
+   for incremental sync — critical for Phase 2 LightRAG ingestion). The
+   forked sync image owns `/home/obsidian/.config` as `obsidian:obsidian`
+   at build time, so named-volume mounts are writable by UID 1000 without a
+   separate init container.
+2. **`vault-mcp`** — MCP server. Runs as the `node` user (UID 1000),
    matching obsidian-sync's `PUID` so both containers can read/write the
    shared `/vault` volume. On startup: builds the FTS5 search index,
    bootstraps memory templates if the memory folder doesn't exist, then

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -62,7 +62,7 @@ Then open `~/.config/vault-cortex/.env` and fill in the remaining values:
 The [`.env.example`](./.env.example) file also includes optional configuration for the memory system (`MEMORY_DIR`, `PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`), timezone (`TZ`), and OAuth metadata (`SERVICE_DOCUMENTATION_URL`). All have sensible defaults — see the [Configuration](./README.md#configuration) section in the README.
 
 ```bash
-docker run --rm -it --entrypoint get-token ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+docker run --rm -it --entrypoint get-token ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
 ```
 
 **4. Authenticate to GHCR** (once per machine):
@@ -83,7 +83,7 @@ That runs, in order:
 2. `npm run docker:publish` — builds (targeting linux/amd64) + pushes to GHCR
 3. `npm run lightsail:up` — ensures `/opt/vault-cortex` exists, waits for Docker (cloud-init), logs into GHCR on the instance, SCPs `docker-compose.yml` + `.env`, then `docker compose pull && up -d`
 
-On startup, docker-compose runs three services in order: `init-config-perms` (chowns the obsidian config volume — workaround for an upstream bug) → `obsidian-sync` (syncs your vault) → `vault-mcp` (MCP server). Both `obsidian-sync` and `vault-mcp` run as UID 1000 to share the `/vault` volume. See [ARCHITECTURE.md § Docker Compose Startup](./ARCHITECTURE.md#docker-compose-startup) for the full diagram.
+On startup, docker-compose runs two services in order: `obsidian-sync` (syncs your vault) → `vault-mcp` (MCP server). Both run as UID 1000 to share the `/vault` volume. The obsidian config volume is owned `obsidian:obsidian` at image build time by the forked sync image, so no init container is needed. See [ARCHITECTURE.md § Docker Compose Startup](./ARCHITECTURE.md#docker-compose-startup) for the full diagram.
 
 ## Verify
 
@@ -228,7 +228,7 @@ To find your stage: `cat .sst/stage` (after your first deploy).
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GHCR_TOKEN`             | Personal access token (classic) with `write:packages` + `read:packages`. Used by `docker login` both at build-push and on-instance pull. Persists across runs; rotate when stale. |
 | `MCP_AUTH_TOKEN`         | Same value as the SST secret of the same name. Written into the instance `.env` for the Express auth layer.                                                                       |
-| `OBSIDIAN_AUTH_TOKEN`    | Output of `docker run --rm -it --entrypoint get-token ghcr.io/belphemur/obsidian-headless-sync-docker:latest`.                                                                    |
+| `OBSIDIAN_AUTH_TOKEN`    | Output of `docker run --rm -it --entrypoint get-token ghcr.io/aliasunder/obsidian-headless-sync-docker:latest`.                                                                   |
 | `VAULT_PASSWORD`         | Optional — only set if your vault uses end-to-end encryption. Empty value is fine and ships through to `.env` as `VAULT_PASSWORD=`.                                               |
 | `SSH_PUBKEY`             | Public key contents of your `~/.ssh/vault-cortex.pub` (literal, single line). Same key local dev and CI use — see [Prerequisites](#prerequisites).                                |
 | `SSH_PRIVATE_KEY`        | Private half (`~/.ssh/vault-cortex`, full multi-line block including BEGIN/END markers). Loaded by `webfactory/ssh-agent` for SCP/SSH to the instance.                            |

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ npx skills add aliasunder/agent-skills --skill obsidian-vault
 
 ## Acknowledgments
 
-Vault Cortex's remote capability exists because of [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker) — a [headless Obsidian Sync](https://obsidian.md/help/sync/headless) client that runs in Docker without a display server. It's the piece that makes "access your vault from anywhere" possible.
+Vault Cortex's remote capability exists because of [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker) — a [headless Obsidian Sync](https://obsidian.md/help/sync/headless) client that runs in Docker without a display server. It's the piece that makes "access your vault from anywhere" possible. The remote stack runs a small [fork](https://github.com/aliasunder/obsidian-headless-sync-docker) that adds a build-time config `chown` and `--device-name` on the initial Sync registration ([upstream PR #8](https://github.com/Belphemur/obsidian-headless-sync-docker/pull/8) remains open).
 
 ## Contributing
 

--- a/cli/src/__tests__/env.test.ts
+++ b/cli/src/__tests__/env.test.ts
@@ -78,7 +78,7 @@ describe("buildRemoteEnv", () => {
 
     expect(env).toContain("deploy/remote/.env.example")
     expect(env).toContain("# DEVICE_NAME=vault-cortex")
-    expect(env).toContain("# CONFLICT_STRATEGY=merge")
+    expect(env).toContain("# CONFLICT_STRATEGY=conflict")
     expect(env).toContain("# SYNC_MODE=bidirectional")
     expect(env).toContain("# PUID=1000")
   })

--- a/cli/src/__tests__/scaffold.test.ts
+++ b/cli/src/__tests__/scaffold.test.ts
@@ -26,11 +26,14 @@ describe("buildFilesToWrite", () => {
     expect(files[1].content).toBe("MCP_AUTH_TOKEN=abc\n")
   })
 
-  it("plans the three-service compose file for remote mode", () => {
+  it("plans the two-service remote compose with the forked sync image and no init-config-perms", () => {
     const files = buildFilesToWrite("remote", "MCP_AUTH_TOKEN=abc\n")
 
     expect(files[0].content).toContain("obsidian-sync")
-    expect(files[0].content).toContain("init-config-perms")
+    expect(files[0].content).toContain(
+      "ghcr.io/aliasunder/obsidian-headless-sync-docker:latest",
+    )
+    expect(files[0].content).not.toContain("init-config-perms")
   })
 })
 

--- a/cli/src/docker.ts
+++ b/cli/src/docker.ts
@@ -12,7 +12,7 @@ export type DockerRunner = {
 
 /** The image whose `get-token` entrypoint issues Obsidian Sync auth tokens. */
 export const OBSIDIAN_SYNC_IMAGE =
-  "ghcr.io/belphemur/obsidian-headless-sync-docker:latest"
+  "ghcr.io/aliasunder/obsidian-headless-sync-docker:latest"
 
 export const createDockerRunner = (): DockerRunner => ({
   isComposeAvailable: () =>

--- a/cli/src/env.ts
+++ b/cli/src/env.ts
@@ -73,8 +73,8 @@ const REMOTE_OPTIONAL_BLOCK = `# Optional ────────────�
 # Device name shown in Obsidian Sync settings.
 # DEVICE_NAME=vault-cortex
 
-# Obsidian Sync conflict resolution: merge | ours | theirs (default: merge).
-# CONFLICT_STRATEGY=merge
+# Obsidian Sync conflict resolution: merge | conflict (default: conflict).
+# CONFLICT_STRATEGY=conflict
 
 # Sync direction: bidirectional | pull-only | push-only (default: bidirectional).
 # SYNC_MODE=bidirectional
@@ -109,7 +109,7 @@ VAULT_PASSWORD=${answers.vaultPassword}`
       ? `# Obsidian Sync auth token — FILL THIS IN before docker compose up.
 # Generate once with:
 #   docker run --rm -it --entrypoint get-token \\
-#     ghcr.io/belphemur/obsidian-headless-sync-docker:latest`
+#     ghcr.io/aliasunder/obsidian-headless-sync-docker:latest`
       : `# Obsidian Sync auth token.`
 
   return `# vault-cortex — remote quickstart (Obsidian Sync)

--- a/cli/templates/remote/docker-compose.yml
+++ b/cli/templates/remote/docker-compose.yml
@@ -1,7 +1,7 @@
 # vault-cortex — remote quickstart (Obsidian Sync)
 #
 # Run vault-cortex on a VPS with Obsidian Sync for remote access from any device.
-# Three services: init-config-perms → obsidian-sync → vault-mcp.
+# Two services: obsidian-sync → vault-mcp.
 #
 # 1. cp .env.example .env   (then fill in required values)
 # 2. docker compose up -d
@@ -12,25 +12,10 @@
 name: vault-cortex
 
 services:
-  # Workaround: the upstream Dockerfile creates /home/obsidian/.config as
-  # root. Docker named volumes inherit this root ownership, so the obsidian
-  # user (UID 1000) can't write sync state. This init container chowns the
-  # volume before obsidian-sync starts.
-  # Remove when upstream fixes: github.com/Belphemur/obsidian-headless-sync-docker
-  init-config-perms:
-    image: alpine:latest
-    command: sh -c "chown -R ${PUID:-1000}:${PGID:-1000} /config"
-    volumes:
-      - obsidian_config:/config
-    restart: "no"
-
   obsidian-sync:
-    image: ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+    image: ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
     container_name: obsidian-sync
     restart: unless-stopped
-    depends_on:
-      init-config-perms:
-        condition: service_completed_successfully
     environment:
       OBSIDIAN_AUTH_TOKEN: "${OBSIDIAN_AUTH_TOKEN:?Set OBSIDIAN_AUTH_TOKEN — see .env.example}"
       VAULT_NAME: "${VAULT_NAME:?Set VAULT_NAME to your Obsidian vault name (case-sensitive)}"
@@ -38,7 +23,7 @@ services:
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
       DEVICE_NAME: ${DEVICE_NAME:-vault-cortex}
-      CONFLICT_STRATEGY: ${CONFLICT_STRATEGY:-merge}
+      CONFLICT_STRATEGY: ${CONFLICT_STRATEGY:-conflict}
       SYNC_MODE: ${SYNC_MODE:-bidirectional}
       TZ: ${TZ:-UTC}
     volumes:

--- a/deploy/remote/.env.example
+++ b/deploy/remote/.env.example
@@ -14,7 +14,7 @@ PUBLIC_URL=
 
 # Obsidian Sync auth token. Generate once with:
 #   docker run --rm -it --entrypoint get-token \
-#     ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+#     ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
 OBSIDIAN_AUTH_TOKEN=
 
 # Exact name of your Obsidian vault (case-sensitive).
@@ -51,8 +51,9 @@ VAULT_NAME=
 # Device name shown in Obsidian Sync settings.
 # DEVICE_NAME=vault-cortex
 
-# Obsidian Sync conflict resolution: merge | ours | theirs (default: merge).
-# CONFLICT_STRATEGY=merge
+# Obsidian Sync conflict resolution: merge | conflict (default: conflict).
+# 'conflict' writes a separate conflict file instead of silently merging.
+# CONFLICT_STRATEGY=conflict
 
 # Sync direction: bidirectional | pull-only | push-only (default: bidirectional).
 # SYNC_MODE=bidirectional

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -36,7 +36,7 @@ Or clone the repo and `cd deploy/remote`.
 
 ```bash
 docker run --rm -it --entrypoint get-token \
-  ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+  ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
 ```
 
 **4. Create your `.env` file:**

--- a/deploy/remote/docker-compose.yml
+++ b/deploy/remote/docker-compose.yml
@@ -1,7 +1,7 @@
 # vault-cortex — remote quickstart (Obsidian Sync)
 #
 # Run vault-cortex on a VPS with Obsidian Sync for remote access from any device.
-# Three services: init-config-perms → obsidian-sync → vault-mcp.
+# Two services: obsidian-sync → vault-mcp.
 #
 # 1. cp .env.example .env   (then fill in required values)
 # 2. docker compose up -d
@@ -12,25 +12,10 @@
 name: vault-cortex
 
 services:
-  # Workaround: the upstream Dockerfile creates /home/obsidian/.config as
-  # root. Docker named volumes inherit this root ownership, so the obsidian
-  # user (UID 1000) can't write sync state. This init container chowns the
-  # volume before obsidian-sync starts.
-  # Remove when upstream fixes: github.com/Belphemur/obsidian-headless-sync-docker
-  init-config-perms:
-    image: alpine:latest
-    command: sh -c "chown -R ${PUID:-1000}:${PGID:-1000} /config"
-    volumes:
-      - obsidian_config:/config
-    restart: "no"
-
   obsidian-sync:
-    image: ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+    image: ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
     container_name: obsidian-sync
     restart: unless-stopped
-    depends_on:
-      init-config-perms:
-        condition: service_completed_successfully
     environment:
       OBSIDIAN_AUTH_TOKEN: "${OBSIDIAN_AUTH_TOKEN:?Set OBSIDIAN_AUTH_TOKEN — see .env.example}"
       VAULT_NAME: "${VAULT_NAME:?Set VAULT_NAME to your Obsidian vault name (case-sensitive)}"
@@ -38,7 +23,7 @@ services:
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
       DEVICE_NAME: ${DEVICE_NAME:-vault-cortex}
-      CONFLICT_STRATEGY: ${CONFLICT_STRATEGY:-merge}
+      CONFLICT_STRATEGY: ${CONFLICT_STRATEGY:-conflict}
       SYNC_MODE: ${SYNC_MODE:-bidirectional}
       TZ: ${TZ:-UTC}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,25 +12,10 @@
 name: vault-cortex
 
 services:
-  # Workaround: the upstream Dockerfile creates /home/obsidian/.config as
-  # root (mkdir runs as root before chown). Docker named volumes inherit
-  # this root ownership, so the obsidian user (UID 1000) can't write sync
-  # state. This init container chowns the volume before obsidian-sync starts.
-  # Remove when upstream fixes: github.com/Belphemur/obsidian-headless-sync-docker
-  init-config-perms:
-    image: alpine:latest
-    command: sh -c "chown -R ${PUID:-1000}:${PGID:-1000} /config"
-    volumes:
-      - obsidian_config:/config
-    restart: "no"
-
   obsidian-sync:
-    image: ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+    image: ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
     container_name: obsidian-sync
     restart: unless-stopped
-    depends_on:
-      init-config-perms:
-        condition: service_completed_successfully
     environment:
       OBSIDIAN_AUTH_TOKEN: ${OBSIDIAN_AUTH_TOKEN}
       VAULT_NAME: ${VAULT_NAME}
@@ -38,7 +23,7 @@ services:
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
       DEVICE_NAME: ${DEVICE_NAME:-vault-cortex-lightsail}
-      CONFLICT_STRATEGY: ${CONFLICT_STRATEGY:-merge}
+      CONFLICT_STRATEGY: ${CONFLICT_STRATEGY:-conflict}
       SYNC_MODE: ${SYNC_MODE:-bidirectional}
       TZ: ${TZ:-UTC}
     volumes:


### PR DESCRIPTION
Switches the remote stack to the hardened fork (`ghcr.io/aliasunder/obsidian-headless-sync-docker`) and retires the `init-config-perms` workaround now that the fork chowns its config dir at build time.

> [!IMPORTANT]
> **Do not merge/deploy until the fork image is published.** The companion PR (aliasunder/obsidian-headless-sync-docker) must merge and its **Manual Release** must run first, so `ghcr.io/aliasunder/obsidian-headless-sync-docker:latest` exists. The live `obsidian_config` volume is already `1000:1000`-owned (init-config-perms has been maintaining it), so removing it is safe; fresh deployments rely on the fork's build-time chown.

## Changes
- **`feat:` switch + cleanup** — point all 3 remote compose files at the fork image; remove the `init-config-perms` service and its `depends_on`; retarget the `get-token` image in `cli/src/docker.ts`, `cli/src/env.ts`, and the `.env` examples. Default `CONFLICT_STRATEGY=conflict` everywhere — including `deploy.yml`'s `.env` writer, which hardcoded `merge` and silently reverted the conflict-strategy mitigation on every deploy. Tests updated (scaffold: two-service remote compose, fork image, no `init-config-perms`; env: conflict default).
- **`docs:`** ARCHITECTURE startup diagram + sequence (3→2 services; config volume now owned at build time), AGENTS/DEPLOY service summaries, and the README acknowledgment (credits upstream + notes the fork and its two divergences).

## Verification
`npm test` (619 pass), `npm run lint`, `npm run prettier:check` clean; both compose files validate via `docker compose config` (two services, fork image, `conflict` resolved).