### PR TITLE
fix(logging): include anchors in vault_delete_span log output

### DIFF
--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -343,6 +343,8 @@ const deleteSpan = async (
 
   logger.info("deleted span", {
     path,
+    startAnchor: truncateForMessage(startAnchor),
+    endAnchor: endAnchor ? truncateForMessage(endAnchor) : undefined,
     removedLines: removedLines.length,
     beforeBytes,
     afterBytes,


### PR DESCRIPTION
## Summary

- Log `startAnchor` and `endAnchor` in the `deleteSpan` info log, truncated to 80 chars (matching the existing `truncateForMessage` convention)
- When `endAnchor` is omitted (single-line deletion), the field is `undefined` and excluded from the JSON output

## Context

An agent used `vault_delete_span` with the wrong `end_anchor` (a table header it meant to keep, not the last line of the block to delete). The inclusive semantics deleted the header, leaving a broken table. The production logs showed *that* a span was deleted and how many lines, but not *which anchors* the agent passed — making it impossible to confirm root cause without reconstructing from the agent's conversation. This adds the missing diagnostic.

## Test plan

- [x] 118 existing `vault-patcher` tests pass unchanged — anchors are logged, not behavioral

🤖 Generated with [Claude Code](https://claude.com/claude-code)