### PR TITLE
fix(ci): scope GHCR cleanup token to job-level packages:write

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -12,12 +12,15 @@ on:
         default: true
         type: boolean
 
+# Top-level token is read-only; the job declares its writes.
 permissions:
-  packages: write
+  contents: read
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Delete untagged GHCR images
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2


### PR DESCRIPTION
## Summary

- Move `packages: write` from **top-level** to **job-level** in
  `ghcr-cleanup.yml`, and set the top-level default to `contents: read`
  (matching every other workflow in the repo)
- This was the only workflow with a top-level write permission, which
  dropped the repo-wide Scorecard Token-Permissions score to 0 and
  cascaded into 7 code scanning alerts across all release workflows

## Scorecard alerts resolved

All 7 open `TokenPermissionsID` alerts:

| # | File | Finding |
|---|------|---------|
| 118 | `ghcr-cleanup.yml:16` | topLevel packages write |
| 117 | `manual_release.yml:120` | jobLevel contents write |
| 116 | `manual_release.yml:96` | jobLevel packages write |
| 115 | `force_deploy.yml:47` | jobLevel packages write |
| 114 | `cli_release.yml:39` | jobLevel contents write |
| 113 | `auto_release.yml:48` | jobLevel packages write |
| 112 | `auto_release.yml:72` | jobLevel contents write |

The 6 job-level alerts (113–117) were only flagged because the repo-wide
score was 0. Those jobs already run under workflows with restrictive
top-level permissions — they're properly scoped least-privilege
escalations.

## Test plan

- [ ] CI passes (no workflow changes affect test matrix)
- [ ] Merge → trigger Scorecard re-scan (`workflow_dispatch` on
  `scorecard.yml`) → verify all 7 alerts close

🤖 Generated with [Claude Code](https://claude.com/claude-code)