### PR TITLE
feat(callouts)!: surface note leading-callouts + self-documenting memory files

### DIFF
--- a/.github/scripts/generate-notes.sh
+++ b/.github/scripts/generate-notes.sh
@@ -16,20 +16,21 @@ else
   RANGE="$NEW_TAG"
 fi
 
-# Collect commits (skip release commits — server "release:" and CLI
-# "release(cli):" bumps — and merge commits)
-COMMITS=$(git log --oneline --no-merges "$RANGE" | grep -vE '^[a-f0-9]+ release(\(cli\))?:' || true)
+# Write one record per non-merge commit as `<subject>\x1f<body>`, records
+# NUL-separated, to a temp file. The body is included so BREAKING CHANGE:
+# footers are visible. A file (not a pipe) is used because the Python program
+# is fed to `python3 -` on stdin via the heredoc — the data must come from
+# elsewhere. Release commits are filtered out in Python.
+NOTES_INPUT="$(mktemp)"
+trap 'rm -f "$NOTES_INPUT"' EXIT
+git log --no-merges --format='%s%x1f%b%x00' "$RANGE" > "$NOTES_INPUT"
 
-if [ -z "$COMMITS" ]; then
-  echo "No notable changes."
-  exit 0
-fi
-
-# Use python for reliable parsing — bash regex with nested groups is fragile
-python3 - "$COMMITS" << 'PYTHON'
+python3 - "$NOTES_INPUT" << 'PYTHON'
 import sys, re
 
-commits = sys.argv[1]
+with open(sys.argv[1], "rb") as fh:
+    raw = fh.read().decode("utf-8", "replace")
+records = [r for r in raw.split("\x00") if r.strip()]
 
 # Category config: (prefix, heading)
 categories = [
@@ -46,47 +47,53 @@ cat_order = [c[0] for c in categories]
 
 buckets = {c[0]: [] for c in categories}
 other = []
+breaking = []
 
-# Pattern: type(scope): description  OR  type: description
-pat = re.compile(r'^([a-z]+)(?:\(([^)]+)\))?:\s+(.+)$')
+# Pattern: type(scope)!: description — scope and the breaking `!` are optional.
+pat = re.compile(r'^([a-z]+)(?:\(([^)]+)\))?(!)?:\s+(.+)$')
+# Release bump commits (server "release:" and CLI "release(cli):") are noise.
+release_pat = re.compile(r'^release(\(cli\))?:')
+# A BREAKING CHANGE footer — conventional commits allows a space or hyphen.
+breaking_pat = re.compile(r'^BREAKING[ -]CHANGE:\s*(.+)$', re.MULTILINE)
 
-for line in commits.strip().split('\n'):
-    if not line.strip():
+for rec in records:
+    subject, _, body = rec.partition("\x1f")
+    subject = subject.strip()
+    if not subject or release_pat.match(subject):
         continue
-    # Strip the short hash prefix
-    msg = line.split(' ', 1)[1] if ' ' in line else line
 
-    m = pat.match(msg)
+    m = pat.match(subject)
+    footer = breaking_pat.search(body or "")
+    is_breaking = bool((m and m.group(3)) or footer)
+
     if m:
-        typ, scope, desc = m.group(1), m.group(2), m.group(3)
+        typ, scope, _, desc = m.group(1), m.group(2), m.group(3), m.group(4)
         desc = desc[0].upper() + desc[1:]  # capitalize
-        if scope:
-            entry = f"- **{scope}:** {desc}"
-        else:
-            entry = f"- {desc}"
-        if typ in buckets:
-            buckets[typ].append(entry)
-        else:
-            other.append(entry)
+        entry = f"- **{scope}:** {desc}" if scope else f"- {desc}"
+        (buckets[typ] if typ in buckets else other).append(entry)
     else:
-        msg = msg[0].upper() + msg[1:] if msg else msg
-        other.append(f"- {msg}")
+        desc = subject[0].upper() + subject[1:] if subject else subject
+        other.append(f"- {desc}")
 
-# Output
-first = True
+    if is_breaking:
+        # Prefer the footer's explanatory text; fall back to the subject desc.
+        breaking.append(f"- {footer.group(1).strip() if footer else desc}")
+
+# Output — BREAKING CHANGES lead so they're impossible to miss.
+out = []
+if breaking:
+    out += ["### ⚠ BREAKING CHANGES", ""] + breaking
+
 for typ in cat_order:
     if buckets[typ]:
-        if not first:
-            print()
-        first = False
-        print(f"### {cat_map[typ]}")
-        print()
-        print('\n'.join(buckets[typ]))
+        if out:
+            out.append("")
+        out += [f"### {cat_map[typ]}", ""] + buckets[typ]
 
 if other:
-    if not first:
-        print()
-    print("### Other Changes")
-    print()
-    print('\n'.join(other))
+    if out:
+        out.append("")
+    out += ["### Other Changes", ""] + other
+
+print("\n".join(out) if out else "No notable changes.")
 PYTHON

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,7 +226,7 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 | `vault_delete_memory`     | `file, section, date, entry`     | destructiveHint |
 | `vault_list_memory_files` | —                                | readOnlyHint    |
 
-**Auto-initialization:** On first startup, if the memory folder (default: `About Me/`) doesn't exist, the server creates it with template files (Principles.md, Opinions.md) so agents discover a ready structure. `vault_update_memory` also auto-creates files and sections on write — agents can save preferences without manual setup. This is the two-layer bootstrap: startup seeds the default structure, write-time handles growth beyond templates.
+**Auto-initialization:** On first startup, if the memory folder (default: `About Me/`) doesn't exist, the server creates it with template files (Me.md, Opinions.md, Principles.md), each opening with a `> [!info] Scope of this file` callout so agents discover a ready, self-documenting structure. `vault_update_memory` also auto-creates files and sections on write — agents can save preferences without manual setup, and a newly-created file is seeded with a placeholder scope callout to fill in. This is the two-layer bootstrap: startup seeds the default structure, write-time handles growth beyond templates.
 
 ### Phase 1: Link Queries
 

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import Database from "better-sqlite3"
 import {
   createSearchIndex,
   sanitizeFtsQuery,
@@ -38,6 +39,21 @@ const NOTE_MINIMAL = `# Just a note
 Some content without frontmatter.
 `
 
+const NOTE_WITH_CALLOUT = `---
+title: Me
+---
+
+# Me
+
+> [!info] Scope of this file
+> **Contains:** identity facts.
+> **Convention:** append newest first.
+
+## Identity
+
+- a fact about burnout boundaries
+`
+
 describe("schema creation", () => {
   it("creates without throwing", () => {
     expect(() => createSearchIndex(":memory:")).not.toThrow()
@@ -47,6 +63,67 @@ describe("schema creation", () => {
     index.upsertNote("test.md", "# Test\n", Date.now())
     const results = index.fullTextSearch({ query: "Test" }, logger)
     expect(results).toHaveLength(1)
+  })
+})
+
+describe("leading callout", () => {
+  it("surfaces a note's leading callout in discovery results", () => {
+    index.upsertNote("About Me/Me.md", NOTE_WITH_CALLOUT, 1000)
+    const results = index.searchByFolder({ folder: "About Me" }, logger)
+    expect(results[0].callout).toEqual({
+      type: "info",
+      title: "Scope of this file",
+      body: "**Contains:** identity facts.\n**Convention:** append newest first.",
+    })
+  })
+
+  it("returns callout null for a note without a leading callout", () => {
+    index.upsertNote("notes/plain.md", NOTE_MINIMAL, 1000)
+    const results = index.searchByFolder({ folder: "notes" }, logger)
+    expect(results[0].callout).toBeNull()
+  })
+
+  it("omits the callout from fullTextSearch by default, includes it on request", () => {
+    index.upsertNote("About Me/Me.md", NOTE_WITH_CALLOUT, 1000)
+
+    const withoutFlag = index.fullTextSearch({ query: "burnout" }, logger)
+    expect(withoutFlag).toHaveLength(1)
+    expect(withoutFlag[0].callout).toBeUndefined()
+
+    const withFlag = index.fullTextSearch(
+      { query: "burnout", filters: { include_callout: true } },
+      logger,
+    )
+    expect(withFlag[0].callout?.title).toBe("Scope of this file")
+  })
+
+  it("adds the callout column to a pre-existing notes table (warm-DB migration)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "warm-db-"))
+    const dbPath = join(dir, "search.db")
+    // Simulate a database file created before the callout column existed.
+    const legacy = new Database(dbPath)
+    legacy.exec(`
+      CREATE TABLE notes (
+        path TEXT PRIMARY KEY, title TEXT, content TEXT, tags TEXT, related TEXT,
+        folder TEXT, type TEXT, created TEXT, mtime INTEGER, properties TEXT
+      );
+      CREATE VIRTUAL TABLE notes_fts USING fts5(
+        path UNINDEXED, title, content, tokenize='porter unicode61'
+      );
+      CREATE TABLE links (
+        source TEXT NOT NULL, target TEXT NOT NULL, PRIMARY KEY (source, target)
+      );
+    `)
+    legacy.close()
+
+    // Opening through the factory must add the missing column, not throw on upsert.
+    const warmIndex = createSearchIndex(dbPath)
+    expect(() =>
+      warmIndex.upsertNote("About Me/Me.md", NOTE_WITH_CALLOUT, 1000),
+    ).not.toThrow()
+    const results = warmIndex.searchByFolder({ folder: "About Me" }, logger)
+    expect(results[0].callout?.title).toBe("Scope of this file")
+    await rm(dir, { recursive: true })
   })
 })
 

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -70,7 +70,7 @@ describe("leading callout", () => {
   it("surfaces a note's leading callout in discovery results", () => {
     index.upsertNote("About Me/Me.md", NOTE_WITH_CALLOUT, 1000)
     const results = index.searchByFolder({ folder: "About Me" }, logger)
-    expect(results[0].callout).toEqual({
+    expect(results[0].leading_callout).toEqual({
       type: "info",
       title: "Scope of this file",
       body: "**Contains:** identity facts.\n**Convention:** append newest first.",
@@ -80,7 +80,7 @@ describe("leading callout", () => {
   it("returns callout null for a note without a leading callout", () => {
     index.upsertNote("notes/plain.md", NOTE_MINIMAL, 1000)
     const results = index.searchByFolder({ folder: "notes" }, logger)
-    expect(results[0].callout).toBeNull()
+    expect(results[0].leading_callout).toBeNull()
   })
 
   it("omits the callout from fullTextSearch by default, includes it on request", () => {
@@ -88,21 +88,21 @@ describe("leading callout", () => {
 
     const withoutFlag = index.fullTextSearch({ query: "burnout" }, logger)
     expect(withoutFlag).toHaveLength(1)
-    expect(withoutFlag[0].callout).toBeUndefined()
+    expect(withoutFlag[0].leading_callout).toBeUndefined()
 
     const withFlag = index.fullTextSearch(
-      { query: "burnout", filters: { include_callout: true } },
+      { query: "burnout", filters: { include_leading_callout: true } },
       logger,
     )
-    expect(withFlag[0].callout?.title).toBe("Scope of this file")
+    expect(withFlag[0].leading_callout?.title).toBe("Scope of this file")
   })
 
-  it("adds the callout column to a pre-existing notes table (warm-DB migration)", async () => {
+  it("adds the leading_callout column to a pre-existing notes table (warm-DB migration)", async () => {
     const dir = await mkdtemp(join(tmpdir(), "warm-db-"))
     const dbPath = join(dir, "search.db")
-    // Simulate a database file created before the callout column existed.
-    const legacy = new Database(dbPath)
-    legacy.exec(`
+    // Simulate a database file created before the leading_callout column existed.
+    const legacyDb = new Database(dbPath)
+    legacyDb.exec(`
       CREATE TABLE notes (
         path TEXT PRIMARY KEY, title TEXT, content TEXT, tags TEXT, related TEXT,
         folder TEXT, type TEXT, created TEXT, mtime INTEGER, properties TEXT
@@ -114,7 +114,7 @@ describe("leading callout", () => {
         source TEXT NOT NULL, target TEXT NOT NULL, PRIMARY KEY (source, target)
       );
     `)
-    legacy.close()
+    legacyDb.close()
 
     // Opening through the factory must add the missing column, not throw on upsert.
     const warmIndex = createSearchIndex(dbPath)
@@ -122,7 +122,7 @@ describe("leading callout", () => {
       warmIndex.upsertNote("About Me/Me.md", NOTE_WITH_CALLOUT, 1000),
     ).not.toThrow()
     const results = warmIndex.searchByFolder({ folder: "About Me" }, logger)
-    expect(results[0].callout?.title).toBe("Scope of this file")
+    expect(results[0].leading_callout?.title).toBe("Scope of this file")
     await rm(dir, { recursive: true })
   })
 })

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -379,8 +379,9 @@ export const createSearchIndex = (dbPath: string) => {
 
     const tags = coerceToArray(frontmatter.tags)
     const related = coerceToArray(frontmatter.related)
-    // Store the leading callout (top-of-file scope/summary block) as JSON so
-    // discovery tools can return it structured; null when the note has none.
+    // Store the leading callout (a top-of-file `> [!type]` block — info,
+    // warning, etc.) as JSON so discovery tools can return it structured;
+    // null when the note has none.
     const leadingCallout = parseLeadingCallout(parsed.content.split("\n"))
 
     const note = {

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -4,6 +4,8 @@ import { readFile, readdir, stat } from "node:fs/promises"
 import { join, basename, relative, resolve } from "node:path"
 import { logger, type Logger } from "../../logger.js"
 import { parseNote } from "../vault-operations/frontmatter.js"
+import { parseLeadingCallout } from "../vault-operations/callout-parser.js"
+import type { LeadingCallout } from "../vault-operations/callout-parser.js"
 
 // ── Type guards ─────────────────────────────────────────────────
 
@@ -103,6 +105,7 @@ type SearchResult = {
   type: string | null
   created?: string
   modified: string
+  callout?: LeadingCallout
 }
 
 type NoteMetadata = {
@@ -115,6 +118,7 @@ type NoteMetadata = {
   created: string | null
   modified: string
   properties: Record<string, unknown>
+  callout: LeadingCallout | null
 }
 
 type TagCount = {
@@ -141,6 +145,7 @@ type SearchFilters = {
   properties?: Record<string, string | number | boolean>
   limit?: number
   snippet_tokens?: number
+  include_callout?: boolean
 }
 
 type NoteRow = {
@@ -153,6 +158,7 @@ type NoteRow = {
   created: string | null
   mtime: number
   properties: string
+  callout: string | null
 }
 
 type BacklinkEntry = { path: string; title: string }
@@ -305,7 +311,8 @@ export const createSearchIndex = (dbPath: string) => {
       type        TEXT,
       created     TEXT,
       mtime       INTEGER,
-      properties  TEXT
+      properties  TEXT,
+      callout     TEXT
     );
 
     CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
@@ -322,12 +329,24 @@ export const createSearchIndex = (dbPath: string) => {
   `)
   // path UNINDEXED: stored for JOIN/DELETE but not searchable, saves index space
 
+  // CREATE TABLE IF NOT EXISTS is a no-op on a pre-existing DB file, so a warm
+  // database from before the `callout` column was added would lack it (and the
+  // upsert below would throw). Add it idempotently when absent. `callout` is
+  // not FTS-indexed — the callout text already lives in `content`, so it's
+  // searchable; this column only stores the parsed block for cheap retrieval.
+  const noteColumns = db.prepare(`PRAGMA table_info(notes)`).all() as Array<{
+    name: string
+  }>
+  if (!noteColumns.some((column) => column.name === "callout")) {
+    db.exec(`ALTER TABLE notes ADD COLUMN callout TEXT`)
+  }
+
   // Prepared statements are compiled once here and reused across all calls.
   // db.prepare() caches the compiled SQL — calling it inside a function
   // would re-compile on every invocation.
   const upsertNotesStmt = db.prepare(`
-    INSERT OR REPLACE INTO notes (path, title, content, tags, related, folder, type, created, mtime, properties)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT OR REPLACE INTO notes (path, title, content, tags, related, folder, type, created, mtime, properties, callout)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
   const deleteFtsStmt = db.prepare(`DELETE FROM notes_fts WHERE path = ?`)
   const insertFtsStmt = db.prepare(
@@ -360,6 +379,9 @@ export const createSearchIndex = (dbPath: string) => {
 
     const tags = coerceToArray(frontmatter.tags)
     const related = coerceToArray(frontmatter.related)
+    // Store the leading callout (top-of-file scope/summary block) as JSON so
+    // discovery tools can return it structured; null when the note has none.
+    const callout = parseLeadingCallout(parsed.content.split("\n"))
 
     const note = {
       path: filePath,
@@ -376,6 +398,7 @@ export const createSearchIndex = (dbPath: string) => {
         : null,
       mtime: lastModifiedMs,
       properties: JSON.stringify(frontmatter),
+      callout: callout ? JSON.stringify(callout) : null,
     }
 
     deleteFtsStmt.run(note.path)
@@ -390,6 +413,7 @@ export const createSearchIndex = (dbPath: string) => {
       note.created,
       note.mtime,
       note.properties,
+      note.callout,
     )
     insertFtsStmt.run(note.path, note.title, note.content)
 
@@ -543,12 +567,17 @@ export const createSearchIndex = (dbPath: string) => {
 
     const limit = params.filters?.limit ?? 20
     const snippetTokens = params.filters?.snippet_tokens ?? 30
+    // Opt-in: the leading callout is omitted by default to keep this hot-path
+    // result lean; callers triaging which note to open can request it.
+    const includeCallout = params.filters?.include_callout ?? false
     queryParams.push(limit)
 
     const sql = `
       SELECT n.path, n.title,
              snippet(notes_fts, 2, '', '', '...', ${Number(snippetTokens)}) as snippet,
-             rank * -1 as score, n.tags, n.folder, n.type, n.created, n.mtime
+             rank * -1 as score, n.tags, n.folder, n.type, n.created, n.mtime${
+               includeCallout ? ", n.callout" : ""
+             }
       FROM notes_fts
       JOIN notes n ON n.path = notes_fts.path
       WHERE ${conditions.join(" AND ")}
@@ -565,6 +594,7 @@ export const createSearchIndex = (dbPath: string) => {
         > & {
           snippet: string
           score: number
+          callout?: string | null
         }
       >
 
@@ -578,6 +608,9 @@ export const createSearchIndex = (dbPath: string) => {
         type: row.type,
         ...(row.created !== null ? { created: row.created } : {}),
         modified: DateTime.fromMillis(Math.round(row.mtime)).toISO()!,
+        ...(includeCallout && row.callout
+          ? { callout: JSON.parse(row.callout) as LeadingCallout }
+          : {}),
       }))
       logger.info("full text search", {
         query: params.query,
@@ -609,7 +642,7 @@ export const createSearchIndex = (dbPath: string) => {
       : [params.tag, params.tag, limit]
 
     const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties
+      SELECT path, title, tags, related, folder, type, created, mtime, properties, callout
       FROM notes n
       WHERE ${condition}
       LIMIT ?
@@ -641,7 +674,7 @@ export const createSearchIndex = (dbPath: string) => {
       : [params.folder, params.folder, limit]
 
     const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties
+      SELECT path, title, tags, related, folder, type, created, mtime, properties, callout
       FROM notes
       WHERE ${condition}
       ORDER BY mtime DESC
@@ -685,7 +718,7 @@ export const createSearchIndex = (dbPath: string) => {
         : "ORDER BY mtime DESC" // SQL column is still `mtime`
 
     const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties
+      SELECT path, title, tags, related, folder, type, created, mtime, properties, callout
       FROM notes
       ${orderClause}
       LIMIT ?
@@ -824,7 +857,7 @@ export const createSearchIndex = (dbPath: string) => {
     // - Scalar properties (status: "active"): check direct equality
     // Both branches CAST to TEXT for type-safe comparison (integer 4 = text "4")
     const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties
+      SELECT path, title, tags, related, folder, type, created, mtime, properties, callout
       FROM notes n
       WHERE (
         (json_type(n.properties, '$.' || @key) = 'array'
@@ -932,7 +965,7 @@ export const createSearchIndex = (dbPath: string) => {
     // Self-links (source = target) are excluded from the backlink subquery
     // so a note that only links to itself is still considered an orphan.
     const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties
+      SELECT path, title, tags, related, folder, type, created, mtime, properties, callout
       FROM notes
       WHERE path NOT IN (SELECT DISTINCT target FROM links WHERE source != target)
         ${whereClause}
@@ -977,6 +1010,7 @@ const rowToMetadata = (row: NoteRow): NoteMetadata => ({
   created: row.created,
   modified: DateTime.fromMillis(Math.round(row.mtime)).toISO()!,
   properties: JSON.parse(row.properties) as Record<string, unknown>,
+  callout: row.callout ? (JSON.parse(row.callout) as LeadingCallout) : null,
 })
 
 export type SearchIndex = ReturnType<typeof createSearchIndex>

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -105,7 +105,7 @@ type SearchResult = {
   type: string | null
   created?: string
   modified: string
-  callout?: LeadingCallout
+  leading_callout?: LeadingCallout
 }
 
 type NoteMetadata = {
@@ -118,7 +118,7 @@ type NoteMetadata = {
   created: string | null
   modified: string
   properties: Record<string, unknown>
-  callout: LeadingCallout | null
+  leading_callout: LeadingCallout | null
 }
 
 type TagCount = {
@@ -145,7 +145,7 @@ type SearchFilters = {
   properties?: Record<string, string | number | boolean>
   limit?: number
   snippet_tokens?: number
-  include_callout?: boolean
+  include_leading_callout?: boolean
 }
 
 type NoteRow = {
@@ -158,7 +158,7 @@ type NoteRow = {
   created: string | null
   mtime: number
   properties: string
-  callout: string | null
+  leading_callout: string | null
 }
 
 type BacklinkEntry = { path: string; title: string }
@@ -312,7 +312,7 @@ export const createSearchIndex = (dbPath: string) => {
       created     TEXT,
       mtime       INTEGER,
       properties  TEXT,
-      callout     TEXT
+      leading_callout TEXT
     );
 
     CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
@@ -330,22 +330,22 @@ export const createSearchIndex = (dbPath: string) => {
   // path UNINDEXED: stored for JOIN/DELETE but not searchable, saves index space
 
   // CREATE TABLE IF NOT EXISTS is a no-op on a pre-existing DB file, so a warm
-  // database from before the `callout` column was added would lack it (and the
-  // upsert below would throw). Add it idempotently when absent. `callout` is
-  // not FTS-indexed — the callout text already lives in `content`, so it's
-  // searchable; this column only stores the parsed block for cheap retrieval.
+  // database from before the `leading_callout` column was added would lack it
+  // (and the upsert below would throw). Add it idempotently when absent. The
+  // column is not FTS-indexed — the callout text already lives in `content`, so
+  // it's searchable; this column only stores the parsed block for cheap retrieval.
   const noteColumns = db.prepare(`PRAGMA table_info(notes)`).all() as Array<{
     name: string
   }>
-  if (!noteColumns.some((column) => column.name === "callout")) {
-    db.exec(`ALTER TABLE notes ADD COLUMN callout TEXT`)
+  if (!noteColumns.some((column) => column.name === "leading_callout")) {
+    db.exec(`ALTER TABLE notes ADD COLUMN leading_callout TEXT`)
   }
 
   // Prepared statements are compiled once here and reused across all calls.
   // db.prepare() caches the compiled SQL — calling it inside a function
   // would re-compile on every invocation.
   const upsertNotesStmt = db.prepare(`
-    INSERT OR REPLACE INTO notes (path, title, content, tags, related, folder, type, created, mtime, properties, callout)
+    INSERT OR REPLACE INTO notes (path, title, content, tags, related, folder, type, created, mtime, properties, leading_callout)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
   const deleteFtsStmt = db.prepare(`DELETE FROM notes_fts WHERE path = ?`)
@@ -381,7 +381,7 @@ export const createSearchIndex = (dbPath: string) => {
     const related = coerceToArray(frontmatter.related)
     // Store the leading callout (top-of-file scope/summary block) as JSON so
     // discovery tools can return it structured; null when the note has none.
-    const callout = parseLeadingCallout(parsed.content.split("\n"))
+    const leadingCallout = parseLeadingCallout(parsed.content.split("\n"))
 
     const note = {
       path: filePath,
@@ -398,7 +398,7 @@ export const createSearchIndex = (dbPath: string) => {
         : null,
       mtime: lastModifiedMs,
       properties: JSON.stringify(frontmatter),
-      callout: callout ? JSON.stringify(callout) : null,
+      leading_callout: leadingCallout ? JSON.stringify(leadingCallout) : null,
     }
 
     deleteFtsStmt.run(note.path)
@@ -413,7 +413,7 @@ export const createSearchIndex = (dbPath: string) => {
       note.created,
       note.mtime,
       note.properties,
-      note.callout,
+      note.leading_callout,
     )
     insertFtsStmt.run(note.path, note.title, note.content)
 
@@ -569,14 +569,15 @@ export const createSearchIndex = (dbPath: string) => {
     const snippetTokens = params.filters?.snippet_tokens ?? 30
     // Opt-in: the leading callout is omitted by default to keep this hot-path
     // result lean; callers triaging which note to open can request it.
-    const includeCallout = params.filters?.include_callout ?? false
+    const includeLeadingCallout =
+      params.filters?.include_leading_callout ?? false
     queryParams.push(limit)
 
     const sql = `
       SELECT n.path, n.title,
              snippet(notes_fts, 2, '', '', '...', ${Number(snippetTokens)}) as snippet,
              rank * -1 as score, n.tags, n.folder, n.type, n.created, n.mtime${
-               includeCallout ? ", n.callout" : ""
+               includeLeadingCallout ? ", n.leading_callout" : ""
              }
       FROM notes_fts
       JOIN notes n ON n.path = notes_fts.path
@@ -594,7 +595,7 @@ export const createSearchIndex = (dbPath: string) => {
         > & {
           snippet: string
           score: number
-          callout?: string | null
+          leading_callout?: string | null
         }
       >
 
@@ -608,8 +609,12 @@ export const createSearchIndex = (dbPath: string) => {
         type: row.type,
         ...(row.created !== null ? { created: row.created } : {}),
         modified: DateTime.fromMillis(Math.round(row.mtime)).toISO()!,
-        ...(includeCallout && row.callout
-          ? { callout: JSON.parse(row.callout) as LeadingCallout }
+        ...(includeLeadingCallout && row.leading_callout
+          ? {
+              leading_callout: JSON.parse(
+                row.leading_callout,
+              ) as LeadingCallout,
+            }
           : {}),
       }))
       logger.info("full text search", {
@@ -642,7 +647,7 @@ export const createSearchIndex = (dbPath: string) => {
       : [params.tag, params.tag, limit]
 
     const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties, callout
+      SELECT path, title, tags, related, folder, type, created, mtime, properties, leading_callout
       FROM notes n
       WHERE ${condition}
       LIMIT ?
@@ -674,7 +679,7 @@ export const createSearchIndex = (dbPath: string) => {
       : [params.folder, params.folder, limit]
 
     const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties, callout
+      SELECT path, title, tags, related, folder, type, created, mtime, properties, leading_callout
       FROM notes
       WHERE ${condition}
       ORDER BY mtime DESC
@@ -718,7 +723,7 @@ export const createSearchIndex = (dbPath: string) => {
         : "ORDER BY mtime DESC" // SQL column is still `mtime`
 
     const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties, callout
+      SELECT path, title, tags, related, folder, type, created, mtime, properties, leading_callout
       FROM notes
       ${orderClause}
       LIMIT ?
@@ -857,7 +862,7 @@ export const createSearchIndex = (dbPath: string) => {
     // - Scalar properties (status: "active"): check direct equality
     // Both branches CAST to TEXT for type-safe comparison (integer 4 = text "4")
     const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties, callout
+      SELECT path, title, tags, related, folder, type, created, mtime, properties, leading_callout
       FROM notes n
       WHERE (
         (json_type(n.properties, '$.' || @key) = 'array'
@@ -965,7 +970,7 @@ export const createSearchIndex = (dbPath: string) => {
     // Self-links (source = target) are excluded from the backlink subquery
     // so a note that only links to itself is still considered an orphan.
     const sql = `
-      SELECT path, title, tags, related, folder, type, created, mtime, properties, callout
+      SELECT path, title, tags, related, folder, type, created, mtime, properties, leading_callout
       FROM notes
       WHERE path NOT IN (SELECT DISTINCT target FROM links WHERE source != target)
         ${whereClause}
@@ -1010,7 +1015,9 @@ const rowToMetadata = (row: NoteRow): NoteMetadata => ({
   created: row.created,
   modified: DateTime.fromMillis(Math.round(row.mtime)).toISO()!,
   properties: JSON.parse(row.properties) as Record<string, unknown>,
-  callout: row.callout ? (JSON.parse(row.callout) as LeadingCallout) : null,
+  leading_callout: row.leading_callout
+    ? (JSON.parse(row.leading_callout) as LeadingCallout)
+    : null,
 })
 
 export type SearchIndex = ReturnType<typeof createSearchIndex>

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -50,9 +50,9 @@ const formatNoteMetadata = (meta: {
   properties: Record<string, unknown>
   [key: string]: unknown
 }) => {
-  // Drop a null `callout` so notes without a leading callout don't carry the
-  // key; keep it (the { type, title, body } block) when present.
-  const { properties, callout, ...fields } = meta
+  // Drop a null `leading_callout` so notes without one don't carry the key;
+  // keep it (the { type, title, body } block) when present.
+  const { properties, leading_callout: leadingCallout, ...fields } = meta
 
   const additional_properties = Object.fromEntries(
     Object.entries(properties).filter(([key]) => !PROMOTED_KEYS.has(key)),
@@ -60,7 +60,7 @@ const formatNoteMetadata = (meta: {
 
   return {
     ...fields,
-    ...(callout ? { callout } : {}),
+    ...(leadingCallout ? { leading_callout: leadingCallout } : {}),
     ...(Object.keys(additional_properties).length > 0
       ? { additional_properties }
       : {}),
@@ -127,7 +127,7 @@ Errors:
 - "ambiguous heading" — multiple headings match; use heading_level to disambiguate
 - "outline, heading, and properties_only are mutually exclusive" — only one mode per call
 
-Returns: Raw markdown string (default); JSON object of properties (properties_only); for outline, a JSON object { callout?, headings } where headings is an array of { level, text, bytes } and callout (when present) is the note's leading callout { type, title, body } — a top-of-file scope/summary block; raw markdown of the section, heading line included (heading).`,
+Returns: Raw markdown string (default); JSON object of properties (properties_only); for outline, a JSON object { leading_callout?, headings } where headings is an array of { level, text, bytes } and leading_callout (when present) is the note's top-of-file callout { type, title, body } — a scope/summary block; raw markdown of the section, heading line included (heading).`,
       inputSchema: {
         path: z
           .string()
@@ -145,7 +145,7 @@ Returns: Raw markdown string (default); JSON object of properties (properties_on
           .boolean()
           .optional()
           .describe(
-            "If true, returns { callout?, headings } as JSON — the heading tree (level, text, section byte size) plus any leading callout (top-of-file scope/summary block) — instead of any body content. A cheap structure fetch for large notes.",
+            "If true, returns { leading_callout?, headings } as JSON — the heading tree (level, text, section byte size) plus any leading callout (top-of-file scope/summary block) — instead of any body content. A cheap structure fetch for large notes.",
           ),
         heading: z
           .string()
@@ -632,7 +632,7 @@ Errors:
 - No matches returns { results: [], total: 0 }, not an error
 - Malformed query syntax is sanitized automatically — the tool never throws a query syntax error
 
-Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified) and total count. created is omitted when null. With filters.include_callout, each result also carries callout ({ type, title, body }) when the note has a leading callout.`,
+Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified) and total count. created is omitted when null. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when the note has a top-of-file callout.`,
       inputSchema: {
         query: z
           .string()
@@ -675,7 +675,7 @@ Returns: JSON with results array (path, title, snippet, score, tags, folder, typ
               .number()
               .optional()
               .describe("Snippet length in tokens (default 30)"),
-            include_callout: z
+            include_leading_callout: z
               .boolean()
               .optional()
               .describe(
@@ -726,7 +726,7 @@ Parameters:
 Errors:
 - An unknown tag or no matches returns an empty array, not an error — don't use as an existence check.
 
-Returns: JSON array of up to 20 notes' metadata (path, title, tags, related, folder, type, created, modified, callout? (the note's leading scope/summary callout, when present), additional_properties), sorted by most recently modified. Promoted keys are in top-level fields; additional_properties contains only unpromoted keys.`,
+Returns: JSON array of up to 20 notes' metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file scope/summary callout, when present), additional_properties), sorted by most recently modified. Promoted keys are in top-level fields; additional_properties contains only unpromoted keys.`,
       inputSchema: {
         tag: z.string().describe("Tag to search for"),
         exact: z
@@ -800,7 +800,7 @@ Example: vault_recent_notes({ sort_by: "modified", limit: 10 })
 When to use: Catching up on vault changes or finding recent work.
 Prefer vault_search for content-based discovery. Prefer vault_search_by_folder for browsing a specific folder.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, callout? (the note's leading scope/summary callout, when present), additional_properties), sorted by chosen timestamp.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file scope/summary callout, when present), additional_properties), sorted by chosen timestamp.`,
       inputSchema: {
         sort_by: z
           .enum(["created", "modified"])
@@ -848,7 +848,7 @@ Parameters:
 Errors:
 - An empty or nonexistent folder returns an empty array, not an error.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, callout? (the note's leading scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
       inputSchema: {
         folder: z
           .string()
@@ -1031,7 +1031,7 @@ Example: vault_list_memory_files() returns file outlines with headings like "Dec
 
 When to use: Discovering what memory files and sections exist — and what each file is for — BEFORE calling vault_get_memory, vault_update_memory, or vault_delete_memory. Always call this first to get valid file and section names.
 
-Returns: JSON array of file outlines, each { file, title, callout, headings } — callout is the file's leading scope callout ({ type, title, body }) or null.`,
+Returns: JSON array of file outlines, each { file, title, leading_callout, headings } — leading_callout is the file's top-of-file scope callout ({ type, title, body }) or null.`,
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -1255,7 +1255,7 @@ Example: vault_search_by_property({ key: "status", value: "in-progress" })
 When to use: Finding notes by metadata when you don't have a text query. Fills the gap where vault_search requires search text.
 Prefer vault_search when you also have a text query (it supports property filters too). Prefer vault_search_by_tag for tag-specific queries (supports hierarchical prefix matching).
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, callout? (the note's leading scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
       inputSchema: {
         key: z.string().describe("Property key name"),
         value: z.string().describe("Value to match (exact, case-sensitive)"),
@@ -1399,7 +1399,7 @@ Parameters:
 Errors:
 - An empty array means no orphans were found (after exclusions), not an error.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, callout? (the note's leading scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
       inputSchema: {
         exclude_folders: z
           .array(z.string())

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -127,7 +127,7 @@ Errors:
 - "ambiguous heading" — multiple headings match; use heading_level to disambiguate
 - "outline, heading, and properties_only are mutually exclusive" — only one mode per call
 
-Returns: Raw markdown string (default); JSON object of properties (properties_only); for outline, a JSON object { leading_callout?, headings } where headings is an array of { level, text, bytes } and leading_callout (when present) is the note's top-of-file callout { type, title, body } — a scope/summary block; raw markdown of the section, heading line included (heading).`,
+Returns: Raw markdown string (default); JSON object of properties (properties_only); for outline, a JSON object { leading_callout?, headings } where headings is an array of { level, text, bytes } and leading_callout (when present) is the note's top-of-file callout — a \`> [!type]\` block (info, warning, etc.) flagging context or state about the note, as { type, title, body }; raw markdown of the section, heading line included (heading).`,
       inputSchema: {
         path: z
           .string()
@@ -145,7 +145,7 @@ Returns: Raw markdown string (default); JSON object of properties (properties_on
           .boolean()
           .optional()
           .describe(
-            "If true, returns { leading_callout?, headings } as JSON — the heading tree (level, text, section byte size) plus any leading callout (top-of-file scope/summary block) — instead of any body content. A cheap structure fetch for large notes.",
+            "If true, returns { leading_callout?, headings } as JSON — the heading tree (level, text, section byte size) plus any leading callout (a top-of-file `> [!type]` block — info, warning, etc.) — instead of any body content. A cheap structure fetch for large notes.",
           ),
         heading: z
           .string()
@@ -679,7 +679,7 @@ Returns: JSON with results array (path, title, snippet, score, tags, folder, typ
               .boolean()
               .optional()
               .describe(
-                "If true, each result includes its leading callout (top-of-file scope/summary block { type, title, body }) when present. Off by default to keep results lean.",
+                "If true, each result includes its leading callout — a top-of-file `> [!type]` block (info, warning, etc.) flagging context or state about the note, as { type, title, body } — when present. Off by default to keep results lean.",
               ),
           })
           .optional()
@@ -726,7 +726,7 @@ Parameters:
 Errors:
 - An unknown tag or no matches returns an empty array, not an error — don't use as an existence check.
 
-Returns: JSON array of up to 20 notes' metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file scope/summary callout, when present), additional_properties), sorted by most recently modified. Promoted keys are in top-level fields; additional_properties contains only unpromoted keys.`,
+Returns: JSON array of up to 20 notes' metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file callout — info/warning/etc. — when present), additional_properties), sorted by most recently modified. Promoted keys are in top-level fields; additional_properties contains only unpromoted keys.`,
       inputSchema: {
         tag: z.string().describe("Tag to search for"),
         exact: z
@@ -800,7 +800,7 @@ Example: vault_recent_notes({ sort_by: "modified", limit: 10 })
 When to use: Catching up on vault changes or finding recent work.
 Prefer vault_search for content-based discovery. Prefer vault_search_by_folder for browsing a specific folder.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file scope/summary callout, when present), additional_properties), sorted by chosen timestamp.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file callout — info/warning/etc. — when present), additional_properties), sorted by chosen timestamp.`,
       inputSchema: {
         sort_by: z
           .enum(["created", "modified"])
@@ -848,7 +848,7 @@ Parameters:
 Errors:
 - An empty or nonexistent folder returns an empty array, not an error.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file callout — info/warning/etc. — when present), additional_properties), sorted by most recently modified.`,
       inputSchema: {
         folder: z
           .string()
@@ -1025,13 +1025,13 @@ Returns: Confirmation message.`,
     TOOL_NAMES.VAULT_LIST_MEMORY_FILES,
     {
       title: "List Memory Files",
-      description: `Discovery tool — lists ${config.memoryDir}/ memory files with their H1/H2 heading structure, per-section entry counts, and each file's leading scope callout (the top-of-file block describing what belongs in the file). Does NOT return actual entries.
+      description: `Discovery tool — lists ${config.memoryDir}/ memory files with their H1/H2 heading structure, per-section entry counts, and each file's leading callout (by convention a "Scope of this file" block describing what belongs in it). Does NOT return actual entries.
 
 Example: vault_list_memory_files() returns file outlines with headings like "Decision heuristics (newest first)", entry counts, and the file's scope callout.
 
 When to use: Discovering what memory files and sections exist — and what each file is for — BEFORE calling vault_get_memory, vault_update_memory, or vault_delete_memory. Always call this first to get valid file and section names.
 
-Returns: JSON array of file outlines, each { file, title, leading_callout, headings } — leading_callout is the file's top-of-file scope callout ({ type, title, body }) or null.`,
+Returns: JSON array of file outlines, each { file, title, leading_callout, headings } — leading_callout is the file's top-of-file callout ({ type, title, body }), by convention a "Scope of this file" block, or null.`,
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -1255,7 +1255,7 @@ Example: vault_search_by_property({ key: "status", value: "in-progress" })
 When to use: Finding notes by metadata when you don't have a text query. Fills the gap where vault_search requires search text.
 Prefer vault_search when you also have a text query (it supports property filters too). Prefer vault_search_by_tag for tag-specific queries (supports hierarchical prefix matching).
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file callout — info/warning/etc. — when present), additional_properties), sorted by most recently modified.`,
       inputSchema: {
         key: z.string().describe("Property key name"),
         value: z.string().describe("Value to match (exact, case-sensitive)"),
@@ -1399,7 +1399,7 @@ Parameters:
 Errors:
 - An empty array means no orphans were found (after exclusions), not an error.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file callout — info/warning/etc. — when present), additional_properties), sorted by most recently modified.`,
       inputSchema: {
         exclude_folders: z
           .array(z.string())

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -127,7 +127,9 @@ Errors:
 - "ambiguous heading" — multiple headings match; use heading_level to disambiguate
 - "outline, heading, and properties_only are mutually exclusive" — only one mode per call
 
-Returns: Raw markdown string (default); JSON object of properties (properties_only); for outline, a JSON object { leading_callout?, headings } where headings is an array of { level, text, bytes } and leading_callout (when present) is the note's top-of-file callout — a \`> [!type]\` block (info, warning, etc.) flagging context or state about the note, as { type, title, body }; raw markdown of the section, heading line included (heading).`,
+Returns: Raw markdown string (default); JSON object of properties (properties_only); JSON outline object (outline); raw markdown of the section, heading line included (heading).
+
+Outline shape: { leading_callout?, headings } — headings is [{ level, text, bytes }]; leading_callout ({ type, title, body }) is the note's top-of-file callout, when present.`,
       inputSchema: {
         path: z
           .string()
@@ -145,7 +147,7 @@ Returns: Raw markdown string (default); JSON object of properties (properties_on
           .boolean()
           .optional()
           .describe(
-            "If true, returns { leading_callout?, headings } as JSON — the heading tree (level, text, section byte size) plus any leading callout (a top-of-file `> [!type]` block — info, warning, etc.) — instead of any body content. A cheap structure fetch for large notes.",
+            "If true, returns { leading_callout?, headings } as JSON instead of body content — a cheap structure fetch for large notes. headings: [{ level, text, bytes }]; leading_callout: { type, title, body } when the note has a top-of-file callout.",
           ),
         heading: z
           .string()
@@ -324,13 +326,13 @@ Prefer vault_write_note for creating new notes or full rewrites. Prefer vault_re
 
 Operations:
 - append: add content at end of section (or end of file if no heading)
-- prepend: add content after heading line (or at the very top of the body, just below frontmatter, if no heading)
+- prepend: add content after heading line (or at the top of the body, below frontmatter, if no heading — how you add a leading callout)
 - replace: replace section body (heading preserved; requires heading)
 - insert_before: insert content above the heading line (requires heading)
 
-Top-of-file callout: prepend with NO heading is how you add a leading callout (e.g. an Obsidian "> [!info] Scope of this file" block) right below the frontmatter — the block surfaced by vault_read_note outline and discovery tools. To edit an existing leading callout, read it via vault_read_note(outline: true), then vault_replace_in_note the old block for the new one (prepend would stack a second callout above it).
-
 Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section.
+
+Editing a leading callout: read it via vault_read_note(outline: true), then vault_replace_in_note the old block for the new one (a no-heading prepend would stack a second callout above it).
 
 Errors:
 - "note not found" — path does not exist; check vault_list_notes for valid paths
@@ -632,7 +634,7 @@ Errors:
 - No matches returns { results: [], total: 0 }, not an error
 - Malformed query syntax is sanitized automatically — the tool never throws a query syntax error
 
-Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified) and total count. created is omitted when null. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when the note has a top-of-file callout.`,
+Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified) and total count. created is omitted when null. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when present.`,
       inputSchema: {
         query: z
           .string()
@@ -679,7 +681,7 @@ Returns: JSON with results array (path, title, snippet, score, tags, folder, typ
               .boolean()
               .optional()
               .describe(
-                "If true, each result includes its leading callout — a top-of-file `> [!type]` block (info, warning, etc.) flagging context or state about the note, as { type, title, body } — when present. Off by default to keep results lean.",
+                "If true, each result includes its leading_callout ({ type, title, body }) when present. Off by default to keep results lean.",
               ),
           })
           .optional()
@@ -726,7 +728,7 @@ Parameters:
 Errors:
 - An unknown tag or no matches returns an empty array, not an error — don't use as an existence check.
 
-Returns: JSON array of up to 20 notes' metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file callout — info/warning/etc. — when present), additional_properties), sorted by most recently modified. Promoted keys are in top-level fields; additional_properties contains only unpromoted keys.`,
+Returns: JSON array of up to 20 notes' metadata (path, title, tags, related, folder, type, created, modified, leading_callout?, additional_properties), sorted by most recently modified. Promoted keys are in top-level fields; additional_properties contains only unpromoted keys.`,
       inputSchema: {
         tag: z.string().describe("Tag to search for"),
         exact: z
@@ -800,7 +802,7 @@ Example: vault_recent_notes({ sort_by: "modified", limit: 10 })
 When to use: Catching up on vault changes or finding recent work.
 Prefer vault_search for content-based discovery. Prefer vault_search_by_folder for browsing a specific folder.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file callout — info/warning/etc. — when present), additional_properties), sorted by chosen timestamp.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout?, additional_properties), sorted by chosen timestamp.`,
       inputSchema: {
         sort_by: z
           .enum(["created", "modified"])
@@ -848,7 +850,7 @@ Parameters:
 Errors:
 - An empty or nonexistent folder returns an empty array, not an error.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file callout — info/warning/etc. — when present), additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout?, additional_properties), sorted by most recently modified.`,
       inputSchema: {
         folder: z
           .string()
@@ -936,14 +938,12 @@ Returns: Raw markdown text.`,
       title: "Update Memory",
       description: `Append a dated entry to a section of a ${config.memoryDir}/ memory file. The server prefixes the date automatically (format: "- **YYYY-MM-DD**: entry text") and inserts newest-first by default. Pass raw entry text without a date prefix.
 
-Append-only by design: never overwrite or delete an entry to reflect a change. When a preference or fact changes, record the new state as a fresh dated entry — the newest entry wins on conflict and the older one stays as history (the timeline is the point). Delete (vault_delete_memory) is only for entries that were wrong when written.
-
 Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
 
 When to use: Recording a new preference, principle, opinion, or fact about the user. Call vault_list_memory_files first and reuse existing file and section names so entries stay grouped.
 Prefer vault_write_note for creating non-memory notes.
 
-Behavior: Additive — existing entries are never overwritten, and repeat calls add duplicate entries. A missing file or section is created automatically; if the section name omits "(newest first)" the server appends it when creating a new section ("Design preferences" becomes "Design preferences (newest first)"); an existing section is matched with or without the suffix. Creating a brand-new file also seeds a placeholder scope callout — the confirmation message nudges you to fill in its Contains/Does NOT contain via vault_patch_note so other agents know what belongs in the file.
+Behavior: Append-only by design — existing entries are never overwritten, and repeat calls add duplicate entries. When a preference or fact changes, append a new dated entry (newest wins; older entries stay as history); delete (vault_delete_memory) is only for entries that were wrong when written. A missing file or section is created automatically; if the section name omits "(newest first)" the server appends it when creating a new section ("Design preferences" becomes "Design preferences (newest first)"); an existing section is matched with or without the suffix. Creating a brand-new file also seeds a placeholder scope callout — the confirmation message nudges you to fill in its Contains/Does NOT contain via vault_patch_note so other agents know what belongs in the file.
 
 Parameters:
 - options.date — ISO YYYY-MM-DD, defaults to today (server timezone).
@@ -1062,7 +1062,7 @@ Returns: JSON array of file outlines, each { file, title, leading_callout, headi
 
 Example: vault_delete_memory({ file: "Opinions", section: "AI tooling & memory (newest first)", date: "2026-05-01", entry: "Prefer X over Y" })
 
-When to use: Removing an entry that was wrong when it was written — a mistake, a misattribution, or something never true. Memory is append-only by design, so do NOT delete to reflect a change: when a preference or fact has since evolved, append the new state via vault_update_memory (newest-first naturally supersedes, and the timeline is preserved). Deleting a genuinely-changed entry destroys the history the dated model exists to keep. Call vault_get_memory(file, section) first to see exact entry text for matching.
+When to use: Removing an entry that was wrong when it was written — a mistake, a misattribution, or something never true. Memory is append-only by design, so do NOT delete to reflect a change: when a preference or fact has since evolved, append the new state via vault_update_memory (newest-first naturally supersedes). Call vault_get_memory(file, section) first to see exact entry text for matching.
 Prefer vault_update_memory to supersede a changed entry; prefer vault_delete_note for deleting entire non-protected notes.
 
 Errors:
@@ -1255,7 +1255,7 @@ Example: vault_search_by_property({ key: "status", value: "in-progress" })
 When to use: Finding notes by metadata when you don't have a text query. Fills the gap where vault_search requires search text.
 Prefer vault_search when you also have a text query (it supports property filters too). Prefer vault_search_by_tag for tag-specific queries (supports hierarchical prefix matching).
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file callout — info/warning/etc. — when present), additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout?, additional_properties), sorted by most recently modified.`,
       inputSchema: {
         key: z.string().describe("Property key name"),
         value: z.string().describe("Value to match (exact, case-sensitive)"),
@@ -1399,7 +1399,7 @@ Parameters:
 Errors:
 - An empty array means no orphans were found (after exclusions), not an error.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout? (the note's top-of-file callout — info/warning/etc. — when present), additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, leading_callout?, additional_properties), sorted by most recently modified.`,
       inputSchema: {
         exclude_folders: z
           .array(z.string())

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -50,7 +50,9 @@ const formatNoteMetadata = (meta: {
   properties: Record<string, unknown>
   [key: string]: unknown
 }) => {
-  const { properties, ...fields } = meta
+  // Drop a null `callout` so notes without a leading callout don't carry the
+  // key; keep it (the { type, title, body } block) when present.
+  const { properties, callout, ...fields } = meta
 
   const additional_properties = Object.fromEntries(
     Object.entries(properties).filter(([key]) => !PROMOTED_KEYS.has(key)),
@@ -58,6 +60,7 @@ const formatNoteMetadata = (meta: {
 
   return {
     ...fields,
+    ...(callout ? { callout } : {}),
     ...(Object.keys(additional_properties).length > 0
       ? { additional_properties }
       : {}),
@@ -124,7 +127,7 @@ Errors:
 - "ambiguous heading" — multiple headings match; use heading_level to disambiguate
 - "outline, heading, and properties_only are mutually exclusive" — only one mode per call
 
-Returns: Raw markdown string (default); JSON object of properties (properties_only); JSON array of { level, text, bytes } per heading (outline); raw markdown of the section, heading line included (heading).`,
+Returns: Raw markdown string (default); JSON object of properties (properties_only); for outline, a JSON object { callout?, headings } where headings is an array of { level, text, bytes } and callout (when present) is the note's leading callout { type, title, body } — a top-of-file scope/summary block; raw markdown of the section, heading line included (heading).`,
       inputSchema: {
         path: z
           .string()
@@ -142,7 +145,7 @@ Returns: Raw markdown string (default); JSON object of properties (properties_on
           .boolean()
           .optional()
           .describe(
-            "If true, returns the heading tree as JSON (level, text, and section byte size per heading) instead of any body content — a cheap structure fetch for large notes",
+            "If true, returns { callout?, headings } as JSON — the heading tree (level, text, section byte size) plus any leading callout (top-of-file scope/summary block) — instead of any body content. A cheap structure fetch for large notes.",
           ),
         heading: z
           .string()
@@ -321,9 +324,11 @@ Prefer vault_write_note for creating new notes or full rewrites. Prefer vault_re
 
 Operations:
 - append: add content at end of section (or end of file if no heading)
-- prepend: add content after heading line (or after frontmatter if no heading)
+- prepend: add content after heading line (or at the very top of the body, just below frontmatter, if no heading)
 - replace: replace section body (heading preserved; requires heading)
 - insert_before: insert content above the heading line (requires heading)
+
+Top-of-file callout: prepend with NO heading is how you add a leading callout (e.g. an Obsidian "> [!info] Scope of this file" block) right below the frontmatter — the block surfaced by vault_read_note outline and discovery tools. To edit an existing leading callout, read it via vault_read_note(outline: true), then vault_replace_in_note the old block for the new one (prepend would stack a second callout above it).
 
 Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section.
 
@@ -627,7 +632,7 @@ Errors:
 - No matches returns { results: [], total: 0 }, not an error
 - Malformed query syntax is sanitized automatically — the tool never throws a query syntax error
 
-Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified) and total count. created is omitted when null.`,
+Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified) and total count. created is omitted when null. With filters.include_callout, each result also carries callout ({ type, title, body }) when the note has a leading callout.`,
       inputSchema: {
         query: z
           .string()
@@ -670,6 +675,12 @@ Returns: JSON with results array (path, title, snippet, score, tags, folder, typ
               .number()
               .optional()
               .describe("Snippet length in tokens (default 30)"),
+            include_callout: z
+              .boolean()
+              .optional()
+              .describe(
+                "If true, each result includes its leading callout (top-of-file scope/summary block { type, title, body }) when present. Off by default to keep results lean.",
+              ),
           })
           .optional()
           .describe(
@@ -715,7 +726,7 @@ Parameters:
 Errors:
 - An unknown tag or no matches returns an empty array, not an error — don't use as an existence check.
 
-Returns: JSON array of up to 20 notes' metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified. Promoted keys are in top-level fields; additional_properties contains only unpromoted keys.`,
+Returns: JSON array of up to 20 notes' metadata (path, title, tags, related, folder, type, created, modified, callout? (the note's leading scope/summary callout, when present), additional_properties), sorted by most recently modified. Promoted keys are in top-level fields; additional_properties contains only unpromoted keys.`,
       inputSchema: {
         tag: z.string().describe("Tag to search for"),
         exact: z
@@ -789,7 +800,7 @@ Example: vault_recent_notes({ sort_by: "modified", limit: 10 })
 When to use: Catching up on vault changes or finding recent work.
 Prefer vault_search for content-based discovery. Prefer vault_search_by_folder for browsing a specific folder.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by chosen timestamp.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, callout? (the note's leading scope/summary callout, when present), additional_properties), sorted by chosen timestamp.`,
       inputSchema: {
         sort_by: z
           .enum(["created", "modified"])
@@ -837,7 +848,7 @@ Parameters:
 Errors:
 - An empty or nonexistent folder returns an empty array, not an error.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, callout? (the note's leading scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
       inputSchema: {
         folder: z
           .string()
@@ -925,12 +936,14 @@ Returns: Raw markdown text.`,
       title: "Update Memory",
       description: `Append a dated entry to a section of a ${config.memoryDir}/ memory file. The server prefixes the date automatically (format: "- **YYYY-MM-DD**: entry text") and inserts newest-first by default. Pass raw entry text without a date prefix.
 
+Append-only by design: never overwrite or delete an entry to reflect a change. When a preference or fact changes, record the new state as a fresh dated entry — the newest entry wins on conflict and the older one stays as history (the timeline is the point). Delete (vault_delete_memory) is only for entries that were wrong when written.
+
 Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
 
 When to use: Recording a new preference, principle, opinion, or fact about the user. Call vault_list_memory_files first and reuse existing file and section names so entries stay grouped.
 Prefer vault_write_note for creating non-memory notes.
 
-Behavior: Additive — existing entries are never overwritten, and repeat calls add duplicate entries. A missing file or section is created automatically; if the section name omits "(newest first)" the server appends it when creating a new section ("Design preferences" becomes "Design preferences (newest first)"); an existing section is matched with or without the suffix.
+Behavior: Additive — existing entries are never overwritten, and repeat calls add duplicate entries. A missing file or section is created automatically; if the section name omits "(newest first)" the server appends it when creating a new section ("Design preferences" becomes "Design preferences (newest first)"); an existing section is matched with or without the suffix. Creating a brand-new file also seeds a placeholder scope callout — the confirmation message nudges you to fill in its Contains/Does NOT contain via vault_patch_note so other agents know what belongs in the file.
 
 Parameters:
 - options.date — ISO YYYY-MM-DD, defaults to today (server timezone).
@@ -996,7 +1009,14 @@ Returns: Confirmation message.`,
             },
             reqLogger,
           ),
-        () => `Added entry to ${config.memoryDir}/${file}.md → ## ${section}`,
+        (outcome) => {
+          const confirmation = `Added entry to ${config.memoryDir}/${file}.md → ## ${section}`
+          // Nudge the caller to author the scope callout the new file was
+          // seeded with, so the file self-documents what belongs in it.
+          return outcome === "created-file"
+            ? `${confirmation}. Created a new memory file with a placeholder scope callout — fill in its "Contains"/"Does NOT contain" via vault_patch_note (operation "prepend", no heading) so other agents know what this file is for.`
+            : confirmation
+        },
       )
     },
   )
@@ -1005,13 +1025,13 @@ Returns: Confirmation message.`,
     TOOL_NAMES.VAULT_LIST_MEMORY_FILES,
     {
       title: "List Memory Files",
-      description: `Discovery tool — lists ${config.memoryDir}/ memory files with their H1/H2 heading structure and per-section entry counts. Does NOT return actual entries.
+      description: `Discovery tool — lists ${config.memoryDir}/ memory files with their H1/H2 heading structure, per-section entry counts, and each file's leading scope callout (the top-of-file block describing what belongs in the file). Does NOT return actual entries.
 
-Example: vault_list_memory_files() returns file outlines with headings like "Decision heuristics (newest first)" and entry counts.
+Example: vault_list_memory_files() returns file outlines with headings like "Decision heuristics (newest first)", entry counts, and the file's scope callout.
 
-When to use: Discovering what memory files and sections exist BEFORE calling vault_get_memory, vault_update_memory, or vault_delete_memory. Always call this first to get valid file and section names.
+When to use: Discovering what memory files and sections exist — and what each file is for — BEFORE calling vault_get_memory, vault_update_memory, or vault_delete_memory. Always call this first to get valid file and section names.
 
-Returns: JSON array of file outlines.`,
+Returns: JSON array of file outlines, each { file, title, callout, headings } — callout is the file's leading scope callout ({ type, title, body }) or null.`,
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -1042,8 +1062,8 @@ Returns: JSON array of file outlines.`,
 
 Example: vault_delete_memory({ file: "Opinions", section: "AI tooling & memory (newest first)", date: "2026-05-01", entry: "Prefer X over Y" })
 
-When to use: Removing an outdated or incorrect entry from a memory file. Call vault_get_memory(file, section) first to see exact entry text for matching.
-Prefer vault_delete_note for deleting entire non-protected notes.
+When to use: Removing an entry that was wrong when it was written — a mistake, a misattribution, or something never true. Memory is append-only by design, so do NOT delete to reflect a change: when a preference or fact has since evolved, append the new state via vault_update_memory (newest-first naturally supersedes, and the timeline is preserved). Deleting a genuinely-changed entry destroys the history the dated model exists to keep. Call vault_get_memory(file, section) first to see exact entry text for matching.
+Prefer vault_update_memory to supersede a changed entry; prefer vault_delete_note for deleting entire non-protected notes.
 
 Errors:
 - "no entry matching …" — no bullet matched the given date and entry text; verify exact text via vault_get_memory(file, section).
@@ -1235,7 +1255,7 @@ Example: vault_search_by_property({ key: "status", value: "in-progress" })
 When to use: Finding notes by metadata when you don't have a text query. Fills the gap where vault_search requires search text.
 Prefer vault_search when you also have a text query (it supports property filters too). Prefer vault_search_by_tag for tag-specific queries (supports hierarchical prefix matching).
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, callout? (the note's leading scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
       inputSchema: {
         key: z.string().describe("Property key name"),
         value: z.string().describe("Value to match (exact, case-sensitive)"),
@@ -1379,7 +1399,7 @@ Parameters:
 Errors:
 - An empty array means no orphans were found (after exclusions), not an error.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, additional_properties), sorted by most recently modified.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, callout? (the note's leading scope/summary callout, when present), additional_properties), sorted by most recently modified.`,
       inputSchema: {
         exclude_folders: z
           .array(z.string())

--- a/src/vault-mcp/vault-operations/__tests__/callout-parser.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/callout-parser.test.ts
@@ -128,14 +128,14 @@ describe("parseLeadingCallout", () => {
       "# Me\r\n> [!info] Scope\r\n> line one\r\n> line two\r\n\r\n## H\r".split(
         "\n",
       )
-    const callout = parseLeadingCallout(lines)
-    expect(callout).toEqual({
+    const leadingCallout = parseLeadingCallout(lines)
+    expect(leadingCallout).toEqual({
       type: "info",
       title: "Scope",
       body: "line one\nline two",
     })
-    expect(callout?.body).not.toContain("\r")
-    expect(callout?.title).not.toContain("\r")
+    expect(leadingCallout?.body).not.toContain("\r")
+    expect(leadingCallout?.title).not.toContain("\r")
   })
 
   it("handles a callout with no space after the blockquote marker", () => {

--- a/src/vault-mcp/vault-operations/__tests__/callout-parser.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/callout-parser.test.ts
@@ -80,7 +80,7 @@ describe("parseLeadingCallout", () => {
     })
   })
 
-  it("returns null when the first significant line opens a code fence", () => {
+  it("returns null when the first significant line is a code fence, not a callout opener", () => {
     const lines = ["```md", "> [!info] inside a fence", "> body", "```"]
     expect(parseLeadingCallout(lines)).toBeNull()
   })

--- a/src/vault-mcp/vault-operations/__tests__/callout-parser.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/callout-parser.test.ts
@@ -122,6 +122,22 @@ describe("parseLeadingCallout", () => {
     expect(parseLeadingCallout(["", "   ", ""])).toBeNull()
   })
 
+  it("handles CRLF line endings without leaking carriage returns", () => {
+    // A CRLF file split on "\n" leaves a trailing "\r" on every line.
+    const lines =
+      "# Me\r\n> [!info] Scope\r\n> line one\r\n> line two\r\n\r\n## H\r".split(
+        "\n",
+      )
+    const callout = parseLeadingCallout(lines)
+    expect(callout).toEqual({
+      type: "info",
+      title: "Scope",
+      body: "line one\nline two",
+    })
+    expect(callout?.body).not.toContain("\r")
+    expect(callout?.title).not.toContain("\r")
+  })
+
   it("handles a callout with no space after the blockquote marker", () => {
     const lines = [">[!tip] Tight", "> body"]
     expect(parseLeadingCallout(lines)).toEqual({

--- a/src/vault-mcp/vault-operations/__tests__/callout-parser.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/callout-parser.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest"
+import { parseLeadingCallout } from "../callout-parser.js"
+
+describe("parseLeadingCallout", () => {
+  it("parses a callout that is the first body line (before any heading)", () => {
+    const lines = [
+      "> [!info] Scope of this file",
+      "> **Contains:** identity facts.",
+      "",
+      "## Identity",
+    ]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Scope of this file",
+      body: "**Contains:** identity facts.",
+    })
+  })
+
+  it("skips a single leading H1 and blank lines before the callout", () => {
+    const lines = [
+      "",
+      "# Me",
+      "",
+      "> [!info] Scope of this file",
+      "> line one",
+      "> line two",
+      "",
+      "## Section",
+    ]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Scope of this file",
+      body: "line one\nline two",
+    })
+  })
+
+  it("returns null when there is no callout", () => {
+    const lines = ["# Title", "", "Just prose, no callout.", "", "## Section"]
+    expect(parseLeadingCallout(lines)).toBeNull()
+  })
+
+  it("returns null when a callout appears after real body content", () => {
+    const lines = [
+      "# Title",
+      "",
+      "Intro paragraph.",
+      "",
+      "> [!note] Too late",
+      "> not a leading callout",
+    ]
+    expect(parseLeadingCallout(lines)).toBeNull()
+  })
+
+  it("returns null when a deeper heading precedes the callout", () => {
+    // Only a single leading H1 is skipped; an H2 is body content.
+    const lines = ["## Section", "> [!info] Not leading", "> body"]
+    expect(parseLeadingCallout(lines)).toBeNull()
+  })
+
+  it("collects only the first of two stacked callouts", () => {
+    const lines = [
+      "> [!info] First",
+      "> first body",
+      "> [!warning] Second",
+      "> second body",
+    ]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "First",
+      body: "first body",
+    })
+  })
+
+  it("strips the fold marker and lowercases the type", () => {
+    const lines = ["> [!INFO]- Folded", "> body"]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Folded",
+      body: "body",
+    })
+  })
+
+  it("returns null when the first significant line opens a code fence", () => {
+    const lines = ["```md", "> [!info] inside a fence", "> body", "```"]
+    expect(parseLeadingCallout(lines)).toBeNull()
+  })
+
+  it("allows an empty title", () => {
+    const lines = ["> [!warning]", "> heads up"]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "warning",
+      title: "",
+      body: "heads up",
+    })
+  })
+
+  it("stops the body at the first non-blockquote line", () => {
+    const lines = [
+      "> [!info] Scope",
+      "> kept",
+      "plain text ends the callout",
+      "> not part of it",
+    ]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Scope",
+      body: "kept",
+    })
+  })
+
+  it("trims trailing blank body lines", () => {
+    const lines = ["> [!info] Scope", "> content", ">", ">  ", "", "## Next"]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Scope",
+      body: "content",
+    })
+  })
+
+  it("returns null for an empty or whitespace-only body", () => {
+    expect(parseLeadingCallout([])).toBeNull()
+    expect(parseLeadingCallout(["", "   ", ""])).toBeNull()
+  })
+
+  it("handles a callout with no space after the blockquote marker", () => {
+    const lines = [">[!tip] Tight", "> body"]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "tip",
+      title: "Tight",
+      body: "body",
+    })
+  })
+})

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -1066,6 +1066,7 @@ describe("memory write size logging", () => {
       file: "Principles",
       section: "Working style (newest first)",
       date: "2026-06-14",
+      outcome: "appended",
       beforeBytes: Buffer.byteLength(PRINCIPLES_MD, "utf8"),
       afterBytes: Buffer.byteLength(written, "utf8"),
     })

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -452,6 +452,50 @@ describe("updateMemory auto-creation", () => {
     await rm(emptyVault, { recursive: true })
   })
 
+  it("seeds a generic scope callout in an auto-created file and reports created-file", async () => {
+    const emptyVault = await mkdtemp(join(tmpdir(), "new-callout-"))
+    const outcome = await updateMemory(
+      {
+        vaultPath: emptyVault,
+        file: "Health",
+        section: "Sleep",
+        entry: "Aims for 8 hours",
+        date: "2026-05-15",
+      },
+      logger,
+    )
+    expect(outcome).toBe("created-file")
+    const outlines = await listMemoryFiles({ vaultPath: emptyVault }, logger)
+    const health = outlines.find((outline) => outline.file === "Health")!
+    expect(health.callout?.title).toBe("Scope of this file")
+    // Generic form: convention present, but no per-file Does-NOT-contain yet.
+    expect(health.callout?.body).toContain("append newest first")
+    expect(health.callout?.body).toContain(
+      "(describe what belongs in this file",
+    )
+    await rm(emptyVault, { recursive: true })
+  })
+
+  it("reports created-section then appended for subsequent writes", async () => {
+    const emptyVault = await mkdtemp(join(tmpdir(), "outcome-"))
+    const first = await updateMemory(
+      { vaultPath: emptyVault, file: "Notes", section: "A", entry: "one" },
+      logger,
+    )
+    const second = await updateMemory(
+      { vaultPath: emptyVault, file: "Notes", section: "B", entry: "two" },
+      logger,
+    )
+    const third = await updateMemory(
+      { vaultPath: emptyVault, file: "Notes", section: "B", entry: "three" },
+      logger,
+    )
+    expect(first).toBe("created-file")
+    expect(second).toBe("created-section")
+    expect(third).toBe("appended")
+    await rm(emptyVault, { recursive: true })
+  })
+
   it("auto-created file has correct H1 and H2 structure", async () => {
     const emptyVault = await mkdtemp(join(tmpdir(), "structure-"))
     await updateMemory(
@@ -709,6 +753,19 @@ describe("listMemoryFiles", () => {
     expect(outlines[1].title).toBe("Principles — About Me")
   })
 
+  it("surfaces each file's leading scope callout (null when absent)", async () => {
+    const outlines = await listMemoryFiles({ vaultPath: vault }, logger)
+    const principles = outlines.find((o) => o.file === "Principles")!
+    const opinions = outlines.find((o) => o.file === "Opinions")!
+    expect(principles.callout).toEqual({
+      type: "info",
+      title: "Scope of this file",
+      body: "**Contains:** Values, decision heuristics, non-negotiables.\n**Convention:** Append newest first; never overwrite dated entries.",
+    })
+    // OPINIONS_MD has no leading callout.
+    expect(opinions.callout).toBeNull()
+  })
+
   it("falls back to filename when no frontmatter title", async () => {
     await writeFile(
       join(vault, "About Me/NoTitle.md"),
@@ -860,6 +917,23 @@ describe("bootstrapMemoryDir", () => {
       "Working style (newest first)",
       "Non-negotiables (newest first)",
     ])
+    await rm(emptyVault, { recursive: true })
+  })
+
+  it("template files open with a scope callout and count zero entries", async () => {
+    const emptyVault = await mkdtemp(join(tmpdir(), "bootstrap-callout-"))
+    await bootstrapMemoryDir({ vaultPath: emptyVault }, logger)
+    const outlines = await listMemoryFiles({ vaultPath: emptyVault }, logger)
+    const opinions = outlines.find((outline) => outline.file === "Opinions")!
+    // The callout is surfaced and is NOT miscounted as a dated entry.
+    expect(opinions.callout?.type).toBe("info")
+    expect(opinions.callout?.title).toBe("Scope of this file")
+    expect(opinions.callout?.body).toContain("**Contains:**")
+    const totalEntries = opinions.headings.reduce(
+      (sum, heading) => sum + (heading.entryCount ?? 0),
+      0,
+    )
+    expect(totalEntries).toBe(0)
     await rm(emptyVault, { recursive: true })
   })
 

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -467,9 +467,9 @@ describe("updateMemory auto-creation", () => {
     expect(outcome).toBe("created-file")
     const outlines = await listMemoryFiles({ vaultPath: emptyVault }, logger)
     const health = outlines.find((outline) => outline.file === "Health")!
-    expect(health.callout?.title).toBe("Scope of this file")
+    expect(health.leading_callout?.title).toBe("Scope of this file")
     // Generic form: convention + a Contains placeholder, no per-file Does-NOT-contain.
-    expect(health.callout?.body).toBe(
+    expect(health.leading_callout?.body).toBe(
       "**Contains:** (describe what belongs in this file — and what doesn't)\n**Convention:** append newest first; never overwrite dated entries; ISO dates only.",
     )
     await rm(emptyVault, { recursive: true })
@@ -756,13 +756,13 @@ describe("listMemoryFiles", () => {
     const outlines = await listMemoryFiles({ vaultPath: vault }, logger)
     const principles = outlines.find((o) => o.file === "Principles")!
     const opinions = outlines.find((o) => o.file === "Opinions")!
-    expect(principles.callout).toEqual({
+    expect(principles.leading_callout).toEqual({
       type: "info",
       title: "Scope of this file",
       body: "**Contains:** Values, decision heuristics, non-negotiables.\n**Convention:** Append newest first; never overwrite dated entries.",
     })
     // OPINIONS_MD has no leading callout.
-    expect(opinions.callout).toBeNull()
+    expect(opinions.leading_callout).toBeNull()
   })
 
   it("falls back to filename when no frontmatter title", async () => {
@@ -925,9 +925,9 @@ describe("bootstrapMemoryDir", () => {
     const outlines = await listMemoryFiles({ vaultPath: emptyVault }, logger)
     const opinions = outlines.find((outline) => outline.file === "Opinions")!
     // The callout is surfaced and is NOT miscounted as a dated entry.
-    expect(opinions.callout?.type).toBe("info")
-    expect(opinions.callout?.title).toBe("Scope of this file")
-    expect(opinions.callout?.body).toContain("**Contains:**")
+    expect(opinions.leading_callout?.type).toBe("info")
+    expect(opinions.leading_callout?.title).toBe("Scope of this file")
+    expect(opinions.leading_callout?.body).toContain("**Contains:**")
     const totalEntries = opinions.headings.reduce(
       (sum, heading) => sum + (heading.entryCount ?? 0),
       0,

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -468,10 +468,9 @@ describe("updateMemory auto-creation", () => {
     const outlines = await listMemoryFiles({ vaultPath: emptyVault }, logger)
     const health = outlines.find((outline) => outline.file === "Health")!
     expect(health.callout?.title).toBe("Scope of this file")
-    // Generic form: convention present, but no per-file Does-NOT-contain yet.
-    expect(health.callout?.body).toContain("append newest first")
-    expect(health.callout?.body).toContain(
-      "(describe what belongs in this file",
+    // Generic form: convention + a Contains placeholder, no per-file Does-NOT-contain.
+    expect(health.callout?.body).toBe(
+      "**Contains:** (describe what belongs in this file — and what doesn't)\n**Convention:** append newest first; never overwrite dated entries; ISO dates only.",
     )
     await rm(emptyVault, { recursive: true })
   })

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -672,7 +672,7 @@ describe("readNoteOutline", () => {
 
     // "# Title" (H1) has no later H1, so its span includes the nested "## Active"
     // child — its byte size is the whole body. "## Active" is just its own span.
-    // No leading callout, so `callout` is omitted from the outline object.
+    // No leading callout, so `leading_callout` is omitted from the outline object.
     expect(outline).toEqual({
       headings: [
         { level: 1, text: "Title", bytes: Buffer.byteLength(body, "utf8") },
@@ -702,7 +702,7 @@ describe("readNoteOutline", () => {
       logger,
     )
 
-    expect(outline.callout).toEqual({
+    expect(outline.leading_callout).toEqual({
       type: "info",
       title: "Scope of this file",
       body: "**Contains:** identity facts.\n**Convention:** append newest first.",
@@ -720,8 +720,8 @@ describe("readNoteOutline", () => {
       { vaultPath: vault, path: "nocallout.md" },
       logger,
     )
-    expect(outline.callout).toBeUndefined()
-    expect("callout" in outline).toBe(false)
+    expect(outline.leading_callout).toBeUndefined()
+    expect("leading_callout" in outline).toBe(false)
   })
 
   it("excludes frontmatter from section line ranges", async () => {

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -672,21 +672,56 @@ describe("readNoteOutline", () => {
 
     // "# Title" (H1) has no later H1, so its span includes the nested "## Active"
     // child — its byte size is the whole body. "## Active" is just its own span.
-    expect(outline).toEqual([
-      { level: 1, text: "Title", bytes: Buffer.byteLength(body, "utf8") },
-      {
-        level: 2,
-        text: "Active",
-        bytes: Buffer.byteLength("## Active\n\n- one\n- two\n", "utf8"),
-      },
-    ])
+    // No leading callout, so `callout` is omitted from the outline object.
+    expect(outline).toEqual({
+      headings: [
+        { level: 1, text: "Title", bytes: Buffer.byteLength(body, "utf8") },
+        {
+          level: 2,
+          text: "Active",
+          bytes: Buffer.byteLength("## Active\n\n- one\n- two\n", "utf8"),
+        },
+      ],
+    })
   })
 
-  it("returns an empty array for a note with no headings", async () => {
+  it("returns an empty headings array for a note with no headings", async () => {
     await writeFile(join(vault, "flat.md"), "just prose, no headings\n", "utf8")
     expect(
       await readNoteOutline({ vaultPath: vault, path: "flat.md" }, logger),
-    ).toEqual([])
+    ).toEqual({ headings: [] })
+  })
+
+  it("surfaces a leading callout below the H1 alongside the headings", async () => {
+    const body =
+      "# Me\n\n> [!info] Scope of this file\n> **Contains:** identity facts.\n> **Convention:** append newest first.\n\n## Identity\n\n- a\n"
+    await writeFile(join(vault, "scoped.md"), body, "utf8")
+
+    const outline = await readNoteOutline(
+      { vaultPath: vault, path: "scoped.md" },
+      logger,
+    )
+
+    expect(outline.callout).toEqual({
+      type: "info",
+      title: "Scope of this file",
+      body: "**Contains:** identity facts.\n**Convention:** append newest first.",
+    })
+    expect(outline.headings.map((heading) => heading.text)).toEqual([
+      "Me",
+      "Identity",
+    ])
+  })
+
+  it("omits callout when the first body content is not a callout", async () => {
+    const body = "# Title\n\nIntro prose, not a callout.\n\n## Section\n"
+    await writeFile(join(vault, "nocallout.md"), body, "utf8")
+    const outline = await readNoteOutline(
+      { vaultPath: vault, path: "nocallout.md" },
+      logger,
+    )
+    expect(outline.callout).toBeUndefined()
+    expect("callout" in outline).toBe(false)
   })
 
   it("excludes frontmatter from section line ranges", async () => {
@@ -702,9 +737,11 @@ describe("readNoteOutline", () => {
       { vaultPath: vault, path: "fm.md" },
       logger,
     )
-    expect(outline).toEqual([
-      { level: 2, text: "Only", bytes: Buffer.byteLength(body, "utf8") },
-    ])
+    expect(outline).toEqual({
+      headings: [
+        { level: 2, text: "Only", bytes: Buffer.byteLength(body, "utf8") },
+      ],
+    })
   })
 
   it("throws note not found for a missing path", async () => {

--- a/src/vault-mcp/vault-operations/callout-parser.ts
+++ b/src/vault-mcp/vault-operations/callout-parser.ts
@@ -31,10 +31,11 @@ const CALLOUT_BODY_REGEX = /^>\s?(.*)$/
 const H1_REGEX = /^# .+$/
 
 /**
- * Index of the first body line, skipping leading blank lines and at most one H1
- * title. Recursion (rather than a mutable cursor) carries the scan position and
- * the one-H1 allowance, so the parser stays `let`-free. Returns lines.length
- * when nothing but blanks/an H1 remain.
+ * Returns the index of the first body line — the first line that is neither
+ * blank nor the note's single leading H1 title. Returns lines.length when the
+ * note contains only blank lines and/or that H1.
+ *
+ * `index` and `skippedH1` are recursion accumulators; callers pass neither.
  */
 const firstBodyLineIndex = (
   lines: readonly string[],

--- a/src/vault-mcp/vault-operations/callout-parser.ts
+++ b/src/vault-mcp/vault-operations/callout-parser.ts
@@ -43,13 +43,21 @@ const H1_REGEX = /^# .+$/
 export const parseLeadingCallout = (
   lines: readonly string[],
 ): LeadingCallout | null => {
+  // Callers split on "\n", so a CRLF (Windows-authored) file leaves a trailing
+  // "\r" on each line. `.` never matches "\r" and a non-multiline `$` only
+  // anchors at end-of-input, so a stray "\r" would defeat the regexes below
+  // (and leak into the captured body) — strip it once, up front.
+  const normalizedLines = lines.map((line) =>
+    line.endsWith("\r") ? line.slice(0, -1) : line,
+  )
+
   // Scan past leading blank lines and at most one H1 title to find where the
   // first real body content begins. `let` carries the scan position and the
   // one-H1 allowance across lines — a reduce can't early-exit cleanly here.
   let cursor = 0
   let skippedH1 = false
-  while (cursor < lines.length) {
-    const line = lines[cursor]
+  while (cursor < normalizedLines.length) {
+    const line = normalizedLines[cursor]
     if (line.trim() === "") {
       cursor++
       continue
@@ -63,7 +71,9 @@ export const parseLeadingCallout = (
   }
 
   const openerMatch =
-    cursor < lines.length ? CALLOUT_OPENER_REGEX.exec(lines[cursor]) : null
+    cursor < normalizedLines.length
+      ? CALLOUT_OPENER_REGEX.exec(normalizedLines[cursor])
+      : null
   if (!openerMatch) return null
 
   const type = openerMatch[1].toLowerCase()
@@ -71,7 +81,7 @@ export const parseLeadingCallout = (
 
   // Body = consecutive `>` lines after the opener, until the next callout
   // opener (stacked callout), a non-blockquote line (incl. a blank line), or EOF.
-  const afterOpener = lines.slice(cursor + 1)
+  const afterOpener = normalizedLines.slice(cursor + 1)
   const stopIndex = afterOpener.findIndex(
     (line) => CALLOUT_OPENER_REGEX.test(line) || !CALLOUT_BODY_REGEX.test(line),
   )

--- a/src/vault-mcp/vault-operations/callout-parser.ts
+++ b/src/vault-mcp/vault-operations/callout-parser.ts
@@ -1,5 +1,6 @@
 /** Markdown leading-callout parser — extracts the first callout block at the
- * top of a note body, so a note's scope/summary can be surfaced cheaply
+ * top of a note body (an info/warning/etc. block flagging context or state),
+ * so it can be surfaced cheaply
  * (outline, discovery, search) without reading the whole file.
  *
  * A "leading callout" is the first Obsidian callout block appearing before any

--- a/src/vault-mcp/vault-operations/callout-parser.ts
+++ b/src/vault-mcp/vault-operations/callout-parser.ts
@@ -1,0 +1,89 @@
+/** Markdown leading-callout parser — extracts the first callout block at the
+ * top of a note body, so a note's scope/summary can be surfaced cheaply
+ * (outline, discovery, search) without reading the whole file.
+ *
+ * A "leading callout" is the first Obsidian callout block appearing before any
+ * other body content, allowing a single optional H1 title line above it. This
+ * covers both "callout immediately after frontmatter" and "callout right after
+ * the H1" (the About Me/ memory-file pattern). Frontmatter is assumed already
+ * stripped by the caller (parseNote), matching heading-parser.ts.
+ */
+
+// ── Types ───────────────────────────────────────────────────────
+
+export type LeadingCallout = Readonly<{
+  type: string
+  title: string
+  body: string
+}>
+
+// ── Internal regexes ────────────────────────────────────────────
+
+/** Matches a callout opener line `> [!type] Title`: captures the type, an
+ *  optional fold marker (+/-), and the (possibly empty) title. */
+const CALLOUT_OPENER_REGEX = /^>\s*\[!([A-Za-z][\w-]*)\]([+-]?)\s*(.*)$/
+
+/** Matches any blockquote/callout body line `> text` (one optional space). A
+ *  blank line has no `>` and so does not match — it ends the callout body. */
+const CALLOUT_BODY_REGEX = /^>\s?(.*)$/
+
+/** Matches an H1 heading line (`# Title`). Only one leading H1 is skipped. */
+const H1_REGEX = /^# .+$/
+
+// ── Exported parser ─────────────────────────────────────────────
+
+/**
+ * Returns the note's leading callout, or null when the first body content is
+ * not a callout. Walks from the top, skipping blank lines and at most one H1
+ * title line; the next non-blank line must be a callout opener (so a leading
+ * code fence or prose yields null). The body is the run of following `>` lines,
+ * stopping at the next callout opener (a stacked sibling callout), the first
+ * non-blockquote line, or EOF.
+ */
+export const parseLeadingCallout = (
+  lines: readonly string[],
+): LeadingCallout | null => {
+  // Scan past leading blank lines and at most one H1 title to find where the
+  // first real body content begins. `let` carries the scan position and the
+  // one-H1 allowance across lines — a reduce can't early-exit cleanly here.
+  let cursor = 0
+  let skippedH1 = false
+  while (cursor < lines.length) {
+    const line = lines[cursor]
+    if (line.trim() === "") {
+      cursor++
+      continue
+    }
+    if (!skippedH1 && H1_REGEX.test(line)) {
+      skippedH1 = true
+      cursor++
+      continue
+    }
+    break
+  }
+
+  const openerMatch =
+    cursor < lines.length ? CALLOUT_OPENER_REGEX.exec(lines[cursor]) : null
+  if (!openerMatch) return null
+
+  const type = openerMatch[1].toLowerCase()
+  const title = openerMatch[3].trim()
+
+  // Body = consecutive `>` lines after the opener, until the next callout
+  // opener (stacked callout), a non-blockquote line (incl. a blank line), or EOF.
+  const afterOpener = lines.slice(cursor + 1)
+  const stopIndex = afterOpener.findIndex(
+    (line) => CALLOUT_OPENER_REGEX.test(line) || !CALLOUT_BODY_REGEX.test(line),
+  )
+  const bodyRange =
+    stopIndex === -1 ? afterOpener : afterOpener.slice(0, stopIndex)
+  const bodyLines = bodyRange.map(
+    (line) => CALLOUT_BODY_REGEX.exec(line)?.[1] ?? "",
+  )
+
+  // Drop trailing blank body lines so the body ends cleanly.
+  const lastContentIndex = bodyLines.findLastIndex((line) => line.trim() !== "")
+  const body = bodyLines.slice(0, lastContentIndex + 1).join("\n")
+
+  return { type, title, body }
+}

--- a/src/vault-mcp/vault-operations/callout-parser.ts
+++ b/src/vault-mcp/vault-operations/callout-parser.ts
@@ -30,6 +30,25 @@ const CALLOUT_BODY_REGEX = /^>\s?(.*)$/
 /** Matches an H1 heading line (`# Title`). Only one leading H1 is skipped. */
 const H1_REGEX = /^# .+$/
 
+/**
+ * Index of the first body line, skipping leading blank lines and at most one H1
+ * title. Recursion (rather than a mutable cursor) carries the scan position and
+ * the one-H1 allowance, so the parser stays `let`-free. Returns lines.length
+ * when nothing but blanks/an H1 remain.
+ */
+const firstBodyLineIndex = (
+  lines: readonly string[],
+  index = 0,
+  skippedH1 = false,
+): number => {
+  if (index >= lines.length) return index
+  const line = lines[index]
+  if (line.trim() === "") return firstBodyLineIndex(lines, index + 1, skippedH1)
+  if (!skippedH1 && H1_REGEX.test(line))
+    return firstBodyLineIndex(lines, index + 1, true)
+  return index
+}
+
 // ── Exported parser ─────────────────────────────────────────────
 
 /**
@@ -51,24 +70,8 @@ export const parseLeadingCallout = (
     line.endsWith("\r") ? line.slice(0, -1) : line,
   )
 
-  // Scan past leading blank lines and at most one H1 title to find where the
-  // first real body content begins. `let` carries the scan position and the
-  // one-H1 allowance across lines — a reduce can't early-exit cleanly here.
-  let cursor = 0
-  let skippedH1 = false
-  while (cursor < normalizedLines.length) {
-    const line = normalizedLines[cursor]
-    if (line.trim() === "") {
-      cursor++
-      continue
-    }
-    if (!skippedH1 && H1_REGEX.test(line)) {
-      skippedH1 = true
-      cursor++
-      continue
-    }
-    break
-  }
+  // Find where the first real body content begins (past blank lines + one H1).
+  const cursor = firstBodyLineIndex(normalizedLines)
 
   const openerMatch =
     cursor < normalizedLines.length

--- a/src/vault-mcp/vault-operations/callout-parser.ts
+++ b/src/vault-mcp/vault-operations/callout-parser.ts
@@ -32,8 +32,8 @@ const H1_REGEX = /^# .+$/
 
 /**
  * Returns the index of the first body line — the first line that is neither
- * blank nor the note's single leading H1 title. Returns lines.length when the
- * note contains only blank lines and/or that H1.
+ * blank nor the note's single leading H1 title. Returns lines.length when no
+ * such line exists (an empty, blank-only, or H1-only note).
  *
  * `index` and `skippedH1` are recursion accumulators; callers pass neither.
  */

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -100,7 +100,7 @@ type MemoryHeading = Readonly<{
 type MemoryFileOutline = Readonly<{
   file: string
   title: string
-  callout: LeadingCallout | null
+  leading_callout: LeadingCallout | null
   headings: MemoryHeading[]
 }>
 
@@ -564,7 +564,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         const name = basename(filename, ".md")
         const title = isString(parsed.data.title) ? parsed.data.title : name
         const lines = parsed.content.split("\n")
-        const callout = parseLeadingCallout(lines)
+        const leadingCallout = parseLeadingCallout(lines)
         const sections = parseSections(lines)
 
         const headings: MemoryHeading[] = sections.map((section) =>
@@ -577,7 +577,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
               },
         )
 
-        return { file: name, title, callout, headings }
+        return { file: name, title, leading_callout: leadingCallout, headings }
       }),
     )
 

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -452,6 +452,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
           file: params.file,
           section: newSection,
           date,
+          outcome: "created-file",
           beforeBytes: 0,
           afterBytes: Buffer.byteLength(content, "utf8"),
         })
@@ -480,6 +481,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
           file: params.file,
           section: newSection,
           date,
+          outcome: "created-section",
           beforeBytes,
           afterBytes,
         })
@@ -534,6 +536,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         file: params.file,
         section: params.section,
         date,
+        outcome: "appended",
         beforeBytes,
         afterBytes,
       })

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -5,6 +5,8 @@ import { constants } from "node:fs"
 import { join, basename, dirname } from "node:path"
 import { parseNote, stringifyNote } from "./frontmatter.js"
 import { atomicWriteFile } from "./vault-filesystem.js"
+import { parseLeadingCallout } from "./callout-parser.js"
+import type { LeadingCallout } from "./callout-parser.js"
 import { DateTime } from "luxon"
 import type { Logger } from "../../logger.js"
 
@@ -98,8 +100,16 @@ type MemoryHeading = Readonly<{
 type MemoryFileOutline = Readonly<{
   file: string
   title: string
+  callout: LeadingCallout | null
   headings: MemoryHeading[]
 }>
+
+/** What an updateMemory call did — lets the tool layer tailor its confirmation
+ *  (e.g. nudge the caller to fill in a new file's scope callout). */
+export type UpdateMemoryOutcome =
+  | "created-file"
+  | "created-section"
+  | "appended"
 
 type ParsedSection = Readonly<{
   heading: string
@@ -213,6 +223,12 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         "",
         "# Me",
         "",
+        "> [!info] Scope of this file",
+        "> **Contains:** Identity, interests, and durable context about the user — who they are, what they're into, situational facts.",
+        "> **Does NOT contain:** Opinions or preferences (→ Opinions), guiding principles (→ Principles), recurring routines (→ Routines).",
+        '> **Section structure:** H2 sections grouped by theme, each suffixed "(newest first)".',
+        "> **Convention:** append newest first; never overwrite dated entries; ISO dates only.",
+        "",
         "## Identity (newest first)",
         "",
         "## Interests (newest first)",
@@ -234,6 +250,12 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         "",
         "# Opinions",
         "",
+        "> [!info] Scope of this file",
+        "> **Contains:** Evolving views on tools, patterns, methods, and processes — stances that may shift over time.",
+        "> **Does NOT contain:** Stable values or decision heuristics (→ Principles), identity or interests (→ Me).",
+        '> **Section structure:** H2 sections by topic, each suffixed "(newest first)".',
+        "> **Convention:** append newest first; never overwrite dated entries; ISO dates only.",
+        "",
         "## Tools and workflows (newest first)",
         "",
         "## Code patterns (newest first)",
@@ -254,6 +276,12 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         "---",
         "",
         "# Principles",
+        "",
+        "> [!info] Scope of this file",
+        "> **Contains:** Stable values, decision heuristics, and non-negotiables — how the user thinks and what they hold firm.",
+        "> **Does NOT contain:** Evolving opinions on tools or methods (→ Opinions), identity facts (→ Me).",
+        '> **Section structure:** H2 sections by theme, each suffixed "(newest first)".',
+        "> **Convention:** append newest first; never overwrite dated entries; ISO dates only.",
         "",
         "## Decision heuristics (newest first)",
         "",
@@ -306,9 +334,17 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       tags: ["memory", toKebabCase(params.fileName)],
       created: DateTime.now().toISO(),
     }
+    // A programmatically-created file has an unknown purpose, so seed only the
+    // generic convention + a Contains placeholder for the caller to fill in
+    // (the full scope callout — Does NOT contain / Section structure — is
+    // authored per-file in MEMORY_TEMPLATES for the known seed files).
     const body = [
       "",
       `# ${params.fileName}`,
+      "",
+      "> [!info] Scope of this file",
+      "> **Contains:** (describe what belongs in this file — and what doesn't)",
+      "> **Convention:** append newest first; never overwrite dated entries; ISO dates only.",
       "",
       `## ${params.section}`,
       params.bullet,
@@ -388,7 +424,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       position?: "top" | "bottom"
     },
     logger: Logger,
-  ): Promise<void> =>
+  ): Promise<UpdateMemoryOutcome> =>
     // Serialize the read-modify-write so concurrent appends to the same file
     // don't clobber each other's entries (lost update).
     withFileLock(memoryFilePath(params.vaultPath, params.file), async () => {
@@ -419,7 +455,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
           beforeBytes: 0,
           afterBytes: Buffer.byteLength(content, "utf8"),
         })
-        return
+        return "created-file"
       }
 
       const parsed = parseNote(existingContent)
@@ -447,7 +483,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
           beforeBytes,
           afterBytes,
         })
-        return
+        return "created-section"
       }
 
       // File + section exist — find the first and last dated bullet within the
@@ -501,6 +537,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         beforeBytes,
         afterBytes,
       })
+      return "appended"
     })
 
   const listMemoryFiles = async (
@@ -527,6 +564,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         const name = basename(filename, ".md")
         const title = isString(parsed.data.title) ? parsed.data.title : name
         const lines = parsed.content.split("\n")
+        const callout = parseLeadingCallout(lines)
         const sections = parseSections(lines)
 
         const headings: MemoryHeading[] = sections.map((section) =>
@@ -539,7 +577,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
               },
         )
 
-        return { file: name, title, headings }
+        return { file: name, title, callout, headings }
       }),
     )
 

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -117,8 +117,9 @@ export type HeadingOutline = Readonly<{
   bytes: number
 }>
 
-/** A note's outline: its optional leading callout (a top-of-file scope/summary
- *  block) plus the heading tree. `leading_callout` is omitted when the note has none. */
+/** A note's outline: its optional leading callout (a top-of-file `> [!type]`
+ *  block — info, warning, etc.) plus the heading tree. `leading_callout` is
+ *  omitted when the note has none. */
 export type NoteOutline = Readonly<{
   leading_callout?: LeadingCallout
   headings: HeadingOutline[]
@@ -127,8 +128,9 @@ export type NoteOutline = Readonly<{
 /**
  * Returns a note's heading tree (no bodies) — H1–H6 with each section's byte
  * size, so an agent can pick which section to read without pulling the whole
- * file — plus any leading callout (the top-of-file scope/summary block), so a
- * note's purpose is visible without a full read. Frontmatter is excluded (line
+ * file — plus any leading callout (a top-of-file `> [!type]` block — info,
+ * warning, etc.), so notable context or state is visible without a full read.
+ * Frontmatter is excluded (line
  * ranges are body-relative, matching vault_patch_note). A note with no headings
  * returns an empty headings array.
  */

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -13,6 +13,8 @@ import type { Dirent } from "node:fs"
 import picomatch from "picomatch"
 import { parseNote, stringifyNote, mergeFrontmatter } from "./frontmatter.js"
 import { parseHeadings, findHeading } from "./heading-parser.js"
+import { parseLeadingCallout } from "./callout-parser.js"
+import type { LeadingCallout } from "./callout-parser.js"
 import type { Logger } from "../../logger.js"
 
 /** Resolves a note path within the vault, throwing on traversal attempts. */
@@ -115,22 +117,32 @@ export type HeadingOutline = Readonly<{
   bytes: number
 }>
 
+/** A note's outline: its optional leading callout (a top-of-file scope/summary
+ *  block) plus the heading tree. `callout` is omitted when the note has none. */
+export type NoteOutline = Readonly<{
+  callout?: LeadingCallout
+  headings: HeadingOutline[]
+}>
+
 /**
  * Returns a note's heading tree (no bodies) — H1–H6 with each section's byte
  * size, so an agent can pick which section to read without pulling the whole
- * file. Frontmatter is excluded (line ranges are body-relative, matching
- * vault_patch_note). A note with no headings returns an empty array.
+ * file — plus any leading callout (the top-of-file scope/summary block), so a
+ * note's purpose is visible without a full read. Frontmatter is excluded (line
+ * ranges are body-relative, matching vault_patch_note). A note with no headings
+ * returns an empty headings array.
  */
 const readNoteOutline = async (
   params: { vaultPath: string; path: string },
   logger: Logger,
-): Promise<HeadingOutline[]> => {
+): Promise<NoteOutline> => {
   const fullPath = resolveSafePath(params.vaultPath, params.path)
   const content = await readFileOrNull(fullPath)
   if (content === null) {
     throw new Error(`note not found: "${params.path}"`)
   }
   const lines = parseNote(content).content.split("\n")
+  const callout = parseLeadingCallout(lines)
   const headings = parseHeadings(lines)
   const outline = headings.map((heading) => {
     // Section span = heading line through bodyEndLine (the same span a section
@@ -148,9 +160,11 @@ const readNoteOutline = async (
   logger.info("read note outline", {
     path: params.path,
     headingCount: outline.length,
+    hasCallout: callout !== null,
     totalBytes,
   })
-  return outline
+  // Omit `callout` entirely when absent, rather than emitting `callout: null`.
+  return callout ? { callout, headings: outline } : { headings: outline }
 }
 
 /**

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -118,9 +118,9 @@ export type HeadingOutline = Readonly<{
 }>
 
 /** A note's outline: its optional leading callout (a top-of-file scope/summary
- *  block) plus the heading tree. `callout` is omitted when the note has none. */
+ *  block) plus the heading tree. `leading_callout` is omitted when the note has none. */
 export type NoteOutline = Readonly<{
-  callout?: LeadingCallout
+  leading_callout?: LeadingCallout
   headings: HeadingOutline[]
 }>
 
@@ -142,7 +142,7 @@ const readNoteOutline = async (
     throw new Error(`note not found: "${params.path}"`)
   }
   const lines = parseNote(content).content.split("\n")
-  const callout = parseLeadingCallout(lines)
+  const leadingCallout = parseLeadingCallout(lines)
   const headings = parseHeadings(lines)
   const outline = headings.map((heading) => {
     // Section span = heading line through bodyEndLine (the same span a section
@@ -160,11 +160,13 @@ const readNoteOutline = async (
   logger.info("read note outline", {
     path: params.path,
     headingCount: outline.length,
-    hasCallout: callout !== null,
+    hasCallout: leadingCallout !== null,
     totalBytes,
   })
-  // Omit `callout` entirely when absent, rather than emitting `callout: null`.
-  return callout ? { callout, headings: outline } : { headings: outline }
+  // Omit `leading_callout` when absent, rather than emitting `leading_callout: null`.
+  return leadingCallout
+    ? { leading_callout: leadingCallout, headings: outline }
+    : { headings: outline }
 }
 
 /**

--- a/templates/memory/Me.md
+++ b/templates/memory/Me.md
@@ -8,6 +8,12 @@ tags:
 
 # Me
 
+> [!info] Scope of this file
+> **Contains:** Identity, interests, and durable context about the user — who they are, what they're into, situational facts.
+> **Does NOT contain:** Opinions or preferences (→ Opinions), guiding principles (→ Principles), recurring routines (→ Routines).
+> **Section structure:** H2 sections grouped by theme, each suffixed "(newest first)".
+> **Convention:** append newest first; never overwrite dated entries; ISO dates only.
+
 ## Identity (newest first)
 
 ## Interests (newest first)

--- a/templates/memory/Opinions.md
+++ b/templates/memory/Opinions.md
@@ -8,6 +8,12 @@ tags:
 
 # Opinions
 
+> [!info] Scope of this file
+> **Contains:** Evolving views on tools, patterns, methods, and processes — stances that may shift over time.
+> **Does NOT contain:** Stable values or decision heuristics (→ Principles), identity or interests (→ Me).
+> **Section structure:** H2 sections by topic, each suffixed "(newest first)".
+> **Convention:** append newest first; never overwrite dated entries; ISO dates only.
+
 ## Tools and workflows (newest first)
 
 ## Code patterns (newest first)

--- a/templates/memory/Principles.md
+++ b/templates/memory/Principles.md
@@ -8,6 +8,12 @@ tags:
 
 # Principles
 
+> [!info] Scope of this file
+> **Contains:** Stable values, decision heuristics, and non-negotiables — how the user thinks and what they hold firm.
+> **Does NOT contain:** Evolving opinions on tools or methods (→ Opinions), identity facts (→ Me).
+> **Section structure:** H2 sections by theme, each suffixed "(newest first)".
+> **Convention:** append newest first; never overwrite dated entries; ISO dates only.
+
 ## Decision heuristics (newest first)
 
 ## Working style (newest first)

--- a/templates/memory/README.md
+++ b/templates/memory/README.md
@@ -31,6 +31,11 @@ Then copy into that folder instead.
 Memory files use a specific format that Vault Cortex tools understand:
 
 - **H1 heading**: file title (one per file)
+- **Scope callout** (recommended): an Obsidian `> [!info] Scope of this file`
+  block right below the H1, describing what the file contains and what it
+  doesn't. Surfaced by `vault_read_note` (outline) and `vault_list_memory_files`
+  so an agent can see a file's purpose without reading it. Edit it with
+  `vault_patch_note` (operation `prepend`, no heading).
 - **H2 headings**: sections (topics, categories)
 - **Dated bullets**: entries under each section, in `- **YYYY-MM-DD**: text` format
 

--- a/templates/memory/Routines.md
+++ b/templates/memory/Routines.md
@@ -8,6 +8,12 @@ tags:
 
 # Routines
 
+> [!info] Scope of this file
+> **Contains:** Recurring routines, cadences, and practiced habits — what the user actually does on a regular rhythm.
+> **Does NOT contain:** One-off events or plans, identity facts (→ Me), principles (→ Principles).
+> **Section structure:** H2 sections by cadence, each suffixed "(newest first)".
+> **Convention:** append newest first; never overwrite dated entries; ISO dates only.
+
 ## Daily (newest first)
 
 ## Weekly (newest first)


### PR DESCRIPTION
## Summary

Makes the memory system self-documenting and clarifies how it should be maintained, then surfaces top-of-file callouts cheaply through the read/discovery tools. Three threads: (1) clarify the append-only memory model in the tool descriptions, (2) ship a scope callout into every memory file, (3) expose a note's leading callout without a full read.

A "leading callout" is the first Obsidian callout block at the top of a note body (after frontmatter, optionally below a single H1) — e.g. `> [!info] Scope of this file`, or a `> [!warning] Superseded` lifecycle marker. Previously this high-signal block was visible only on a full read; outline returned headings only, and discovery tools returned metadata only.

## ⚠ Breaking change

`vault_read_note`'s `outline` mode now returns an **object** `{ leading_callout?, headings }` instead of a bare **array** of headings. Clients that parsed the outline result as an array must update to read `.headings`.

## Memory model: append-only, supersede-don't-delete

The memory layer is append-only by design — recency is encoded in dated entries, contradictions form a timeline, and history is preserved. That intent lived only in the repo's template README, never reaching MCP clients. Two tool descriptions now carry it:

- **`vault_update_memory`** states the principle (in `Behavior:`): never overwrite or delete an entry to reflect a change — when a preference or fact changes, append a new dated entry; the newest wins on conflict and the older one stays as history.
- **`vault_delete_memory`** is reframed as **supersede-don't-delete**: delete is only for entries that were *wrong when written* (a mistake / misattribution / never true); for a *changed* preference, append via `vault_update_memory` instead. Cross-referenced both ways.

## Ship the scope callout into memory files

- Seed a `> [!info] Scope of this file` callout (Contains / Does NOT contain / Section structure / Convention) in the bootstrap templates (`Me`, `Opinions`, `Principles`) and the on-disk `templates/memory/*` set (incl. `Routines`).
- `buildNewMemoryFile` seeds a generic convention-only callout with a `(describe…)` placeholder for programmatically-created files; `updateMemory` now reports its outcome (`created-file` / `created-section` / `appended`) so `vault_update_memory` nudges the caller to fill in a new file's scope — and that outcome is logged as a queryable field alongside `beforeBytes`/`afterBytes`.
- `vault_patch_note` documents the no-heading `prepend` for adding/editing a leading callout.

## Surface the leading callout (read side)

- New shared `parseLeadingCallout` parser (sibling of `heading-parser`).
- `vault_read_note` outline now returns `{ leading_callout?, headings }` (see Breaking change above).
- Index the leading callout into a `notes.leading_callout` column — **not** FTS-indexed, since the text already lives in `content` — with an idempotent `ALTER TABLE` guard so a pre-existing (warm) DB gains the column instead of crashing.
- Discovery tools surface the callout (omitted when null); `vault_search` exposes it via opt-in `include_leading_callout` (default off, to keep the hot path lean); `vault_list_memory_files` returns each file's scope callout.

## Docs / release

- `ARCHITECTURE.md` auto-init note and `templates/memory/README.md` updated to describe the scope callout.
- `generate-notes.sh` now detects breaking changes (a `!` type marker or a `BREAKING CHANGE:` footer) and leads the release notes with a `### ⚠ BREAKING CHANGES` section.

## Testing

- `npm run build` (server + CLI): clean
- `npx vitest run`: **689 pass**, including leading-callout parser edge cases (incl. CRLF), the outcome-logging field, and a warm-DB `ALTER` migration test
- `npm run lint`: clean

BREAKING CHANGE: vault_read_note outline mode now returns { leading_callout?, headings } instead of a bare array of headings; clients parsing it as an array must read .headings.