### PR TITLE
ci(release): detect breaking changes from the merged PR, not the squash body

### DIFF
--- a/.github/scripts/generate-notes.sh
+++ b/.github/scripts/generate-notes.sh
@@ -2,6 +2,14 @@
 # Generate structured release notes from conventional commits between two tags.
 # Usage: generate-notes.sh <new-tag> [previous-tag]
 # If previous-tag is omitted, uses the tag before new-tag.
+#
+# Breaking changes are detected from the *merged PR* — a `breaking-change` label
+# or a `BREAKING CHANGE:` footer in the PR body — as well as from the commit
+# itself (a `!` type marker or a `BREAKING CHANGE:` footer). The PR is the
+# reliable source: a squash commit's body is often dropped at merge time
+# (e.g. the GitHub mobile app), but PR labels/body always survive. PR lookups
+# use `gh` + GH_TOKEN; when `gh` is unavailable (local runs without auth) the
+# commit-only signals are used.
 
 set -euo pipefail
 
@@ -17,16 +25,15 @@ else
 fi
 
 # Write one record per non-merge commit as `<subject>\x1f<body>`, records
-# NUL-separated, to a temp file. The body is included so BREAKING CHANGE:
-# footers are visible. A file (not a pipe) is used because the Python program
-# is fed to `python3 -` on stdin via the heredoc — the data must come from
-# elsewhere. Release commits are filtered out in Python.
+# NUL-separated, to a temp file. A file (not a pipe) is used because the Python
+# program is fed to `python3 -` on stdin via the heredoc. Release commits are
+# filtered out in Python.
 NOTES_INPUT="$(mktemp)"
 trap 'rm -f "$NOTES_INPUT"' EXIT
 git log --no-merges --format='%s%x1f%b%x00' "$RANGE" > "$NOTES_INPUT"
 
 python3 - "$NOTES_INPUT" << 'PYTHON'
-import sys, re
+import sys, re, os, json, shutil, subprocess
 
 with open(sys.argv[1], "rb") as fh:
     raw = fh.read().decode("utf-8", "replace")
@@ -55,6 +62,38 @@ pat = re.compile(r'^([a-z]+)(?:\(([^)]+)\))?(!)?:\s+(.+)$')
 release_pat = re.compile(r'^release(\(cli\))?:')
 # A BREAKING CHANGE footer — conventional commits allows a space or hyphen.
 breaking_pat = re.compile(r'^BREAKING[ -]CHANGE:\s*(.+)$', re.MULTILINE)
+# Squash subjects end with the PR number, e.g. "… (#142)".
+pr_pat = re.compile(r'\(#(\d+)\)\s*$')
+
+GH = shutil.which("gh")
+REPO = os.environ.get("GITHUB_REPOSITORY", "")
+BREAKING_LABEL = "breaking-change"
+_pr_cache = {}
+
+def pr_info(num):
+    """Return {labels, body} for a merged PR via `gh`, or None when `gh` is
+    unavailable or the lookup fails (so local runs degrade to commit-only)."""
+    if not GH:
+        return None
+    if num in _pr_cache:
+        return _pr_cache[num]
+    info = None
+    try:
+        repo_args = ["-R", REPO] if REPO else []
+        result = subprocess.run(
+            [GH, "pr", "view", num, *repo_args, "--json", "labels,body"],
+            capture_output=True, text=True, timeout=20,
+        )
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+            info = {
+                "labels": {label["name"] for label in data.get("labels", [])},
+                "body": data.get("body") or "",
+            }
+    except Exception:
+        info = None
+    _pr_cache[num] = info
+    return info
 
 for rec in records:
     subject, _, body = rec.partition("\x1f")
@@ -62,12 +101,13 @@ for rec in records:
     if not subject or release_pat.match(subject):
         continue
 
-    m = pat.match(subject)
-    footer = breaking_pat.search(body or "")
-    is_breaking = bool((m and m.group(3)) or footer)
+    match = pat.match(subject)
+    pr_num = pr_pat.search(subject)
+    pr = pr_info(pr_num.group(1)) if pr_num else None
 
-    if m:
-        typ, scope, _, desc = m.group(1), m.group(2), m.group(3), m.group(4)
+    # Categorize from the commit subject.
+    if match:
+        typ, scope, _bang, desc = match.group(1, 2, 3, 4)
         desc = desc[0].upper() + desc[1:]  # capitalize
         entry = f"- **{scope}:** {desc}" if scope else f"- {desc}"
         (buckets[typ] if typ in buckets else other).append(entry)
@@ -75,9 +115,19 @@ for rec in records:
         desc = subject[0].upper() + subject[1:] if subject else subject
         other.append(f"- {desc}")
 
-    if is_breaking:
-        # Prefer the footer's explanatory text; fall back to the subject desc.
-        breaking.append(f"- {footer.group(1).strip() if footer else desc}")
+    # Breaking signals, in preference order for the descriptive line:
+    #   PR body footer > commit body footer > subject (when only `!`/label flags).
+    commit_footer = breaking_pat.search(body or "")
+    pr_footer = breaking_pat.search(pr["body"]) if pr else None
+    has_label = bool(pr and BREAKING_LABEL in pr["labels"])
+    if (match and match.group(3)) or commit_footer or pr_footer or has_label:
+        if pr_footer:
+            note = pr_footer.group(1).strip()
+        elif commit_footer:
+            note = commit_footer.group(1).strip()
+        else:
+            note = desc
+        breaking.append(f"- {note}")
 
 # Output — BREAKING CHANGES lead so they're impossible to miss.
 out = []

--- a/.github/scripts/generate-notes.sh
+++ b/.github/scripts/generate-notes.sh
@@ -8,8 +8,9 @@
 # itself (a `!` type marker or a `BREAKING CHANGE:` footer). The PR is the
 # reliable source: a squash commit's body is often dropped at merge time
 # (e.g. the GitHub mobile app), but PR labels/body always survive. PR lookups
-# use `gh` + GH_TOKEN; when `gh` is unavailable (local runs without auth) the
-# commit-only signals are used.
+# need both the `gh` binary and GH_TOKEN; when either is missing (local runs
+# without auth) the commit-only signals are used. A lookup that fails despite
+# being enabled warns on stderr rather than silently dropping the signal.
 
 set -euo pipefail
 
@@ -65,23 +66,31 @@ breaking_pat = re.compile(r'^BREAKING[ -]CHANGE:\s*(.+)$', re.MULTILINE)
 # Squash subjects end with the PR number, e.g. "… (#142)".
 pr_pat = re.compile(r'\(#(\d+)\)\s*$')
 
-GH = shutil.which("gh")
+# PR lookups need both the `gh` binary and a token. CI passes GH_TOKEN; a local
+# run without it skips lookups and falls back to commit-only signals (the
+# documented offline behavior) instead of firing unauthenticated calls.
+GH = shutil.which("gh") if os.environ.get("GH_TOKEN") else None
 REPO = os.environ.get("GITHUB_REPOSITORY", "")
 BREAKING_LABEL = "breaking-change"
 _pr_cache = {}
 
-def pr_info(num):
-    """Return {labels, body} for a merged PR via `gh`, or None when `gh` is
-    unavailable or the lookup fails (so local runs degrade to commit-only)."""
+def warn(message):
+    print(f"generate-notes: {message}", file=sys.stderr)
+
+def pr_info(pr_number):
+    """Return {labels, body} for a merged PR via `gh`, or None when lookups are
+    disabled (no `gh`/token) or the lookup fails. A failed lookup warns on
+    stderr — a silent None could drop a breaking change that lives only in the
+    PR body/label from the release notes."""
     if not GH:
         return None
-    if num in _pr_cache:
-        return _pr_cache[num]
+    if pr_number in _pr_cache:
+        return _pr_cache[pr_number]
     info = None
     try:
         repo_args = ["-R", REPO] if REPO else []
         result = subprocess.run(
-            [GH, "pr", "view", num, *repo_args, "--json", "labels,body"],
+            [GH, "pr", "view", pr_number, *repo_args, "--json", "labels,body"],
             capture_output=True, text=True, timeout=20,
         )
         if result.returncode == 0:
@@ -90,9 +99,13 @@ def pr_info(num):
                 "labels": {label["name"] for label in data.get("labels", [])},
                 "body": data.get("body") or "",
             }
-    except Exception:
-        info = None
-    _pr_cache[num] = info
+        else:
+            warn(f"gh pr view #{pr_number} failed (exit {result.returncode}): "
+                 f"{result.stderr.strip()} — falling back to commit-only signals")
+    except Exception as error:
+        warn(f"gh pr view #{pr_number} errored: {error} — "
+             f"falling back to commit-only signals")
+    _pr_cache[pr_number] = info
     return info
 
 for rec in records:

--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -65,9 +65,12 @@ jobs:
     needs: [validate, deploy]
     runs-on: ubuntu-latest
     # gh release create uses GITHUB_TOKEN; the CHANGELOG push to main
-    # authenticates as the release App, not this token.
+    # authenticates as the release App, not this token. generate-notes.sh
+    # reads merged PRs (labels/body) for breaking-change detection, so the
+    # token also needs pull-requests: read.
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Generate App token
         id: app-token
@@ -82,6 +85,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/generate-notes.sh "$GITHUB_REF_NAME" > /tmp/release-notes.md
 
       - name: Update changelog

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -113,9 +113,12 @@ jobs:
     needs: [bump-and-tag, deploy]
     runs-on: ubuntu-latest
     # gh release create uses GITHUB_TOKEN; the CHANGELOG push to main
-    # authenticates as the release App, not this token.
+    # authenticates as the release App, not this token. generate-notes.sh
+    # reads merged PRs (labels/body) for breaking-change detection, so the
+    # token also needs pull-requests: read.
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Generate App token
         id: app-token
@@ -133,6 +136,7 @@ jobs:
       - name: Generate release notes
         env:
           TAG: ${{ needs.bump-and-tag.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/generate-notes.sh "$TAG" > /tmp/release-notes.md
 
       - name: Update changelog

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,5 +257,6 @@ file focused on conventions; don't duplicate procedure here.
 
 Contributor and release conventions live in
 [`CONTRIBUTING.md`](./CONTRIBUTING.md) — notably, flag a **breaking change**
-for the generated release notes with a `!` type marker (`feat(scope)!:`)
-and/or a `BREAKING CHANGE:` footer in the PR description.
+for the generated release notes with the `breaking-change` PR label (primary)
+plus a `BREAKING CHANGE:` footer in the PR description for the descriptive
+line; a `!` type marker (`feat(scope)!:`) also works.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,8 @@ file focused on conventions; don't duplicate procedure here.
 
 Contributor and release conventions live in
 [`CONTRIBUTING.md`](./CONTRIBUTING.md) — notably, flag a **breaking change**
-for the generated release notes with the `breaking-change` PR label (primary)
-plus a `BREAKING CHANGE:` footer in the PR description for the descriptive
-line; a `!` type marker (`feat(scope)!:`) also works.
+for the generated release notes with a `BREAKING CHANGE:` footer in the PR
+description (primary: it carries the descriptive line and is read from the
+merged PR via the API, so it survives even when the squash body is dropped).
+A `breaking-change` PR label or a `!` type marker (`feat(scope)!:`) also work
+as flags.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,25 +131,25 @@ truth. Key points:
 ## Breaking changes
 
 Release notes (`.github/scripts/generate-notes.sh`) lead with a **⚠ BREAKING
-CHANGES** section. Breaking changes are detected from the **merged PR**, which
-is the reliable source: a squash commit's body is often dropped at merge time
-(e.g. the GitHub mobile app), but PR labels and the PR body always survive.
+CHANGES** section. Breaking changes are detected from the **merged PR**, read
+via the API at release time — the reliable source: a squash commit's body is
+often dropped at merge (e.g. the GitHub mobile app), but the PR body and labels
+always survive.
 
-To mark a PR as breaking:
-
-- **Add the `breaking-change` label** — the primary signal. The release reads
-  it from the PR via the API, so it works regardless of how the PR was merged.
-- **Add a `BREAKING CHANGE:` footer** (its own paragraph) at the **end of the
-  PR description** — its text becomes the descriptive line in the notes. Prefer
-  including it; without it the entry falls back to the PR title.
-
-A `!` after the type in the PR title (`feat(scope)!: …`) also flags a breaking
-change — it rides in the squash subject — and serves as a fallback. Example
-footer:
+To mark a PR as breaking, add a **`BREAKING CHANGE:` footer** (its own
+paragraph) at the **end of the PR description**. Its text becomes the
+descriptive line in the ⚠ section. Example:
 
 > BREAKING CHANGE: `vault_read_note` outline mode now returns an object
 > `{ leading_callout?, headings }` instead of a bare array; clients parsing it
 > as an array must read `.headings`.
+
+Also recognized as breaking signals: a **`breaking-change` PR label** (optional —
+create it once under repo Settings → Labels if you want a clickable flag) and a
+**`!` type marker** in the squash subject (`feat(scope)!: …`), which survives the
+merge even when the body is dropped. The `BREAKING CHANGE:` footer is preferred
+because it carries the descriptive line; the label and `!` only flag that a change
+is breaking.
 
 ## Release Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,19 +130,21 @@ truth. Key points:
 
 ## Breaking changes
 
-Release notes are generated from commit messages (`.github/scripts/generate-notes.sh`),
-which detects breaking changes and leads the notes with a **⚠ BREAKING CHANGES**
-section. To mark a change as breaking, do **either** (both is fine):
+Release notes (`.github/scripts/generate-notes.sh`) lead with a **⚠ BREAKING
+CHANGES** section. Breaking changes are detected from the **merged PR**, which
+is the reliable source: a squash commit's body is often dropped at merge time
+(e.g. the GitHub mobile app), but PR labels and the PR body always survive.
 
-- **`!` after the type** in the PR title — `feat(scope)!: …` — which carries
-  into the squash commit subject.
-- **A `BREAKING CHANGE:` footer** (its own paragraph) at the **end of the PR
-  description**. Squash merges use the PR **title and description** as the
-  commit message, so the footer lands in the commit body and its text becomes
-  the breaking-changes entry.
+To mark a PR as breaking:
 
-The `!` alone guarantees the section appears (it falls back to the subject as
-the entry); the footer adds a descriptive line, so prefer including it. Example
+- **Add the `breaking-change` label** — the primary signal. The release reads
+  it from the PR via the API, so it works regardless of how the PR was merged.
+- **Add a `BREAKING CHANGE:` footer** (its own paragraph) at the **end of the
+  PR description** — its text becomes the descriptive line in the notes. Prefer
+  including it; without it the entry falls back to the PR title.
+
+A `!` after the type in the PR title (`feat(scope)!: …`) also flags a breaking
+change — it rides in the squash subject — and serves as a fallback. Example
 footer:
 
 > BREAKING CHANGE: `vault_read_note` outline mode now returns an object


### PR DESCRIPTION
## Why

Release notes (`generate-notes.sh`) lead with a **⚠ BREAKING CHANGES** section. Until now, the descriptive line for a breaking change came from a `BREAKING CHANGE:` footer in the **squash commit body** — but that body is unreliable. When a PR is squash-merged from the GitHub mobile app (and in some other flows), the commit lands with a **title-only** message: the body, footer and all, is dropped. We confirmed this on `main` for both #140 and #142 (`git log --format=%b` → empty), even with the repo's squash default set to "Pull request title and description." That setting only *pre-fills* the web merge dialog; it isn't enforced at merge time.

Net effect: the breaking change in #140 (`vault_read_note` outline now returns `{ leading_callout?, headings }`) would not have surfaced in the v0.19.0 release notes.

## What

Read the breaking-change signal from the **merged PR via the API** — the source that always survives a merge, regardless of client.

- **`generate-notes.sh`** — parse the `(#NN)` PR number from each squash subject and look the PR up with `gh pr view --json labels,body`. A change is breaking if **any** of: a `BREAKING CHANGE:` footer in the PR body, a `breaking-change` label, a `BREAKING CHANGE:` footer in the commit body, or a `!` type marker in the subject. Descriptive-line preference: **PR-body footer → commit-body footer → subject**. Degrades gracefully — when `gh` is unavailable (local runs without auth), it falls back to the commit-only signals, so the script still works offline.
- **`auto_release.yml` / `manual_release.yml`** — the `release` job now declares `pull-requests: read` and passes `GH_TOKEN` to the "Generate release notes" step so `gh pr view` can authenticate.
- **`CONTRIBUTING.md` / `AGENTS.md`** — document the flow and make the `BREAKING CHANGE:` footer the **primary** signal (it carries the descriptive line and is read from the PR, so it's merge-surface-independent). The `breaking-change` label and the `!` marker are documented as optional flags.

## Notes

- The `breaking-change` label is **optional** one-time setup (create it under Settings → Labels). The footer alone is fully sufficient.
- #140 is already covered for the next release: its **PR-body** footer is read by the new script, so v0.19.0's notes will carry the outline breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVgJqto9rc4gRT6vb3E3vU)_