### PR TITLE
docs: document promoted properties and fix prompt client support claims

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,6 +207,8 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 
 `filters` covers `folder`, `tags`, `related`, `type`, `properties` (arbitrary frontmatter keys), `limit`, `snippet_tokens`, and `include_leading_callout` (opt-in; adds each result's top-of-file callout). The discovery tools (`vault_search_by_tag`, `vault_search_by_folder`, `vault_recent_notes`, `vault_search_by_property`, `vault_find_orphans`) include each note's `leading_callout` in its metadata when present. `sort_by` is `"created" | "modified"` (default `"modified"`).
 
+**Promoted properties:** Five frontmatter keys — `title`, `tags`, `type`, `created`, `related` — get dedicated indexed columns in the `notes` table for efficient filtering. In tool responses, these appear as top-level fields; remaining frontmatter keys are returned under `additional_properties` (via `formatNoteMetadata` in `tool-definitions.ts`). All other properties live in a JSON `properties` column, queryable via `json_extract` — functional for any schema, but without dedicated column indexing.
+
 ### Phase 1: Property Discovery + Daily Notes
 
 | Tool                         | Input                         | Annotation   |
@@ -249,7 +251,7 @@ Link queries use a `links` table populated from `[[wikilink]]` and `[text](path.
 
 ## MCP Prompts
 
-Alongside tools, the server registers MCP **prompts** (`prompts/list` / `prompts/get`) in `prompt-definitions.ts`, mirroring the tool factory and registered per session in `mcp-router.ts`. Prompts are user-initiated — the client surfaces them as slash commands, a **+** menu, or similar — and assemble live vault content at invocation time over the same data layer the tools use, so there is no embedded procedure that can drift, only live content plus thin, durable instruction.
+Alongside tools, the server registers MCP **prompts** (`prompts/list` / `prompts/get`) in `prompt-definitions.ts`, mirroring the tool factory and registered per session in `mcp-router.ts`. Prompts are user-initiated — clients that support the `prompts/list` capability surface them as slash commands or menu actions (Claude Code, OpenCode, Zed); support varies by client and most (Cursor, Windsurf, claude.ai) currently expose tools only. Handlers assemble live vault content at invocation time over the same data layer the tools use, so there is no embedded procedure that can drift, only live content plus thin, durable instruction.
 
 | Prompt              | Arguments             | Purpose                                                                                                |
 | ------------------- | --------------------- | ------------------------------------------------------------------------------------------------------ |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,7 +207,7 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 
 `filters` covers `folder`, `tags`, `related`, `type`, `properties` (arbitrary frontmatter keys), `limit`, `snippet_tokens`, and `include_leading_callout` (opt-in; adds each result's top-of-file callout). The discovery tools (`vault_search_by_tag`, `vault_search_by_folder`, `vault_recent_notes`, `vault_search_by_property`, `vault_find_orphans`) include each note's `leading_callout` in its metadata when present. `sort_by` is `"created" | "modified"` (default `"modified"`).
 
-**Promoted properties:** Five frontmatter keys — `title`, `tags`, `type`, `created`, `related` — get dedicated indexed columns in the `notes` table for efficient filtering. In tool responses, these appear as top-level fields; remaining frontmatter keys are returned under `additional_properties` (via `formatNoteMetadata` in `tool-definitions.ts`). All other properties live in a JSON `properties` column, queryable via `json_extract` — functional for any schema, but without dedicated column indexing.
+**Promoted properties:** Five frontmatter keys — `title`, `tags`, `type`, `created`, `related` — get dedicated columns in the `notes` table for direct `WHERE`-clause filtering (no `json_extract` needed). In tool responses, these appear as top-level fields; remaining frontmatter keys are returned under `additional_properties` (via `formatNoteMetadata` in `tool-definitions.ts`). All other properties live in a JSON `properties` column, queryable via `json_extract` — functional for any schema, but without dedicated columns.
 
 ### Phase 1: Property Discovery + Daily Notes
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ See [Authentication](#authentication) for both methods and token lifetimes.
 | Category        | Tool                         | Description                                                |
 | --------------- | ---------------------------- | ---------------------------------------------------------- |
 | **Vault CRUD**  | `vault_read_note`            | Read a note — full body, properties, outline, or a section |
-|                 | `vault_write_note`           | Create or overwrite a note with frontmatter                |
+|                 | `vault_write_note`           | Create or overwrite a note with properties                 |
 |                 | `vault_patch_note`           | Heading-targeted edit (append, prepend, replace, insert)   |
 |                 | `vault_replace_in_note`      | Find-and-replace text in a note                            |
 |                 | `vault_list_notes`           | List notes with optional glob/folder filter                |
@@ -167,9 +167,9 @@ See [Authentication](#authentication) for both methods and token lifetimes.
 |                 | `vault_update_memory`        | Append a dated entry to a memory section                   |
 |                 | `vault_delete_memory`        | Remove a specific memory entry by date                     |
 |                 | `vault_list_memory_files`    | Discover memory files and their sections                   |
-| **Properties**  | `vault_list_property_keys`   | All frontmatter keys with sample values                    |
+| **Properties**  | `vault_list_property_keys`   | All property keys with sample values                       |
 |                 | `vault_list_property_values` | Distinct values for a property key                         |
-|                 | `vault_search_by_property`   | Find notes by frontmatter key-value                        |
+|                 | `vault_search_by_property`   | Find notes by property key-value                           |
 |                 | `vault_update_properties`    | Add or update properties without touching the body         |
 | **Links**       | `vault_get_backlinks`        | Notes linking to a given path                              |
 |                 | `vault_get_outgoing_links`   | Links from a given note                                    |
@@ -190,9 +190,9 @@ Prompts adapt to your configuration (`MEMORY_DIR`, daily-notes settings) and wor
 
 > **Client support:** Prompts work in Claude Code and OpenCode today. Support in other clients (Cursor, Claude Desktop, Windsurf) varies — most currently support tools only. See the [MCP clients matrix](https://modelcontextprotocol.io/clients) for the latest.
 
-## Frontmatter Properties
+## Properties
 
-Vault Cortex indexes every frontmatter property in your notes, but five get **promoted** treatment — dedicated indexed columns for fast filtering, and top-level fields in every search and discovery result:
+Vault Cortex indexes every [property](https://help.obsidian.md/Editing+and+formatting/Properties) in your notes, but five get **promoted** treatment — dedicated indexed columns for fast filtering, and top-level fields in every search and discovery result:
 
 | Property  | What you can do                                                                                              |
 | --------- | ------------------------------------------------------------------------------------------------------------ |
@@ -204,7 +204,7 @@ Vault Cortex indexes every frontmatter property in your notes, but five get **pr
 
 **All other properties** are still fully queryable — use `vault_search` with `filters.properties` for combined text + metadata queries, or `vault_search_by_property` for metadata-only lookups. `vault_list_property_keys` and `vault_list_property_values` discover what properties exist across your vault.
 
-These are conventions, not requirements — Vault Cortex works with any frontmatter schema. Promoted properties just give you richer filtering and cleaner results out of the box.
+These are conventions, not requirements — Vault Cortex works with any property schema. Promoted properties just give you richer filtering and cleaner results out of the box.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Prompts adapt to your configuration (`MEMORY_DIR`, daily-notes settings) and wor
 
 ## Properties
 
-Vault Cortex indexes every [property](https://help.obsidian.md/Editing+and+formatting/Properties) in your notes, but five get **promoted** treatment — dedicated indexed columns for fast filtering, and top-level fields in every search and discovery result:
+Vault Cortex indexes every [property](https://help.obsidian.md/Editing+and+formatting/Properties) in your notes, but five get **promoted** treatment — dedicated columns for fast filtering, and top-level fields in every search and discovery result:
 
 | Property  | What you can do                                                                                              |
 | --------- | ------------------------------------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The typical Obsidian + MCP setup requires three moving parts running simultaneou
 - **Ranked search** — SQLite FTS5 with BM25 scoring, stemming, phrase matching, and tag/property/folder filtering
 - **Structured memory** — dated entries, section targeting, auto-initialization for AI personalization
 - **Obsidian-native** — understands frontmatter, wikilinks, tags, headings, and daily notes
-- **Guided workflows** — user-initiated prompts (orientation, memory review, daily review) that your MCP client surfaces as slash commands or **+**-menu actions, assembling live vault content on demand when you run them
+- **Guided workflows** — three built-in prompts that orient a new session to your vault's conventions, review your memory layer as a timeline, or reconcile a day's work — assembled from live vault content each time you run them
 
 ### Roadmap
 
@@ -178,15 +178,33 @@ See [Authentication](#authentication) for both methods and token lifetimes.
 
 ## Prompts (3)
 
-Where tools are model-driven, **prompts** are workflows you trigger explicitly — their live vault content is assembled only when you run them. MCP clients surface them as user-initiated actions: for example, slash commands in Claude Code (`/mcp__vault-cortex__<name>`) or the **+** menu in Claude Desktop and claude.ai connectors. Other clients expose them in their own UI.
+Tools are model-driven — the assistant calls them. **Prompts** are workflows _you_ trigger: run one to instantly ground a session in your vault's structure, reflect on how your preferences have evolved, or reconcile a day's work into follow-ups and memory. Each prompt assembles live vault content when you invoke it, so the context is always current.
 
-| Prompt              | Arguments             | What it does                                                                                                                                    |
-| ------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `vault-orientation` | —                     | Surveys the vault's folders, tags, property keys, recent notes, and memory layer so the assistant works with your conventions, not assumptions. |
-| `memory-review`     | `file?`, `max_chars?` | Reads the `About Me/` memory layer as a dated timeline — an evolution, not "latest wins" — and proposes append-only updates. Never prunes.      |
-| `daily-review`      | `date?`, `max_chars?` | Reviews a day's daily note against recent activity, captures follow-ups, and surfaces durable facts worth saving to memory.                     |
+| Prompt              | Arguments             | What it does                                                                                                                           |
+| ------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `vault-orientation` | —                     | Surveys your folders, tags, property keys, recent notes, and memory layer — grounds a new session in your vault's real conventions     |
+| `memory-review`     | `file?`, `max_chars?` | Reads your memory as a dated timeline (an evolution, not "latest wins"), surfaces scope-fit issues, and proposes append-only updates   |
+| `daily-review`      | `date?`, `max_chars?` | Cross-references a day's daily note with recent vault activity, captures follow-ups, and surfaces durable facts worth saving to memory |
 
-Prompts are parameterized through the same config as the tools (`MEMORY_DIR`, daily-notes settings), so they work for any vault out of the box. `memory-review` and `daily-review` embed full vault content by default; pass the optional `max_chars` argument when invoking them to cap that content (truncated with a marker pointing to the relevant tool) if your client has strict payload limits.
+Prompts adapt to your configuration (`MEMORY_DIR`, daily-notes settings) and work for any vault out of the box. Pass `max_chars` to cap embedded content if your client has payload limits.
+
+> **Client support:** Prompts work in Claude Code and OpenCode today. Support in other clients (Cursor, Claude Desktop, Windsurf) varies — most currently support tools only. See the [MCP clients matrix](https://modelcontextprotocol.io/clients) for the latest.
+
+## Frontmatter Properties
+
+If you already use `tags`, `type`, or `created` in your frontmatter, Vault Cortex picks them up automatically. Five properties are **promoted** — indexed for fast filtering and surfaced as top-level fields in every search and discovery result:
+
+| Property  | What you can do                                                                                              |
+| --------- | ------------------------------------------------------------------------------------------------------------ |
+| `title`   | Display name in search results; falls back to the filename when missing                                      |
+| `tags`    | Search and filter by tag, including parent-child hierarchies (`project` matches `project/vault-cortex`)      |
+| `type`    | Filter by note type — `meeting`, `person`, `session-log`, or any value your vault uses                       |
+| `created` | Sort by creation date and see when each note was created alongside every search result                       |
+| `related` | Filter for notes that cross-reference a specific link — surfaces connections invisible without a graph query |
+
+**All other properties** are still fully queryable — use `vault_search` with `filters.properties` for combined text + metadata queries, or `vault_search_by_property` for metadata-only lookups. `vault_list_property_keys` and `vault_list_property_values` discover what properties exist across your vault.
+
+These are conventions, not requirements — Vault Cortex works with any frontmatter schema. Promoted properties just give you richer filtering and cleaner results out of the box.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Prompts adapt to your configuration (`MEMORY_DIR`, daily-notes settings) and wor
 
 ## Frontmatter Properties
 
-If you already use `tags`, `type`, or `created` in your frontmatter, Vault Cortex picks them up automatically. Five properties are **promoted** — indexed for fast filtering and surfaced as top-level fields in every search and discovery result:
+Vault Cortex indexes every frontmatter property in your notes, but five get **promoted** treatment — dedicated indexed columns for fast filtering, and top-level fields in every search and discovery result:
 
 | Property  | What you can do                                                                                              |
 | --------- | ------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
## Summary

- **New "Frontmatter Properties" section** in the README documenting the five promoted properties (`title`, `tags`, `type`, `created`, `related`) — what users can do with them, how they differ from general properties, and that all other frontmatter remains fully queryable
- **Corrected prompt client support claims** across README and ARCHITECTURE.md — live testing and the MCP clients matrix confirm prompts work in Claude Code and OpenCode today; most other clients (Cursor, Claude Desktop, Windsurf, claude.ai) currently support tools only
- **Rewritten Prompts section copy** to lead with user value ("workflows _you_ trigger") instead of spec jargon (`prompts/list` capability)
- **Added promoted properties paragraph** to ARCHITECTURE.md Search section for the architecture audience

## Test plan

- [x] Verify README renders correctly on GitHub (tables, blockquote, formatting)
- [x] Verify [MCP clients matrix link](https://modelcontextprotocol.io/clients) resolves
- [x] Confirm no unconditional prompt-availability claims remain in README or ARCHITECTURE.md
- [x] `npm run prettier:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)