### PR TITLE
feat(patch): reject content that duplicates the target heading

### DIFF
--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -335,7 +335,7 @@ Operations:
 - replace: replace section body (heading preserved; requires heading)
 - insert_before: insert content above the heading line (requires heading)
 
-Heading-targeted ops write content as the section body and keep the matched heading — don't repeat the heading in content (a content that begins with the target heading is rejected to avoid duplicating it).
+Heading-targeted ops keep the matched heading and write content verbatim — don't begin content with the target heading (it's rejected to avoid a duplicate).
 
 Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section.
 
@@ -346,7 +346,7 @@ Errors:
 - "heading not found" — no heading matches the text; error lists available headings
 - "ambiguous heading" — multiple headings match; use heading_level to disambiguate, or rename a heading if they share the same level
 - "operation requires a heading target" — replace and insert_before need a heading
-- "content duplicates the target heading" — content begins with the targeted heading; pass the section body only (the heading is kept automatically)
+- "content begins with the heading … which would duplicate it" — content's first line repeats the target heading; omit it (the matched heading is kept automatically)
 
 Obsidian syntax: Content is rendered as Obsidian Flavored Markdown with no escaping applied. Beyond standard Markdown, watch for: #word (no space) = tag, [[ = wikilink, %% = comment block. Escape with \\# or \\[[ when unintentional.
 Structural note: inserting heading-level content (e.g. ## New Section) changes the note's section structure — future patch calls targeting headings may resolve differently.

--- a/src/vault-mcp/tool-definitions.ts
+++ b/src/vault-mcp/tool-definitions.ts
@@ -335,6 +335,8 @@ Operations:
 - replace: replace section body (heading preserved; requires heading)
 - insert_before: insert content above the heading line (requires heading)
 
+Heading-targeted ops write content as the section body and keep the matched heading — don't repeat the heading in content (a content that begins with the target heading is rejected to avoid duplicating it).
+
 Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section.
 
 Editing a leading callout: read it via vault_read_note(outline: true), then vault_replace_in_note the old block for the new one (a no-heading prepend would stack a second callout above it).
@@ -344,6 +346,7 @@ Errors:
 - "heading not found" — no heading matches the text; error lists available headings
 - "ambiguous heading" — multiple headings match; use heading_level to disambiguate, or rename a heading if they share the same level
 - "operation requires a heading target" — replace and insert_before need a heading
+- "content duplicates the target heading" — content begins with the targeted heading; pass the section body only (the heading is kept automatically)
 
 Obsidian syntax: Content is rendered as Obsidian Flavored Markdown with no escaping applied. Beyond standard Markdown, watch for: #word (no space) = tag, [[ = wikilink, %% = comment block. Escape with \\# or \\[[ when unintentional.
 Structural note: inserting heading-level content (e.g. ## New Section) changes the note's section structure — future patch calls targeting headings may resolve differently.

--- a/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
@@ -1589,6 +1589,63 @@ describe("patchNote errors", () => {
   })
 })
 
+describe("patchNote — duplicate-heading guard", () => {
+  it.each(["replace", "prepend", "append", "insert_before"] as const)(
+    "rejects %s when content begins with the target heading, leaving the note untouched",
+    async (operation) => {
+      await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+      await expect(
+        patchNote(
+          {
+            vaultPath: vault,
+            path: "note.md",
+            operation,
+            content: "## Up Next\n- [ ] New task\n",
+            heading: "Up Next",
+          },
+          logger,
+        ),
+      ).rejects.toThrow('content begins with the heading "## Up Next"')
+      // Rejected before any write — the file is byte-for-byte unchanged.
+      expect(await readTestNote("note.md")).toBe(NOTE_WITH_SECTIONS)
+    },
+  )
+
+  it("allows content whose leading heading differs from the target", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "replace",
+        content: "## Other Heading\nbody\n",
+        heading: "Up Next",
+      },
+      logger,
+    )
+    expect(await readTestNote("note.md")).toContain(
+      "## Up Next\n## Other Heading\nbody",
+    )
+  })
+
+  it("allows a same-text heading at a different level (not a duplicate)", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await patchNote(
+      {
+        vaultPath: vault,
+        path: "note.md",
+        operation: "replace",
+        content: "### Up Next\nsub\n",
+        heading: "Up Next",
+      },
+      logger,
+    )
+    expect(await readTestNote("note.md")).toContain(
+      "## Up Next\n### Up Next\nsub",
+    )
+  })
+})
+
 // ── Edge cases ──────────────────────────────────────────────────
 
 describe("patchNote edge cases", () => {

--- a/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
@@ -1623,9 +1623,31 @@ describe("patchNote — duplicate-heading guard", () => {
       },
       logger,
     )
-    expect(await readTestNote("note.md")).toContain(
-      "## Up Next\n## Other Heading\nbody",
-    )
+    // Exact whole-file result — frontmatter is normalized to block style on write.
+    expect(await readTestNote("note.md")).toBe(`---
+title: Test Note
+tags:
+  - test
+---
+
+# Main Title
+
+Intro paragraph.
+
+## Active
+- [ ] Task A
+- [ ] Task B
+
+### Subtasks
+- [ ] Sub-task 1
+
+## Up Next
+## Other Heading
+body
+
+## Done
+- [x] Task D
+`)
   })
 
   it("allows a same-text heading at a different level (not a duplicate)", async () => {
@@ -1640,9 +1662,31 @@ describe("patchNote — duplicate-heading guard", () => {
       },
       logger,
     )
-    expect(await readTestNote("note.md")).toContain(
-      "## Up Next\n### Up Next\nsub",
-    )
+    // Exact whole-file result — frontmatter is normalized to block style on write.
+    expect(await readTestNote("note.md")).toBe(`---
+title: Test Note
+tags:
+  - test
+---
+
+# Main Title
+
+Intro paragraph.
+
+## Active
+- [ ] Task A
+- [ ] Task B
+
+### Subtasks
+- [ ] Sub-task 1
+
+## Up Next
+### Up Next
+sub
+
+## Done
+- [x] Task D
+`)
   })
 })
 

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -138,6 +138,28 @@ const patchNote = async (
   const headings = parseHeadings(lines)
   const target = findHeading(headings, heading, headingLevel)
   const targetDesc = `${"#".repeat(target.level)} ${target.text}`
+
+  // Heading-targeted ops keep the matched heading and write content as the
+  // section body, so a content that begins with that same heading would
+  // duplicate it. Reject with remediation rather than silently doubling it.
+  const firstContentLineIndex = contentLines.findIndex(
+    (line) => line.trim() !== "",
+  )
+  const leadingContentHeading = parseHeadings(contentLines).find(
+    (contentHeading) => contentHeading.startLine === firstContentLineIndex,
+  )
+  if (
+    leadingContentHeading &&
+    leadingContentHeading.level === target.level &&
+    leadingContentHeading.text === target.text
+  ) {
+    throw new Error(
+      `content begins with the heading "${targetDesc}", which would duplicate it — ` +
+        `a heading-targeted ${operation} writes content as the section body and keeps ` +
+        `the matched heading. Pass the section body only (omit the heading line).`,
+    )
+  }
+
   const updatedLines = applySectionOperation(
     lines,
     contentLines,

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -139,9 +139,9 @@ const patchNote = async (
   const target = findHeading(headings, heading, headingLevel)
   const targetDesc = `${"#".repeat(target.level)} ${target.text}`
 
-  // Heading-targeted ops keep the matched heading and write content as the
-  // section body, so a content that begins with that same heading would
-  // duplicate it. Reject with remediation rather than silently doubling it.
+  // Heading-targeted ops keep the matched heading, so a content that begins
+  // with that same heading would duplicate it. Reject with remediation rather
+  // than silently doubling it.
   const firstContentLineIndex = contentLines.findIndex(
     (line) => line.trim() !== "",
   )

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -155,8 +155,7 @@ const patchNote = async (
   ) {
     throw new Error(
       `content begins with the heading "${targetDesc}", which would duplicate it — ` +
-        `a heading-targeted ${operation} writes content as the section body and keeps ` +
-        `the matched heading. Pass the section body only (omit the heading line).`,
+        `heading-targeted ops keep the matched heading, so omit the heading line from content.`,
     )
   }
 

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -148,11 +148,11 @@ const patchNote = async (
   const leadingContentHeading = parseHeadings(contentLines).find(
     (contentHeading) => contentHeading.startLine === firstContentLineIndex,
   )
-  if (
-    leadingContentHeading &&
+  const contentRepeatsTargetHeading =
+    leadingContentHeading !== undefined &&
     leadingContentHeading.level === target.level &&
     leadingContentHeading.text === target.text
-  ) {
+  if (contentRepeatsTargetHeading) {
     throw new Error(
       `content begins with the heading "${targetDesc}", which would duplicate it — ` +
         `heading-targeted ops keep the matched heading, so omit the heading line from content.`,


### PR DESCRIPTION
## What & why

Heading-targeted `vault_patch_note` operations (`replace`/`prepend`/`append`/`insert_before`) **keep the matched heading** and write `content` relative to it. So if `content` itself begins with that same heading, you silently get **two** headings — the original (preserved) plus the one in your content.

This is the root cause of a recurring bug: the duplicate `## Last Session` heading that keeps showing up in `CLAUDE.local.md` during session-end. It looked like a concurrency artifact but it's a single-call footgun — an agent passes `content: "## Last Session\n- bullet"` to a `replace`, expecting the whole section to be swapped, and `replace` (which only swaps the body) duplicates the heading.

Rather than document around it in the session-end protocol, fix it at the source.

## Change

- **Guard** (`vault-patcher.ts`): for heading-targeted ops, if `content`'s first non-empty line is a heading whose **level *and* text both match the target**, reject with a remediating error:
  > `content begins with the heading "## Last Session", which would duplicate it — heading-targeted ops keep the matched heading, so omit the heading line from content.`

  The match is precise (reuses `parseHeadings`, so it's code-fence-aware and consistent with the indexer), so a legitimate **sub-heading** (`### Up Next` under `## Up Next`) or a **different** heading still passes.
- **Description** (`tool-definitions.ts`): documents the keep-the-heading semantics in the Operations block + a new `Errors:` entry.

Chose **reject** (fail-loud) over auto-strip so a malformed write surfaces and the caller learns, rather than being silently masked.

## TDQS

Self-scored old vs. new per the project convention — **4.8 → 5.0**, driven by Behavioral Transparency **4 → 5** (the non-obvious keep-the-heading semantics + the new failure mode with remediation are now documented). No dimension regresses; Conciseness holds (two terse additions). Tool stays Tier A; server min-TDQS unaffected.

## Tests

`vault-patcher.test.ts` — a `duplicate-heading guard` suite: rejection across all four ops (`it.each`) with the note asserted **byte-for-byte unchanged** (no partial write), plus the two negative cases that must still pass (different heading text; same text at a different level), asserted with exact whole-file `toBe`. Mutation-verified: disabling the guard fails exactly the four rejection cases and leaves the negatives green. `npm run build`, `npm run lint`, full suite (**872**) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)