### PR TITLE
infra: Lightsail 4GB upgrade + Phase 2 deploy workflow

### DIFF
--- a/.github/workflows/phase2_deploy.yml
+++ b/.github/workflows/phase2_deploy.yml
@@ -1,0 +1,210 @@
+name: "Phase 2: Deploy"
+
+# Manual deploy from the phase-2 branch. Runs SST (IaC changes) and
+# optionally rebuilds + deploys the Docker image. Use for iterating on
+# Phase 2 infra and code changes before they reach main/release.
+on:
+  workflow_dispatch:
+    inputs:
+      skip_build:
+        description: >-
+          Skip Docker image build/push — only run SST deploy and restart
+          the compose stack with the existing image.
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/phase-2'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    env:
+      AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+      SST_STAGE: ${{ secrets.SST_STAGE }}
+      IMAGE: ghcr.io/${{ vars.GHCR_USER }}/vault-mcp
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: SST deploy
+        env:
+          SSH_PUBKEY: ${{ secrets.SSH_PUBKEY }}
+          SSH_CIDRS: ${{ secrets.SSH_CIDRS }}
+          ORIGIN_URL: ${{ secrets.ORIGIN_URL }}
+          MCP_PORT_CIDRS: ${{ secrets.MCP_PORT_CIDRS }}
+          CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
+          CUSTOM_DOMAIN_CERT_ARN: ${{ secrets.CUSTOM_DOMAIN_CERT_ARN }}
+        run: npx sst deploy --stage "$SST_STAGE"
+
+      - name: Connect to Tailscale
+        if: env.TAILSCALE_SSH_HOST != ''
+        env:
+          TAILSCALE_SSH_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:ci
+
+      - name: Fetch Lightsail IP from AWS
+        id: sst
+        run: |
+          ip=$(aws lightsail get-static-ip \
+            --static-ip-name "vault-cortex-ip-${SST_STAGE}" \
+            --query staticIp.ipAddress --output text)
+          if [ -z "$ip" ] || [ "$ip" = "None" ]; then
+            echo "::error::could not resolve the Lightsail static IP from AWS"
+            exit 1
+          fi
+          echo "::add-mask::$ip"
+          echo "ip=$ip" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve SSH target
+        id: ssh
+        env:
+          TAILSCALE_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
+          PUBLIC_IP: ${{ steps.sst.outputs.ip }}
+        run: |
+          if [ -n "$TAILSCALE_HOST" ]; then
+            echo "host=$TAILSCALE_HOST" >> "$GITHUB_OUTPUT"
+          else
+            echo "host=$PUBLIC_IP" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        if: ${{ !inputs.skip_build }}
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        if: ${{ !inputs.skip_build }}
+
+      - name: Log in to GHCR (build push)
+        if: ${{ !inputs.skip_build }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ vars.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push image
+        if: ${{ !inputs.skip_build }}
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:phase-2
+            ${{ env.IMAGE }}:latest
+          annotations: |
+            index:org.opencontainers.image.title=vault-cortex
+            index:org.opencontainers.image.description=Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1.
+            index:org.opencontainers.image.source=https://github.com/aliasunder/vault-cortex
+            index:org.opencontainers.image.licenses=MIT
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Wait for Docker on Lightsail
+        env:
+          IP: ${{ steps.ssh.outputs.host }}
+        run: |
+          deadline=$((SECONDS + 120))
+          until ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" 'docker --version' >/dev/null 2>&1; do
+            if [ $SECONDS -ge $deadline ]; then
+              echo "::error::Docker not ready on $IP after 120s"
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: Bootstrap deploy directory and GHCR login on instance
+        env:
+          IP: ${{ steps.ssh.outputs.host }}
+          GHCR_USER: ${{ vars.GHCR_USER }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
+            'sudo mkdir -p /opt/vault-cortex && sudo chown ubuntu:ubuntu /opt/vault-cortex'
+          printf '%s' "$GHCR_TOKEN" | ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
+            "docker login ghcr.io -u '$GHCR_USER' --password-stdin"
+
+      - name: Write Lightsail .env from secrets
+        env:
+          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
+          MCP_AUTH_TOKEN: ${{ secrets.MCP_AUTH_TOKEN }}
+          OBSIDIAN_AUTH_TOKEN: ${{ secrets.OBSIDIAN_AUTH_TOKEN }}
+          VAULT_NAME: ${{ secrets.VAULT_NAME }}
+          VAULT_PASSWORD: ${{ secrets.VAULT_PASSWORD }}
+          GHCR_USER: ${{ vars.GHCR_USER }}
+          MEMORY_DIR: ${{ vars.MEMORY_DIR }}
+          PROTECTED_PATHS: ${{ vars.PROTECTED_PATHS }}
+          ORPHAN_EXCLUDE_FOLDERS: ${{ vars.ORPHAN_EXCLUDE_FOLDERS }}
+          SERVICE_DOCUMENTATION_URL: ${{ vars.SERVICE_DOCUMENTATION_URL }}
+          TZ: ${{ vars.TZ }}
+        run: |
+          umask 077
+          cat > "$RUNNER_TEMP/lightsail.env" <<EOF
+          MCP_AUTH_TOKEN=$MCP_AUTH_TOKEN
+          PUBLIC_URL=$PUBLIC_URL
+          OBSIDIAN_AUTH_TOKEN=$OBSIDIAN_AUTH_TOKEN
+          VAULT_NAME=$VAULT_NAME
+          VAULT_PASSWORD=$VAULT_PASSWORD
+          GHCR_USER=$GHCR_USER
+          MEMORY_DIR=${MEMORY_DIR:-About Me}
+          PROTECTED_PATHS=$PROTECTED_PATHS
+          ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS
+          SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL
+          PUID=1000
+          PGID=1000
+          DEVICE_NAME=vault-cortex-lightsail
+          CONFLICT_STRATEGY=merge
+          SYNC_MODE=bidirectional
+          LOG_LEVEL=info
+          LOG_RETENTION_DAYS=365
+          TZ=${TZ:-UTC}
+          EOF
+
+      - name: Ship compose + .env to instance
+        env:
+          IP: ${{ steps.ssh.outputs.host }}
+        run: |
+          scp -o StrictHostKeyChecking=accept-new docker-compose.yml ubuntu@"$IP":/opt/vault-cortex/docker-compose.yml
+          scp -o StrictHostKeyChecking=accept-new "$RUNNER_TEMP/lightsail.env" ubuntu@"$IP":/opt/vault-cortex/.env
+
+      - name: Pull and restart compose stack
+        env:
+          IP: ${{ steps.ssh.outputs.host }}
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
+            'cd /opt/vault-cortex && docker compose pull && docker compose up -d --wait --wait-timeout 180 && docker image prune -f'
+
+      - name: Healthcheck
+        env:
+          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
+        run: curl -fsS --retry 6 --retry-delay 5 "$PUBLIC_URL/healthz"

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -121,7 +121,7 @@ export default $config({
     })
 
     // ── Lightsail ─────────────────────────────────────────────────
-    // small_3_0 = 2 vCPU, 2 GB RAM, 60 GB SSD, 3 TB transfer, $12/mo.
+    // medium_3_0 = 2 vCPU, 4 GB RAM, 80 GB SSD, 4 TB transfer, $24/mo.
     //
     // Auto-snapshot: daily disk-image backup retained 7 days by
     // Lightsail. Captures everything on the boot disk (Docker volumes,
@@ -137,11 +137,10 @@ export default $config({
     //
     // GOTCHA #1: Changing userData, bundleId, or keyPairName WOULD
     //            normally replace the instance. With protect:true,
-    //            Pulumi refuses and the deploy fails loudly. To
-    //            intentionally replace (e.g. bundle upgrade for
-    //            Phase 2), see the "Intentional replace" section
-    //            of RECOVERY.md — unprotect via state command,
-    //            deploy, then it re-protects on next regular deploy.
+    //            Pulumi refuses and the deploy fails loudly. For
+    //            bundle upgrades, use a snapshot-based upgrade
+    //            (preserves all state) then reconcile SST state
+    //            afterward — see RECOVERY.md.
     // GOTCHA #2: The deploy-key convention above keeps keyPairName
     //            stable across local and CI deploys.
     // GOTCHA #3: userData is visible via get-instance API/console.
@@ -152,8 +151,8 @@ export default $config({
       {
         name: `vault-cortex-${$app.stage}`,
         availabilityZone: `${awsRegion}a`,
-        blueprintId: "ubuntu_22_04",
-        bundleId: "small_3_0",
+        blueprintId: "ubuntu_24_04",
+        bundleId: "medium_3_0",
         keyPairName: keyPair.name,
         addOn: {
           type: "AutoSnapshot",

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -172,7 +172,16 @@ export default $config({
         ].join("\n"),
         tags: { Project: "vault-cortex", Stage: $app.stage, ManagedBy: "sst" },
       },
-      { protect: true, retainOnDelete: true },
+      {
+        protect: true,
+        retainOnDelete: true,
+        // Lightsail treats userData and blueprintId as create-time-only
+        // properties. Changing either triggers a full instance replacement
+        // (not an in-place update). After a snapshot-based bundle upgrade
+        // or an in-place OS update, these values in Pulumi state won't
+        // match the config — ignore them so deploys stay clean.
+        ignoreChanges: ["userData", "blueprintId"],
+      },
     )
 
     const staticIp = new aws.lightsail.StaticIp("VaultCortexIp", {


### PR DESCRIPTION
## Summary

- Update `sst.config.ts` to reflect the snapshot-based Lightsail upgrade from `small_3_0` (2GB, $12/mo) to `medium_3_0` (4GB, $24/mo) and the in-place OS upgrade from Ubuntu 22.04 to 24.04
- Add `ignoreChanges` for `userData` and `blueprintId` — both are create-time-only Lightsail properties that become stale after snapshot restores and in-place OS upgrades, causing every deploy to fail on a replacement diff blocked by `protect: true`
- Add `phase2_deploy.yml` — manual dispatch workflow for deploying from the `phase-2` feature branch (SST + optional Docker build)

These are infra-only changes needed on main so that:
1. Bug fix releases don't fail on SST deploy (ignoreChanges prevents userData/blueprintId replacement)
2. The Phase 2 deploy workflow is visible in the GitHub Actions UI (workflow_dispatch requires default branch)

## Test plan

- [ ] Verify `sst deploy` succeeds without attempting instance replacement
- [ ] Verify Phase 2 deploy workflow appears in GitHub Actions UI
- [ ] Verify a fresh forker's first `sst deploy` still creates the instance with userData and blueprintId (ignoreChanges only affects updates, not creates — [Pulumi docs](https://www.pulumi.com/docs/iac/concepts/resources/options/ignorechanges/))

🤖 Generated with [Claude Code](https://claude.com/claude-code)