### PR TITLE
chore(deploy): set LOG_RETENTION_DAYS=365 for production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -202,6 +202,7 @@ jobs:
           CONFLICT_STRATEGY=conflict
           SYNC_MODE=bidirectional
           LOG_LEVEL=info
+          LOG_RETENTION_DAYS=365
           TZ=${TZ:-UTC}
           EOF
 


### PR DESCRIPTION
## Summary

- Sets `LOG_RETENTION_DAYS=365` in the deploy workflow's inline `.env` block (production-only)
- OSS default stays at `30` (docker-compose fallback) — conservative for strangers on small VPS/Pi deployments
- Production needs a full year of logs for usage analysis — the W25 analysis nearly lost the oldest file to the 30-day pruning window

## Test plan

- [x] Verify deploy.yml has the new line alongside `LOG_LEVEL=info`
- [x] Confirm docker-compose defaults are unchanged at `${LOG_RETENTION_DAYS:-30}`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)