### PR TITLE
infra: Lightsail 4GB upgrade + Phase 2 deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
       SST_STAGE: ${{ secrets.SST_STAGE }}
       IMAGE: ghcr.io/${{ vars.GHCR_USER }}/vault-mcp
+      TAILSCALE_SSH_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
     steps:
       # Build from the release tag, not the default checkout SHA. On a manual
       # release the tag (created by bump-and-tag) points at the version-bump
@@ -67,8 +68,6 @@ jobs:
 
       - name: Connect to Tailscale
         if: env.TAILSCALE_SSH_HOST != ''
-        env:
-          TAILSCALE_SSH_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
       SST_STAGE: ${{ secrets.SST_STAGE }}
       IMAGE: ghcr.io/${{ vars.GHCR_USER }}/vault-mcp
-      TAILSCALE_SSH_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
+      TAILSCALE_ENABLED: ${{ secrets.TAILSCALE_SSH_HOST != '' }}
     steps:
       # Build from the release tag, not the default checkout SHA. On a manual
       # release the tag (created by bump-and-tag) points at the version-bump
@@ -67,7 +67,7 @@ jobs:
         run: npx sst deploy --stage "$SST_STAGE"
 
       - name: Connect to Tailscale
-        if: env.TAILSCALE_SSH_HOST != ''
+        if: env.TAILSCALE_ENABLED == 'true'
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}

--- a/.github/workflows/force_deploy.yml
+++ b/.github/workflows/force_deploy.yml
@@ -9,6 +9,10 @@ name: Force Deploy
 on:
   workflow_dispatch:
 
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
 # Top-level token is read-only; jobs declare their writes.
 permissions:
   contents: read

--- a/.github/workflows/phase2_deploy.yml
+++ b/.github/workflows/phase2_deploy.yml
@@ -33,9 +33,11 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
       SST_STAGE: ${{ secrets.SST_STAGE }}
       IMAGE: ghcr.io/${{ vars.GHCR_USER }}/vault-mcp
-      TAILSCALE_SSH_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
+      TAILSCALE_ENABLED: ${{ secrets.TAILSCALE_SSH_HOST != '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -61,7 +63,7 @@ jobs:
         run: npx sst deploy --stage "$SST_STAGE"
 
       - name: Connect to Tailscale
-        if: env.TAILSCALE_SSH_HOST != ''
+        if: env.TAILSCALE_ENABLED == 'true'
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
@@ -189,6 +191,7 @@ jobs:
           LOG_LEVEL=info
           LOG_RETENTION_DAYS=365
           TZ=${TZ:-UTC}
+          VAULT_MCP_TAG=phase-2
           EOF
 
       - name: Ship compose + .env to instance

--- a/.github/workflows/phase2_deploy.yml
+++ b/.github/workflows/phase2_deploy.yml
@@ -69,6 +69,10 @@ jobs:
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           tags: tag:ci
 
+      # The IP is fetched from AWS rather than exposed as an SST output —
+      # SST prints outputs at the end of every deploy, which on a public
+      # repo means public Actions logs. The static-ip name matches
+      # sst.config.ts (`vault-cortex-ip-${stage}`).
       - name: Fetch Lightsail IP from AWS
         id: sst
         run: |
@@ -115,9 +119,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.IMAGE }}:phase-2
-            ${{ env.IMAGE }}:latest
+          tags: ${{ env.IMAGE }}:phase-2
           annotations: |
             index:org.opencontainers.image.title=vault-cortex
             index:org.opencontainers.image.description=Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1.

--- a/.github/workflows/phase2_deploy.yml
+++ b/.github/workflows/phase2_deploy.yml
@@ -33,6 +33,7 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
       SST_STAGE: ${{ secrets.SST_STAGE }}
       IMAGE: ghcr.io/${{ vars.GHCR_USER }}/vault-mcp
+      TAILSCALE_SSH_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -61,8 +62,6 @@ jobs:
 
       - name: Connect to Tailscale
         if: env.TAILSCALE_SSH_HOST != ''
-        env:
-          TAILSCALE_SSH_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}

--- a/.github/workflows/phase2_deploy.yml
+++ b/.github/workflows/phase2_deploy.yml
@@ -1,0 +1,210 @@
+name: "Phase 2: Deploy"
+
+# Manual deploy from the phase-2 branch. Runs SST (IaC changes) and
+# optionally rebuilds + deploys the Docker image. Use for iterating on
+# Phase 2 infra and code changes before they reach main/release.
+on:
+  workflow_dispatch:
+    inputs:
+      skip_build:
+        description: >-
+          Skip Docker image build/push — only run SST deploy and restart
+          the compose stack with the existing image.
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/phase-2'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    env:
+      AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+      SST_STAGE: ${{ secrets.SST_STAGE }}
+      IMAGE: ghcr.io/${{ vars.GHCR_USER }}/vault-mcp
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: SST deploy
+        env:
+          SSH_PUBKEY: ${{ secrets.SSH_PUBKEY }}
+          SSH_CIDRS: ${{ secrets.SSH_CIDRS }}
+          ORIGIN_URL: ${{ secrets.ORIGIN_URL }}
+          MCP_PORT_CIDRS: ${{ secrets.MCP_PORT_CIDRS }}
+          CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
+          CUSTOM_DOMAIN_CERT_ARN: ${{ secrets.CUSTOM_DOMAIN_CERT_ARN }}
+        run: npx sst deploy --stage "$SST_STAGE"
+
+      - name: Connect to Tailscale
+        if: env.TAILSCALE_SSH_HOST != ''
+        env:
+          TAILSCALE_SSH_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:ci
+
+      - name: Fetch Lightsail IP from AWS
+        id: sst
+        run: |
+          ip=$(aws lightsail get-static-ip \
+            --static-ip-name "vault-cortex-ip-${SST_STAGE}" \
+            --query staticIp.ipAddress --output text)
+          if [ -z "$ip" ] || [ "$ip" = "None" ]; then
+            echo "::error::could not resolve the Lightsail static IP from AWS"
+            exit 1
+          fi
+          echo "::add-mask::$ip"
+          echo "ip=$ip" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve SSH target
+        id: ssh
+        env:
+          TAILSCALE_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
+          PUBLIC_IP: ${{ steps.sst.outputs.ip }}
+        run: |
+          if [ -n "$TAILSCALE_HOST" ]; then
+            echo "host=$TAILSCALE_HOST" >> "$GITHUB_OUTPUT"
+          else
+            echo "host=$PUBLIC_IP" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        if: ${{ !inputs.skip_build }}
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        if: ${{ !inputs.skip_build }}
+
+      - name: Log in to GHCR (build push)
+        if: ${{ !inputs.skip_build }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ vars.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push image
+        if: ${{ !inputs.skip_build }}
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:phase-2
+            ${{ env.IMAGE }}:latest
+          annotations: |
+            index:org.opencontainers.image.title=vault-cortex
+            index:org.opencontainers.image.description=Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1.
+            index:org.opencontainers.image.source=https://github.com/aliasunder/vault-cortex
+            index:org.opencontainers.image.licenses=MIT
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Wait for Docker on Lightsail
+        env:
+          IP: ${{ steps.ssh.outputs.host }}
+        run: |
+          deadline=$((SECONDS + 120))
+          until ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" 'docker --version' >/dev/null 2>&1; do
+            if [ $SECONDS -ge $deadline ]; then
+              echo "::error::Docker not ready on $IP after 120s"
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: Bootstrap deploy directory and GHCR login on instance
+        env:
+          IP: ${{ steps.ssh.outputs.host }}
+          GHCR_USER: ${{ vars.GHCR_USER }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
+            'sudo mkdir -p /opt/vault-cortex && sudo chown ubuntu:ubuntu /opt/vault-cortex'
+          printf '%s' "$GHCR_TOKEN" | ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
+            "docker login ghcr.io -u '$GHCR_USER' --password-stdin"
+
+      - name: Write Lightsail .env from secrets
+        env:
+          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
+          MCP_AUTH_TOKEN: ${{ secrets.MCP_AUTH_TOKEN }}
+          OBSIDIAN_AUTH_TOKEN: ${{ secrets.OBSIDIAN_AUTH_TOKEN }}
+          VAULT_NAME: ${{ secrets.VAULT_NAME }}
+          VAULT_PASSWORD: ${{ secrets.VAULT_PASSWORD }}
+          GHCR_USER: ${{ vars.GHCR_USER }}
+          MEMORY_DIR: ${{ vars.MEMORY_DIR }}
+          PROTECTED_PATHS: ${{ vars.PROTECTED_PATHS }}
+          ORPHAN_EXCLUDE_FOLDERS: ${{ vars.ORPHAN_EXCLUDE_FOLDERS }}
+          SERVICE_DOCUMENTATION_URL: ${{ vars.SERVICE_DOCUMENTATION_URL }}
+          TZ: ${{ vars.TZ }}
+        run: |
+          umask 077
+          cat > "$RUNNER_TEMP/lightsail.env" <<EOF
+          MCP_AUTH_TOKEN=$MCP_AUTH_TOKEN
+          PUBLIC_URL=$PUBLIC_URL
+          OBSIDIAN_AUTH_TOKEN=$OBSIDIAN_AUTH_TOKEN
+          VAULT_NAME=$VAULT_NAME
+          VAULT_PASSWORD=$VAULT_PASSWORD
+          GHCR_USER=$GHCR_USER
+          MEMORY_DIR=${MEMORY_DIR:-About Me}
+          PROTECTED_PATHS=$PROTECTED_PATHS
+          ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS
+          SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL
+          PUID=1000
+          PGID=1000
+          DEVICE_NAME=vault-cortex-lightsail
+          CONFLICT_STRATEGY=merge
+          SYNC_MODE=bidirectional
+          LOG_LEVEL=info
+          LOG_RETENTION_DAYS=365
+          TZ=${TZ:-UTC}
+          EOF
+
+      - name: Ship compose + .env to instance
+        env:
+          IP: ${{ steps.ssh.outputs.host }}
+        run: |
+          scp -o StrictHostKeyChecking=accept-new docker-compose.yml ubuntu@"$IP":/opt/vault-cortex/docker-compose.yml
+          scp -o StrictHostKeyChecking=accept-new "$RUNNER_TEMP/lightsail.env" ubuntu@"$IP":/opt/vault-cortex/.env
+
+      - name: Pull and restart compose stack
+        env:
+          IP: ${{ steps.ssh.outputs.host }}
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
+            'cd /opt/vault-cortex && docker compose pull && docker compose up -d --wait --wait-timeout 180 && docker image prune -f'
+
+      - name: Healthcheck
+        env:
+          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
+        run: curl -fsS --retry 6 --retry-delay 5 "$PUBLIC_URL/healthz"

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -149,10 +149,13 @@ survive — only on-disk state carries over.
 7. Start Docker Compose and verify
 8. Update `sst.config.ts` with the new `bundleId` (and `blueprintId`
    if the OS was upgraded in-place)
-9. Reconcile SST state: `sst state remove 'VaultCortexVm'`, then add
-   `import: "<instance-name>"` to the resource options, deploy once,
-   remove the import line, run `sst refresh`, deploy again
-10. Delete the old instance after verification
+9. Remove the old instance from SST state:
+   `sst state remove 'VaultCortexVm'`
+10. Import the new instance: add `import: "<instance-name>"` to the
+    resource options in `sst.config.ts`, then `sst deploy`
+11. Clean up the import: remove the `import` line, run `sst refresh`,
+    then `sst deploy` again to confirm a clean no-diff deploy
+12. Delete the old instance after verification
 
 If the new instance name differs from the canonical name (`vault-cortex-<stage>`),
 use Path 1 from "Reconciling SST state" below to rename it back before
@@ -166,8 +169,7 @@ but destroys all on-disk state: installed packages, Docker volumes,
 Claude Code, etc.). Only use this if you don't have state worth preserving or
 you're comfortable re-provisioning from scratch.
 
-To intentionally replace (e.g. bundle upgrade from
-`small_3_0` 2 GB → `medium_3_0` 4 GB):
+To intentionally replace (e.g. changing `bundleId` or `blueprintId`):
 
 ```bash
 # 1. Take a manual snapshot first — the auto-snapshot from up to 23h ago

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -129,7 +129,44 @@ their next token refresh.
 ## Intentional replace (bundle upgrade, blueprint change, etc.)
 
 The `protect: true` seatbelt blocks any deploy that would replace the
-Instance. To intentionally replace (e.g. Phase 2 bundle upgrade from
+Instance. Two approaches depending on how much state you want to preserve:
+
+### Option A — Snapshot-based upgrade (recommended)
+
+Preserves everything on disk: installed packages, Docker volumes,
+credentials, SSH keys. The new instance is an exact copy at a larger
+bundle. Running processes (tmux sessions, background jobs) do not
+survive — only on-disk state carries over.
+
+1. Stop Docker Compose (clean SQLite state for snapshot)
+2. Create a manual snapshot of the current instance
+3. Create a new instance from the snapshot at the larger bundle
+4. Swap the static IP to the new instance
+5. Open port 8000 on the new instance (Lightsail firewall rules don't
+   carry over from snapshots)
+6. If Tailscale is installed: reset state and re-authenticate (snapshot
+   restore creates a duplicate node key)
+7. Start Docker Compose and verify
+8. Update `sst.config.ts` with the new `bundleId` (and `blueprintId`
+   if the OS was upgraded in-place)
+9. Reconcile SST state: `sst state remove 'VaultCortexVm'`, then add
+   `import: "<instance-name>"` to the resource options, deploy once,
+   remove the import line, run `sst refresh`, deploy again
+10. Delete the old instance after verification
+
+If the new instance name differs from the canonical name (`vault-cortex-<stage>`),
+use Path 1 from "Reconciling SST state" below to rename it back before
+reconciling — avoids permanent state drift.
+
+### Option B — SST replace (clean provision)
+
+Provisions a fresh instance from the `userData` bootstrap script. Simpler
+but destroys all on-disk state: installed packages, Docker volumes,
+`/opt/vault-cortex/.env`, SSH keys, and any ad-hoc tools (Tailscale,
+Claude Code, etc.). Only use this if you don't have state worth preserving or
+you're comfortable re-provisioning from scratch.
+
+To intentionally replace (e.g. bundle upgrade from
 `small_3_0` 2 GB → `medium_3_0` 4 GB):
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       options: { max-size: "10m", max-file: "3" }
 
   vault-mcp:
-    image: ghcr.io/${GHCR_USER:?GHCR_USER required}/vault-mcp:latest
+    image: ghcr.io/${GHCR_USER:?GHCR_USER required}/vault-mcp:${VAULT_MCP_TAG:-latest}
     container_name: vault-mcp
     restart: unless-stopped
     depends_on:

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -121,7 +121,7 @@ export default $config({
     })
 
     // ── Lightsail ─────────────────────────────────────────────────
-    // small_3_0 = 2 vCPU, 2 GB RAM, 60 GB SSD, 3 TB transfer, $12/mo.
+    // medium_3_0 = 2 vCPU, 4 GB RAM, 80 GB SSD, 4 TB transfer, $24/mo.
     //
     // Auto-snapshot: daily disk-image backup retained 7 days by
     // Lightsail. Captures everything on the boot disk (Docker volumes,
@@ -137,11 +137,10 @@ export default $config({
     //
     // GOTCHA #1: Changing userData, bundleId, or keyPairName WOULD
     //            normally replace the instance. With protect:true,
-    //            Pulumi refuses and the deploy fails loudly. To
-    //            intentionally replace (e.g. bundle upgrade for
-    //            Phase 2), see the "Intentional replace" section
-    //            of RECOVERY.md — unprotect via state command,
-    //            deploy, then it re-protects on next regular deploy.
+    //            Pulumi refuses and the deploy fails loudly. For
+    //            bundle upgrades, use a snapshot-based upgrade
+    //            (preserves all state) then reconcile SST state
+    //            afterward — see RECOVERY.md.
     // GOTCHA #2: The deploy-key convention above keeps keyPairName
     //            stable across local and CI deploys.
     // GOTCHA #3: userData is visible via get-instance API/console.
@@ -152,8 +151,8 @@ export default $config({
       {
         name: `vault-cortex-${$app.stage}`,
         availabilityZone: `${awsRegion}a`,
-        blueprintId: "ubuntu_22_04",
-        bundleId: "small_3_0",
+        blueprintId: "ubuntu_24_04",
+        bundleId: "medium_3_0",
         keyPairName: keyPair.name,
         addOn: {
           type: "AutoSnapshot",

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -122,6 +122,9 @@ export default $config({
 
     // ── Lightsail ─────────────────────────────────────────────────
     // medium_3_0 = 2 vCPU, 4 GB RAM, 80 GB SSD, 4 TB transfer, $24/mo.
+    // Phase 1 runs fine on small_3_0 (2 GB, $12/mo). Phase 2 (hybrid
+    // search with local embeddings) needs the extra RAM. To downgrade,
+    // change bundleId to "small_3_0" — no snapshot needed, just redeploy.
     //
     // Auto-snapshot: daily disk-image backup retained 7 days by
     // Lightsail. Captures everything on the boot disk (Docker volumes,
@@ -172,7 +175,16 @@ export default $config({
         ].join("\n"),
         tags: { Project: "vault-cortex", Stage: $app.stage, ManagedBy: "sst" },
       },
-      { protect: true, retainOnDelete: true },
+      {
+        protect: true,
+        retainOnDelete: true,
+        // Lightsail treats userData and blueprintId as create-time-only
+        // properties. Changing either triggers a full instance replacement
+        // (not an in-place update). After a snapshot-based bundle upgrade
+        // or an in-place OS update, these values in Pulumi state won't
+        // match the config — ignore them so deploys stay clean.
+        ignoreChanges: ["userData", "blueprintId"],
+      },
     )
 
     const staticIp = new aws.lightsail.StaticIp("VaultCortexIp", {


### PR DESCRIPTION
## Summary

- Update `sst.config.ts` to reflect the snapshot-based Lightsail upgrade from `small_3_0` (2GB, $12/mo) to `medium_3_0` (4GB, $24/mo) and the in-place OS upgrade from Ubuntu 22.04 to 24.04
- Add `ignoreChanges` for `userData` and `blueprintId` — both are create-time-only Lightsail properties that become stale after snapshot restores and in-place OS upgrades, causing every deploy to fail on a replacement diff blocked by `protect: true`
- Add `phase2_deploy.yml` — manual dispatch workflow for deploying from the `phase-2` feature branch (SST + optional Docker build)

These are infra-only changes needed on main so that:
1. Bug fix releases don't fail on SST deploy (ignoreChanges prevents userData/blueprintId replacement)
2. The Phase 2 deploy workflow is visible in the GitHub Actions UI (workflow_dispatch requires default branch)

## Test plan

- [ ] Verify `sst deploy` succeeds without attempting instance replacement
- [ ] Verify Phase 2 deploy workflow appears in GitHub Actions UI
- [ ] Verify a fresh forker's first `sst deploy` still creates the instance with userData and blueprintId (ignoreChanges only affects updates, not creates — [Pulumi docs](https://www.pulumi.com/docs/iac/concepts/resources/options/ignorechanges/))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual Phase 2 deployment workflow with safer rollout handling, image publishing, server update steps, and a final health check.

* **Bug Fixes**
  * Improved deployment reliability by making Tailscale connection checks work consistently.
  * Prevented overlapping production deploys from running at the same time.

* **Documentation**
  * Expanded recovery guidance with clearer upgrade paths and restore options.

* **Chores**
  * Updated server sizing settings and deployment safeguards to better support future upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->