### PR TITLE
docs: sync AGENTS.md with tool group modules + TDQS lifts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,8 +231,9 @@ root logger (src/logger.ts)
 - `server.ts` creates a **session logger** when a new MCP session
   initializes, adding `sessionId` + `clientIp`
 - Each tool group module (`mcp-core/tools/*.ts`) creates a **request
-  logger** per tool call, adding `requestId` + `tool` name from the
-  MCP SDK's `RequestHandlerExtra`
+  logger** per tool call, adding `requestId` (from the MCP SDK's
+  `RequestHandlerExtra`) + `tool` name (from the module's own
+  `TOOL_NAMES` constant)
 - Data-layer functions (`vault-filesystem`, `vault-patcher`,
   `note-mover`, `memory-store`, `search-index`) take the logger as a
   **required** second argument (two-arg pattern: `(params, logger)`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,14 @@ src/
       daily-notes.ts                   # Daily note config reader + path resolver
     mcp-core/                          # MCP protocol surface
       mcp-router.ts                    # /mcp session routes + transport lifecycle
-      tool-definitions.ts              # MCP tool registrations + Zod schemas
+      tool-definitions.ts              # Tool orchestrator — TOOL_NAMES + conditional group registration
       prompt-definitions.ts            # MCP prompt registrations + Zod arg schemas
+      tools/                           # Tool group modules (one per data-layer domain)
+        tool-helpers.ts                # Shared ToolRegistrationContext type + safeHandler
+        vault-crud-tools.ts            # 9 tools: read, write, patch, replace, delete, move
+        search-tools.ts                # 11 tools: search, tags, properties, graph queries
+        memory-tools.ts                # 4 tools: get/update/list/delete memory
+        daily-note-tools.ts            # 1 tool: get daily note
     search/                            # SQLite FTS5 indexing + file watching
       search-index.ts                  # SQLite FTS5 factory (tags, folders, etc)
       file-watcher.ts                  # chokidar -> keeps index current
@@ -121,8 +127,14 @@ on**, not just its topic:
   stays in `vault-filesystem.ts`. "Mechanically generic" (an atomic write works on
   any file) isn't enough to demote something to `utils/` if it's load-bearing
   vault-I/O policy.
-- **`mcp-core/`** — the MCP protocol surface (`mcp-router`, `tool-definitions`,
-  `prompt-definitions`).
+- **`mcp-core/`** — the MCP protocol surface. `tool-definitions.ts` is the
+  orchestrator that composes `TOOL_NAMES` from four domain group modules under
+  `mcp-core/tools/` (vault-crud, search, memory, daily-note) and calls each
+  register function — conditionally skipping memory tools when `MEMORY_ENABLED`
+  is `false`. Each group module is self-contained: its own tool name constants,
+  register function, and data-layer imports. Shared helpers (`safeHandler`,
+  `formatNoteMetadata`, `ToolRegistrationContext` type) live in `tool-helpers.ts`.
+  `prompt-definitions.ts` registers the MCP prompts (not yet split into groups).
 - **`search/`** — SQLite FTS5 index + file watcher. **`oauth/`** — the OAuth 2.1
   server (distinct from the shared `src/auth.ts` token utilities).
 - **`utils/`** (at `src/`) — generic cross-cutting helpers.
@@ -218,9 +230,9 @@ root logger (src/logger.ts)
 
 - `server.ts` creates a **session logger** when a new MCP session
   initializes, adding `sessionId` + `clientIp`
-- `tool-definitions.ts` creates a **request logger** per tool call,
-  adding `requestId` + `tool` name from the MCP SDK's
-  `RequestHandlerExtra`
+- Each tool group module (`mcp-core/tools/*.ts`) creates a **request
+  logger** per tool call, adding `requestId` + `tool` name from the
+  MCP SDK's `RequestHandlerExtra`
 - Data-layer functions (`vault-filesystem`, `vault-patcher`,
   `note-mover`, `memory-store`, `search-index`) take the logger as a
   **required** second argument (two-arg pattern: `(params, logger)`)
@@ -363,8 +375,8 @@ Two naming layers — MCP (JSON wire format) and TypeScript (internal):
 - **Internal TypeScript** uses `camelCase` — function params,
   local variables, internal types that never reach the wire.
   Examples: `oldText`, `headingLevel`, `snippetTokens`.
-- The mapping happens in `tool-definitions.ts` handlers:
-  `replaceAllOccurrences: replace_all_occurrences`.
+- The mapping happens in each tool group module's handlers
+  (`mcp-core/tools/*.ts`): `replaceAllOccurrences: replace_all_occurrences`.
 - Types that ARE the JSON response shape (`PropertyKeyInfo`,
   `SearchResult`, `NoteMetadata`) use `snake_case` for any
   multi-word fields to match the wire format. Single-word fields

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -227,13 +227,21 @@ Example: vault_recent_notes({ sort_by: "modified", limit: 10 })
 When to use: Catching up on vault changes or finding recent work.
 Prefer vault_search for content-based discovery. Prefer vault_search_by_folder for browsing a specific folder.
 
+Errors:
+- An empty vault returns an empty array, not an error.
+
 Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, bytes, leading_callout?, additional_properties), sorted by chosen timestamp. bytes is the on-disk file size.`,
       inputSchema: {
         sort_by: z
           .enum(["created", "modified"])
           .optional()
-          .describe('Sort field: "created" or "modified" (default "modified")'),
-        limit: z.number().optional().describe("Max results (default 20)"),
+          .describe(
+            'Sort by "created" (frontmatter created timestamp) or "modified" (filesystem mtime). Default "modified". Notes without a created property are excluded from created-sorted results.',
+          ),
+        limit: z
+          .number()
+          .optional()
+          .describe("Max results to return (default 20)"),
       },
       annotations: {
         readOnlyHint: true,

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -272,6 +272,7 @@ Errors:
 
 Obsidian syntax: Content is rendered as Obsidian Flavored Markdown with no escaping applied. Beyond standard Markdown, watch for: #word (no space) = tag, [[ = wikilink, %% = comment block. Escape with \\# or \\[[ when unintentional.
 Structural note: inserting heading-level content (e.g. ## New Section) changes the note's section structure — future patch calls targeting headings may resolve differently.
+Table note: when prepending/appending a row to an existing markdown table, send only the data row (e.g. "| cell1 | cell2 |") — do not include the table header or separator row, which already exist. A duplicated header splits the table in two.
 
 Returns: Confirmation message.`,
       inputSchema: {


### PR DESCRIPTION
## Summary

AGENTS.md and tool descriptions fell out of sync with PR \#185 (tool group module refactor). This PR catches up the documentation and fixes two TDQS gaps.

- **AGENTS.md structure tree** — added `mcp-core/tools/` directory with all 5 group modules; updated `tool-definitions.ts` comment to reflect its new orchestrator role
- **AGENTS.md module layering prose** — expanded `mcp-core/` description to explain the orchestrator + group module pattern and `MEMORY_ENABLED` conditional
- **AGENTS.md logger chain** — clarified that `requestId` comes from `RequestHandlerExtra` and `tool` comes from the module's own `TOOL_NAMES` constant (not both from the SDK)
- **AGENTS.md MCP naming conventions** — updated "mapping happens in" reference from `tool-definitions.ts` to `mcp-core/tools/*.ts`
- **`vault_patch_note` description** — added table-row guidance: when prepending/appending to an existing table, send only the data row — a duplicated header splits the table in two
- **`vault_recent_notes` TDQS lift** — enriched `sort_by` parameter (created vs modified semantics + exclusion behavior), added `Errors:` empty-result contract. TDQS 3.90 → 4.25 (+0.35)

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 941 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)