### PR TITLE
docs: align server.json and package.json descriptions with README positioning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,7 +136,7 @@ jobs:
           # page). Mirror the server.json / Dockerfile description here.
           annotations: |
             index:org.opencontainers.image.title=vault-cortex
-            index:org.opencontainers.image.description=MCP server for Obsidian vaults — search, memory, link graph, 25 tools, OAuth-protected.
+            index:org.opencontainers.image.description=Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1.
             index:org.opencontainers.image.source=https://github.com/aliasunder/vault-cortex
             index:org.opencontainers.image.licenses=MIT
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0 VAULT_PATH=/vault INDEX_DB_PATH=/
 # set in deploy.yml — keep that description and the one here in sync.
 LABEL io.modelcontextprotocol.server.name="io.github.aliasunder/vault-cortex" \
       org.opencontainers.image.title="vault-cortex" \
-      org.opencontainers.image.description="MCP server for Obsidian vaults — search, memory, link graph, 25 tools, OAuth-protected." \
+      org.opencontainers.image.description="Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1." \
       org.opencontainers.image.source="https://github.com/aliasunder/vault-cortex" \
       org.opencontainers.image.licenses="MIT"
 COPY --from=deps  /app/node_modules ./node_modules

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vault-cortex",
   "version": "0.22.0",
   "private": true,
-  "description": "Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Context Protocol",
+  "description": "Standalone MCP server for Obsidian vaults — plugin-free search, memory, link graph, and daily notes over Streamable HTTP",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.aliasunder/vault-cortex",
   "title": "Vault Cortex",
-  "description": "MCP server for Obsidian vaults — search, memory, links, 25 tools + 3 prompts, OAuth-protected.",
+  "description": "Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1.",
   "version": "0.22.0",
   "websiteUrl": "https://github.com/aliasunder/vault-cortex",
   "repository": {


### PR DESCRIPTION
## Summary

- **server.json** description updated from generic "MCP server for Obsidian vaults" to "Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1." (89 chars, under the 100-char schema limit). This feeds the MCP registry listing.
- **package.json** description updated from "Remote MCP server that exposes an Obsidian vault over HTTPS via the Model Context Protocol" to "Standalone MCP server for Obsidian vaults — plugin-free search, memory, link graph, and daily notes over Streamable HTTP". Fixes two inaccuracies: "Remote" (it's local or remote) and "HTTPS" (local mode is HTTP).

Both now match the hero positioning from the README rewrite (PR #184): **standalone** and **plugin-free** as the two lead differentiators.

## Context

Audit of all messaging surfaces found the README, llms-install.md, wiki.json, and DeepWiki badge are current, but server.json and package.json still carried pre-rewrite copy. The social preview has been uploaded manually. mcp.so listing and the Shared Strings task note have also been updated separately (vault-side).

## Test plan

- [x] npm run build passes (no runtime impact — metadata only)
- [x] npx mcp-publisher validate passes with the new server.json description
- [x] Verify server.json description is <= 100 chars (confirmed: 89)

🤖 Generated with [Claude Code](https://claude.com/claude-code)