### PR TITLE
feat(search): include frontmatter in FTS5 search index

### DIFF
--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -605,6 +605,148 @@ describe("fullTextSearch", () => {
   })
 })
 
+// ── Metadata search (frontmatter in FTS5) ──────────────────────
+//
+// Test notes use terms that appear ONLY in frontmatter — never in
+// the title or body — so the tests genuinely prove FTS metadata
+// indexing (and fail if the metadata column is empty).
+
+const NOTE_WITH_TAXONOMY = `---
+title: Garden Layout
+type: blueprint
+tags: [perennial, xeriscaping]
+status: dormant
+lifecycle: evergreen
+---
+
+# Garden Layout
+
+Raised beds along the south fence with drip irrigation.
+`
+
+const NOTE_WITH_PRIORITY = `---
+title: Fence Repair
+type: maintenance
+tags: [structural]
+status: overdue
+priority: critical
+---
+
+# Fence Repair
+
+Replace the rotted posts on the north side.
+`
+
+describe("metadata search", () => {
+  beforeEach(() => {
+    index.upsertNote(
+      {
+        filePath: "garden/layout.md",
+        rawContent: NOTE_WITH_TAXONOMY,
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    index.upsertNote(
+      {
+        filePath: "garden/fence.md",
+        rawContent: NOTE_WITH_PRIORITY,
+        fileStat: testStat(2000),
+      },
+      logger,
+    )
+    index.upsertNote(
+      {
+        filePath: "garden/notes.md",
+        rawContent:
+          "---\ntitle: Soil Notes\ntype: reference\ntags: [compost]\n---\n\nAmend with gypsum before planting season.\n",
+        fileStat: testStat(3000),
+      },
+      logger,
+    )
+  })
+
+  it("finds a note by a type value that appears only in frontmatter", () => {
+    const results = index.fullTextSearch({ query: "blueprint" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("garden/layout.md")
+  })
+
+  it("finds a note by a status value that appears only in frontmatter", () => {
+    const results = index.fullTextSearch({ query: "overdue" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("garden/fence.md")
+  })
+
+  it("finds a note by a tag that appears only in frontmatter", () => {
+    const results = index.fullTextSearch({ query: "xeriscaping" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("garden/layout.md")
+  })
+
+  it("finds a note by a frontmatter key name", () => {
+    const results = index.fullTextSearch({ query: "lifecycle" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("garden/layout.md")
+  })
+
+  it("cross-field query matches a frontmatter term + body term together", () => {
+    const results = index.fullTextSearch({ query: "compost gypsum" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("garden/notes.md")
+  })
+
+  it("snippet contains body text, not metadata, for a frontmatter-only match", () => {
+    const results = index.fullTextSearch({ query: "overdue" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].snippet).not.toContain("status")
+    expect(results[0].snippet).not.toContain("overdue")
+    expect(results[0].snippet).toContain("rotted posts")
+  })
+
+  it("does not match notes that lack the queried frontmatter term", () => {
+    const results = index.fullTextSearch({ query: "dormant" }, logger)
+    const paths = results.map((result) => result.path)
+    expect(paths).toEqual(["garden/layout.md"])
+  })
+
+  it("warm-DB migration: FTS metadata column is added to a pre-existing database", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "warm-fts-"))
+    const dbPath = join(dir, "search.db")
+    const legacyDb = new Database(dbPath)
+    legacyDb.exec(`
+      CREATE TABLE notes (
+        path TEXT PRIMARY KEY, title TEXT, content TEXT, tags TEXT, related TEXT,
+        folder TEXT, type TEXT, created TEXT, mtime INTEGER, properties TEXT,
+        leading_callout TEXT, bytes INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE VIRTUAL TABLE notes_fts USING fts5(
+        path UNINDEXED, title, content, tokenize='porter unicode61'
+      );
+      CREATE TABLE links (
+        source TEXT NOT NULL, target TEXT NOT NULL, PRIMARY KEY (source, target)
+      );
+    `)
+    legacyDb.close()
+
+    const warmIndex = createSearchIndex(dbPath)
+    warmIndex.upsertNote(
+      {
+        filePath: "garden/layout.md",
+        rawContent: NOTE_WITH_TAXONOMY,
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+
+    const results = warmIndex.fullTextSearch({ query: "xeriscaping" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("garden/layout.md")
+
+    await rm(dir, { recursive: true })
+  })
+})
+
 describe("sanitizeFtsQuery", () => {
   const scenarios = [
     {

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  onTestFinished,
+} from "vitest"
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
@@ -133,6 +140,7 @@ describe("leading callout", () => {
 
   it("adds the leading_callout column to a pre-existing notes table (warm-DB migration)", async () => {
     const dir = await mkdtemp(join(tmpdir(), "warm-db-"))
+    onTestFinished(() => rm(dir, { recursive: true }))
     const dbPath = join(dir, "search.db")
     // Simulate a database file created before the leading_callout column existed.
     const legacyDb = new Database(dbPath)
@@ -165,7 +173,6 @@ describe("leading callout", () => {
     const results = warmIndex.searchByFolder({ folder: "About Me" }, logger)
     expect(results[0].leading_callout?.title).toBe("Scope of this file")
     expect(results[0].bytes).toBe(100)
-    await rm(dir, { recursive: true })
   })
 })
 
@@ -712,6 +719,7 @@ describe("metadata search", () => {
 
   it("warm-DB migration: FTS metadata column is added to a pre-existing database", async () => {
     const dir = await mkdtemp(join(tmpdir(), "warm-fts-"))
+    onTestFinished(() => rm(dir, { recursive: true }))
     const dbPath = join(dir, "search.db")
     const legacyDb = new Database(dbPath)
     legacyDb.exec(`
@@ -742,8 +750,6 @@ describe("metadata search", () => {
     const results = warmIndex.fullTextSearch({ query: "xeriscaping" }, logger)
     expect(results).toHaveLength(1)
     expect(results[0].path).toBe("garden/layout.md")
-
-    await rm(dir, { recursive: true })
   })
 })
 

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -374,6 +374,19 @@ export const createSearchIndex = (dbPath: string) => {
   db.pragma("journal_mode = WAL")
   db.pragma("synchronous = NORMAL")
 
+  // FTS5 doesn't support ALTER TABLE ADD COLUMN. When opening a warm database
+  // that lacks the metadata column, drop the table so the CREATE below rebuilds
+  // it with the new schema. rebuildFromVault repopulates on every startup.
+  const ftsColumns = db.prepare("PRAGMA table_info(notes_fts)").all() as Array<{
+    name: string
+  }>
+  if (
+    ftsColumns.length > 0 &&
+    !ftsColumns.some((column) => column.name === "metadata")
+  ) {
+    db.exec("DROP TABLE notes_fts")
+  }
+
   db.exec(`
     CREATE TABLE IF NOT EXISTS notes (
       path        TEXT PRIMARY KEY,
@@ -391,7 +404,7 @@ export const createSearchIndex = (dbPath: string) => {
     );
 
     CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
-      path UNINDEXED, title, content, tokenize='porter unicode61'
+      path UNINDEXED, title, content, metadata, tokenize='porter unicode61'
     );
 
     CREATE TABLE IF NOT EXISTS links (
@@ -428,7 +441,7 @@ export const createSearchIndex = (dbPath: string) => {
   `)
   const deleteFtsStmt = db.prepare(`DELETE FROM notes_fts WHERE path = ?`)
   const insertFtsStmt = db.prepare(
-    `INSERT INTO notes_fts (path, title, content) VALUES (?, ?, ?)`,
+    `INSERT INTO notes_fts (path, title, content, metadata) VALUES (?, ?, ?, ?)`,
   )
   const removeNotesStmt = db.prepare(`DELETE FROM notes WHERE path = ?`)
   const deleteLinksStmt = db.prepare(`DELETE FROM links WHERE source = ?`)
@@ -450,6 +463,24 @@ export const createSearchIndex = (dbPath: string) => {
 
   // FTS rows are managed manually (delete-then-insert) because SQLite triggers
   // combined with INSERT OR REPLACE cause FTS5 corruption.
+
+  /** Flattens frontmatter into a searchable text block for the FTS metadata column.
+   *  Keys are included (so "lifecycle" is findable), title is excluded (separate FTS column). */
+  const buildFtsMetadataText = (
+    frontmatter: Record<string, unknown>,
+  ): string => {
+    const lines: string[] = []
+    for (const [key, value] of Object.entries(frontmatter)) {
+      if (key === "title") continue
+      if (value == null) continue
+      if (Array.isArray(value)) {
+        lines.push(`${key}: ${value.map(String).join(" ")}`)
+      } else if (typeof value !== "object") {
+        lines.push(`${key}: ${String(value)}`)
+      }
+    }
+    return lines.join("\n")
+  }
 
   /** Parses a note's content and frontmatter, then indexes it for search. */
   const upsertNote = (
@@ -507,7 +538,8 @@ export const createSearchIndex = (dbPath: string) => {
       note.leading_callout,
       note.bytes,
     )
-    insertFtsStmt.run(note.path, note.title, note.content)
+    const metadataText = buildFtsMetadataText(frontmatter)
+    insertFtsStmt.run(note.path, note.title, note.content, metadataText)
     logger.debug("indexed note", { path: note.path, bytes: note.bytes })
 
     if (skipLinks) return

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -474,7 +474,12 @@ export const createSearchIndex = (dbPath: string) => {
       if (key === "title") continue
       if (value == null) continue
       if (Array.isArray(value)) {
-        lines.push(`${key}: ${value.map(String).join(" ")}`)
+        const primitiveElements = value
+          .filter((element) => element != null && typeof element !== "object")
+          .map(String)
+        if (primitiveElements.length > 0) {
+          lines.push(`${key}: ${primitiveElements.join(" ")}`)
+        }
       } else if (typeof value !== "object") {
         lines.push(`${key}: ${String(value)}`)
       }


### PR DESCRIPTION
## Summary

- Add a dedicated `metadata` FTS5 column populated with flattened frontmatter values (tags, type, status, custom properties) so `vault_search` free-text queries see the full note — not just body text
- Add warm-DB migration that detects the old 3-column FTS5 schema and drops/recreates with the new 4-column schema (FTS5 doesn't support ALTER TABLE ADD COLUMN)
- `snippet(notes_fts, 2, ...)` still targets the body column — zero metadata leakage in snippets

### Problem

`vault_search` had a **24.4% zero-result rate** (55/225 queries over 31 days of production logs). Agents use `vault_search` as pure free-text search — **0% of calls used the structured filter API** — so when frontmatter content is invisible to BM25, there's no fallback. Searching "session-log" returned daily notes (body wikilink hits) instead of actual session logs (`type: session-log`). ~12 zero-result queries are directly fixable.

### Approach

Research ([three-way comparison](https://github.com/aliasunder/vault-cortex/blob/main/docs/research/frontmatter-in-fts5-comparison.md)) proved the separate FTS5 column approach: identical recall and BM25 scores as naive prepend, zero snippet leaks (vs 15/15 in prepend). The new `metadata` column at index 3 is scored by BM25 but never snippeted.

### Changes

| Area | Detail |
|---|---|
| Schema | `notes_fts` gains `metadata` column (index 3) |
| Migration | `PRAGMA table_info(notes_fts)` → detect old schema → `DROP TABLE` → `CREATE` with new schema |
| Builder | `buildFtsMetadataText(frontmatter)` — flattens to `key: value` lines, excludes title, skips nested objects |
| Insert | `insertFtsStmt` now passes metadata as 4th bind parameter |
| Snippet | Unchanged — `snippet(notes_fts, 2, ...)` still targets body (column 2) |

## Test plan

- [x] 8 new tests in `metadata search` describe block — all mutation-verified (8/8 fail when metadata is empty string)
- [x] Frontmatter-only search: type value, status value, tag name, key name
- [x] Cross-field search: frontmatter term + body term
- [x] Snippet cleanliness: body text in snippet, no metadata leakage
- [x] Negative test: notes without the queried term excluded
- [x] Warm-DB migration: legacy 3-column FTS5 schema → drop → recreate → frontmatter search works
- [x] All 764 existing tests pass
- [x] Clean build (`npm run build`)
- [ ] Post-deploy: re-run 10 baseline queries from research note, compare against documented baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search functionality now indexes frontmatter metadata fields, enabling users to find notes by type, status, tags, and other YAML properties. Search across all metadata attributes provides more flexible and powerful note discovery alongside traditional title and body content searches.
  * Existing databases automatically upgrade to support this enhanced search capability on first startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->