### PR TITLE
feat(memory): harden writes against partial-write and clobber data loss

### DIFF
--- a/src/vault-mcp/__tests__/server.test.ts
+++ b/src/vault-mcp/__tests__/server.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  onTestFinished,
+} from "vitest"
 import type { Request, Response, NextFunction } from "express"
-import { createErrorMiddleware } from "../server.js"
+import { createErrorMiddleware, createShutdownHandler } from "../server.js"
 import { logger } from "../../logger.js"
 
 type MockRes = {
@@ -121,5 +129,47 @@ describe("createErrorMiddleware", () => {
     middleware(new Error("x"), req, res, next)
 
     expect(next).not.toHaveBeenCalled()
+  })
+})
+
+describe("createShutdownHandler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(logger, "info").mockImplementation(() => {})
+    vi.spyOn(logger, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("closes the server and exits 0 once draining completes", () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never)
+    onTestFinished(() => exitSpy.mockRestore())
+    // close() that immediately invokes its callback = drain completes at once.
+    const close = vi.fn((callback: () => void) => callback())
+
+    createShutdownHandler({ close })()
+
+    expect(close).toHaveBeenCalledOnce()
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
+
+  it("forces exit 1 if the drain does not finish within the timeout", () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never)
+    onTestFinished(() => exitSpy.mockRestore())
+    // close() that never invokes its callback = drain hangs.
+    const close = vi.fn()
+
+    createShutdownHandler({ close }, 10_000)()
+
+    expect(exitSpy).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(10_000)
+    expect(exitSpy).toHaveBeenCalledWith(1)
   })
 })

--- a/src/vault-mcp/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/__tests__/tool-definitions.test.ts
@@ -133,6 +133,15 @@ describe("registerTools", () => {
     expect(call[1].description).toContain("Cross-section move")
   })
 
+  it.each([TOOL_NAMES.VAULT_UPDATE_MEMORY, TOOL_NAMES.VAULT_DELETE_MEMORY])(
+    "%s description documents the shrink-guard error",
+    (name) => {
+      const call = findCall(name)!
+      expect(call[1].description).toContain("Errors:")
+      expect(call[1].description).toContain("refusing memory write")
+    },
+  )
+
   it("vault_update_properties description documents null-deletes-key contract", () => {
     const call = findCall(TOOL_NAMES.VAULT_UPDATE_PROPERTIES)!
     expect(call[1].description).toContain("null as a value to delete")

--- a/src/vault-mcp/server.ts
+++ b/src/vault-mcp/server.ts
@@ -39,7 +39,7 @@ export const createShutdownHandler =
   (
     httpServer: { close: (callback: () => void) => void },
     forceExitMs = 10_000,
-  ) =>
+  ): (() => void) =>
   (): void => {
     logger.info("SIGTERM received, draining")
     httpServer.close(() => {

--- a/src/vault-mcp/server.ts
+++ b/src/vault-mcp/server.ts
@@ -29,6 +29,29 @@ export const createErrorMiddleware =
     }
   }
 
+/**
+ * SIGTERM handler that drains in-flight requests before exiting, so a write
+ * can't be interrupted mid-flight. `close()` stops accepting new connections
+ * and waits for active requests to finish; the fallback forces exit if a
+ * connection hangs the drain longer than `forceExitMs`.
+ */
+export const createShutdownHandler =
+  (
+    httpServer: { close: (callback: () => void) => void },
+    forceExitMs = 10_000,
+  ) =>
+  (): void => {
+    logger.info("SIGTERM received, draining")
+    httpServer.close(() => {
+      logger.info("drained, exiting")
+      process.exit(0)
+    })
+    setTimeout(() => {
+      logger.warn("drain timed out, forcing exit")
+      process.exit(1)
+    }, forceExitMs).unref()
+  }
+
 const startServer = async (): Promise<void> => {
   const config = loadConfig()
   // Trim so a stray trailing space or newline on MCP_AUTH_TOKEN in .env
@@ -89,14 +112,11 @@ const startServer = async (): Promise<void> => {
 
   app.use(createErrorMiddleware())
 
-  app.listen(port, host, () => {
+  const httpServer = app.listen(port, host, () => {
     logger.info("server started", { host, port })
   })
 
-  process.on("SIGTERM", () => {
-    logger.info("SIGTERM received, shutting down")
-    process.exit(0)
-  })
+  process.on("SIGTERM", createShutdownHandler(httpServer))
 }
 
 // Node ESM has no `require.main` — compare argv[1] to this module's path

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -818,6 +818,9 @@ Parameters:
 
 Obsidian syntax: Entry text renders as Obsidian Flavored Markdown. Watch for: #word = tag, [[ = wikilink. Escape with backslash or backticks when unintentional.
 
+Errors:
+- "refusing memory write: … would shrink content from N to M bytes" — a safety guard blocked a write that would remove more than half of the existing file. An append should never shrink a file, so this signals the on-disk copy has diverged from what you expect (e.g. a stale/truncated server copy). Re-read with vault_get_memory or vault_read_note to confirm the current content before retrying.
+
 Returns: Confirmation message.`,
       inputSchema: {
         file: z
@@ -921,6 +924,11 @@ Example: vault_delete_memory({ file: "Opinions", section: "AI tooling & memory (
 
 When to use: Removing an outdated or incorrect entry from a memory file. Call vault_get_memory(file, section) first to see exact entry text for matching.
 Prefer vault_delete_note for deleting entire non-protected notes.
+
+Errors:
+- "no entry matching …" — no bullet matched the given date and entry text; verify exact text via vault_get_memory(file, section).
+- "ambiguous: N entries match …" — more than one bullet matched; the entry text is not unique within the section.
+- "refusing memory write: … would shrink content from N to M bytes" — a safety guard blocked a write that would remove more than half of the file. Removing a single entry should not halve a file with real content, so this signals the on-disk copy has diverged (e.g. a stale/truncated server copy). Re-read with vault_get_memory or vault_read_note to confirm current content before retrying.
 
 Returns: Confirmation message.`,
       inputSchema: {

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  onTestFinished,
+} from "vitest"
 import { mkdtemp, rm, writeFile, mkdir, readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
@@ -802,5 +810,147 @@ describe("bootstrapMemoryDir", () => {
     const parsed = matter(raw)
     expect(parsed.data.title).toBe("Principles — About Me")
     expect(raw).toContain("Secrets invisible at every layer")
+  })
+})
+
+describe("large-shrink guard", () => {
+  it("refuses a delete that would shrink the file by more than half", async () => {
+    // One dominant entry: deleting it drops the file from ~2 KB to ~90 bytes,
+    // a >50% shrink the guard must reject (the June 13 skeleton-clobber shape).
+    const dominantEntry = "x".repeat(2000)
+    const fileContent = `---
+title: Big
+---
+
+# Big
+
+## Notes (newest first)
+- **2026-06-14**: ${dominantEntry}
+- **2026-06-13**: small tail entry
+`
+    await writeFile(join(vault, "About Me/Big.md"), fileContent, "utf8")
+
+    await expect(
+      deleteMemory(
+        {
+          vaultPath: vault,
+          file: "Big",
+          section: "Notes (newest first)",
+          date: "2026-06-14",
+          entry: dominantEntry,
+        },
+        logger,
+      ),
+    ).rejects.toThrow("refusing memory write")
+
+    // The guard fires before the write, so the file is left fully intact.
+    expect(await readFile(join(vault, "About Me/Big.md"), "utf8")).toBe(
+      fileContent,
+    )
+  })
+
+  it("allows a normal single-entry delete on a real-sized file", async () => {
+    await deleteMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+        date: "2026-05-05",
+        entry: "Least-privilege for AI agents",
+      },
+      logger,
+    )
+    const content = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+    expect(content).not.toContain("Least-privilege for AI agents")
+    expect(content).toContain("Secrets invisible at every layer")
+  })
+
+  it("skips the guard for files at or below the 200-byte floor", async () => {
+    const tiny = `---
+title: T
+---
+
+# T
+
+## S (newest first)
+- **2026-06-14**: hi
+`
+    // Sanity-check the fixture is genuinely under the guard's floor.
+    expect(Buffer.byteLength(tiny, "utf8")).toBeLessThan(200)
+    await writeFile(join(vault, "About Me/T.md"), tiny, "utf8")
+
+    await deleteMemory(
+      {
+        vaultPath: vault,
+        file: "T",
+        section: "S (newest first)",
+        date: "2026-06-14",
+        entry: "hi",
+      },
+      logger,
+    )
+    const content = await readFile(join(vault, "About Me/T.md"), "utf8")
+    expect(content).not.toContain("- **2026-06-14**: hi")
+  })
+})
+
+describe("memory write size logging", () => {
+  it("updateMemory logs before/after byte counts", async () => {
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {})
+    onTestFinished(() => infoSpy.mockRestore())
+
+    await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Working style (newest first)",
+        entry: "new entry",
+        date: "2026-06-14",
+      },
+      logger,
+    )
+    const written = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+
+    expect(infoSpy).toHaveBeenCalledWith("updated memory", {
+      file: "Principles",
+      section: "Working style (newest first)",
+      date: "2026-06-14",
+      beforeBytes: Buffer.byteLength(PRINCIPLES_MD, "utf8"),
+      afterBytes: Buffer.byteLength(written, "utf8"),
+    })
+  })
+
+  it("deleteMemory logs before/after byte counts", async () => {
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {})
+    onTestFinished(() => infoSpy.mockRestore())
+
+    await deleteMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+        date: "2026-05-05",
+        entry: "Least-privilege for AI agents",
+      },
+      logger,
+    )
+    const written = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+
+    expect(infoSpy).toHaveBeenCalledWith("deleted memory entry", {
+      file: "Principles",
+      section: "Decision heuristics (newest first)",
+      date: "2026-05-05",
+      beforeBytes: Buffer.byteLength(PRINCIPLES_MD, "utf8"),
+      afterBytes: Buffer.byteLength(written, "utf8"),
+    })
   })
 })

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -1,9 +1,24 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest"
-import { mkdtemp, rm, writeFile, mkdir, readFile } from "node:fs/promises"
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  onTestFinished,
+} from "vitest"
+import {
+  mkdtemp,
+  rm,
+  writeFile,
+  mkdir,
+  readFile,
+  readdir,
+} from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import matter from "gray-matter"
-import { vaultFs } from "../vault-filesystem.js"
+import { vaultFs, atomicWriteFile } from "../vault-filesystem.js"
 import { logger } from "../../../logger.js"
 
 const {
@@ -23,6 +38,31 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(vault, { recursive: true })
+})
+
+describe("atomicWriteFile", () => {
+  it("writes the exact content to the target path", async () => {
+    const target = join(vault, "atomic.md")
+    await atomicWriteFile(target, "exact content\n")
+    expect(await readFile(target, "utf8")).toBe("exact content\n")
+  })
+
+  it("leaves no .tmp staging file behind on success", async () => {
+    await atomicWriteFile(join(vault, "clean.md"), "body\n")
+    const entries = await readdir(vault)
+    expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
+  })
+
+  it("cleans up the staging file and rethrows when the rename fails", async () => {
+    // A directory sitting at the target path makes the final rename fail with
+    // EISDIR — after the temp file has already been staged — so this exercises
+    // the catch-and-cleanup branch, not the initial writeFile.
+    const target = join(vault, "occupied")
+    await mkdir(target)
+    await expect(atomicWriteFile(target, "body\n")).rejects.toThrow()
+    const entries = await readdir(vault)
+    expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
+  })
 })
 
 describe("path traversal", () => {
@@ -564,5 +604,56 @@ describe("updateProperties", () => {
         logger,
       ),
     ).rejects.toThrow("path traversal blocked")
+  })
+})
+
+describe("write size logging", () => {
+  it("writeNote logs beforeBytes 0 and afterBytes for a new file", async () => {
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {})
+    onTestFinished(() => infoSpy.mockRestore())
+
+    await writeNote({ vaultPath: vault, path: "n.md", body: "hello\n" }, logger)
+    const written = await readFile(join(vault, "n.md"), "utf8")
+
+    expect(infoSpy).toHaveBeenCalledWith("wrote note", {
+      path: "n.md",
+      beforeBytes: 0,
+      afterBytes: Buffer.byteLength(written, "utf8"),
+    })
+  })
+
+  it("writeNote logs the prior file size as beforeBytes when overwriting", async () => {
+    const original = "---\ntitle: T\n---\nold body\n"
+    await writeFile(join(vault, "e.md"), original, "utf8")
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {})
+    onTestFinished(() => infoSpy.mockRestore())
+
+    await writeNote({ vaultPath: vault, path: "e.md", body: "new\n" }, logger)
+    const written = await readFile(join(vault, "e.md"), "utf8")
+
+    expect(infoSpy).toHaveBeenCalledWith("wrote note", {
+      path: "e.md",
+      beforeBytes: Buffer.byteLength(original, "utf8"),
+      afterBytes: Buffer.byteLength(written, "utf8"),
+    })
+  })
+
+  it("updateProperties logs before/after byte counts", async () => {
+    const original = "---\ntitle: Original\n---\nBody content\n"
+    await writeFile(join(vault, "p.md"), original, "utf8")
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {})
+    onTestFinished(() => infoSpy.mockRestore())
+
+    await updateProperties(
+      { vaultPath: vault, path: "p.md", properties: { status: "active" } },
+      logger,
+    )
+    const written = await readFile(join(vault, "p.md"), "utf8")
+
+    expect(infoSpy).toHaveBeenCalledWith("updated properties", {
+      path: "p.md",
+      beforeBytes: Buffer.byteLength(original, "utf8"),
+      afterBytes: Buffer.byteLength(written, "utf8"),
+    })
   })
 })

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -1,11 +1,36 @@
 /** Memory store factory — heading-aware parser/writer for semantic memory files. */
 
-import { readFile, writeFile, readdir, mkdir, access } from "node:fs/promises"
+import { readFile, readdir, mkdir, access } from "node:fs/promises"
 import { constants } from "node:fs"
 import { join, basename, dirname } from "node:path"
 import { parseNote, stringifyNote } from "./frontmatter.js"
+import { atomicWriteFile } from "./vault-filesystem.js"
 import { DateTime } from "luxon"
 import type { Logger } from "../../logger.js"
+
+// Refuse a memory write that would remove more than half of an existing file's
+// bytes — a catastrophic shrink almost always means the on-disk copy diverged
+// (e.g. a skeleton template clobbering real content, the June 13 data loss)
+// rather than a legitimate single-entry edit. The 200-byte floor sits just
+// above the largest empty memory template (Me 152 B, Principles 193 B,
+// Opinions 197 B — frontmatter + headings, no entries), so a file with no real
+// content is never guarded, while a file with even one dated entry (~240 B+) is.
+const SHRINK_FLOOR_BYTES = 200
+const SHRINK_RATIO = 0.5
+const guardAgainstShrink = (
+  beforeBytes: number,
+  afterBytes: number,
+  context: string,
+): void => {
+  if (
+    beforeBytes > SHRINK_FLOOR_BYTES &&
+    afterBytes < beforeBytes * SHRINK_RATIO
+  ) {
+    throw new Error(
+      `refusing memory write: ${context} would shrink content from ${beforeBytes} to ${afterBytes} bytes (>50% reduction); re-read with vault_get_memory to confirm current content before retrying`,
+    )
+  }
+}
 
 // Matches dated bullet entries: `- **YYYY-MM-DD**: ...`
 // The date portion is the reliable anchor — entry text after `: ` may contain its own **bold**
@@ -342,11 +367,13 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         section: newSection,
         bullet,
       })
-      await writeFile(filePath, content, "utf8")
+      await atomicWriteFile(filePath, content)
       logger.info("created memory file", {
         file: params.file,
         section: newSection,
         date,
+        beforeBytes: 0,
+        afterBytes: Buffer.byteLength(content, "utf8"),
       })
       return
     }
@@ -362,15 +389,19 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       const appendedLines = [...contentLines, `## ${newSection}`, bullet]
       const newContent = appendedLines.join("\n")
       const serialized = stringifyNote(newContent, parsed.data)
-      await writeFile(
+      const beforeBytes = Buffer.byteLength(existingContent, "utf8")
+      const afterBytes = Buffer.byteLength(serialized, "utf8")
+      guardAgainstShrink(beforeBytes, afterBytes, "creating memory section")
+      await atomicWriteFile(
         memoryFilePath(params.vaultPath, params.file),
         serialized,
-        "utf8",
       )
       logger.info("created memory section", {
         file: params.file,
         section: newSection,
         date,
+        beforeBytes,
+        afterBytes,
       })
       return
     }
@@ -409,15 +440,19 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
 
     const newContent = updatedLines.join("\n")
     const serialized = stringifyNote(newContent, parsed.data)
-    await writeFile(
+    const beforeBytes = Buffer.byteLength(existingContent, "utf8")
+    const afterBytes = Buffer.byteLength(serialized, "utf8")
+    guardAgainstShrink(beforeBytes, afterBytes, "updating memory entry")
+    await atomicWriteFile(
       memoryFilePath(params.vaultPath, params.file),
       serialized,
-      "utf8",
     )
     logger.info("updated memory", {
       file: params.file,
       section: params.section,
       date,
+      beforeBytes,
+      afterBytes,
     })
   }
 
@@ -518,15 +553,19 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
 
     const newContent = updatedLines.join("\n")
     const serialized = stringifyNote(newContent, parsed.data)
-    await writeFile(
+    const beforeBytes = Buffer.byteLength(raw, "utf8")
+    const afterBytes = Buffer.byteLength(serialized, "utf8")
+    guardAgainstShrink(beforeBytes, afterBytes, "deleting memory entry")
+    await atomicWriteFile(
       memoryFilePath(params.vaultPath, params.file),
       serialized,
-      "utf8",
     )
     logger.info("deleted memory entry", {
       file: params.file,
       section: params.section,
       date: params.date,
+      beforeBytes,
+      afterBytes,
     })
   }
 
@@ -545,10 +584,9 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     await mkdir(dirPath, { recursive: true })
     await Promise.all(
       MEMORY_TEMPLATES.map((template) =>
-        writeFile(
+        atomicWriteFile(
           join(dirPath, `${template.fileName}.md`),
           template.content,
-          "utf8",
         ),
       ),
     )

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -1,4 +1,13 @@
-import { readFile, writeFile, readdir, mkdir, unlink } from "node:fs/promises"
+import {
+  readFile,
+  writeFile,
+  readdir,
+  mkdir,
+  unlink,
+  rename,
+  rm,
+} from "node:fs/promises"
+import { randomUUID } from "node:crypto"
 import { join, dirname, relative, resolve } from "node:path"
 import type { Dirent } from "node:fs"
 import picomatch from "picomatch"
@@ -16,6 +25,28 @@ export const resolveSafePath = (
     throw new Error(`path traversal blocked: "${notePath}" escapes vault root`)
   }
   return resolved
+}
+
+/**
+ * Writes a file atomically: stage to a unique temp file, then rename over the
+ * target. `rename` is atomic on the same filesystem, so the target is never
+ * truncated — readers (notably the obsidian-sync container) see either the old
+ * content or the new content, never a 0-byte or partial write. This is the
+ * core defense against the partial-write clobber class of bug.
+ */
+export const atomicWriteFile = async (
+  filePath: string,
+  content: string,
+): Promise<void> => {
+  const tmpPath = `${filePath}.${randomUUID()}.tmp`
+  try {
+    await writeFile(tmpPath, content, "utf8")
+    await rename(tmpPath, filePath)
+  } catch (err) {
+    // Best-effort cleanup so a failed write never strands a temp file.
+    await rm(tmpPath, { force: true })
+    throw err
+  }
 }
 
 /** Reads a file, returning null instead of throwing on ENOENT. */
@@ -99,8 +130,12 @@ const writeNote = async (
 
   const existing = await readFileOrNull(fullPath)
   const serialized = serializeNote(existing, params.body, params.properties)
-  await writeFile(fullPath, serialized, "utf8")
-  logger.info("wrote note", { path: params.path })
+  await atomicWriteFile(fullPath, serialized)
+  logger.info("wrote note", {
+    path: params.path,
+    beforeBytes: existing ? Buffer.byteLength(existing, "utf8") : 0,
+    afterBytes: Buffer.byteLength(serialized, "utf8"),
+  })
 }
 
 /** Merges properties into an existing note's YAML frontmatter without touching the body. Keys set to null are removed. */
@@ -119,12 +154,13 @@ const updateProperties = async (
   }
   const parsed = parseNote(existing)
   const mergedProperties = mergeFrontmatter(parsed.data, params.properties)
-  await writeFile(
-    fullPath,
-    stringifyNote(parsed.content, mergedProperties),
-    "utf8",
-  )
-  logger.info("updated properties", { path: params.path })
+  const serialized = stringifyNote(parsed.content, mergedProperties)
+  await atomicWriteFile(fullPath, serialized)
+  logger.info("updated properties", {
+    path: params.path,
+    beforeBytes: Buffer.byteLength(existing, "utf8"),
+    afterBytes: Buffer.byteLength(serialized, "utf8"),
+  })
 }
 
 /** Deletes a note. Rejects paths under the configured protected paths. */

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -43,8 +43,13 @@ export const atomicWriteFile = async (
     await writeFile(tmpPath, content, "utf8")
     await rename(tmpPath, filePath)
   } catch (err) {
-    // Best-effort cleanup so a failed write never strands a temp file.
-    await rm(tmpPath, { force: true })
+    // Best-effort cleanup so a failed write never strands a temp file. Swallow
+    // any cleanup error so the original write/rename failure is still thrown.
+    try {
+      await rm(tmpPath, { force: true })
+    } catch {
+      // ignore — preserving the root-cause error below matters more
+    }
     throw err
   }
 }

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -1,8 +1,8 @@
 /** Surgical note editing — heading-targeted patches and find-and-replace. */
 
-import { readFile, writeFile } from "node:fs/promises"
+import { readFile } from "node:fs/promises"
 import { parseNote, stringifyNote } from "./frontmatter.js"
-import { resolveSafePath } from "./vault-filesystem.js"
+import { resolveSafePath, atomicWriteFile } from "./vault-filesystem.js"
 import type { Logger } from "../../logger.js"
 
 // ── Types ───────────────────────────────────────────────────────
@@ -299,6 +299,8 @@ const readNoteForPatch = async (
   fullPath: string
   data: Record<string, unknown>
   lines: string[]
+  /** Raw on-disk file bytes — used for before/after size logging. */
+  beforeBytes: number
 }> => {
   const fullPath = resolveSafePath(vaultPath, path)
   try {
@@ -308,6 +310,7 @@ const readNoteForPatch = async (
       fullPath,
       data: parsed.data as Record<string, unknown>,
       lines: parsed.content.split("\n"),
+      beforeBytes: Buffer.byteLength(fileContent, "utf8"),
     }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
@@ -317,14 +320,16 @@ const readNoteForPatch = async (
   }
 }
 
-/** Writes modified content back with preserved frontmatter. */
+/** Writes modified content back with preserved frontmatter (atomically).
+ *  Returns the serialized byte length for size logging. */
 const writePatchedNote = async (
   fullPath: string,
   data: Record<string, unknown>,
   lines: readonly string[],
-): Promise<void> => {
+): Promise<number> => {
   const serialized = stringifyNote(lines.join("\n"), data)
-  await writeFile(fullPath, serialized, "utf8")
+  await atomicWriteFile(fullPath, serialized)
+  return Buffer.byteLength(serialized, "utf8")
 }
 
 // ── Exported functions ──────────────────────────────────────────
@@ -342,7 +347,7 @@ const patchNote = async (
   logger: Logger,
 ): Promise<string> => {
   const { path, operation, content, heading, headingLevel } = params
-  const { fullPath, data, lines } = await readNoteForPatch(
+  const { fullPath, data, lines, beforeBytes } = await readNoteForPatch(
     params.vaultPath,
     path,
   )
@@ -357,11 +362,13 @@ const patchNote = async (
       operation === "append"
         ? [...lines, ...contentLines]
         : [...contentLines, ...lines]
-    await writePatchedNote(fullPath, data, updatedLines)
+    const afterBytes = await writePatchedNote(fullPath, data, updatedLines)
     logger.info("patched note", {
       path,
       operation,
       target: "file body",
+      beforeBytes,
+      afterBytes,
     })
     return `Applied ${operation} to ${path} → file body`
   }
@@ -377,8 +384,14 @@ const patchNote = async (
     operation,
   )
 
-  await writePatchedNote(fullPath, data, updatedLines)
-  logger.info("patched note", { path, operation, target: targetDesc })
+  const afterBytes = await writePatchedNote(fullPath, data, updatedLines)
+  logger.info("patched note", {
+    path,
+    operation,
+    target: targetDesc,
+    beforeBytes,
+    afterBytes,
+  })
   return `Applied ${operation} to ${path} → ${targetDesc}`
 }
 
@@ -399,7 +412,7 @@ const replaceInNote = async (
     throw new Error("old_text cannot be empty")
   }
 
-  const { fullPath, data, lines } = await readNoteForPatch(
+  const { fullPath, data, lines, beforeBytes } = await readNoteForPatch(
     params.vaultPath,
     path,
   )
@@ -430,8 +443,8 @@ const replaceInNote = async (
     newText.length === 0 ? updatedBody.replace(/\n{3,}/g, "\n\n") : updatedBody
 
   const updatedLines = normalizedBody.split("\n")
-  await writePatchedNote(fullPath, data, updatedLines)
-  logger.info("replaced in note", { path, count })
+  const afterBytes = await writePatchedNote(fullPath, data, updatedLines)
+  logger.info("replaced in note", { path, count, beforeBytes, afterBytes })
   return `Replaced ${count} occurrence${count > 1 ? "s" : ""} in ${path}`
 }
 


### PR DESCRIPTION
## Why

In-app defense-in-depth for the memory-layer data-loss class — partial/truncated writes and silent catastrophic shrinks — so the `About Me/` memory layer is safe even for adopters without Obsidian Sync version history (which is the only recovery path today).

## What

Four safety fixes plus a tool-description update:

1. **Atomic writes.** A new `atomicWriteFile` helper (stage to a unique temp file, then `rename` over the target) replaces every note/memory `writeFile` in `vault-filesystem`, `vault-patcher`, and `memory-store`. `rename` is atomic on the same filesystem, so the target is never truncated — a concurrent reader (the obsidian-sync container) sees either the old or the new content, never a 0-byte or partial write. Bonus: `*.tmp` staging files are ignored by the file watcher (`.md`-only), and the rename hands the watcher a guaranteed-complete file.
2. **Large-shrink guard (memory writes only).** `updateMemory`/`deleteMemory` refuse a write that would drop an existing file below 50% of its size, above a 200-byte floor (which sits just past the empty memory templates, so files with no real content aren't guarded). Fails loud instead of silently truncating. `write_note`/`patch`/`replace` are intentionally left unguarded — their shrinks (full overwrite, empty-`new_text` deletion) are legitimate.
3. **Size logging.** `beforeBytes`/`afterBytes` on every write log line for observability.
4. **Graceful SIGTERM.** Drain in-flight requests via `server.close()` with a 10s force-exit fallback, instead of a hard `process.exit(0)` that could interrupt a write mid-flight.
5. **Tool descriptions.** `vault_update_memory` / `vault_delete_memory` gain `Errors:` sections documenting the guard refusal and how to recover.

## Testing

- `npm test` — 634 passing (15 new: atomic-write success/cleanup, shrink-guard throw/allow/floor, before/after size logging, SIGTERM drain + force-exit, tool-description errors). Guards mutation-checked (verified each test fails when the guard is neutered).
- `npm run build:server` and `npm run lint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzbgK2o5tysvjxMVA44Vir)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file operation reliability with atomic writes, preventing incomplete file states.
  * Added protective measure against unintended large-scale memory content reduction.

* **Chores**
  * Enhanced diagnostic logging with byte-count metrics for improved observability.
  * Strengthened server shutdown handling with graceful closure and configurable timeout protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->