### PR TITLE
docs(coderabbit): clarify the scope of auto_incremental_review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,4 +9,13 @@ reviews:
     # Review once when a PR opens; skip the re-review on every push so the
     # summary comment (and its large hidden state blob) isn't reposted per
     # commit. Trigger a manual re-review with "@coderabbitai review".
+    #
+    # Scope: this only suppresses the incremental *code re-review*. It does NOT
+    # stop CodeRabbit from editing its single summary comment on each push
+    # (walkthrough + pre-merge checks re-render regardless), nor the initial
+    # on-open review. The per-push noise in watched Claude Code sessions comes
+    # from the PR-activity relay forwarding the whole comment body on every
+    # edit — an upstream gap, not something this key controls. Fewer pushes per
+    # PR is the only in-repo lever; auto_review.enabled: false (manual-only) is
+    # the heavier hammer.
     auto_incremental_review: false


### PR DESCRIPTION
## What

Adds a scope-clarifying comment to `.coderabbit.yaml` above `auto_incremental_review: false`. No behavior change — comment only.

## Why

The existing comment could be read as "this silences CodeRabbit per push." It doesn't. The key only suppresses the **incremental code re-review**; it does **not** stop:

- CodeRabbit editing its single summary comment on each push (walkthrough + pre-merge checks re-render regardless),
- the initial on-open review.

The per-push noise in watched Claude Code sessions actually comes from the **PR-activity relay forwarding the whole comment body on every edit** — an upstream gap, not something this key controls. The note records that, plus the two real levers: fewer pushes per PR (in-repo), and `auto_review.enabled: false` (manual-only, heavier hammer).

This stops a future session from assuming the toggle quiets per-push comment activity and "fixing" something that's already configured correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UePdCDDjDDp6jtFKmCn1KR)_