### PR TITLE
docs(tools): fix vault_get_backlinks TDQS regression, improve 4 sub-5.0 tools

### DIFF
--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -148,7 +148,7 @@ describe("registerTools", () => {
 
   it("vault_update_properties description documents null-deletes-key contract", () => {
     const [, config] = findCall(TOOL_NAMES.VAULT_UPDATE_PROPERTIES)!
-    expect(config.description).toContain("null as a value to delete")
+    expect(config.description).toContain("null deletes a key")
   })
 
   it("vault_write_note description documents null-deletes-key contract", () => {

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -191,17 +191,14 @@ Returns: JSON array of up to 20 notes' metadata (path, title, tags, related, fol
     TOOL_NAMES.VAULT_LIST_TAGS,
     {
       title: "List Tags",
-      description: `List all tags in the vault with their note counts, ordered by count descending. Only frontmatter tags are counted (inline #tags in note bodies are not indexed separately). Each tag is listed as its full string — a hierarchical tag like "project/vault-cortex" appears as one entry, not split into parent segments. Count is unique notes, not occurrences within a note.
+      description: `List all tags in the vault with note counts, ordered by count descending. Only frontmatter tags are counted (inline #tags in note bodies are not indexed). Each hierarchical tag (e.g. "project/vault-cortex") appears as one full entry, not split into segments. Count is unique notes, not occurrences. A vault with no tagged notes returns an empty array.
 
 Example: vault_list_tags() returns [{ tag: "session-log", count: 42 }, { tag: "project/vault-cortex", count: 8 }, ...]
 
 When to use: Discovering what tags exist before searching by tag. Good first step for vault orientation.
 Prefer vault_search_by_tag once you know which tag to query — it supports hierarchical prefix matching ("project" matches "project/*").
 
-Errors:
-- A vault with no tagged notes returns an empty array, not an error.
-
-Returns: JSON array of { tag (string — without "#" prefix, e.g. "session-log"), count (number — unique notes with this tag) }, sorted by count descending.`,
+Returns: JSON array of { tag, count } sorted by count descending. tag omits the "#" prefix; count is unique notes with this tag.`,
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -447,7 +444,7 @@ Returns: JSON array of { value, count } sorted by count descending.`,
     TOOL_NAMES.VAULT_SEARCH_BY_PROPERTY,
     {
       title: "Search by Property",
-      description: `Find notes where a frontmatter property matches a value — metadata-only search, no text query needed. Handles both scalar properties (status: "active") and array properties (tags contains "project").
+      description: `Find notes where a frontmatter property matches a value — metadata-only search, no text query needed. Handles both scalar properties (status: "active") and array properties (tags, related): for arrays, matches if any element equals the value (contains check, not exact array match). Matching is exact and case-sensitive; an unknown key or unmatched value returns an empty array, not an error.
 
 Example: vault_search_by_property({ key: "status", value: "in-progress" })
 Example: vault_search_by_property({ key: "type", value: "session-log", folder: "Code Projects" })
@@ -455,10 +452,7 @@ Example: vault_search_by_property({ key: "type", value: "session-log", folder: "
 When to use: Finding notes by metadata when you don't have a text query.
 Prefer vault_search when you also have a text query (it supports property filters too). Prefer vault_search_by_tag for tag-specific queries (supports hierarchical prefix matching). Use vault_list_property_keys to discover valid keys and vault_list_property_values to see what values a key takes.
 
-Errors:
-- No matches returns an empty array, not an error.
-
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, bytes, leading_callout?, additional_properties), sorted by most recently modified. bytes is the on-disk file size.`,
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, bytes, leading_callout?, additional_properties), sorted by most recently modified.`,
       inputSchema: {
         key: z
           .string()
@@ -513,23 +507,23 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
     TOOL_NAMES.VAULT_GET_BACKLINKS,
     {
       title: "Get Backlinks",
-      description: `Find all notes that link to a given note via incoming [[wikilinks]] or [markdown](links). Links inside code blocks are ignored; a note that links to itself appears in its own backlinks.
+      description: `Find all notes that link to a given note — captures [[wikilinks]], [markdown](links), ![[embeds]], and wikilinks inside frontmatter properties (e.g. related:). Heading anchors ([[note#heading]]) and aliases ([[note|alias]]) resolve as backlinks to the base note. Links inside code blocks are ignored; a note linking to itself appears in its own backlinks.
 
 Example: vault_get_backlinks({ path: "Projects/vault-cortex.md" })
 
-When to use: Understanding what references a note or assessing its connectivity.
+When to use: Understanding what references a note, assessing its connectivity before editing or deleting, or finding related notes via the graph.
 For outgoing links (what a note links TO), use vault_get_outgoing_links. To find notes with no backlinks at all, use vault_find_orphans.
 
-Errors:
-- A note with no inbound links, or a path not in the index, returns an empty array (count 0), not an error — don't use this as an existence check.
+Parameters:
+- path: exact vault-relative path including .md extension, case-sensitive. A non-indexed path returns an empty result (count 0), not an error — use vault_list_notes or vault_search to discover valid paths.
 
-Returns: JSON with path (the queried note), backlinks (array of { path, title, bytes }, sorted by title), and count. bytes is the on-disk file size.`,
+Returns: JSON with path (the queried note), backlinks (array of { path, title, bytes } sorted by title), and count.`,
       inputSchema: {
         path: z
           .string()
           .min(1)
           .describe(
-            'Vault-relative path to the note (e.g. "Projects/vault-cortex.md")',
+            'Exact vault-relative path including .md extension (e.g. "Projects/vault-cortex.md"). Case-sensitive.',
           ),
       },
       annotations: {
@@ -564,13 +558,13 @@ Returns: JSON with path (the queried note), backlinks (array of { path, title, b
 
 Example: vault_get_outgoing_links({ path: "Projects/vault-cortex.md" })
 
-When to use: Seeing what a note references, navigating the graph forward, or finding broken links in one note.
+When to use: Navigating the graph forward, auditing broken links in one note, or checking what a note depends on before editing.
 For incoming links (what links TO a note), use vault_get_backlinks.
 
 Errors:
 - A note with no outbound links, or a path not in the index, returns an empty array (count 0), not an error.
 
-Returns: JSON with path (the queried note), outgoing_links (array of { path, title, exists, kind, bytes }, sorted by target path), and count. kind is "note" or "asset". bytes is the on-disk file size (null for broken links and assets).`,
+Returns: JSON with path (the queried note), outgoing_links (array of { path, title, exists, kind, bytes } sorted by target path), and count. bytes is null for broken links and assets.`,
       inputSchema: {
         path: z
           .string()

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -246,15 +246,11 @@ Returns: JSON array of { path (string), title (string), tags (string[]), related
         sort_by: z
           .enum(["created", "modified"])
           .optional()
-          .describe(
-            '"created" or "modified" (default). "modified" uses filesystem mtime (any write, including sync, updates it). "created" uses the frontmatter created property — notes without it sort last; pair with a higher limit to include them.',
-          ),
+          .describe('Sort order (default "modified")'),
         limit: z
           .number()
           .optional()
-          .describe(
-            "Max results (default 20, no upper cap). Example: limit: 5 returns the top 5 by chosen timestamp.",
-          ),
+          .describe("Max results (default 20, no upper cap)"),
       },
       annotations: {
         readOnlyHint: true,

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -782,20 +782,18 @@ Returns: JSON with moved_to (the new path), links_updated (count of link occurre
     TOOL_NAMES.VAULT_UPDATE_PROPERTIES,
     {
       title: "Update Properties",
-      description: `Update properties on a single note. Merges with existing properties — new keys are added, matching keys are overwritten, unmentioned keys are preserved. Pass null as a value to delete that key. Body content is never modified.
+      description: `Update a note's frontmatter properties via shallow merge — new keys added, matching keys overwritten, null deletes a key, unmentioned keys preserved. Body is never modified.
 
-Example: vault_update_properties({ path: "Projects/todo.md", properties: { status: "active", draft: null } }) — sets status and deletes the draft key.
+Example: vault_update_properties({ path: "Projects/todo.md", properties: { status: "active", draft: null } })
 
-Read current properties first with vault_read_note({ properties_only: true }) — merge overwrites each key entirely (arrays are replaced, not appended to). Deleting the last remaining property removes the frontmatter block entirely.
-
-When to use: Changing tags, status, type, or any property without reading/rewriting the full note body. Saves tokens on large notes.
-Prefer vault_write_note when creating a new note or replacing the body.
+When to use: Changing tags, status, type, or any property without reading/rewriting the full note body.
+Prefer vault_write_note when creating a new note or replacing the body. Read current properties first with vault_read_note({ properties_only: true }) — arrays are replaced entirely, not appended to.
 
 Errors:
 - "note not found" — path does not exist; create the note first with vault_write_note
 - "path traversal blocked" — path escapes vault root
 
-Obsidian syntax: Use arrays for multi-value fields (tags: [a, b]), quote wikilink values ("[[Note]]"). Keep property types consistent (mismatches cause silent query failures).
+Obsidian syntax: Use arrays for multi-value fields (tags: [a, b]), quote wikilinks ("[[Note]]"), keep types consistent (mismatches cause silent query failures).
 
 Returns: Confirmation message.`,
       inputSchema: {

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -469,18 +469,17 @@ Example: vault_delete_span({ path: "Notes/Plan.md", start_anchor: "> [!warning] 
 When to use: Removing a block you have already read — a single long line (e.g. a wide table row) or a multi-line block (a callout, a run of list items) — where reproducing it exactly as old_text would be error-prone or wasteful. Pick a short, unique fragment of the first line for start_anchor and, for a multi-line block, the last line for end_anchor; you never paste the block itself.
 Prefer vault_replace_in_note for small in-place edits or renames where sending old_text is fine, and for replacing text (this tool only deletes). To replace a block, delete it here, then vault_patch_note (append/prepend by heading) to add the new content.
 
-Anchoring: the span covers whole lines — from the line containing start_anchor through the line containing end_anchor (inclusive), or just that one line when end_anchor is omitted. An anchor only locates a line; the entire line is removed regardless of where in it the anchor matches — it never cuts mid-line (prefer vault_replace_in_note for character-precise, in-place edits).
-Matching: end_anchor is searched at or after the start line, so the span can never run backward. By default each anchor must match exactly one line; on a tie, pass first_match to take the first. After deletion, runs of blank lines are collapsed so no gap is left. A trailing %% comment block (e.g. kanban:settings) is affected only if your anchors point into it.
+Anchoring: the span covers whole lines — from the line containing start_anchor through the line containing end_anchor (inclusive), or just that one line when end_anchor is omitted. An anchor locates a line; the entire line is removed regardless of where the anchor matches — it never cuts mid-line.
+Matching: end_anchor is searched at or after the start line, so the span can never run backward. By default each anchor must match exactly one line; on a tie, pass first_match to take the first. After deletion, runs of blank lines are collapsed so no gap is left.
 
 Errors:
-- "note not found" — path does not exist; check vault_list_notes for valid paths
-- "start anchor not found" / "end anchor not found ... at or after the start anchor" — the fragment is not on any (qualifying) line; verify exact text with vault_read_note
-- "ambiguous start anchor ... matches N lines" / "ambiguous end anchor ..." — the fragment is on more than one line; use a longer, unique fragment or set first_match: true
-- "start_anchor cannot be empty" / "end_anchor cannot be empty"
+- "note not found" — verify path with vault_list_notes
+- "anchor not found" — fragment not on any line; verify with vault_read_note
+- "ambiguous anchor" — matches multiple lines; use a longer fragment or set first_match: true
 
-Obsidian syntax: Anchors match literal text against the raw Markdown source, never regex — match #tags, [[wikilinks|aliases]], and %% comments exactly as they appear (verify with vault_read_note). This tool only removes content.
+Obsidian syntax: Anchors match literal text, not regex — match #tags, [[wikilinks|aliases]], and %% comments exactly as they appear in the source.
 
-Returns: Confirmation message with lines removed (number) and a truncated preview of the deleted text.`,
+Returns: Confirmation with lines removed and a truncated preview of the deleted text.`,
       inputSchema: {
         path: z
           .string()


### PR DESCRIPTION
## Summary

- **Fix vault_get_backlinks TDQS regression** (4.9→4.3): PR #199 removed the Parameters section and didn't enrich the Zod schema, crashing Parameters from 5→3. Restores the Parameters section with case-sensitivity/extension detail, enriches the Zod to match vault_get_outgoing_links' format, and adds behavioral detail (embeds, frontmatter wikilinks, heading anchor/alias resolution)
- **Improve vault_search_by_property** (4.7→4.9): Add array contains-check semantics to Behavior dimension
- **Improve vault_get_outgoing_links** (4.8→4.9): Remove purpose repetition between opening and When-to-use
- **Improve vault_list_tags** (4.8→4.9): Merge one-line Errors into opening, trim Returns type annotations
- **Improve vault_update_properties** (4.8→4.9): Tighten opening merge description, merge read-first into When-to-use
- **Push vault_delete_span** (4.9→5.0): Condense error messages per Glama feedback, remove redundant parenthetical
- **Push vault_recent_notes** (4.9→5.0): Simplify Zod so description Behavior section adds more value vs schema

## Regression analysis

vault_get_backlinks scored 4.9 pre-PR #199 (only Conciseness dinged at 4/5). PR #199 trimmed the opening and removed the Parameters section to improve Conciseness — but the Zod schema wasn't enriched to compensate (unlike vault_get_outgoing_links, which got enriched Zod in the same PR). Result: Parameters crashed 5→3, Behavior dropped 5→4, Completeness dropped 5→4, and Conciseness didn't even improve (stayed at 4).

**Lesson:** never remove a Parameters section without enriching the Zod schema — the TDQS Parameters dimension scores based on EITHER source.

## 4.9 tools NOT attempted (structural ceilings or risk > reward)

- vault_list_memory_files (Pa=4): No params = baseline 4 — structural ceiling
- vault_read_note (Co=4): 5-mode complexity justifies the length
- vault_search (Co=4): 8 filter params require the length  
- vault_delete_note, vault_update_memory (Co=4): All content valuable, nothing safe to trim
- vault_search_by_tag, vault_replace_in_note, vault_delete_memory, vault_list_property_values (Pa=4): Diminishing returns, risk outweighs reward

## Test plan

- [x] All 1,052 tests pass
- [x] One test updated to match new phrasing (`null deletes a key`)
- [x] Verified behavioral claims from code: `extractFromBody` captures wikilinks/markdown/embeds, `extractFromFrontmatter` captures frontmatter wikilinks, `WIKILINK_RE` strips heading anchors and aliases to base target
- [ ] Deploy and check Glama TDQS scores — targets: vault_get_backlinks ≥4.9, vault_delete_span 5.0, vault_recent_notes 5.0, overall mean ≥4.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)