### PR TITLE
docs: surface 3 guided prompts in CLI README + fix stale memory-template lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@
 ### ⚠ BREAKING CHANGES
 
 - vault_read_note outline mode now returns { leading_callout?, headings } instead of a bare array of headings; clients parsing it as an array must read .headings.
-- vault_read_note outline mode now returns { leading_callout?, headings } instead of a bare array of headings; clients parsing it as an array must read .headings.
 
 ### Features
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -9,8 +9,9 @@ npx vault-cortex@latest init
 
 Vault Cortex is a plugin-free, remote-capable MCP server for Obsidian vaults —
 23 tools for search (SQLite FTS5), notes, frontmatter, links, daily notes, and
-a persistent memory layer. It runs as a Docker container; this CLI scaffolds
-the config so you don't have to.
+a persistent memory layer, plus 3 guided prompts (orientation, memory review,
+daily review). It runs as a Docker container; this CLI scaffolds the config so
+you don't have to.
 
 ## What `init` does
 

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -146,8 +146,8 @@ usual cause.
 ## Memory
 
 On first startup, if your vault doesn't already have a memory folder (default:
-`About Me/`), the server creates one with template files (Principles.md,
-Opinions.md). Agents can also create new memory files and sections on the fly
+`About Me/`), the server creates one with template files (Me.md, Opinions.md,
+Principles.md). Agents can also create new memory files and sections on the fly
 via `vault_update_memory` — no manual setup needed.
 
 ## Configuration

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -216,8 +216,8 @@ docker compose down -v
 ## Memory
 
 On first startup, if your vault doesn't already have a memory folder (default:
-`About Me/`), the server creates one with template files (Principles.md,
-Opinions.md). Agents can also create new memory files and sections on the fly
+`About Me/`), the server creates one with template files (Me.md, Opinions.md,
+Principles.md). Agents can also create new memory files and sections on the fly
 via `vault_update_memory` — no manual setup needed.
 
 ## Configuration

--- a/llms-install.md
+++ b/llms-install.md
@@ -100,7 +100,7 @@ The server is at `http://localhost:8000/mcp`, authenticated by the **raw** `MCP_
 }
 ```
 
-Save, then confirm the connection by calling a read-only tool such as `vault_list_memory_files`. A healthy install discovers **23 tools** (vault CRUD, search, memory, link graph, daily notes) and **3 guided prompts** (orientation, memory review, daily review).
+Save, then confirm the connection by calling a read-only tool such as `vault_list_memory_files`. A healthy install discovers **23 tools** (vault CRUD, search, memory, link graph, daily notes) and **3 guided prompts** (`vault-orientation`, `memory-review`, `daily-review`).
 
 If the client only speaks stdio, bridge with `mcp-remote` (same token):
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -100,7 +100,7 @@ The server is at `http://localhost:8000/mcp`, authenticated by the **raw** `MCP_
 }
 ```
 
-Save, then confirm the connection by calling a read-only tool such as `vault_list_memory_files`. A healthy install discovers **23 tools** (vault CRUD, search, memory, link graph, daily notes).
+Save, then confirm the connection by calling a read-only tool such as `vault_list_memory_files`. A healthy install discovers **23 tools** (vault CRUD, search, memory, link graph, daily notes) and **3 guided prompts** (orientation, memory review, daily review).
 
 If the client only speaks stdio, bridge with `mcp-remote` (same token):
 


### PR DESCRIPTION
## Summary

The CLI README hadn't been updated since the MCP prompts shipped (#139, v0.19.0) — it described the 23 tools and memory layer but never mentioned the 3 guided prompts. This adds them, then sweeps the rest of the markdown/JSON docs for staleness while here.

## Changes

- **`cli/README.md`** — add the 3 guided prompts (orientation, memory review, daily review) to the intro, mirroring the root README and `server.json` phrasing.
- **`deploy/local/README.md`** + **`deploy/remote/README.md`** — both stated the memory bootstrap seeds `(Principles.md, Opinions.md)`. It actually seeds **Me.md, Opinions.md, Principles.md** (`MEMORY_TEMPLATES` in `src/vault-mcp/vault-operations/memory-store.ts`). Corrected to all three; now matches `ARCHITECTURE.md`.
- **`llms-install.md`** — the install-verification step noted "discovers 23 tools" with no mention of the 3 prompts a client now also lists. Added them.
- **`CHANGELOG.md`** — removed a duplicated `⚠ BREAKING CHANGES` bullet under v0.19.0 (the `vault_read_note` outline change was listed twice).

## Verified

- Tool count is **23** and prompt count is **3** (counted from `TOOL_NAMES` and `PROMPT_NAMES`).
- Memory template list verified against the actual `MEMORY_TEMPLATES` array (3 files: Me, Opinions, Principles).
- `prettier --check` passes on all five edited files.
- Already-correct docs left untouched: root `README.md` (Tools/Prompts sections), `ARCHITECTURE.md` (MCP Prompts), `server.json` ("23 tools + 3 guided prompts").

Docs-only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PemJBuBUVdJEpeMT48KRg6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated guides to reflect 3 new guided prompts now available (orientation, memory review, daily review).
* Enhanced memory initialization documentation with Me.md template file included in default setup.
* Updated installation guide to clarify complete feature discovery (23 tools and 3 guided prompts).
* Clarified breaking change in outline mode return format for vault read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->