### PR TITLE
docs: tighten "Why Vault Cortex?" and add a Contents nav row

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 </div>
 
-**Vault Cortex** is a standalone MCP server for [Obsidian](https://obsidian.md) vaults. Most Obsidian MCP servers wrap the Obsidian REST API plugin, which means they only work while the desktop app is open. Vault Cortex takes the opposite approach: it reads your `.md` files directly and owns the whole stack, with its own SQLite search index, a heading-aware memory layer for AI personalization, and OAuth 2.1 authentication that few MCP servers implement. One Docker container gives any MCP client 25 tools and 3 guided prompts, from your phone to claude.ai.
+**Vault Cortex** is a standalone MCP server for [Obsidian](https://obsidian.md) vaults. It reads your `.md` files directly, so the Obsidian desktop app never has to be running. It brings its own SQLite search index, a memory layer for AI personalization, and OAuth 2.1 authentication that few MCP servers implement. One Docker container gives any MCP client 25 tools and 3 guided prompts, from your phone to claude.ai.
 
 **Contents** — [Why Vault Cortex?](#why-vault-cortex) · [Quick Start](#quick-start) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Properties](#properties) · [Configuration](#configuration) · [Authentication](#authentication) · [How It Works](#how-it-works) · [Deployment](#deployment-options)
 
@@ -37,7 +37,7 @@
 
 <p align="center"><em>All three demos run on Claude mobile. The vault is on a remote server, not the phone.</em></p>
 
-Built and tested across a 15-day trip through Europe. 30 sessions from a phone, 70+ tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
+Built and tested across a 15-day trip through Europe. 30+ sessions from a phone, 70+ tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
 
 - **[Remote access](#authentication)** — works from your phone, a remote server, or any MCP client via OAuth 2.1. Deploy on a VPS with Obsidian Sync for access from anywhere.
 - **Plugin-free** — Obsidian doesn't need to be running. The server works directly with `.md` files on disk. Headless sync keeps the vault current.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@
 
 </div>
 
-**Vault Cortex** is a standalone MCP server for [Obsidian](https://obsidian.md) vaults. It reads `.md` files directly. No Obsidian plugins, no running Obsidian, no separate bridge. One Docker container gives any MCP client 25 tools and 3 guided prompts for search, memory, link graph, properties, and daily notes.
+**Vault Cortex** is a standalone MCP server for [Obsidian](https://obsidian.md) vaults. Most Obsidian MCP servers wrap the Obsidian REST API plugin, which means they only work while the desktop app is open. Vault Cortex takes the opposite approach: it reads your `.md` files directly and owns the whole stack, with its own SQLite search index, a heading-aware memory layer for AI personalization, and OAuth 2.1 authentication that few MCP servers implement. One Docker container gives any MCP client 25 tools and 3 guided prompts, from your phone to claude.ai.
 
-The typical Obsidian MCP setup requires three moving parts: Obsidian open, a REST API plugin installed, and a separate MCP server wrapping the plugin. Vault Cortex replaces all of that with one Docker container and your vault folder. Deploy on a VPS with Obsidian Sync and the same vault is accessible from your phone, claude.ai, CI, or any remote MCP client.
+**Contents** — [Why Vault Cortex?](#why-vault-cortex) · [Quick Start](#quick-start) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Properties](#properties) · [Configuration](#configuration) · [Authentication](#authentication) · [How It Works](#how-it-works) · [Deployment](#deployment-options)
+
+## Why Vault Cortex?
 
 <table align="center">
   <tr>
@@ -51,8 +53,6 @@ Built and tested across a 15-day trip through Europe. 30 sessions from a phone, 
 | ----- | ------------------------------------------------------------ | -------- |
 | **1** | Vault CRUD, full-text search (FTS5), memory layer, OAuth 2.1 | Complete |
 | **2** | Semantic search + knowledge graph                            | Planned  |
-
-**Contents** — [Quick Start](#quick-start) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Properties](#properties) · [Configuration](#configuration) · [Authentication](#authentication) · [How It Works](#how-it-works) · [Deployment](#deployment-options)
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ The typical Obsidian MCP setup requires three moving parts: Obsidian open, a RES
 | **1** | Vault CRUD, full-text search (FTS5), memory layer, OAuth 2.1 | Complete |
 | **2** | Semantic search + knowledge graph                            | Planned  |
 
+**Contents** — [Why Vault Cortex?](#why-vault-cortex) · [Quick Start](#quick-start) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Properties](#properties) · [Configuration](#configuration) · [Authentication](#authentication) · [How It Works](#how-it-works) · [Deployment](#deployment-options)
+
 ## Why Vault Cortex?
 
-Vault Cortex is a standalone knowledge layer for your vault, not an HTTP proxy to a running Obsidian instance. It runs its own SQLite FTS5 search index, includes a structured memory system for AI personalization, and protects every connection with OAuth 2.1 (PKCE, dynamic client registration, refresh token rotation). Three built-in prompts pull from the search index, link graph, and memory layer together — surfacing vault health, reviewing memory coverage, and reconciling daily work in one view.
+Vault Cortex is a standalone knowledge layer for your vault, not an HTTP proxy to a running Obsidian instance. Servers built on Obsidian's REST API route every read, write, and search through a running Obsidian; Vault Cortex reads `.md` files directly and owns its own search index, so it runs fully headless — and adds a structured memory layer plus prompts that fuse search, links, and memory in one pass.
 
 Built and tested across a 15-day trip through Europe. 30 sessions from a phone, 70+ tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
 
@@ -246,7 +248,7 @@ See [`templates/memory/`](./templates/memory/) for memory file examples and the 
 
 ## Authentication
 
-For a server with read/write access to personal notes, authentication is not optional. Vault Cortex implements the full OAuth 2.1 specification. The [AWS (SST) deployment](#deployment-options) adds defense-in-depth: requests are validated at two independent layers (API Gateway Lambda authorizer + Express middleware). Per [BlueRock's 2026 MCP security analysis](https://www.bluerock.io/use-cases/safely-adopt-mcp), only 8.5% of MCP servers implement OAuth; 41% have no authentication at all.
+For a server with read/write access to personal notes, authentication is not optional. Vault Cortex implements the full OAuth 2.1 specification, including PKCE and refresh-token rotation. The [AWS (SST) deployment](#deployment-options) adds defense-in-depth: requests are validated at two independent layers (API Gateway Lambda authorizer + Express middleware). Per [BlueRock's 2026 MCP security analysis](https://www.bluerock.io/use-cases/safely-adopt-mcp), only 8.5% of MCP servers implement OAuth; 41% have no authentication at all.
 
 Two methods:
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The typical Obsidian MCP setup requires three moving parts: Obsidian open, a RES
 
 <p align="center"><em>All three demos run on Claude mobile. The vault is on a remote server, not the phone.</em></p>
 
+Built and tested across a 15-day trip through Europe. 30 sessions from a phone, 70+ tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
+
 - **[Remote access](#authentication)** — works from your phone, a remote server, or any MCP client via OAuth 2.1. Deploy on a VPS with Obsidian Sync for access from anywhere.
 - **Plugin-free** — Obsidian doesn't need to be running. The server works directly with `.md` files on disk. Headless sync keeps the vault current.
 - **[Ranked search](#tools-25)** — SQLite FTS5 with BM25 scoring, stemming, phrase matching, and tag/property/folder filtering
@@ -50,13 +52,7 @@ The typical Obsidian MCP setup requires three moving parts: Obsidian open, a RES
 | **1** | Vault CRUD, full-text search (FTS5), memory layer, OAuth 2.1 | Complete |
 | **2** | Semantic search + knowledge graph                            | Planned  |
 
-**Contents** — [Why Vault Cortex?](#why-vault-cortex) · [Quick Start](#quick-start) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Properties](#properties) · [Configuration](#configuration) · [Authentication](#authentication) · [How It Works](#how-it-works) · [Deployment](#deployment-options)
-
-## Why Vault Cortex?
-
-Vault Cortex is a standalone knowledge layer for your vault, not an HTTP proxy to a running Obsidian instance. Servers built on Obsidian's REST API route every read, write, and search through a running Obsidian; Vault Cortex reads `.md` files directly and owns its own search index, so it runs fully headless — and adds a structured memory layer plus prompts that fuse search, links, and memory in one pass.
-
-Built and tested across a 15-day trip through Europe. 30 sessions from a phone, 70+ tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
+**Contents** — [Quick Start](#quick-start) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Properties](#properties) · [Configuration](#configuration) · [Authentication](#authentication) · [How It Works](#how-it-works) · [Deployment](#deployment-options)
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 </div>
 
-**Vault Cortex** is a standalone MCP server for [Obsidian](https://obsidian.md) vaults. It reads your `.md` files directly, so the Obsidian desktop app never has to be running. It brings its own SQLite search index, a memory layer for AI personalization, and OAuth 2.1 authentication that few MCP servers implement. One Docker container gives any MCP client 25 tools and 3 guided prompts, from your phone to claude.ai.
+**Vault Cortex** is a standalone MCP server that gives any AI assistant a way into your [Obsidian](https://obsidian.md) vault: search it, reason across it, and write back to it, without Obsidian running and without your notes leaving a server you control. It indexes every note for ranked full-text search, remembers what matters about you across sessions, and guards every connection with OAuth 2.1, [still rare among MCP servers](#authentication). It all runs in one Docker container, reachable from your laptop or your phone.
 
 **Contents** — [Why Vault Cortex?](#why-vault-cortex) · [Quick Start](#quick-start) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Properties](#properties) · [Configuration](#configuration) · [Authentication](#authentication) · [How It Works](#how-it-works) · [Deployment](#deployment-options)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 </div>
 
-**Vault Cortex** is a standalone MCP server that gives any AI assistant a way into your [Obsidian](https://obsidian.md) vault: search it, reason across it, and write back to it, without Obsidian running and without your notes leaving a server you control. It indexes every note for ranked full-text search, remembers what matters about you across sessions, and guards every connection with OAuth 2.1, [still rare among MCP servers](#authentication). It all runs in one Docker container, reachable from your laptop or your phone.
+**Vault Cortex** is a standalone MCP server that gives any AI assistant a way into your [Obsidian](https://obsidian.md) vault: search it, reason across it, and write back to it, without Obsidian running and without your notes leaving a server you control. It indexes every note for ranked full-text search, remembers what matters about you across sessions, and guards every connection with [OAuth 2.1](#authentication), the emerging standard for secure MCP access. It all runs in one Docker container, reachable from your laptop or your phone.
 
 **Contents** — [Why Vault Cortex?](#why-vault-cortex) · [Quick Start](#quick-start) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Properties](#properties) · [Configuration](#configuration) · [Authentication](#authentication) · [How It Works](#how-it-works) · [Deployment](#deployment-options)
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 **Vault Cortex** is a standalone MCP server that gives any AI assistant a way into your [Obsidian](https://obsidian.md) vault: search it, reason across it, and write back to it, without Obsidian running and without your notes leaving a server you control. It indexes every note for ranked full-text search, remembers what matters about you across sessions, and guards every connection with [OAuth 2.1](#authentication), the emerging standard for secure MCP access. It all runs in one Docker container, reachable from your laptop or your phone.
 
-**Contents** — [Why Vault Cortex?](#why-vault-cortex) · [Quick Start](#quick-start) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Properties](#properties) · [Configuration](#configuration) · [Authentication](#authentication) · [How It Works](#how-it-works) · [Deployment](#deployment-options)
+**Contents** — [What you get](#what-you-get) · [Quick Start](#quick-start) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Properties](#properties) · [Configuration](#configuration) · [Authentication](#authentication) · [How It Works](#how-it-works) · [Deployment](#deployment-options)
 
-## Why Vault Cortex?
+## What you get
 
 <table align="center">
   <tr>


### PR DESCRIPTION
Three small README edits to make the front door read cleaner and navigate faster.

## What changed

- **Tightened the "Why Vault Cortex?" opening.** The first paragraph used to restate the intro and re-list the feature bullets (search index, memory, OAuth, prompts) — capabilities each already covered in their own section. It now states the one architectural distinction instead: Vault Cortex reads `.md` files directly and owns its own search index, rather than proxying every read/write/search through a running Obsidian. The dogfooding paragraph below it is unchanged.
- **Added a one-line Contents row** above the first section. GitHub's built-in table of contents is tucked behind an icon that's easy to miss — especially on mobile. A visible `Contents — …` row links the high-traffic sections (Quick Start, Tools, Prompts, Properties, Configuration, Authentication, How It Works, Deployment) directly.
- **Kept the OAuth spec detail** (PKCE, refresh-token rotation) by moving it into the Authentication section, where it sits next to the rest of the auth model rather than in the positioning paragraph.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5Mn5QWV9uyXobzm8fuYXg)_