### PR TITLE
fix(security): override js-yaml to 4.2.0, drop ignore files

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -54,7 +54,6 @@ jobs:
           scanners: vuln
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          trivyignores: .trivyignore
           format: sarif
           output: trivy-results.sarif
           exit-code: "0"
@@ -98,7 +97,6 @@ jobs:
           scanners: vuln
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          trivyignores: .trivyignore
           format: sarif
           output: trivy-results.sarif
           exit-code: "1" # gate: fail the PR on CRITICAL/HIGH findings

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,0 @@
-# js-yaml is a transitive dep of gray-matter but never executes: gray-matter's
-# YAML engine is overridden with the `yaml` package (YAML 1.2) via
-# src/vault-mcp/vault-operations/frontmatter.ts
-CVE-2026-53550

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,0 @@
-[[IgnoredVulns]]
-id = "GHSA-h67p-54hq-rp68"
-reason = "js-yaml is a transitive dep of gray-matter but never executes: gray-matter's YAML engine is overridden with the `yaml` package (YAML 1.2) via src/vault-mcp/vault-operations/frontmatter.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3180,13 +3180,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -3902,19 +3899,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -4678,13 +4662,22 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -6169,12 +6162,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/sst": {
       "version": "4.15.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "yaml": "2.9.0",
     "zod": "4.4.3"
   },
+  "overrides": {
+    "js-yaml": "4.2.0"
+  },
   "devDependencies": {
     "@clack/prompts": "1.5.1",
     "@eslint/js": "10.0.1",

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -10,7 +10,6 @@ import {
 import { mkdtemp, rm, writeFile, mkdir, readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import matter from "gray-matter"
 import { parseNote } from "../frontmatter.js"
 import { createMemoryStore } from "../memory-store.js"
 import { logger } from "../../../logger.js"
@@ -839,7 +838,7 @@ describe("bootstrapMemoryDir", () => {
       join(emptyVault, "About Me/Principles.md"),
       "utf8",
     )
-    const parsed = matter(raw)
+    const parsed = parseNote(raw)
     expect(parsed.data.title).toBe("Principles")
     expect(parsed.data.type).toBe("profile")
     expect(parsed.data.tags).toEqual(["memory", "principles"])
@@ -880,7 +879,7 @@ describe("bootstrapMemoryDir", () => {
   it("preserves existing files when directory already exists", async () => {
     await bootstrapMemoryDir({ vaultPath: vault }, logger)
     const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")
-    const parsed = matter(raw)
+    const parsed = parseNote(raw)
     expect(parsed.data.title).toBe("Principles — About Me")
     expect(raw).toContain("Secrets invisible at every layer")
   })

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -17,8 +17,8 @@ import {
 } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import matter from "gray-matter"
 import { vaultFs, atomicWriteFile } from "../vault-filesystem.js"
+import { parseNote } from "../frontmatter.js"
 import { logger } from "../../../logger.js"
 
 const {
@@ -414,7 +414,7 @@ describe("updateProperties", () => {
       logger,
     )
     const content = await readFile(join(vault, "test.md"), "utf8")
-    const parsed = matter(content)
+    const parsed = parseNote(content)
     expect(parsed.content.trim()).toBe("Body content")
     expect(parsed.data.status).toBe("active")
     expect(parsed.data.title).toBe("Original")
@@ -454,7 +454,7 @@ describe("updateProperties", () => {
       logger,
     )
     const content = await readFile(join(vault, "test.md"), "utf8")
-    const parsed = matter(content)
+    const parsed = parseNote(content)
     expect(parsed.data.title).toBe("Keep")
     expect(parsed.data.tags).toEqual(["a", "b"])
     expect(parsed.data.status).toBe("active")


### PR DESCRIPTION
## Summary

Follow-up to #137 — resolves GHSA-h67p-54hq-rp68 at the dependency level rather than suppressing alerts.

- Add npm `overrides` to pin `js-yaml` to 4.2.0 (patched). js-yaml 4.x re-exports `safeLoad`/`safeDump` as stub functions that satisfy gray-matter's `.bind()` at import but throw if called — safe because gray-matter's YAML engine is overridden by `parseNote` (YAML 1.2 via the `yaml` package)
- Remove `osv-scanner.toml`, `.trivyignore`, and the `trivyignores` workflow references (no longer needed)
- Switch remaining bare `matter()` calls in test files to `parseNote` for consistency

Resolves code scanning alert [#105](https://github.com/aliasunder/vault-cortex/security/code-scanning/105). Resolves Dependabot alert [#13](https://github.com/aliasunder/vault-cortex/security/dependabot/13).

## Test plan

- [x] 665 tests pass
- [x] `npm ls js-yaml` → `4.2.0 overridden` under gray-matter
- [x] `npm audit` → 0 vulnerabilities
- [x] Build + lint clean
- [x] After merge, verify Scorecard + Trivy runs close their respective alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)