### PR TITLE
docs: add .devin/wiki.json to steer DeepWiki page generation

### DIFF
--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -1,0 +1,104 @@
+{
+  "repo_notes": [
+    {
+      "content": "Vault Cortex is a remote MCP (Model Context Protocol) server that exposes an Obsidian vault over HTTPS. Unlike other Obsidian MCP integrations that proxy requests to the Obsidian REST API plugin, Vault Cortex works directly with .md files on disk — no Obsidian desktop instance required at runtime. It owns its own search engine (SQLite FTS5 with indexed metadata columns for tags, folders, frontmatter, and leading callouts), a full Obsidian link resolution engine, and a heading-aware memory layer. 25 MCP tools and 3 user-initiated prompts. Deployment ranges from a single Docker container with a bind-mounted vault folder to a full AWS reference deployment with API Gateway, Lambda authorizer, and Obsidian Sync. The repo also ships a CLI (cli/ directory, published as the vault-cortex npm package) that scaffolds a deployment in one command: npx vault-cortex@latest init."
+    },
+    {
+      "content": "The codebase is organized into four internal layers under src/vault-mcp/: (1) obsidian-markdown/ — pure Obsidian/Markdown parsers with no I/O: link grammar, extraction, and resolution for all of Obsidian's link formats (wikilinks, markdown links, embeds, frontmatter links, relative paths); fence-aware line classification; frontmatter parsing; callout extraction; heading section parsing. (2) vault-operations/ — filesystem I/O for vault content: CRUD, surgical heading-targeted patching, note moving with vault-wide link rewriting, the About Me/ memory store, and daily note resolution. (3) search/ — SQLite FTS5 search index with chokidar file watcher that keeps the index current on every file change. (4) mcp-core/ — the MCP protocol surface: streamable-http transport, tool registrations with Zod schemas (70KB of rich tool descriptions with examples and cross-references), and prompt definitions. Authentication lives in src/vault-mcp/oauth/ (OAuth 2.1 with JWT tokens) and src/functions/authorizer.ts (AWS Lambda, path-aware). Infrastructure-as-code (sst.config.ts) is specific to the AWS reference deployment and should not be documented as the primary deployment path."
+    }
+  ],
+  "pages": [
+    {
+      "title": "Overview",
+      "purpose": "What Vault Cortex is, why it exists (replacing the 3-part Obsidian + REST API plugin + MCP server chain), the architecture diagram, Phase 1 (current) vs Phase 2 (semantic search) scope, and the key differentiators: plugin-free, Docker-based, remote-capable, owns its own search engine."
+    },
+    {
+      "title": "Getting Started",
+      "purpose": "Quickstart guide covering the three deployment paths (local Docker, remote with Obsidian Sync, AWS reference) with links to the deploy/ directory walkthroughs. Includes MCP client configuration examples for Claude Desktop, Claude Code, and other clients. Highlights the npx vault-cortex init CLI as the fastest path to a working setup."
+    },
+    {
+      "title": "CLI",
+      "purpose": "The vault-cortex npm package (cli/) — a scaffolding tool that sets up a Vault Cortex deployment in one command: npx vault-cortex@latest init. Covers: the interactive init flow (mode selection, vault path, token generation, docker-compose.yml and .env scaffolding, optional docker compose up with health-check wait); non-interactive flags (--mode, --vault-path, --dir, --yes); the module structure (bin.ts entry point, program.ts command definition, init.ts orchestration, prompts.ts interactive flow, scaffold.ts file generation, docker.ts container management, env.ts environment file handling, token.ts secure token generation, vault.ts path validation, node-version.ts compatibility check, messages.ts user-facing output); and the templates/ directory used for scaffolding."
+    },
+    {
+      "title": "Configuration Reference",
+      "purpose": "All environment variables (from config.ts and .env.example files), the ServerConfig type, and how configuration differs across the three deployment modes. Covers VAULT_PATH, MCP_AUTH_TOKEN, OBSIDIAN_AUTH_TOKEN, VAULT_NAME, LOG_LEVEL, MEMORY_FOLDER, DAILY_NOTES_FOLDER, DAILY_NOTES_FORMAT, and Windows bind-mount mode."
+    },
+    {
+      "title": "Architecture",
+      "purpose": "Parent page providing an overview of the four-layer internal architecture (obsidian-markdown, vault-operations, search, mcp-core), the data flow from MCP client request through transport to data layer and back, and the component diagram showing how Obsidian Sync, the vault filesystem, SQLite, and the MCP server interact."
+    },
+    {
+      "title": "Server and Transport",
+      "purpose": "How the Express server bootstraps (server.ts), the MCP streamable-http transport lifecycle (mcp-core/mcp-router.ts), session management, and the logger chain that flows context (sessionId, clientIp, requestId, tool) through child loggers.",
+      "parent": "Architecture"
+    },
+    {
+      "title": "Authentication and Security",
+      "purpose": "The two-layer auth model: AWS Lambda authorizer (path-aware — OAuth endpoints pass through, /mcp validates static token or JWT) and the OAuth 2.1 provider (oauth-provider.ts with JWT tokens and SQLite persistence, consent page, SDK auth routes). Covers src/auth.ts (safeEqual, parseBearer), src/jwt.ts (HS256 sign/verify), and the security policy.",
+      "parent": "Architecture"
+    },
+    {
+      "title": "Obsidian Markdown Parsing",
+      "purpose": "The pure parser layer in obsidian-markdown/ — no filesystem I/O, just domain knowledge about the Obsidian/Markdown format. Covers: links.ts (link grammar, fence-aware extraction, resolution for wikilinks, markdown links, embeds, frontmatter links, and relative path-from-current-file links — all three of Obsidian's 'New link format' modes); lines.ts (CRLF-safe line splitting, the consolidated fence state machine, classifyLines for identifying fenced regions); frontmatter.ts (gray-matter parse/stringify, frontmatter merge); callouts.ts (leading-callout parser for > [!type] blocks); headings.ts (shared H1-H6 section-span parser used by both read and patch operations). This layer is architecturally significant — it encodes the Obsidian-parity behavior that distinguishes Vault Cortex from simpler file-based integrations.",
+      "parent": "Architecture",
+      "page_notes": [
+        {
+          "content": "The link resolution engine in links.ts is one of the project's key differentiators. It handles every link format Obsidian recognizes: [[wikilink]], [[wikilink|alias]], [[wikilink#heading]], ![[embed]], [markdown](path.md), links in frontmatter properties (e.g. related:), and all three 'New link format' modes (shortest path, path from vault folder, path from current file including relative ../ paths). The fence state machine was consolidated from three separate implementations into one shared classifyLines function in lines.ts during a recent restructure."
+        }
+      ]
+    },
+    {
+      "title": "Vault Operations",
+      "purpose": "The filesystem I/O layer in vault-operations/ that reads, writes, and transforms vault content. Covers: vault-filesystem.ts (read/write/list/delete .md files, outline and section reads, protected-path validation); vault-patcher.ts (surgical edits — heading-targeted patch with prepend/append/replace operations, and find-and-replace with optional replace-all); note-mover.ts (move/rename a note and rewrite every vault-wide link that pointed to it, using the link resolution engine from obsidian-markdown/links.ts). All functions follow the (params, logger) two-argument pattern.",
+      "parent": "Architecture"
+    },
+    {
+      "title": "Search and Indexing",
+      "purpose": "The SQLite FTS5 search system in search/. Covers: search-index.ts (the factory/closure that creates the SQLite database, FTS5 virtual table with body + metadata columns, indexing pipeline that extracts tags/folder/type/leading-callout/frontmatter, and query functions for full-text search, tag queries, folder browsing, property queries, recent notes, backlinks, outgoing links, and orphan detection); file-watcher.ts (chokidar watcher that keeps the index current on every file add/change/unlink, with Windows polling mode support). The index is rebuilt from scratch on startup and maintained incrementally thereafter.",
+      "parent": "Architecture"
+    },
+    {
+      "title": "Memory Layer",
+      "purpose": "The About Me/ memory system and daily note support. Covers: memory-store.ts (heading-aware read/append/delete for structured memory files — each file has H2 sections with dated bullet entries, supporting get/update/delete by file and section); daily-notes.ts (reads daily note configuration from the vault's .obsidian/daily-notes.json and resolves the path for any date using Luxon); templates/memory/ (bootstrap templates for new vaults). The memory layer enables personalized AI interactions — agents read user preferences, principles, and context from About Me/ files.",
+      "parent": "Architecture"
+    },
+    {
+      "title": "MCP Interface",
+      "purpose": "Parent page for the MCP protocol surface — the tools and prompts that clients interact with. Overview of the 25 tools (grouped by domain: vault CRUD, search and discovery, memory, graph queries, properties, daily notes) and the 3 user-initiated prompts. Explains the distinction: tools are model-driven (the AI decides when to call them), prompts are user-initiated (surfaced as slash commands or menu items in the client)."
+    },
+    {
+      "title": "Tool Reference",
+      "purpose": "The 25 MCP tools registered in mcp-core/tool-definitions.ts, grouped by domain. Vault CRUD: vault_read_note, vault_write_note, vault_patch_note, vault_replace_in_note, vault_delete_span, vault_list_notes, vault_delete_note, vault_move_note. Search and discovery: vault_search (full-text + structured filters), vault_search_by_tag, vault_search_by_folder, vault_recent_notes, vault_list_tags. Memory: vault_get_memory, vault_update_memory, vault_list_memory_files, vault_delete_memory. Properties: vault_list_property_keys, vault_list_property_values, vault_search_by_property, vault_update_properties. Graph: vault_get_backlinks, vault_get_outgoing_links, vault_find_orphans. Daily notes: vault_get_daily_note. Each tool description includes Example, When to use, Returns, and Errors sections.",
+      "parent": "MCP Interface"
+    },
+    {
+      "title": "Prompt Reference",
+      "purpose": "The 3 MCP prompts registered in mcp-core/prompt-definitions.ts: vault-orientation (assembles a vault overview with structure, recent notes, memory files, and tag cloud at invocation time), memory-review (reads the About Me/ memory layer as a dated evolution and proposes append-only updates), daily-review (assembles the daily note with recent activity context). Prompts are user-initiated workflows that assemble live vault content — distinct from tools, which are model-driven.",
+      "parent": "MCP Interface"
+    },
+    {
+      "title": "Deployment",
+      "purpose": "Parent page for the three deployment modes, from simplest to most capable. All modes run the same vault-mcp Docker image; they differ in how the vault reaches the container and whether remote access is available."
+    },
+    {
+      "title": "Local Docker Deployment",
+      "purpose": "The simplest deployment: a single Docker container with the vault folder bind-mounted from the host. No Obsidian Sync, no cloud services. Documented in deploy/local/. Covers the docker-compose.yml, .env.example (just MCP_AUTH_TOKEN and VAULT_PATH), and MCP client configuration. Includes Windows bind-mount support (WINDOWS_MODE flag for polling watcher and exclusive-write strategy).",
+      "parent": "Deployment"
+    },
+    {
+      "title": "Remote Deployment with Obsidian Sync",
+      "purpose": "Docker Compose with two services: obsidian-sync (bidirectional Obsidian Sync via a headless fork of obsidian-headless-sync-docker) and vault-mcp. Named Docker volumes, no bind mounts. Documented in deploy/remote/. Requires an Obsidian Sync subscription and HTTPS (reverse proxy or cloud provider). This is the deployment that enables mobile/remote access — the key differentiator over local-only solutions.",
+      "parent": "Deployment"
+    },
+    {
+      "title": "AWS Reference Deployment",
+      "purpose": "The full reference deployment using SST v4 infrastructure-as-code: Lightsail container service (~$12/mo) running Docker Compose (obsidian-sync + vault-mcp), API Gateway HTTP API for HTTPS with automatic TLS, and a Lambda authorizer (path-aware: OAuth endpoints pass through, /mcp validates static token or JWT). Covers sst.config.ts, the Lightsail Docker Compose setup, and DEPLOY.md. This is the author's production deployment but is not required — Vault Cortex runs anywhere Docker does.",
+      "parent": "Deployment"
+    },
+    {
+      "title": "Development Guide",
+      "purpose": "Contributing to Vault Cortex: local development setup (Node.js via nvm, npm run dev, docker-compose.local.yml for building from source), the test suite (vitest with table-driven tests and behavioral spec naming), the structured JSON logging system (logger.ts with auto-captured source locations and the child-logger context chain), and release conventions (conventional commits, automated changelog, GitHub Actions CI/CD). References CONTRIBUTING.md."
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,3 +460,24 @@ description (primary: it carries the descriptive line and is read from the
 merged PR via the API, so it survives even when the squash body is dropped).
 A `breaking-change` PR label or a `!` type marker (`feat(scope)!:`) also work
 as flags.
+
+### Files that track feature surface
+
+Several files outside `src/` reflect the project's feature surface and
+need updating alongside code changes. What to check depends on what
+changed:
+
+| File                                 | Update when…                                                                                                                                             |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `README.md`                          | Tool/prompt count changes, new deployment mode, new feature worth mentioning in the value prop                                                           |
+| `ARCHITECTURE.md`                    | New component, requirement, or design decision; component diagram changes                                                                                |
+| `server.json`                        | Tool/prompt count changes (the `tools` and `prompts` fields)                                                                                             |
+| `assets/social-preview.svg` + `.png` | Tool count changes (rendered in the image); regenerate PNG after SVG edits                                                                               |
+| `.devin/wiki.json`                   | New architectural area (new page), module renamed/moved (update `repo_notes` or `purpose` references), significant tool count jump (update `repo_notes`) |
+| `CONTRIBUTING.md`                    | CI pipeline, repo settings, or release conventions change                                                                                                |
+| `DEPLOY.md`                          | Infrastructure, env vars, or deployment procedure changes                                                                                                |
+
+Not every PR touches these — a new tool in an existing category needs
+a `server.json` + `README.md` count bump but nothing else. A module
+rename needs `.devin/wiki.json` + `ARCHITECTURE.md`. Use the table as
+a checklist, not a mandate to touch every file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,6 +474,8 @@ changed:
 | `server.json`                        | Tool/prompt count changes (the `tools` and `prompts` fields)                                                                                             |
 | `assets/social-preview.svg` + `.png` | Tool count changes (rendered in the image); regenerate PNG after SVG edits                                                                               |
 | `.devin/wiki.json`                   | New architectural area (new page), module renamed/moved (update `repo_notes` or `purpose` references), significant tool count jump (update `repo_notes`) |
+| `deploy/local/` + `deploy/remote/`   | New env var, changed default, new deployment step, or Docker Compose service change — update `.env.example` and `README.md` in the affected directory    |
+| `.env.example` (root)                | New env var or changed default for the Lightsail reference deployment                                                                                    |
 | `CONTRIBUTING.md`                    | CI pipeline, repo settings, or release conventions change                                                                                                |
 | `DEPLOY.md`                          | Infrastructure, env vars, or deployment procedure changes                                                                                                |
 


### PR DESCRIPTION
## Summary

- Adds `.devin/wiki.json` with 2 `repo_notes` (project framing + architecture context) and 19 explicit `pages` organized under a 4-parent hierarchy
- Fixes structural gaps in the [auto-generated DeepWiki](https://deepwiki.com/aliasunder/vault-cortex) (last indexed May 21): the Obsidian markdown parsing layer, link resolution engine, memory system, and CLI were all missing or underrepresented
- Positions the project correctly for DeepWiki's AI — not an Obsidian REST API proxy, SST is a reference deployment not the only path, the parser layer is architecturally significant

### Page hierarchy (19 pages)

```
Overview
Getting Started
CLI
Configuration Reference
Architecture
  ├── Server and Transport
  ├── Authentication and Security
  ├── Obsidian Markdown Parsing  ← new, with page_note on link resolution
  ├── Vault Operations
  ├── Search and Indexing
  └── Memory Layer               ← elevated from auto-wiki's thin coverage
MCP Interface
  ├── Tool Reference (25 tools)
  └── Prompt Reference (3 prompts)
Deployment
  ├── Local Docker
  ├── Remote with Obsidian Sync
  └── AWS Reference Deployment
Development Guide
```

### Why explicit pages over repo_notes-only

The auto-generated wiki (23 pages) had decent tool/deployment coverage but missed domain concepts DeepWiki can't infer from code structure alone — the link resolution engine as a distinct architectural module, the memory layer as a first-class feature (not just "file read"), and the CLI as a user-facing tool. Explicit pages fix this with minimal maintenance cost: the page list maps to stable Phase 1 architectural areas, and new tools/features extend existing categories without config changes.

Schema constraints verified: 19/30 pages, 3/100 notes, max note 1,177/10,000 chars.

## Test plan

- [x] Verify JSON is valid and prettier-formatted
- [x] Confirm all parent references resolve to existing page titles
- [x] Confirm page titles are unique and non-empty
- [ ] After merge, monitor next DeepWiki reindex for improved structure (triggered by the badge from PR #170)

🤖 Generated with [Claude Code](https://claude.com/claude-code)