### PR TITLE
chore: migrate jwt.ts from Date.now() to Luxon DateTime

### DIFF
--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -6,6 +6,7 @@
  */
 
 import { createHmac, timingSafeEqual } from "node:crypto"
+import { DateTime } from "luxon"
 
 export type JwtPayload = {
   sub: string
@@ -46,7 +47,10 @@ export const verifyJwt = (token: string, secret: string): JwtPayload | null => {
       Buffer.from(payload, "base64url").toString(),
     ) as JwtPayload
     // Reject expired tokens (exp is Unix seconds)
-    if (typeof decoded.exp === "number" && decoded.exp < Date.now() / 1000) {
+    if (
+      typeof decoded.exp === "number" &&
+      decoded.exp < DateTime.now().toUnixInteger()
+    ) {
       return null
     }
     return decoded


### PR DESCRIPTION
## Summary

- Replaces the last `Date.now() / 1000` in the codebase with `DateTime.now().toUnixInteger()`
- `jwt.ts` was the sole holdout — left out of the original Luxon migration (PR #8) by strict scope (library code, not the OAuth provider)
- No behavior change — both produce Unix epoch seconds

## Test plan

- [x] 927 tests pass (jwt.test.ts already uses Luxon for test fixtures)
- [x] `grep -rn "Date.now" src/` returns zero hits
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)