### PR TITLE
fix(memory): resolve section names with or without the "(newest first)" suffix

### DIFF
--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -867,7 +867,7 @@ Returns: Raw markdown text.`,
           .string()
           .optional()
           .describe(
-            'H2 section heading (e.g. "Decision heuristics (newest first)"). Call vault_list_memory_files first to discover valid names.',
+            'H2 section heading (e.g. "Decision heuristics (newest first)"). Matched case-insensitively, with or without the "(newest first)" suffix. Call vault_list_memory_files first to discover valid names.',
           ),
       },
       annotations: {
@@ -902,7 +902,7 @@ Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest
 When to use: Recording a new preference, principle, opinion, or fact about the user. Call vault_list_memory_files first and reuse existing file and section names so entries stay grouped.
 Prefer vault_write_note for creating non-memory notes.
 
-Behavior: Additive — existing entries are never overwritten, and repeat calls add duplicate entries. A missing file or section is created automatically; if the section name omits "(newest first)" the server appends it ("Design preferences" becomes "Design preferences (newest first)") — use that full name in later calls.
+Behavior: Additive — existing entries are never overwritten, and repeat calls add duplicate entries. A missing file or section is created automatically; if the section name omits "(newest first)" the server appends it when creating a new section ("Design preferences" becomes "Design preferences (newest first)"); an existing section is matched with or without the suffix.
 
 Parameters:
 - options.date — ISO YYYY-MM-DD, defaults to today (server timezone).
@@ -921,7 +921,7 @@ Returns: Confirmation message.`,
         section: z
           .string()
           .describe(
-            'H2 section heading (e.g. "Decision heuristics (newest first)")',
+            'H2 section heading (e.g. "Decision heuristics (newest first)"). Matched case-insensitively, with or without the "(newest first)" suffix.',
           ),
         entry: z.string().describe("Entry text (no date prefix)"),
         options: z
@@ -1027,7 +1027,11 @@ Returns: Confirmation message.`,
         file: z
           .string()
           .describe('Memory file name without .md (e.g. "Principles")'),
-        section: z.string().describe("H2 section heading containing the entry"),
+        section: z
+          .string()
+          .describe(
+            'H2 section heading containing the entry. Matched case-insensitively, with or without the "(newest first)" suffix.',
+          ),
         date: z.string().describe("ISO YYYY-MM-DD date of the entry"),
         entry: z
           .string()

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -44,7 +44,7 @@ related:
 ## Working style (newest first)
 - **2026-05-04**: Single-purpose files
 
-## Empty section
+## Empty section (newest first)
 `
 
 const OPINIONS_MD = `---
@@ -131,9 +131,25 @@ describe("getMemory", () => {
     expect(result).toContain("Secrets invisible at every layer")
   })
 
+  it("resolves a section addressed by its short name (no suffix)", async () => {
+    const result = await getMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Working style",
+      },
+      logger,
+    )
+    expect(result).toBe("- **2026-05-04**: Single-purpose files")
+  })
+
   it("returns empty string for section with no entries", async () => {
     const result = await getMemory(
-      { vaultPath: vault, file: "Principles", section: "Empty section" },
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Empty section (newest first)",
+      },
       logger,
     )
     expect(result).toBe("")
@@ -220,14 +236,18 @@ describe("updateMemory", () => {
       {
         vaultPath: vault,
         file: "Principles",
-        section: "Empty section",
+        section: "Empty section (newest first)",
         entry: "first entry",
         date: "2026-05-08",
       },
       logger,
     )
     const result = await getMemory(
-      { vaultPath: vault, file: "Principles", section: "Empty section" },
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Empty section (newest first)",
+      },
       logger,
     )
     expect(result).toBe("- **2026-05-08**: first entry")
@@ -345,6 +365,36 @@ describe("updateMemory", () => {
       logger,
     )
     expect(result).toBe("- **2026-05-15**: section entry")
+  })
+
+  it("appends to an existing section by its short name without duplicating it", async () => {
+    await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Working style",
+        entry: "short-name entry",
+        date: "2026-05-09",
+      },
+      logger,
+    )
+    const principlesContent = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+    // The entry lands in the existing section — no second "## Working style …"
+    // heading is appended at EOF (the duplicate-section bug).
+    expect(principlesContent.match(/^## Working style/gm)).toHaveLength(1)
+    expect(principlesContent).toContain("- **2026-05-09**: short-name entry")
+
+    const outlines = await listMemoryFiles({ vaultPath: vault }, logger)
+    const principles = outlines.find(
+      (outline) => outline.file === "Principles",
+    )!
+    const workingStyle = principles.headings.find(
+      (heading) => heading.text === "Working style (newest first)",
+    )
+    expect(workingStyle?.entryCount).toBe(2)
   })
 })
 
@@ -510,6 +560,29 @@ describe("deleteMemory", () => {
     expect(result).toContain("Secrets invisible")
   })
 
+  it("resolves a section addressed by its short name (no suffix)", async () => {
+    await deleteMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics",
+        date: "2026-05-06",
+        entry: "Secrets invisible at every layer",
+      },
+      logger,
+    )
+    const result = await getMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+      },
+      logger,
+    )
+    expect(result).not.toContain("Secrets invisible")
+    expect(result).toContain("Least-privilege for AI agents")
+  })
+
   it("throws on no matching entry", async () => {
     await expect(
       deleteMemory(
@@ -532,7 +605,7 @@ title: Dupe
 
 # Dupe
 
-## Section
+## Section (newest first)
 - **2026-01-01**: same entry
 - **2026-01-01**: same entry
 `
@@ -542,7 +615,7 @@ title: Dupe
         {
           vaultPath: vault,
           file: "Dupe",
-          section: "Section",
+          section: "Section (newest first)",
           date: "2026-01-01",
           entry: "same entry",
         },
@@ -662,7 +735,7 @@ describe("listMemoryFiles", () => {
     expect(workingStyle?.entryCount).toBe(1)
 
     const emptySection = principles.headings.find(
-      (h) => h.text === "Empty section",
+      (h) => h.text === "Empty section (newest first)",
     )
     expect(emptySection?.entryCount).toBe(0)
   })

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -38,8 +38,8 @@ const ENTRY_PATTERN = /^- \*\*\d{4}-\d{2}-\d{2}\*\*:/
 
 const isString = (value: unknown): value is string => typeof value === "string"
 
-/** Appends "(newest first)" to a section name if not already present (case-insensitive). */
-const ensureNewestFirstSuffix = (sectionName: string): string =>
+/** Returns the heading name with the "(newest first)" suffix, appending it if absent (case-insensitive). */
+const headingWithNewestFirstSuffix = (sectionName: string): string =>
   sectionName.trimEnd().toLowerCase().endsWith("(newest first)")
     ? sectionName
     : `${sectionName} (newest first)`
@@ -140,10 +140,16 @@ const findSection = (
   sectionName: string,
   level: 1 | 2,
 ): ParsedSection | undefined => {
-  const needle = sectionName.trim().toLowerCase()
+  // Memory headings are canonically suffixed "(newest first)"; resolve the
+  // caller's name to that form so a short name matches the stored heading
+  // (and update_memory doesn't append a duplicate section).
+  const normalizedSectionName = headingWithNewestFirstSuffix(sectionName)
+    .trim()
+    .toLowerCase()
   return sections.find(
     (section) =>
-      section.level === level && section.heading.toLowerCase() === needle,
+      section.level === level &&
+      section.heading.toLowerCase() === normalizedSectionName,
   )
 }
 
@@ -359,7 +365,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
 
     // File does not exist — create directory + file with section and entry
     if (existingContent === null) {
-      const newSection = ensureNewestFirstSuffix(params.section)
+      const newSection = headingWithNewestFirstSuffix(params.section)
       const filePath = memoryFilePath(params.vaultPath, params.file)
       await mkdir(dirname(filePath), { recursive: true })
       const content = buildNewMemoryFile({
@@ -385,7 +391,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
 
     // File exists but section does not — append new H2 + entry at end
     if (!match) {
-      const newSection = ensureNewestFirstSuffix(params.section)
+      const newSection = headingWithNewestFirstSuffix(params.section)
       const appendedLines = [...contentLines, `## ${newSection}`, bullet]
       const newContent = appendedLines.join("\n")
       const serialized = stringifyNote(newContent, parsed.data)


### PR DESCRIPTION
## Problem

Memory section headings are canonically suffixed `(newest first)` (e.g. `## Working style (newest first)`). The convention lets callers refer to a section by its short name, and `vault_update_memory` already enforces the suffix when *creating* a section — but the **lookup** side (`findSection`) matched the raw section name, so a short name missed:

- `vault_get_memory` / `vault_delete_memory` → threw `section not found`.
- `vault_update_memory` → the miss fell into its "section does not exist" branch, which re-applied the suffix and **appended a duplicate `## … (newest first)` heading at EOF** instead of inserting into the existing section.

## Fix

Canonicalize the lookup name through `headingWithNewestFirstSuffix` inside `findSection` before matching. A single change fixes all three tools: short and full names now resolve to the same canonical section across get/update/delete, and the create branch only fires for a section that genuinely doesn't exist.

```text
"Working style"                  → matches "Working style (newest first)"  (was: duplicate / not found)
"Working style (newest first)"   → matches "Working style (newest first)"  (unchanged)
"WORKING STYLE (NEWEST FIRST)"   → matches (case-insensitivity preserved)
```

`findSection`'s positional signature is left unchanged (scoped to the bug, no wider refactor).

## Docs

The memory tools never documented how section names are matched, while the other heading-addressing tools (`vault_read_note`, `vault_patch_note`) explicitly say "case-sensitive exact match". Now that memory lookups are both case- and suffix-insensitive, the contract is documented on the `section` param of all three memory tools:

> Matched case-insensitively, with or without the `(newest first)` suffix.

`vault_update_memory`'s description is also corrected — the suffix is auto-appended **when creating a new section**; an existing section matches with or without it (previously implied you had to use the full name in later calls).

## Tests

- New: get/delete resolve a section by its short name; update appends to an existing section by short name **without** creating a duplicate heading (asserts a single `## Working style` heading and `entryCount: 2`).
- Updated two fixtures whose section headings lacked the suffix (`## Empty section`, `## Section`) to comply with the all-headings-suffixed convention.
- Full suite green (662 passing); `lint` + `build` clean. Reverting the fix makes exactly the three new tests fail.