### PR TITLE
docs: callout/outline docs, breaking-change release flow, tech-agnostic Phase 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,3 +254,8 @@ The README is the front door — humans land there first. The full AWS/SST
 deployment walkthrough lives in [`DEPLOY.md`](./DEPLOY.md); the local and
 Obsidian-Sync quickstarts live under [`deploy/`](./deploy/). Keep this
 file focused on conventions; don't duplicate procedure here.
+
+Contributor and release conventions live in
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) — notably, flag a **breaking change**
+for the generated release notes with a `!` type marker (`feat(scope)!:`)
+and/or a `BREAKING CHANGE:` footer in the PR description.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ endpoints pass through, /mcp validates static token or JWT). IaC via SST v4.
 **Phase 1** delivers vault CRUD, full-text search (SQLite FTS5), and the
 About Me/ memory layer — enough to make any MCP client personalized.
 
-**Phase 2** adds LightRAG for semantic/knowledge-graph queries over the
-vault. The file watcher gains a second hook for LightRAG ingestion,
-and a new `vault_query_kb` tool is added. Additive — not a rewrite.
+**Phase 2** adds semantic / knowledge-graph queries over the vault. The
+file watcher gains a second hook for semantic ingestion, and a new
+`vault_query_kb` tool is added. Additive — not a rewrite.
 
 All solutions must be portable — they can't rely on one-off manual fixes,
 hardcoded paths, or user-specific configuration. If it works only on
@@ -68,7 +68,7 @@ src/
     search/                            # SQLite FTS5 indexing + file watching
       search-index.ts                  # SQLite FTS5 factory (tags, folders, etc)
       file-watcher.ts                  # chokidar -> keeps index current
-                                       # Phase 2: gains LightRAG ingestion hook
+                                       # Phase 2: gains a semantic-ingestion hook
     auth/                              # OAuth 2.1
       oauth-provider.ts                # OAuthServerProvider — JWT tokens, SQLite persistence
       oauth-routes.ts                  # SDK auth router + consent form handler

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -188,7 +188,7 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 | `vault_list_notes`      | `folder?, glob?`                                             | readOnlyHint    |
 | `vault_delete_note`     | `path`                                                       | destructiveHint |
 
-`vault_read_note` returns full content by default; optional `properties_only`, `outline`, or `heading` (with `heading_level` to disambiguate) modes return just the properties, the heading tree, or a single section — cheap partial reads for large notes.
+`vault_read_note` returns full content by default; optional `properties_only`, `outline`, or `heading` (with `heading_level` to disambiguate) modes return just the properties, the structure, or a single section — cheap partial reads for large notes. `outline` returns an object `{ leading_callout?, headings }` — the heading tree plus any top-of-file callout (a `> [!type]` block) when present.
 
 `vault_patch_note` supports 4 operations: `append`, `prepend`, `replace`, `insert_before` — heading-targeted with optional file-level mode. `vault_replace_in_note` does exact text find-and-replace in the note body.
 
@@ -204,7 +204,7 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 | `vault_list_tags`        | —                            | readOnlyHint |
 | `vault_recent_notes`     | `sort_by?, limit?`           | readOnlyHint |
 
-`filters` covers `folder`, `tags`, `related`, `type`, `properties` (arbitrary frontmatter keys), `limit`, and `snippet_tokens`. `sort_by` is `"created" | "modified"` (default `"modified"`).
+`filters` covers `folder`, `tags`, `related`, `type`, `properties` (arbitrary frontmatter keys), `limit`, `snippet_tokens`, and `include_leading_callout` (opt-in; adds each result's top-of-file callout). The discovery tools (`vault_search_by_tag`, `vault_search_by_folder`, `vault_recent_notes`, `vault_search_by_property`, `vault_find_orphans`) include each note's `leading_callout` in its metadata when present. `sort_by` is `"created" | "modified"` (default `"modified"`).
 
 ### Phase 1: Property Discovery + Daily Notes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -27,12 +27,11 @@ API Gateway, SST — but Vault Cortex runs anywhere Docker does.
 About Me/ memory layer. This alone makes any MCP client vault-aware and
 personalized across conversations.
 
-**Phase 2** adds a LightRAG container for semantic and knowledge-graph
-queries over the vault. The file watcher gains a second hook for LightRAG
-ingestion (delete + re-insert on change), a new `vault_query_kb` MCP tool
-is added, and the Lightsail instance upgrades to 2–4 GB ($24/mo). The
-architecture is designed so this is additive — no rewrites, just a new
-container, a new watcher callback, and a new tool.
+**Phase 2** adds semantic and knowledge-graph queries over the vault. The
+file watcher gains a second hook for semantic ingestion (re-index on
+change) and a new `vault_query_kb` MCP tool is added — additive, no
+rewrites. The retrieval stack is being finalized in a design spike, so the
+detailed Phase 2 sections below reflect the original candidate.
 
 ## User Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,27 @@ truth. Key points:
 - **Security issues:** see [SECURITY.md](./SECURITY.md) — report privately, not
   as a public issue
 
+## Breaking changes
+
+Release notes are generated from commit messages (`.github/scripts/generate-notes.sh`),
+which detects breaking changes and leads the notes with a **⚠ BREAKING CHANGES**
+section. To mark a change as breaking, do **either** (both is fine):
+
+- **`!` after the type** in the PR title — `feat(scope)!: …` — which carries
+  into the squash commit subject.
+- **A `BREAKING CHANGE:` footer** (its own paragraph) at the **end of the PR
+  description**. Squash merges use the PR **title and description** as the
+  commit message, so the footer lands in the commit body and its text becomes
+  the breaking-changes entry.
+
+The `!` alone guarantees the section appears (it falls back to the subject as
+the entry); the footer adds a descriptive line, so prefer including it. Example
+footer:
+
+> BREAKING CHANGE: `vault_read_note` outline mode now returns an object
+> `{ leading_callout?, headings }` instead of a bare array; clients parsing it
+> as an array must read `.headings`.
+
 ## Release Process
 
 Releases are cut by the maintainer. Two paths:

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ The typical Obsidian + MCP setup requires three moving parts running simultaneou
 
 ### Roadmap
 
-| Phase | What                                                                                | Status   |
-| ----- | ----------------------------------------------------------------------------------- | -------- |
-| **1** | Vault CRUD, full-text search (FTS5), memory layer, OAuth 2.1                        | Complete |
-| **2** | Semantic search + knowledge graph via [LightRAG](https://github.com/HKUDS/LightRAG) | Planned  |
+| Phase | What                                                         | Status   |
+| ----- | ------------------------------------------------------------ | -------- |
+| **1** | Vault CRUD, full-text search (FTS5), memory layer, OAuth 2.1 | Complete |
+| **2** | Semantic search + knowledge graph                            | Planned  |
 
 ## Quick Start
 

--- a/templates/memory/README.md
+++ b/templates/memory/README.md
@@ -64,7 +64,7 @@ convention:
    months ago saying "prefers tabs" followed by a recent one saying "switched to
    spaces" is more useful than a single overwritten value
 3. **Semantic retrieval (Phase 2)** — dated entries become the corpus for
-   LightRAG's knowledge graph, enabling temporal queries ("how has the user's
+   semantic/vector search, enabling temporal queries ("how has the user's
    stance on X evolved?", "what did they believe about Y last month?")
 
 This is append-only by design. Entries are never overwritten — new entries are


### PR DESCRIPTION
## What

Documentation follow-ups, mostly cleaning up after #140 (which shipped the leading-callout feature but under-documented it):

- **Callout/outline feature docs** — `ARCHITECTURE.md`: `vault_read_note` `outline` now returns `{ leading_callout?, headings }`; `vault_search` gains `include_leading_callout` and the discovery tools surface each note's `leading_callout`.
- **Breaking-change release flow** — `CONTRIBUTING.md` now documents how to flag a breaking change for the generated release notes: a `!` type marker and/or a `BREAKING CHANGE:` footer in the PR description, which the squash commit carries into `generate-notes.sh`.
- **Tech-agnostic Phase 2 language** — drop the LightRAG brand from the high-level Phase 2 roadmap statements (README phases table, AGENTS + ARCHITECTURE intros, memory template README) so they describe the capability consistently. ARCHITECTURE's detailed Phase 2 design is left as the candidate, now noted as pending the design spike.

No code change; docs only.

> Heads-up: the open #139 (MCP prompts) also edits `ARCHITECTURE.md` / `README.md` / `AGENTS.md` — different sections, so likely no conflict, but worth merging with that in mind.

BREAKING CHANGE: vault_read_note outline mode now returns { leading_callout?, headings } instead of a bare array of headings; clients parsing it as an array must read .headings.