### PR TITLE
docs: fix v0.21.0 changelog entry and delete orphan v0.20.3 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,60 +1,10 @@
 # Changelog
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 ## [0.21.0] — 2026-06-21
 
-No notable changes.
+### Features
+
+- Add vault_delete_span for anchor-based block deletion (#166)
 
 ## [0.20.2] — 2026-06-21
 


### PR DESCRIPTION
## Summary

- Replace bare v0.21.0 CHANGELOG entry ("No notable changes") with
  the actual content: `vault_delete_span` (#166)
- Remove ~50 stacked blank lines at the top of CHANGELOG.md left by
  the aborted v0.20.3 + real v0.21.0 insertion sequence
- The orphan `v0.20.3` tag and the GitHub release body were already
  fixed before this commit (tag deleted, release notes updated)

## Context

An accidental patch release was started and cancelled before
publishing. It left behind a `v0.20.3` tag and bump commit between
`v0.20.2` and `v0.21.0`. When the real minor release ran,
`generate-notes.sh` picked `v0.20.3` as the previous tag, saw only
the `release: v0.21.0` bump commit in the range (filtered out), and
produced "No notable changes."

## Test plan

- [x] `v0.20.3` tag deleted from local and remote
- [x] GitHub release notes for v0.21.0 updated
- [ ] CHANGELOG.md v0.21.0 entry shows vault_delete_span (#166)
- [ ] No stacked blank lines at top of CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)