### PR TITLE
docs(tools): fix TDQS regressions in vault_list_property_values, vault_search_by_property, vault_delete_note

### DIFF
--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -390,12 +390,12 @@ Returns: JSON array of { key, count, sample_values } sorted by count descending.
 
 Example: vault_list_property_values({ key: "status" }) returns [{ value: "active", count: 47 }, { value: "done", count: 211 }, ...]
 
-When to use: Enumerating possible values for a property key before calling vault_search_by_property. Call vault_list_property_keys first to discover valid key names.
+When to use: Enumerating possible values for a property key before calling vault_search_by_property. Handles both scalar properties (status: "active") and array properties (tags: ["a", "b"]) — array elements are unpacked and counted individually, so the sum of counts may exceed the note count. An unknown key or empty folder returns an empty array, not an error. Call vault_list_property_keys first to discover valid key names.
 
 Parameters:
-- key is case-sensitive and must match exactly as returned by vault_list_property_keys. Array-valued properties (tags, related) are unpacked — each element is counted individually, so the sum of counts may exceed the note count.
-- folder + key interact: folder restricts counting to notes in that subtree, useful for comparing how a property is used across areas (e.g. vault_list_property_values({ key: "type", folder: "Projects" }) vs the whole vault).
-- limit (default 50) caps the values returned, sorted by count descending. High-cardinality keys like "title" or "created" may have hundreds of unique values — increase limit to see more.
+- key is case-sensitive and must match exactly as returned by vault_list_property_keys. Values are always strings — numeric and boolean properties are stringified for counting.
+- folder + key interact: folder restricts counting to a subtree, so the same key can return different value distributions depending on folder scope.
+- limit (default 50) applies after sorting by count descending, so you always get the most-used values first. Increase for high-cardinality keys like "title" or "created".
 
 Returns: JSON array of { value, count } sorted by count descending.`,
       inputSchema: {
@@ -446,15 +446,20 @@ Returns: JSON array of { value, count } sorted by count descending.`,
     TOOL_NAMES.VAULT_SEARCH_BY_PROPERTY,
     {
       title: "Search by Property",
-      description: `Find notes where a frontmatter property matches a value — metadata-only search, no text query needed. Handles scalar properties (status: "active") and array properties (tags, related) — arrays match if any element equals the value. Matching is exact and case-sensitive; no matches returns an empty array, not an error.
+      description: `Find notes where a frontmatter property matches a value — metadata-only search, no text query needed. Handles both scalar properties (status: "active") and array properties (tags, related): for arrays, matches if any element equals the value (contains check, not exact array match). Matching is exact and case-sensitive; an unknown key or unmatched value returns an empty array, not an error.
 
 Example: vault_search_by_property({ key: "status", value: "in-progress" })
 Example: vault_search_by_property({ key: "type", value: "session-log", folder: "Code Projects" })
 
-When to use: Finding notes by metadata without a text query.
-Prefer vault_search when you also have text (it supports property filters). Prefer vault_search_by_tag for tag queries. Use vault_list_property_keys and vault_list_property_values to discover valid keys and values.
+When to use: Finding notes by metadata when you don't have a text query.
+Prefer vault_search when you also have a text query (it supports property filters too). Prefer vault_search_by_tag for tag-specific queries (supports hierarchical prefix matching). Use vault_list_property_keys to discover valid keys and vault_list_property_values to see what values a key takes.
 
-Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, bytes, leading_callout?, additional_properties), sorted by most recently modified.`,
+Parameters:
+- key + value are both exact and case-sensitive — no partial matching or globbing. All property values are compared as strings, so numeric or boolean properties must be passed as their string representation.
+- For array properties (tags, related), value is tested against each element individually (contains check) — "blog" matches a note with tags: ["blog", "draft"] but not tags: ["my-blog"].
+- folder narrows results to a subtree; omit for vault-wide search. Combined with key+value, this lets you check how a property is used within a specific area.
+
+Returns: JSON array of note metadata (path, title, tags, related, folder, type, created, modified, bytes, leading_callout?, additional_properties), sorted by filesystem mtime descending — recently-synced notes may sort ahead of older content edits.`,
       inputSchema: {
         key: z
           .string()

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -609,18 +609,18 @@ Returns: JSON array of vault-relative path strings (e.g. ["Projects/plan.md", "N
     TOOL_NAMES.VAULT_DELETE_NOTE,
     {
       title: "Delete Note",
-      description: `Permanently delete a markdown note — removed from disk directly (no trash, no undo). After deletion, incoming links from other notes become broken (detectable via vault_get_backlinks on the deleted path, or vault_find_orphans for a vault-wide scan).
+      description: `Permanently delete a markdown note — removed from disk directly (no trash, no undo). Recovery depends on backups or sync history. After deletion, links to it from other notes become broken (detectable via vault_get_backlinks on the path before deletion, or vault_find_orphans for a vault-wide scan).
 
 Example: vault_delete_note({ path: "Scratch/temp.md" })
-Example: vault_delete_note({ path: "Archive/2024/old.md", prune_empty_folders: true }) — also removes empty parent folders.
+Example: vault_delete_note({ path: "Archive/2024/old.md", prune_empty_folders: true })
 
 When to use: Removing a note you no longer need.${config.memoryEnabled ? ` Prefer vault_delete_memory for individual dated entries in ${config.memoryDir}/ files.` : ""}
-Protected paths (${config.protectedPaths.map((p) => p + "/").join(", ")}) are refused. With prune_empty_folders, pruning is best-effort — it never fails the call even if a folder can't be removed.
 
-Errors:
-- "cannot delete protected path …" — path under a protected folder${config.memoryEnabled ? "; use vault_delete_memory for memory entries" : ""}
-- "path traversal blocked" — path escapes the vault root
-- note does not exist — verify with vault_list_notes
+Parameters:
+- path must be vault-relative and outside protected folders (${config.protectedPaths.map((p) => p + "/").join(", ")}). A non-existent path returns an error — verify with vault_list_notes first.
+- prune_empty_folders (default false) runs after the delete and walks up from the note's parent toward the vault root, removing each folder left empty. Pruning is best-effort — it never fails the call, so the note is always removed even if a folder can't be pruned.
+
+Errors: "cannot delete protected path"${config.memoryEnabled ? " (use vault_delete_memory for memory entries)" : ""}, "path traversal blocked" (path escapes vault root), or note not found.
 
 Returns: Confirmation message, noting how many empty folders were pruned when any were.`,
       inputSchema: {

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -609,7 +609,7 @@ Returns: JSON array of vault-relative path strings (e.g. ["Projects/plan.md", "N
     TOOL_NAMES.VAULT_DELETE_NOTE,
     {
       title: "Delete Note",
-      description: `Permanently delete a markdown note — removed from disk directly (no trash, no undo). Recovery depends on backups or sync history. After deletion, links to it from other notes become broken (detectable via vault_get_backlinks on the path before deletion, or vault_find_orphans for a vault-wide scan).
+      description: `Permanently delete a markdown note — removed from disk directly (no trash, no undo). Recovery depends on backups or sync history. After deletion, links to it from other notes become broken — use vault_get_backlinks on the deleted path to find the notes that now contain broken links.
 
 Example: vault_delete_note({ path: "Scratch/temp.md" })
 Example: vault_delete_note({ path: "Archive/2024/old.md", prune_empty_folders: true })
@@ -617,7 +617,7 @@ Example: vault_delete_note({ path: "Archive/2024/old.md", prune_empty_folders: t
 When to use: Removing a note you no longer need.${config.memoryEnabled ? ` Prefer vault_delete_memory for individual dated entries in ${config.memoryDir}/ files.` : ""}
 
 Parameters:
-- path must be vault-relative and outside protected folders (${config.protectedPaths.map((p) => p + "/").join(", ")}). A non-existent path returns an error — verify with vault_list_notes first.
+- path must be vault-relative and outside protected folders (${config.protectedPaths.map((protectedFolder) => protectedFolder + "/").join(", ")}). A non-existent path returns an error — verify with vault_list_notes first.
 - prune_empty_folders (default false) runs after the delete and walks up from the note's parent toward the vault root, removing each folder left empty. Pruning is best-effort — it never fails the call, so the note is always removed even if a folder can't be pruned.
 
 Errors: "cannot delete protected path"${config.memoryEnabled ? " (use vault_delete_memory for memory entries)" : ""}, "path traversal blocked" (path escapes vault root), or note not found.


### PR DESCRIPTION
## Summary

Fixes three TDQS regressions introduced by PR #204, using per-dimension Glama feedback to target the specific dings.

- **vault_list_property_values** (4.7 → target 4.9+, B=4+Pa=4): Added consequence info (empty array on unknown key) for Behavior. Deepened Parameters: string comparison semantics, distribution-varies-by-scope, limit-applies-after-sort. Removed redundancy between opening and Parameters section.
- **vault_search_by_property** (4.7 → target 4.9+, B=4+Pa=4): Added sorting nuance to Returns ("mtime descending, sync implications") for Behavior. Added 3-bullet Parameters section: string comparison, array contains-check with concrete example, folder scope interaction.
- **vault_delete_note** (4.8 → target 4.9+, Co=4+Pa=4): Condensed 3-bullet error list to single line per grader feedback for Conciseness. Added 2-bullet Parameters section: path validation + protected folders, prune_empty_folders walk-up-to-root semantics.

## Test plan
- [x] All 1051 tests pass
- [x] String comparison claims verified against search-index.ts (`String(row.value)`, `CAST(value AS TEXT)`)
- [x] TDQS reference doc updated with post-PR \#204 actuals and regression fix analysis
- [ ] Deploy and verify Glama TDQS scores recover to ≥4.9 for all three tools


🤖 Generated with [Claude Code](https://claude.com/claude-code)