### PR TITLE
docs: Claude Desktop supports prompts (Chat + Cowork)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -251,7 +251,7 @@ Link queries use a `links` table populated from `[[wikilink]]` and `[text](path.
 
 ## MCP Prompts
 
-Alongside tools, the server registers MCP **prompts** (`prompts/list` / `prompts/get`) in `prompt-definitions.ts`, mirroring the tool factory and registered per session in `mcp-router.ts`. Prompts are user-initiated — clients that support the `prompts/list` capability surface them as slash commands or menu actions (Claude Code, OpenCode, Zed); support varies by client and most (Cursor, Windsurf, claude.ai) currently expose tools only. Handlers assemble live vault content at invocation time over the same data layer the tools use, so there is no embedded procedure that can drift, only live content plus thin, durable instruction.
+Alongside tools, the server registers MCP **prompts** (`prompts/list` / `prompts/get`) in `prompt-definitions.ts`, mirroring the tool factory and registered per session in `mcp-router.ts`. Prompts are user-initiated — clients that support the `prompts/list` capability surface them via a **+** menu (Claude Desktop), slash commands (Claude Code), or similar (OpenCode, Zed); support varies by client and some (Cursor, Windsurf) currently expose tools only. Handlers assemble live vault content at invocation time over the same data layer the tools use, so there is no embedded procedure that can drift, only live content plus thin, durable instruction.
 
 | Prompt              | Arguments             | Purpose                                                                                                |
 | ------------------- | --------------------- | ------------------------------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Tools are model-driven — the assistant calls them. **Prompts** are workflows _
 
 Prompts adapt to your configuration (`MEMORY_DIR`, daily-notes settings) and work for any vault out of the box. Pass `max_chars` to cap embedded content if your client has payload limits.
 
-> **Client support:** Prompts work in Claude Code and OpenCode today. Support in other clients (Cursor, Claude Desktop, Windsurf) varies — most currently support tools only. See the [MCP clients matrix](https://modelcontextprotocol.io/clients) for the latest.
+> **Client support:** Prompts work in Claude Desktop (Chat and Cowork — via the **+** menu under your connector), Claude Code (slash commands), and OpenCode. Support in other clients (Cursor, Windsurf) varies — see the [MCP clients matrix](https://modelcontextprotocol.io/clients) for the latest.
 
 ## Properties
 


### PR DESCRIPTION
## Summary

- Move Claude Desktop from the "varies" group to the confirmed-working list for MCP prompt support
- Live testing confirmed all three prompts render in Claude Desktop's **+** menu under the connector — both Chat and Cowork modes
- The earlier claim that Desktop didn't support prompts (PR #148) was based on a transient issue during testing; the official MCP clients matrix was correct

## Test plan

- [x] Verified prompts render in Claude Desktop Chat mode (screenshot)
- [x] Verified prompts render in Claude Desktop Cowork mode (screenshot)
- [ ] Confirm no stale "Claude Desktop doesn't support prompts" claims remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)