### PR TITLE
fix(registry): shorten server.json description under the 100-char cap

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.aliasunder/vault-cortex",
   "title": "Vault Cortex",
-  "description": "MCP server for Obsidian vaults — search, memory, link graph, 23 tools + 3 guided prompts, OAuth-protected.",
+  "description": "MCP server for Obsidian vaults — search, memory, links, 23 tools + 3 prompts, OAuth-protected.",
   "version": "0.19.0",
   "websiteUrl": "https://github.com/aliasunder/vault-cortex",
   "repository": {


### PR DESCRIPTION
## Problem

The **Publish to MCP Registry** step fails with a 422:

```
validation failed: body.description — expected length <= 100
value: "MCP server for Obsidian vaults — search, memory, link graph, 23 tools + 3 guided prompts, OAuth-protected."
```

The registry caps `description` at 100; the current value is **106 chars / 108 bytes**. It crept over when "+ 3 guided prompts" was added to advertise the new prompts.

## Fix

Trim to **94 chars / 96 bytes**, keeping the em-dash house style and the tools + prompts + OAuth signal:

> `MCP server for Obsidian vaults — search, memory, links, 23 tools + 3 prompts, OAuth-protected.`

Changes: drop the redundant "guided", and "link graph" → "links". No other field touched (`version` stays `0.19.0`).

## Scope

Fix-forward only — the next release will publish cleanly. The already-published v0.19.0 isn't being re-published (the publish job checks out the `v0.19.0` **tag**, which still has the old description; re-publishing it would mean moving a release tag, which we're deliberately not doing).

## Verified

- `python` length check: 94 chars / 96 bytes (≤ 100)
- `jq` valid; `version` unchanged at `0.19.0`
- `prettier --check server.json` clean

## Optional follow-up

The publish workflow already verifies `server.json` version matches the release but doesn't pre-check description length, so this failed only at the registry. A one-line `jq` guard in `publish-registry.yml` (fail fast if `.description | length > 100`) would catch it before the network call — happy to add it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PemJBuBUVdJEpeMT48KRg6)_