### PR TITLE
docs: document vault_read_note section-scoped read modes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -179,14 +179,16 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 
 ### Phase 1: Vault Read/Write (R2, R3)
 
-| Tool                    | Input                                                | Annotation      |
-| ----------------------- | ---------------------------------------------------- | --------------- |
-| `vault_read_note`       | `path`                                               | readOnlyHint    |
-| `vault_write_note`      | `path, body, frontmatter?`                           | destructiveHint |
-| `vault_patch_note`      | `path, operation, content, heading?, heading_level?` | destructiveHint |
-| `vault_replace_in_note` | `path, old_text, new_text, replace_all_occurrences?` | destructiveHint |
-| `vault_list_notes`      | `folder?, glob?`                                     | readOnlyHint    |
-| `vault_delete_note`     | `path`                                               | destructiveHint |
+| Tool                    | Input                                                        | Annotation      |
+| ----------------------- | ------------------------------------------------------------ | --------------- |
+| `vault_read_note`       | `path, properties_only?, outline?, heading?, heading_level?` | readOnlyHint    |
+| `vault_write_note`      | `path, body, frontmatter?`                                   | destructiveHint |
+| `vault_patch_note`      | `path, operation, content, heading?, heading_level?`         | destructiveHint |
+| `vault_replace_in_note` | `path, old_text, new_text, replace_all_occurrences?`         | destructiveHint |
+| `vault_list_notes`      | `folder?, glob?`                                             | readOnlyHint    |
+| `vault_delete_note`     | `path`                                                       | destructiveHint |
+
+`vault_read_note` returns full content by default; optional `properties_only`, `outline`, or `heading` (with `heading_level` to disambiguate) modes return just the properties, the heading tree, or a single section — cheap partial reads for large notes.
 
 `vault_patch_note` supports 4 operations: `append`, `prepend`, `replace`, `insert_before` — heading-targeted with optional file-level mode. `vault_replace_in_note` does exact text find-and-replace in the note body.
 

--- a/README.md
+++ b/README.md
@@ -149,31 +149,31 @@ See [Authentication](#authentication) for both methods and token lifetimes.
 
 ## Tools (23)
 
-| Category        | Tool                         | Description                                              |
-| --------------- | ---------------------------- | -------------------------------------------------------- |
-| **Vault CRUD**  | `vault_read_note`            | Read a note by path                                      |
-|                 | `vault_write_note`           | Create or overwrite a note with frontmatter              |
-|                 | `vault_patch_note`           | Heading-targeted edit (append, prepend, replace, insert) |
-|                 | `vault_replace_in_note`      | Find-and-replace text in a note                          |
-|                 | `vault_list_notes`           | List notes with optional glob/folder filter              |
-|                 | `vault_delete_note`          | Delete a note (protected paths enforced)                 |
-| **Search**      | `vault_search`               | Full-text search with tag/folder/property filters        |
-|                 | `vault_search_by_tag`        | Find notes by tag (exact or prefix match)                |
-|                 | `vault_search_by_folder`     | Browse notes in a folder with metadata                   |
-|                 | `vault_recent_notes`         | Recently modified or created notes                       |
-|                 | `vault_list_tags`            | All tags with usage counts                               |
-| **Memory**      | `vault_get_memory`           | Read structured memory (file, section, or all)           |
-|                 | `vault_update_memory`        | Append a dated entry to a memory section                 |
-|                 | `vault_delete_memory`        | Remove a specific memory entry by date                   |
-|                 | `vault_list_memory_files`    | Discover memory files and their sections                 |
-| **Properties**  | `vault_list_property_keys`   | All frontmatter keys with sample values                  |
-|                 | `vault_list_property_values` | Distinct values for a property key                       |
-|                 | `vault_search_by_property`   | Find notes by frontmatter key-value                      |
-|                 | `vault_update_properties`    | Add or update properties without touching the body       |
-| **Links**       | `vault_get_backlinks`        | Notes linking to a given path                            |
-|                 | `vault_get_outgoing_links`   | Links from a given note                                  |
-|                 | `vault_find_orphans`         | Notes with no incoming links                             |
-| **Daily Notes** | `vault_get_daily_note`       | Today's (or any date's) daily note                       |
+| Category        | Tool                         | Description                                                |
+| --------------- | ---------------------------- | ---------------------------------------------------------- |
+| **Vault CRUD**  | `vault_read_note`            | Read a note — full body, properties, outline, or a section |
+|                 | `vault_write_note`           | Create or overwrite a note with frontmatter                |
+|                 | `vault_patch_note`           | Heading-targeted edit (append, prepend, replace, insert)   |
+|                 | `vault_replace_in_note`      | Find-and-replace text in a note                            |
+|                 | `vault_list_notes`           | List notes with optional glob/folder filter                |
+|                 | `vault_delete_note`          | Delete a note (protected paths enforced)                   |
+| **Search**      | `vault_search`               | Full-text search with tag/folder/property filters          |
+|                 | `vault_search_by_tag`        | Find notes by tag (exact or prefix match)                  |
+|                 | `vault_search_by_folder`     | Browse notes in a folder with metadata                     |
+|                 | `vault_recent_notes`         | Recently modified or created notes                         |
+|                 | `vault_list_tags`            | All tags with usage counts                                 |
+| **Memory**      | `vault_get_memory`           | Read structured memory (file, section, or all)             |
+|                 | `vault_update_memory`        | Append a dated entry to a memory section                   |
+|                 | `vault_delete_memory`        | Remove a specific memory entry by date                     |
+|                 | `vault_list_memory_files`    | Discover memory files and their sections                   |
+| **Properties**  | `vault_list_property_keys`   | All frontmatter keys with sample values                    |
+|                 | `vault_list_property_values` | Distinct values for a property key                         |
+|                 | `vault_search_by_property`   | Find notes by frontmatter key-value                        |
+|                 | `vault_update_properties`    | Add or update properties without touching the body         |
+| **Links**       | `vault_get_backlinks`        | Notes linking to a given path                              |
+|                 | `vault_get_outgoing_links`   | Links from a given note                                    |
+|                 | `vault_find_orphans`         | Notes with no incoming links                               |
+| **Daily Notes** | `vault_get_daily_note`       | Today's (or any date's) daily note                         |
 
 ## Configuration
 


### PR DESCRIPTION
## What

The section-scoped read modes added in #130 (`outline`, `heading`, `heading_level`, alongside the pre-existing `properties_only`) were never reflected in the prose/table docs. A reader of the docs couldn't discover that large notes can be read cheaply by outline or single section — the description still read "Read a note by path".

This brings the docs in line with the tool's actual capabilities. Docs-only; no code, tool count (23), or behavior changes.

## Changes

- **README.md** — Tools table: the `vault_read_note` row now reads *"Read a note — full body, properties, outline, or a section"*.
- **ARCHITECTURE.md** — MCP Tools table: the Input column lists `path, properties_only?, outline?, heading?, heading_level?` (matching how `vault_patch_note` shows its optional params), plus a new explanatory sentence after the table mirroring the existing `vault_patch_note`/`vault_delete_note` prose.

Wording matches the canonical tool description in `src/vault-mcp/tool-definitions.ts` (the source of truth, unchanged).

## Verification

- Swept every tool-enumerating doc — `server.json`, `llms-install.md`, the `deploy/*` READMEs, `DEPLOY.md`, `CONTRIBUTING.md` only state a generic "23 tools" count or don't list tools, so no read-mode detail is needed there. `CHANGELOG.md` already records #130. The remaining "read…by path" string is the R2 requirement statement in ARCHITECTURE.md, not a stale tool description.
- `prettier --check` passes on both files (the table column widths re-padded to fit the new cells).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R4TfpeScf76Mhn2ZAdfanf

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4TfpeScf76Mhn2ZAdfanf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced MCP tools documentation with expanded descriptions of Vault read operation parameters and available options.
  * Improved tool reference descriptions across multiple operations for greater clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->