### PR TITLE
docs(jwt): clarify intentional avoidance of Luxon

### DIFF
--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -3,6 +3,9 @@
  * Custom instead of a library (e.g. jose): ~50 lines using only node:crypto,
  * keeps the Lambda esbuild bundle small, and avoids adding a dependency to
  * two deployment targets. HS256-only — the only algorithm we need.
+ *
+ * Intentionally avoids Luxon (and any other runtime dep). The Lambda
+ * authorizer imports verifyJwt — every dependency here enlarges that bundle.
  */
 
 import { createHmac, timingSafeEqual } from "node:crypto"


### PR DESCRIPTION
## Summary

- Adds a comment to `jwt.ts` explaining why it intentionally avoids Luxon (and any runtime dep) — the Lambda authorizer imports `verifyJwt`, so every dependency here enlarges the esbuild bundle
- Closes the `^jwt-luxon-followup` task as "won't do" — the `Date.now() / 1000` is a deliberate design choice, not tech debt

## Test plan

- [x] Comment-only change — 927 tests pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)