### PR TITLE
docs: restructure README opening, add Why section, GIF context, and security positioning

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@ Vault Cortex replaces it:
 - **Remote access** — Obsidian Sync in Docker keeps the vault current; works from your phone, a remote server, or any MCP client
 - **MCP spec-compliant** — streamable-http transport, OAuth 2.1
 
-See the [README](./README.md#what-is-this) for the full value proposition.
+See the [README](./README.md) for the full value proposition.
 
 This document covers the architecture of the reference deployment — Lightsail,
 API Gateway, SST — but Vault Cortex runs anywhere Docker does.

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ See [`templates/memory/`](./templates/memory/) for memory file examples and the 
 
 ## Authentication
 
-For a server with read/write access to personal notes, authentication is not optional. Vault Cortex implements the full OAuth 2.1 specification. The reference deployment adds defense-in-depth: requests are validated at two independent layers (API Gateway Lambda authorizer + Express middleware). Per [BlueRock's 2026 MCP security analysis](https://www.bluerock.io/use-cases/safely-adopt-mcp), only 8.5% of MCP servers implement OAuth; 41% have no authentication at all.
+For a server with read/write access to personal notes, authentication is not optional. Vault Cortex implements the full OAuth 2.1 specification. The [AWS (SST) deployment](#deployment-options) adds defense-in-depth: requests are validated at two independent layers (API Gateway Lambda authorizer + Express middleware). Per [BlueRock's 2026 MCP security analysis](https://www.bluerock.io/use-cases/safely-adopt-mcp), only 8.5% of MCP servers implement OAuth; 41% have no authentication at all.
 
 Two methods:
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,7 @@
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D24-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/aliasunder/vault-cortex)
-
-</div>
-
-<div align="center">
-
-[![vault-cortex MCP server](https://glama.ai/mcp/servers/aliasunder/vault-cortex/badges/card.svg)](https://glama.ai/mcp/servers/aliasunder/vault-cortex)
+[![vault-cortex MCP server](https://glama.ai/mcp/servers/aliasunder/vault-cortex/badges/score.svg)](https://glama.ai/mcp/servers/aliasunder/vault-cortex)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 <div align="center">
 
 [![CI](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/ci.yml?branch=main&logo=github&label=CI&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-898%2B-brightgreen?logo=vitest&logoColor=white)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
 [![Gitleaks](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/gitleaks.yml?branch=main&logo=github&label=Gitleaks&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/gitleaks.yml)
 [![Trivy](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/trivy.yml?branch=main&logo=github&label=Trivy&cacheSeconds=43200&v=1)](https://github.com/aliasunder/vault-cortex/actions/workflows/trivy.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/aliasunder/vault-cortex?cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/releases)

--- a/README.md
+++ b/README.md
@@ -25,19 +25,11 @@
 
 The typical Obsidian MCP setup requires three moving parts: Obsidian open, a REST API plugin installed, and a separate MCP server wrapping the plugin. Vault Cortex replaces all of that with one Docker container and your vault folder. Deploy on a VPS with Obsidian Sync and the same vault is accessible from your phone, claude.ai, CI, or any remote MCP client.
 
-- **Remote access** — works from your phone, a remote server, or any MCP client via OAuth 2.1. Deploy on a VPS with Obsidian Sync for access from anywhere.
-- **Plugin-free** — Obsidian doesn't need to be running. The server works directly with `.md` files on disk. Headless sync keeps the vault current.
-- **Ranked search** — SQLite FTS5 with BM25 scoring, stemming, phrase matching, and tag/property/folder filtering
-- **Structured memory** — dated entries, section targeting, auto-initialization for AI personalization
-- **Link graph** — backlinks, outgoing links, and orphan detection across the vault
-- **Obsidian-native** — understands frontmatter, wikilinks, tags, headings, and daily notes
-- **Guided workflows** — three built-in prompts that orient a new session to your vault's conventions, review your memory layer as a timeline, or reconcile a day's work. Assembled from live vault content each time you run them.
-
 <table align="center">
   <tr>
-    <td align="center"><strong>Remember</strong></td>
-    <td align="center"><strong>Reason</strong></td>
-    <td align="center"><strong>Save</strong></td>
+    <td align="center"><strong>Search the vault</strong></td>
+    <td align="center"><strong>Reason over notes</strong></td>
+    <td align="center"><strong>Write back to Obsidian</strong></td>
   </tr>
   <tr>
     <td><img src="./assets/demo-remember.gif" width="240" alt="Ask Claude about a past trip — it searches the vault and recalls the route, cities, and highlights"></td>
@@ -47,6 +39,14 @@ The typical Obsidian MCP setup requires three moving parts: Obsidian open, a RES
 </table>
 
 <p align="center"><em>All three demos run on Claude mobile. The vault is on a remote server, not the phone.</em></p>
+
+- **[Remote access](#authentication)** — works from your phone, a remote server, or any MCP client via OAuth 2.1. Deploy on a VPS with Obsidian Sync for access from anywhere.
+- **Plugin-free** — Obsidian doesn't need to be running. The server works directly with `.md` files on disk. Headless sync keeps the vault current.
+- **[Ranked search](#tools-25)** — SQLite FTS5 with BM25 scoring, stemming, phrase matching, and tag/property/folder filtering
+- **[Structured memory](#tools-25)** — dated entries, section targeting, auto-initialization for AI personalization
+- **[Link graph](#tools-25)** — backlinks, outgoing links, and orphan detection across the vault
+- **[Obsidian-native](#properties)** — understands frontmatter, wikilinks, tags, headings, and daily notes
+- **[Guided workflows](#prompts-3)** — three built-in prompts that orient a new session to your vault's conventions, review your memory layer as a timeline, or reconcile a day's work. Assembled from live vault content each time you run them.
 
 ### Roadmap
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ See [`templates/memory/`](./templates/memory/) for memory file examples and the 
 
 ## Authentication
 
-For a server with read/write access to personal notes, authentication is not optional. Vault Cortex implements the full OAuth 2.1 specification with defense-in-depth: every request is validated at two independent layers (Lambda authorizer + Express middleware). Per [BlueRock's 2026 MCP security analysis](https://www.bluerock.io/use-cases/safely-adopt-mcp), only 8.5% of MCP servers implement OAuth; 41% have no authentication at all.
+For a server with read/write access to personal notes, authentication is not optional. Vault Cortex implements the full OAuth 2.1 specification. The reference deployment adds defense-in-depth: requests are validated at two independent layers (API Gateway Lambda authorizer + Express middleware). Per [BlueRock's 2026 MCP security analysis](https://www.bluerock.io/use-cases/safely-adopt-mcp), only 8.5% of MCP servers implement OAuth; 41% have no authentication at all.
 
 Two methods:
 

--- a/README.md
+++ b/README.md
@@ -23,23 +23,7 @@
 
 **Vault Cortex** is a standalone MCP server for [Obsidian](https://obsidian.md) vaults. It reads `.md` files directly. No Obsidian plugins, no running Obsidian, no separate bridge. One Docker container gives any MCP client 25 tools and 3 guided prompts for search, memory, link graph, properties, and daily notes.
 
-Deploy on a VPS with Obsidian Sync and the same vault is accessible from your phone, claude.ai, CI, or any remote MCP client. Protected by OAuth 2.1 with defense-in-depth authentication.
-
-```mermaid
-graph LR
-    subgraph before ["Typical Obsidian MCP setup"]
-        direction LR
-        O["Obsidian<br/>(running)"] --> P["REST API<br/>plugin"] --> M1["MCP server"]
-    end
-    subgraph after ["Vault Cortex"]
-        direction LR
-        D["Docker container"] -->|"read/write"| V[("/vault<br/>.md files")]
-        D -->|"query"| S[("SQLite FTS5")]
-    end
-
-    style before fill:#2d2d2d,stroke:#666,color:#ccc
-    style after fill:#1a3a1a,stroke:#4a4,color:#ccc
-```
+The typical Obsidian MCP setup requires three moving parts: Obsidian open, a REST API plugin installed, and a separate MCP server wrapping the plugin. Vault Cortex replaces all of that with one Docker container and your vault folder. Deploy on a VPS with Obsidian Sync and the same vault is accessible from your phone, claude.ai, CI, or any remote MCP client.
 
 - **Remote access** — works from your phone, a remote server, or any MCP client via OAuth 2.1. Deploy on a VPS with Obsidian Sync for access from anywhere.
 - **Plugin-free** — Obsidian doesn't need to be running. The server works directly with `.md` files on disk. Headless sync keeps the vault current.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The typical Obsidian MCP setup requires three moving parts: Obsidian open, a RES
 
 ## Why Vault Cortex?
 
-Vault Cortex is a standalone knowledge layer for your vault, not an HTTP proxy to a running Obsidian instance. It works directly with `.md` files on disk, runs its own SQLite FTS5 search index, and includes a structured memory system for AI personalization. Deploy on a VPS with Obsidian Sync and the same vault is accessible from any device, protected by OAuth 2.1 with PKCE.
+Vault Cortex is a standalone knowledge layer for your vault, not an HTTP proxy to a running Obsidian instance. It runs its own SQLite FTS5 search index, includes a structured memory system for AI personalization, and protects every connection with OAuth 2.1 (PKCE, dynamic client registration, refresh token rotation).
 
 Built and tested across a 15-day trip through Europe. 30 sessions from a phone, 70+ tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
 

--- a/README.md
+++ b/README.md
@@ -52,17 +52,7 @@ The typical Obsidian MCP setup requires three moving parts: Obsidian open, a RES
 
 ## Why Vault Cortex?
 
-Most Obsidian MCP servers follow one of two patterns. Vault Cortex takes a different approach.
-
-|                       | REST API plugin                 | Direct filesystem | Vault Cortex                                                              |
-| --------------------- | ------------------------------- | ----------------- | ------------------------------------------------------------------------- |
-| **Obsidian required** | Yes, with plugin installed      | No                | No                                                                        |
-| **Remote access**     | Localhost only                  | Localhost only    | Any device via OAuth 2.1                                                  |
-| **Search**            | Delegates to Obsidian or plugin | Basic or none     | SQLite FTS5 with BM25 scoring, stemming, and structured filters           |
-| **Structured memory** | No                              | No                | Dated entries, section targeting, auto-initialization                     |
-| **Link graph**        | Limited or none                 | No                | Backlinks, outgoing links, orphan detection                               |
-| **Guided prompts**    | No                              | No                | 3 prompts assembled from live vault content                               |
-| **Authentication**    | Varies                          | None              | OAuth 2.1 (PKCE, refresh rotation) + static bearer, dual-layer validation |
+Vault Cortex is a standalone knowledge layer for your vault, not an HTTP proxy to a running Obsidian instance. It works directly with `.md` files on disk, runs its own SQLite FTS5 search index, and includes a structured memory system for AI personalization. Deploy on a VPS with Obsidian Sync and the same vault is accessible from any device, protected by OAuth 2.1 with PKCE.
 
 Built and tested across a 15-day trip through Europe. 30 sessions from a phone, 70+ tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <div align="center">
 
 [![CI](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/ci.yml?branch=main&logo=github&label=CI&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-898%2B-brightgreen?logo=vitest&logoColor=white)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
 [![Gitleaks](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/gitleaks.yml?branch=main&logo=github&label=Gitleaks&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/gitleaks.yml)
 [![Trivy](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/trivy.yml?branch=main&logo=github&label=Trivy&cacheSeconds=43200&v=1)](https://github.com/aliasunder/vault-cortex/actions/workflows/trivy.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/aliasunder/vault-cortex?cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/releases)
@@ -21,18 +22,33 @@
 
 </div>
 
-## What is this?
+**Vault Cortex** is a standalone MCP server for [Obsidian](https://obsidian.md) vaults. It reads `.md` files directly. No Obsidian plugins, no running Obsidian, no separate bridge. One Docker container gives any MCP client 25 tools and 3 guided prompts for search, memory, link graph, properties, and daily notes.
 
-**Vault Cortex** gives any MCP client — Claude Desktop, Claude Code, Cursor, OpenCode — full access to your [Obsidian](https://obsidian.md) vault. Search notes, read and write content, query the link graph, manage structured memory, and resolve daily notes — all through 25 tools and 3 guided prompts over a single Docker container.
+Deploy on a VPS with Obsidian Sync and the same vault is accessible from your phone, claude.ai, CI, or any remote MCP client. Protected by OAuth 2.1 with defense-in-depth authentication.
 
-The typical Obsidian + MCP setup requires three moving parts running simultaneously: Obsidian open → Local REST API plugin → a separate MCP server wrapping the REST API. **Vault Cortex** replaces all of that with Docker and your vault folder.
+```mermaid
+graph LR
+    subgraph before ["Typical Obsidian MCP setup"]
+        direction LR
+        O["Obsidian<br/>(running)"] --> P["REST API<br/>plugin"] --> M1["MCP server"]
+    end
+    subgraph after ["Vault Cortex"]
+        direction LR
+        D["Docker container"] -->|"read/write"| V[("/vault<br/>.md files")]
+        D -->|"query"| S[("SQLite FTS5")]
+    end
 
-- **Plugin-free** — Obsidian doesn't need to be running; headless sync keeps the vault current, and the server works directly with `.md` files on disk
-- **Remote access** — works from your phone, a remote server, or any MCP client via OAuth 2.1
+    style before fill:#2d2d2d,stroke:#666,color:#ccc
+    style after fill:#1a3a1a,stroke:#4a4,color:#ccc
+```
+
+- **Remote access** — works from your phone, a remote server, or any MCP client via OAuth 2.1. Deploy on a VPS with Obsidian Sync for access from anywhere.
+- **Plugin-free** — Obsidian doesn't need to be running. The server works directly with `.md` files on disk. Headless sync keeps the vault current.
 - **Ranked search** — SQLite FTS5 with BM25 scoring, stemming, phrase matching, and tag/property/folder filtering
 - **Structured memory** — dated entries, section targeting, auto-initialization for AI personalization
+- **Link graph** — backlinks, outgoing links, and orphan detection across the vault
 - **Obsidian-native** — understands frontmatter, wikilinks, tags, headings, and daily notes
-- **Guided workflows** — three built-in prompts that orient a new session to your vault's conventions, review your memory layer as a timeline, or reconcile a day's work — assembled from live vault content each time you run them
+- **Guided workflows** — three built-in prompts that orient a new session to your vault's conventions, review your memory layer as a timeline, or reconcile a day's work. Assembled from live vault content each time you run them.
 
 <table align="center">
   <tr>
@@ -47,12 +63,30 @@ The typical Obsidian + MCP setup requires three moving parts running simultaneou
   </tr>
 </table>
 
+<p align="center"><em>All three demos run on Claude mobile. The vault is on a remote server, not the phone.</em></p>
+
 ### Roadmap
 
 | Phase | What                                                         | Status   |
 | ----- | ------------------------------------------------------------ | -------- |
 | **1** | Vault CRUD, full-text search (FTS5), memory layer, OAuth 2.1 | Complete |
 | **2** | Semantic search + knowledge graph                            | Planned  |
+
+## Why Vault Cortex?
+
+Most Obsidian MCP servers follow one of two patterns. Vault Cortex takes a different approach.
+
+|                       | REST API plugin                 | Direct filesystem | Vault Cortex                                                              |
+| --------------------- | ------------------------------- | ----------------- | ------------------------------------------------------------------------- |
+| **Obsidian required** | Yes, with plugin installed      | No                | No                                                                        |
+| **Remote access**     | Localhost only                  | Localhost only    | Any device via OAuth 2.1                                                  |
+| **Search**            | Delegates to Obsidian or plugin | Basic or none     | SQLite FTS5 with BM25 scoring, stemming, and structured filters           |
+| **Structured memory** | No                              | No                | Dated entries, section targeting, auto-initialization                     |
+| **Link graph**        | Limited or none                 | No                | Backlinks, outgoing links, orphan detection                               |
+| **Guided prompts**    | No                              | No                | 3 prompts assembled from live vault content                               |
+| **Authentication**    | Varies                          | None              | OAuth 2.1 (PKCE, refresh rotation) + static bearer, dual-layer validation |
+
+Built and tested across a 15-day trip through Europe. 30 sessions from a phone, 70+ tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
 
 ## Quick Start
 
@@ -244,7 +278,9 @@ See [`templates/memory/`](./templates/memory/) for memory file examples and the 
 
 ## Authentication
 
-Two methods, both validated at two layers (Lambda authorizer + Express middleware):
+For a server with read/write access to personal notes, authentication is not optional. Vault Cortex implements the full OAuth 2.1 specification with defense-in-depth: every request is validated at two independent layers (Lambda authorizer + Express middleware). Per [BlueRock's 2026 MCP security analysis](https://www.bluerock.io/use-cases/safely-adopt-mcp), only 8.5% of MCP servers implement OAuth; 41% have no authentication at all.
+
+Two methods:
 
 | Method            | Used by                                                  | Token format         |
 | ----------------- | -------------------------------------------------------- | -------------------- |


### PR DESCRIPTION
## Summary

- **Opening restructure**: dropped the "What is this?" heading, rewrote the opening to lead with the architectural distinction (standalone, plugin-free, remote-capable) and the 3-parts-to-1-container contrast
- **GIFs moved above feature list**: demos now appear right after the opening text (claim then proof). Column headers changed from abstract verbs to actions ("Search the vault", "Reason over notes", "Write back to Obsidian"). Caption contextualizes that demos run on Claude mobile against a remote vault.
- **Feature bullets with anchor links**: each capability links to its detailed section further down (Tools, Prompts, Properties, Authentication)
- **"Why Vault Cortex?" section**: standalone positioning paragraph framing vault-cortex as a knowledge layer, not an HTTP proxy. Dogfooding line with real usage numbers from a 15-day Europe trip.
- **Authentication section**: opens with trust context, scopes defense-in-depth to the AWS (SST) deployment path, and cites the BlueRock 2026 MCP security stat (8.5% OAuth adoption, 41% zero auth)
- **Glama card replaced with inline score badge**: A/A/A score badge in the badge row instead of a full card block
- **Broken anchor fixed**: ARCHITECTURE.md linked to the removed `#what-is-this` heading

## Test plan

- [ ] Verify GIF table and caption render correctly on GitHub (light and dark mode)
- [ ] Verify anchor links in feature bullets resolve to the correct sections
- [ ] Confirm BlueRock link resolves
- [ ] Confirm Glama score badge renders inline
- [ ] Prettier passes (`npm run prettier:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)