### PR TITLE
ci: verify gitleaks download checksum before extracting

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,11 +23,18 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false # read-only scan job — no git writes
 
       - name: Install gitleaks
         run: |
-          curl -sL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C /usr/local/bin gitleaks
+          set -euo pipefail
+          ASSET="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          BASE_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+          curl -fsSLO "${BASE_URL}/${ASSET}"
+          curl -fsSLO "${BASE_URL}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          # Verify the archive against the published checksum before extracting.
+          grep " ${ASSET}$" "gitleaks_${GITLEAKS_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "${ASSET}" -C /usr/local/bin gitleaks
 
       - name: Scan full git history
         run: gitleaks detect --source . --log-opts="--all" --redact --verbose


### PR DESCRIPTION
Aligns the gitleaks install with the `obsidian-headless-sync-docker` fork's hardened version.

## What changed
- Download the published `gitleaks_${VERSION}_checksums.txt` and verify the tarball with `sha256sum -c` **before** extracting and running the binary in CI — supply-chain integrity guard against a corrupted download or a tampered/swapped release artifact.
- Switch `curl -sL` → `curl -fsSLO` so an HTTP error fails the step instead of piping a 404 body into `tar`.
- Add `persist-credentials: false` to the checkout (read-only scan job — no git writes).

Both repos now share an identical, verified install step. `.gitleaks.toml` is intentionally left unchanged — its `local-dev-token` allowlist is repo-specific.

## Verification
The fork's CI already runs this exact snippet successfully; the install step is copied verbatim. The Gitleaks job on this PR exercises it end-to-end.