### PR TITLE
docs: fix Remote access bullet anchor to point at Deployment Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 <p align="center"><em>All three demos run on Claude mobile. The vault is on a remote server, not the phone.</em></p>
 
-- **[Remote access](#authentication)** — works from your phone, a remote server, or any MCP client via OAuth 2.1. Deploy on a VPS with Obsidian Sync for access from anywhere.
+- **[Remote access](#deployment-options)** — works from your phone, a remote server, or any MCP client via OAuth 2.1. Deploy on a VPS with Obsidian Sync for access from anywhere.
 - **Plugin-free** — Obsidian doesn't need to be running. The server works directly with `.md` files on disk. Headless sync keeps the vault current.
 - **[Ranked search](#tools-25)** — SQLite FTS5 with BM25 scoring, stemming, phrase matching, and tag/property/folder filtering
 - **[Structured memory](#tools-25)** — dated entries, section targeting, auto-initialization for AI personalization


### PR DESCRIPTION
## What

The **Remote access** bullet in the README's "What you get" list linked to `#authentication`, but its content is about remote/VPS deployment ("works from your phone, a remote server… Deploy on a VPS with Obsidian Sync for access from anywhere"). Retarget it to `#deployment-options` so the anchor lands on the relevant section.

```diff
- - **[Remote access](#authentication)** — works from your phone, a remote server, …
+ - **[Remote access](#deployment-options)** — works from your phone, a remote server, …
```

## Why

Audited every in-page and cross-file anchor link in `README.md`. No slugs are broken — every anchor resolves to a real heading — but this one pointed at a semantically wrong destination (token methods rather than deployment). The other "What you get" bullets (Ranked search / Structured memory / Link graph → Tools, Obsidian-native → Properties, Guided workflows → Prompts) and both cross-file anchors (ARCHITECTURE auth, deploy/local Windows) were verified correct and left unchanged.

## Scope

Single one-line docs change. No tool/prompt count or feature change, so no other feature-surface files need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2AhKQcG88wLfSo9R75igg)_