### PR TITLE
Disable CodeRabbit auto reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,16 +6,8 @@ reviews:
   sequence_diagrams: false
   review_status: false
   auto_review:
-    # Review once when a PR opens; skip the re-review on every push so the
-    # summary comment (and its large hidden state blob) isn't reposted per
-    # commit. Trigger a manual re-review with "@coderabbitai review".
-    #
-    # Scope: this only suppresses the incremental *code re-review*. It does NOT
-    # stop CodeRabbit from editing its single summary comment on each push
-    # (walkthrough + pre-merge checks re-render regardless), nor the initial
-    # on-open review. The per-push noise in watched Claude Code sessions comes
-    # from the PR-activity relay forwarding the whole comment body on every
-    # edit — an upstream gap, not something this key controls. Fewer pushes per
-    # PR is the only in-repo lever; auto_review.enabled: false (manual-only) is
-    # the heavier hammer.
-    auto_incremental_review: false
+    # Turn off automatic reviews entirely — no on-open review and no per-push
+    # re-review. CodeRabbit only reviews when explicitly asked via the
+    # "@coderabbitai review" command. With auto reviews off, the
+    # auto_incremental_review key is redundant and has been removed.
+    enabled: false


### PR DESCRIPTION
## What

Turns off CodeRabbit's automatic reviews entirely by setting `reviews.auto_review.enabled: false` in `.coderabbit.yaml`.

## Why

We no longer want CodeRabbit reviewing PRs automatically (neither on open nor on each push). Reviews can still be requested on demand with the `@coderabbitai review` command.

## Changes

- Set `reviews.auto_review.enabled: false`.
- Removed the now-redundant `auto_incremental_review: false` flag — with auto reviews off entirely, the incremental sub-flag has no effect.

https://claude.ai/code/session_01NS7ANrruwjiS2jXzEUATq9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NS7ANrruwjiS2jXzEUATq9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to require explicit review triggers instead of automatic reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->