### PR TITLE
docs(tools): improve TDQS scores and cross-tool discoverability

### DIFF
--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -156,6 +156,39 @@ describe("registerTools", () => {
     expect(config.description).toContain("keys set to null removed")
   })
 
+  it("vault_recent_notes description documents sorting behavior", () => {
+    const [, config] = findCall(TOOL_NAMES.VAULT_RECENT_NOTES)!
+    expect(config.description).toContain("Sorting behavior:")
+    expect(config.description).toContain("sort to the bottom")
+  })
+
+  it("vault_read_note description cross-references graph tools", () => {
+    const [, config] = findCall(TOOL_NAMES.VAULT_READ_NOTE)!
+    expect(config.description).toContain("vault_get_backlinks")
+    expect(config.description).toContain("vault_get_outgoing_links")
+  })
+
+  it("vault_search_by_property parameters cross-reference discovery tools", () => {
+    const [, config] = findCall(TOOL_NAMES.VAULT_SEARCH_BY_PROPERTY)!
+    expect(config.description).toContain("vault_list_property_keys")
+    expect(config.description).toContain("vault_list_property_values")
+  })
+
+  it("vault_list_notes description cross-references vault_read_note", () => {
+    const [, config] = findCall(TOOL_NAMES.VAULT_LIST_NOTES)!
+    expect(config.description).toContain("vault_read_note")
+  })
+
+  it("vault_get_daily_note description cross-references vault_recent_notes", () => {
+    const [, config] = findCall(TOOL_NAMES.VAULT_GET_DAILY_NOTE)!
+    expect(config.description).toContain("vault_recent_notes")
+  })
+
+  it("vault_search_by_folder description cross-references graph tools", () => {
+    const [, config] = findCall(TOOL_NAMES.VAULT_SEARCH_BY_FOLDER)!
+    expect(config.description).toContain("vault_get_backlinks")
+  })
+
   it("every tool has all 4 annotation hints", () => {
     for (const [, config] of calls) {
       const annotations = config.annotations!

--- a/src/vault-mcp/mcp-core/tools/daily-note-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/daily-note-tools.ts
@@ -24,7 +24,7 @@ export const registerDailyNoteTools = ({
 
 Example: vault_get_daily_note({ date: "2026-05-13" })
 
-When to use: When you need today's or a specific date's daily note. Handles path resolution automatically using the vault's Obsidian config — you don't need to know the folder name or filename format. To append content to a daily note section, use the returned path with vault_patch_note.
+When to use: When you need today's or a specific date's daily note. Handles path resolution automatically using the vault's Obsidian config — you don't need to know the folder name or filename format. To append content to a daily note section, use the returned path with vault_patch_note. Use vault_recent_notes to see what else changed on the same day.
 
 Errors:
 - "invalid date" — use YYYY-MM-DD format (e.g. "2026-05-13")

--- a/src/vault-mcp/mcp-core/tools/daily-note-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/daily-note-tools.ts
@@ -24,7 +24,7 @@ export const registerDailyNoteTools = ({
 
 Example: vault_get_daily_note({ date: "2026-05-13" })
 
-When to use: When you need today's or a specific date's daily note. Handles path resolution automatically using the vault's Obsidian config — you don't need to know the folder name or filename format. To append content to a daily note section, use the returned path with vault_patch_note. Use vault_recent_notes to see what else changed on the same day.
+When to use: When you need today's or a specific date's daily note. Handles path resolution automatically using the vault's Obsidian config — you don't need to know the folder name or filename format. To append content to a daily note section, use the returned path with vault_patch_note. Use vault_recent_notes to review recent vault activity around a date (not date-filtered — returns globally recent notes).
 
 Errors:
 - "invalid date" — use YYYY-MM-DD format (e.g. "2026-05-13")

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -229,25 +229,34 @@ Returns: JSON array of { tag, count } objects.`,
       description: `List recently modified or created notes, sorted by timestamp. Returns the most recent notes first — does not filter by date range.
 
 Example: vault_recent_notes({ sort_by: "modified", limit: 10 })
+Example: vault_recent_notes({ sort_by: "created", limit: 5 })
+Example: vault_recent_notes({}) — defaults to modified-sorted, 20 results.
 
-When to use: Catching up on vault changes or finding recent work.
+When to use: Catching up on vault changes, finding recent work, or orienting after a break. Pair with vault_read_note to read a note you find here.
 Prefer vault_search for content-based discovery. Prefer vault_search_by_folder for browsing a specific folder.
+
+Sorting behavior:
+- "modified" (default) — sorts by filesystem mtime, which updates on any file write (content edits, property changes, or sync touches).
+- "created" — sorts by the frontmatter created property (ISO timestamp). Notes without a created property sort to the bottom, not excluded — so with a small limit you may see only notes that have the property.
 
 Errors:
 - An empty vault returns an empty array, not an error.
+- Sorting by "created" with a small limit may return fewer relevant results when many notes lack a created property — increase limit or use "modified" for broader coverage.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, bytes, leading_callout?, additional_properties), sorted by chosen timestamp. bytes is the on-disk file size.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, bytes, leading_callout?, additional_properties), sorted by chosen timestamp descending. bytes is the on-disk file size.`,
       inputSchema: {
         sort_by: z
           .enum(["created", "modified"])
           .optional()
           .describe(
-            'Sort by "created" (frontmatter created timestamp) or "modified" (filesystem mtime). Default "modified". Notes without a created property are excluded from created-sorted results.',
+            'Sort by "created" (frontmatter created timestamp) or "modified" (filesystem mtime). Default "modified". Notes without a created property sort to the bottom of created-sorted results — with a small limit they may not appear at all.',
           ),
         limit: z
           .number()
           .optional()
-          .describe("Max results to return (default 20)"),
+          .describe(
+            "Max results to return (default 20). When sorting by created, notes without a created property sort last — a small limit may return fewer notes than expected.",
+          ),
       },
       annotations: {
         readOnlyHint: true,
@@ -282,7 +291,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
 Example: vault_search_by_folder({ folder: "Projects" })${config.memoryEnabled ? ` or vault_search_by_folder({ folder: "${config.memoryDir}", recursive: false })` : ""}
 
 When to use: Exploring a folder's contents with full context for vault orientation.
-Prefer vault_list_notes when you only need paths. Prefer vault_search when you have a text query.
+Prefer vault_list_notes when you only need paths. Prefer vault_search when you have a text query. Use vault_get_backlinks or vault_get_outgoing_links to explore how notes in a folder connect to the rest of the vault.
 
 Parameters:
 - folder is matched as a path prefix; pass it without a trailing slash ("Projects").
@@ -434,15 +443,22 @@ Returns: JSON array of { value, count } sorted by count descending.`,
 Example: vault_search_by_property({ key: "status", value: "in-progress" })
 
 When to use: Finding notes by metadata when you don't have a text query. Fills the gap where vault_search requires search text.
-Prefer vault_search when you also have a text query (it supports property filters too). Prefer vault_search_by_tag for tag-specific queries (supports hierarchical prefix matching).
+Prefer vault_search when you also have a text query (it supports property filters too). Prefer vault_search_by_tag for tag-specific queries (supports hierarchical prefix matching). Use vault_list_property_keys to discover valid keys and vault_list_property_values to see what values a key takes.
 
 Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, bytes, leading_callout?, additional_properties), sorted by most recently modified. bytes is the on-disk file size.`,
       inputSchema: {
-        key: z.string().min(1).describe("Property key name"),
+        key: z
+          .string()
+          .min(1)
+          .describe(
+            'Property key name (e.g. "status", "type"). Use vault_list_property_keys to discover valid keys.',
+          ),
         value: z
           .string()
           .min(1)
-          .describe("Value to match (exact, case-sensitive)"),
+          .describe(
+            "Value to match (exact, case-sensitive). Use vault_list_property_values to discover valid values for a key.",
+          ),
         folder: z.string().min(1).optional().describe("Restrict to a folder"),
         limit: z.number().optional().describe("Max results (default 20)"),
       },

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -241,7 +241,7 @@ Sorting behavior:
 
 Errors:
 - An empty vault returns an empty array, not an error.
-- Sorting by "created" with a small limit may return fewer relevant results when many notes lack a created property — increase limit or use "modified" for broader coverage.
+- Sorting by "created" with a small limit: notes without a created property sort last and may fall outside the window — increase limit or use "modified" for broader coverage.
 
 Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, bytes, leading_callout?, additional_properties), sorted by chosen timestamp descending. bytes is the on-disk file size.`,
       inputSchema: {
@@ -255,7 +255,7 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
           .number()
           .optional()
           .describe(
-            "Max results to return (default 20). When sorting by created, notes without a created property sort last — a small limit may return fewer notes than expected.",
+            "Max results to return (default 20). When sorting by created, notes without a created property sort last and may fall outside a small limit.",
           ),
       },
       annotations: {

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -44,7 +44,7 @@ Example: vault_read_note({ path: "TASKS.md", heading: "Active" })
 Example: vault_read_note({ path: "TASKS.md", heading: "Done", heading_level: 2 }) // disambiguate when several "Done" headings exist
 
 When to use: You know the exact path and need a specific note's content. For a large note (a long board or doc), use outline: true to see its headings, then heading: "..." to read just the one section you need — both far cheaper than pulling the whole file. Use properties_only: true when you only need properties.
-Prefer vault_search when you don't know the path.${config.memoryEnabled ? ` Prefer vault_get_memory for ${config.memoryDir}/ files (returns content without properties).` : ""} To edit a section you've read, use vault_patch_note.
+Prefer vault_search when you don't know the path.${config.memoryEnabled ? ` Prefer vault_get_memory for ${config.memoryDir}/ files (returns content without properties).` : ""} To edit a section you've read, use vault_patch_note. To explore what links to this note or what it links to, use vault_get_backlinks and vault_get_outgoing_links.
 
 Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section.
 
@@ -530,7 +530,7 @@ Returns: Confirmation message with the number of lines removed and a truncated p
 Example: vault_list_notes({ folder: "Projects" }) or vault_list_notes({ glob: "**/*session-log*.md" })
 
 When to use: Browsing what exists in a folder by filename, or finding notes matching a path pattern.
-Prefer vault_search_by_folder when you need metadata (tags, type, related) along with paths. Prefer vault_search for content-based discovery.
+Prefer vault_search_by_folder when you need metadata (tags, type, related) along with paths. Prefer vault_search for content-based discovery. Use vault_read_note to read a note from the results.
 
 Returns: JSON array of vault-relative paths.`,
       inputSchema: {

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -1083,6 +1083,7 @@ export const createSearchIndex = (dbPath: string) => {
          AND CAST(json_extract(n.properties, '$.' || @key) AS TEXT) = @value)
       )
       ${folderCondition}
+      ORDER BY mtime DESC
       LIMIT @limit
     `
 


### PR DESCRIPTION
## Summary

- **vault_recent_notes** TDQS lift 4.4→4.75: 3 graduated examples, "Sorting behavior:" section documenting created vs modified semantics, accuracy fix (NULL-sort-last not excluded), expanded Errors, enriched parameter descriptions
- **Cross-tool discoverability** across 5 tools: vault_read_note→graph tools (1,722 calls→4 backlink calls in production), vault_search_by_property→discovery tools, vault_list_notes→vault_read_note, vault_get_daily_note→vault_recent_notes, vault_search_by_folder→graph tools
- **6 regression tests** locking in cross-references and key description content

### TDQS Self-Score

| Tool | Before | After | Delta |
|------|--------|-------|-------|
| vault_recent_notes | 4.40 | 4.75 | **+0.35** |
| vault_search_by_property | 4.20 | 4.65 | **+0.45** |
| vault_list_notes | 4.35 | 4.65 | **+0.30** |
| vault_read_note | 5.00 | 5.00 | — (discoverability) |
| vault_get_daily_note | 4.85 | 4.85 | — (discoverability) |
| vault_search_by_folder | 5.00 | 5.00 | — (discoverability) |

## Test plan

- [x] `npm run build` passes
- [x] All 1,010 tests pass (6 new)
- [x] TDQS self-scored all 6 modified tools — no regressions, 3 lifts
- [ ] Post-deploy: check [Glama TDQS score page](https://glama.ai/mcp/servers/aliasunder/vault-cortex/score) for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)