### PR TITLE
chore(coderabbit): disable per-push incremental reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,3 +5,8 @@ reviews:
   poem: false
   sequence_diagrams: false
   review_status: false
+  auto_review:
+    # Review once when a PR opens; skip the re-review on every push so the
+    # summary comment (and its large hidden state blob) isn't reposted per
+    # commit. Trigger a manual re-review with "@coderabbitai review".
+    auto_incremental_review: false


### PR DESCRIPTION
## What

Adds `reviews.auto_review.auto_incremental_review: false` to `.coderabbit.yaml`.

## Why

CodeRabbit re-runs an incremental review on every push to an open PR. Each
re-review reposts/edits its summary comment, which carries a large hidden
`<!-- internal state -->` blob that grows with PR history. For sessions
subscribed to PR activity, that full comment body is delivered on every
commit — heavy and noisy, and getting worse as PRs accumulate commits.

The three keys already in the file (`poem`, `sequence_diagrams`,
`review_status`) only trim small visible sections; they don't touch the
blob. `auto_incremental_review: false` is the lever that actually stops the
per-commit reposting.

## Behavior after merge

- CodeRabbit reviews **once** when a PR opens, then stays quiet through
  subsequent commits.
- Trigger a fresh pass manually with `@coderabbitai review` (or
  `@coderabbitai full review` for a from-scratch pass).

Takes effect repo-wide once on `main`, since CodeRabbit reads
`.coderabbit.yaml` from the base branch.

https://claude.ai/code/session_01Trpyc4bascYFQyTJZbXhfa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Trpyc4bascYFQyTJZbXhfa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review automation configuration.

*Note: This change is internal tooling configuration with no impact on user-facing functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->