### PR TITLE
chore: bump node:24-alpine base image to clear trivy CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@
 # GOTCHA: build deps (python3/make/g++) are needed as fallback if
 # prebuilds don't exist for your arch. They stay in the build stage.
 
-FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS deps
+FROM node:24-alpine@sha256:21f403ab171f2dc89bad4dd69d7721bfd15f084ccb46cdd225f31f2bc59b5c9a AS deps
 WORKDIR /app
 RUN apk add --no-cache python3 make g++
 COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev --ignore-scripts && npm rebuild better-sqlite3
 
-FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS build
+FROM node:24-alpine@sha256:21f403ab171f2dc89bad4dd69d7721bfd15f084ccb46cdd225f31f2bc59b5c9a AS build
 WORKDIR /app
 RUN apk add --no-cache python3 make g++
 COPY package.json package-lock.json* ./
@@ -21,7 +21,7 @@ COPY src/ ./src/
 # Server compile only — cli/ is npm-distributed and never copied into the image.
 RUN npm run build:server
 
-FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS runtime
+FROM node:24-alpine@sha256:21f403ab171f2dc89bad4dd69d7721bfd15f084ccb46cdd225f31f2bc59b5c9a AS runtime
 WORKDIR /app
 # tini: PID 1 that forwards SIGTERM so SQLite WAL closes cleanly.
 # libstdc++: required by better-sqlite3.node native addon on Alpine.


### PR DESCRIPTION
## What

Re-pins the `node:24-alpine` base image (all three build stages) from `sha256:fb71d0…` to the current `sha256:21f403…`.

## Why

`trivy-pr` began failing on a **fixable CRITICAL/HIGH** CVE in the built image with **no source change** — it was green on the prior commit, and Trivy re-downloads its vulnerability DB each run, so a newly-disclosed (and now-patched) CVE started matching the pinned image. The finding is in the upstream `node:24-alpine` image rather than this repo's code or dependencies:

- The runtime stage already runs `apk upgrade --no-cache`, so Alpine OS packages are patched at build time — pointing the finding at the upstream base layer (most likely the node binary).
- The Dockerfile comment already anticipates this: the digest pin covers "the window between an Alpine security release and the next upstream `node:24-alpine` rebuild + digest-pin refresh." This is that refresh.

`ignore-unfixed: true` in the workflow confirms a fix is available. This affects `main` and every open PR equally — it's not introduced by any feature branch.

## Verification

This PR's own `trivy-pr` check scans the rebuilt branch image and is the source of truth that the bump clears the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01STth8CQHwVALTJfGBq2Tzd)_