### PR TITLE
ci(release): de-duplicate identical breaking-change lines in release notes

### DIFF
--- a/.github/scripts/generate-notes.sh
+++ b/.github/scripts/generate-notes.sh
@@ -142,6 +142,12 @@ for rec in records:
             note = desc
         breaking.append(f"- {note}")
 
+# Collapse identical breaking lines. A follow-up PR (a docs PR documenting the
+# change, or a revert) can carry the same BREAKING CHANGE footer that another PR
+# in the range already contributed; without this, the same line is listed twice.
+# dict.fromkeys preserves first-seen order.
+breaking = list(dict.fromkeys(breaking))
+
 # Output — BREAKING CHANGES lead so they're impossible to miss.
 out = []
 if breaking:


### PR DESCRIPTION
## Problem

`generate-notes.sh` appends one breaking-change line **per PR** in the release range that carries a `BREAKING CHANGE:` footer / `breaking-change` label / `!` marker, and never de-duplicates. So if a follow-up PR repeats an earlier PR's footer, the same line appears twice.

This happened in **v0.19.0**: both **#140** (the `feat(callouts)!` PR that introduced the `vault_read_note` outline change) and **#142** (its docs follow-up) carried the byte-identical footer:

```
BREAKING CHANGE: vault_read_note outline mode now returns { leading_callout?, headings } …
```

The script read both PR bodies (the #143 "detect from the merged PR" path) and emitted the line twice — visible in both the GitHub release notes and CHANGELOG.md.

Note this is a side effect of the footer-from-merged-PR design: any PR body carrying the footer now counts, so a legitimate follow-up (docs, revert) that references an earlier break can re-introduce the duplicate. The one-off trigger this time was debugging, but the failure mode is real.

## Fix

Collapse identical breaking lines with `dict.fromkeys` (first-seen order preserved) just before rendering:

```python
breaking = list(dict.fromkeys(breaking))
```

Only byte-identical lines merge — two genuinely different breaking changes are untouched. No behavior change on the happy path.

## Testing

The script has no test harness (bash + inline python, no fixtures), so none is added here — adding a framework for one script is out of scope. Verified:

- `bash -n .github/scripts/generate-notes.sh` — clean
- dedup logic check: `list(dict.fromkeys(['- a', '- a', '- b'])) == ['- a', '- b']`

The published v0.19.0 release notes / CHANGELOG are being cleaned up separately; this prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PemJBuBUVdJEpeMT48KRg6)_