### PR TITLE
ci: add scheduled GHCR cleanup for untagged image digests

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -23,6 +23,6 @@ jobs:
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           package: vault-mcp
-          owner: ${{ github.repository_owner }}
+          owner: ${{ vars.GHCR_USER }}
           delete-untagged: true
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,28 @@
+name: GHCR Cleanup
+
+on:
+  schedule:
+    # Weekly on Sunday at 03:00 UTC — after any weekend releases settle.
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log what would be deleted without actually deleting"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete untagged GHCR images
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
+        with:
+          package: vault-mcp
+          owner: ${{ github.repository_owner }}
+          delete-untagged: true
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}


### PR DESCRIPTION
## Summary

- Adds a weekly workflow (Sunday 03:00 UTC) that deletes untagged GHCR manifests — per-platform children, provenance attestation manifests, and SBOM manifests that accumulate with each multi-arch release (~4–5 untagged per build)
- Uses [`dataaxiom/ghcr-cleanup-action`](https://github.com/dataaxiom/ghcr-cleanup-action) (v1.2.2, pinned by SHA) which is multi-arch-aware: deleting a manifest index also removes its child platform images, and tagged manifests' children are never orphaned
- Manual dispatch (`workflow_dispatch`) defaults to dry-run for safe one-off inspection

## Test plan

- [x] Merge, then trigger manually with dry-run=true — verify it logs the untagged digests it would delete without actually deleting
- [ ] Trigger again with dry-run=false — verify untagged count drops on the [GHCR package page](https://github.com/aliasunder/vault-cortex/pkgs/container/vault-mcp)
- [ ] After next release, confirm the scheduled run cleans up the new untagged manifests and tagged images still pull correctly (`docker pull ghcr.io/aliasunder/vault-mcp:latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)