### PR TITLE
docs(arch): add SSH hardening cross-reference to Infrastructure section

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -357,9 +357,9 @@ a tunnel or reverse proxy (e.g., Cloudflare Tunnel), then set
 tokens never travel in plaintext on any network segment — all traffic is
 HTTPS end-to-end. See [`DEPLOY.md`](./DEPLOY.md#port-8000-hardening-optional).
 
-**Optional: restrict SSH.** Set `SSH_CIDRS=none` to remove port 22 from the
-Lightsail firewall and reach the instance exclusively via a Tailscale
-WireGuard mesh (Tailscale traffic bypasses the public-IP firewall). See
+**Optional: restrict SSH.** Set `SSH_CIDRS=none` to block public SSH and
+reach the instance exclusively via a Tailscale WireGuard mesh (Tailscale
+traffic bypasses the public-IP firewall). See
 [`DEPLOY.md`](./DEPLOY.md#ssh-hardening-with-tailscale-optional).
 
 **Optional: custom domain.** Set `CUSTOM_DOMAIN` + `CUSTOM_DOMAIN_CERT_ARN`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -357,6 +357,11 @@ a tunnel or reverse proxy (e.g., Cloudflare Tunnel), then set
 tokens never travel in plaintext on any network segment — all traffic is
 HTTPS end-to-end. See [`DEPLOY.md`](./DEPLOY.md#port-8000-hardening-optional).
 
+**Optional: restrict SSH.** Set `SSH_CIDRS=none` to remove port 22 from the
+Lightsail firewall and reach the instance exclusively via a Tailscale
+WireGuard mesh (Tailscale traffic bypasses the public-IP firewall). See
+[`DEPLOY.md`](./DEPLOY.md#ssh-hardening-with-tailscale-optional).
+
 **Optional: custom domain.** Set `CUSTOM_DOMAIN` + `CUSTOM_DOMAIN_CERT_ARN`
 to serve the API Gateway on your own hostname instead of the auto-generated
 execute-api URL (which stays active alongside it). The ACM cert and DNS


### PR DESCRIPTION
## Summary

- Adds an "Optional: restrict SSH" note to ARCHITECTURE.md's Infrastructure section, parallel to the existing port 8000 and custom domain notes
- Cross-references the full walkthrough in DEPLOY.md's SSH Hardening with Tailscale section
- Closes a consistency gap: readers checking ARCHITECTURE.md saw two of three optional hardening options but not the third

## Test plan

- [x] Verify the DEPLOY.md anchor link resolves correctly
- [x] Confirm the three optional notes read consistently in sequence


🤖 Generated with [Claude Code](https://claude.com/claude-code)