### PR TITLE
docs: add DeepWiki badge for auto-reindexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The typical Obsidian + MCP setup requires three moving parts running simultaneou
   <tr>
     <td><img src="./assets/demo-remember.gif" width="240" alt="Ask Claude about a past trip — it searches the vault and recalls the route, cities, and highlights"></td>
     <td><img src="./assets/demo-reason.gif" width="240" alt="Ask what went wrong — Claude synthesizes lessons from session logs and itinerary notes"></td>
-    <td><img src="./assets/demo-save.gif" width="240" alt="Save lessons learned to the vault, update travel preferences, then see both in Obsidian"></td>
+    <td><img src="./assets/demo-writeback.gif" width="240" alt="Save lessons learned to the vault, update travel preferences, then see both in Obsidian"></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![License: MIT](https://img.shields.io/github/license/aliasunder/vault-cortex?v=1&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/blob/main/LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D24-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/aliasunder/vault-cortex)
 
 </div>
 
@@ -42,7 +43,7 @@ The typical Obsidian + MCP setup requires three moving parts running simultaneou
   <tr>
     <td><img src="./assets/demo-remember.gif" width="240" alt="Ask Claude about a past trip — it searches the vault and recalls the route, cities, and highlights"></td>
     <td><img src="./assets/demo-reason.gif" width="240" alt="Ask what went wrong — Claude synthesizes lessons from session logs and itinerary notes"></td>
-    <td><img src="./assets/demo-writeback.gif" width="240" alt="Save lessons learned to the vault, update travel preferences, then see both in Obsidian"></td>
+    <td><img src="./assets/demo-save.gif" width="240" alt="Save lessons learned to the vault, update travel preferences, then see both in Obsidian"></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Adds the [DeepWiki badge](https://deepwiki.com/aliasunder/vault-cortex) to the README badge row.

This enables **automatic weekly re-indexing** of the DeepWiki index for this repo — without it, the index stays frozen at the initial snapshot and has no mechanism to refresh.