### PR TITLE
fix(search): include symlinked files in vault indexing and listing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,9 @@ Two rules keep this honest:
 
 **`utils/` admission:** a helper belongs here only if it is **generic with zero
 domain knowledge** (no vault, Markdown, or MCP concepts) **and** clears one of two
-bars:
+bars. `import type` from infrastructure modules (`Logger`, config types) is fine —
+type-only imports are erased at compile time and don't create runtime coupling.
+Don't reinvent a type with a structural stand-in when the real type exists:
 
 - **(1) It removes real duplication** — already called from more than one place
   (`describeError`, `readFileOrNull`).

--- a/src/utils/filter-valid-symlinks.ts
+++ b/src/utils/filter-valid-symlinks.ts
@@ -10,36 +10,36 @@ type SymlinkLogger = {
   warn: (message: string, meta: Record<string, unknown>) => void
 }
 
-export const filterValidSymlinks = async (
-  entries: ReadonlyArray<Dirent>,
-  canonicalRoot: string,
-  normalizedRoot: string,
-  logger: SymlinkLogger,
-): Promise<Dirent[]> =>
-  (
+export const filterValidSymlinks = async (params: {
+  entries: ReadonlyArray<Dirent>
+  roots: { canonical: string; normalized: string }
+  logger: SymlinkLogger
+}): Promise<Dirent[]> => {
+  const { entries, roots, logger } = params
+  return (
     await Promise.all(
       entries.map(async (entry) => {
         if (!entry.isSymbolicLink()) return entry
         const entryPath = join(entry.parentPath, entry.name)
         try {
           const targetPath = await realpath(entryPath)
-          if (!targetPath.startsWith(canonicalRoot + "/")) {
+          if (!targetPath.startsWith(roots.canonical + "/")) {
             logger.warn("symlink target escapes root, skipping", {
-              path: relative(normalizedRoot, entryPath),
+              path: relative(roots.normalized, entryPath),
             })
             return null
           }
           const targetStat = await stat(targetPath)
           if (!targetStat.isFile()) {
             logger.warn("symlink target is not a file, skipping", {
-              path: relative(normalizedRoot, entryPath),
+              path: relative(roots.normalized, entryPath),
             })
             return null
           }
           return entry
         } catch (error) {
           logger.warn("broken symlink, skipping", {
-            path: relative(normalizedRoot, entryPath),
+            path: relative(roots.normalized, entryPath),
             error: describeError(error),
           })
           return null
@@ -47,3 +47,4 @@ export const filterValidSymlinks = async (
       }),
     )
   ).filter((entry): entry is Dirent => entry !== null)
+}

--- a/src/utils/filter-valid-symlinks.ts
+++ b/src/utils/filter-valid-symlinks.ts
@@ -1,0 +1,47 @@
+/** Filters directory entries, excluding symlinks whose resolved targets are
+ *  broken (dangling), escape the given root directory, or are not regular files. */
+
+import type { Dirent } from "node:fs"
+import { realpath, stat } from "node:fs/promises"
+import { join, relative } from "node:path"
+import { describeError } from "./describe-error.js"
+
+type WarnFn = (message: string, meta: Record<string, unknown>) => void
+
+export const filterValidSymlinks = async (
+  entries: ReadonlyArray<Dirent>,
+  canonicalRoot: string,
+  normalizedRoot: string,
+  warn: WarnFn,
+): Promise<Dirent[]> =>
+  (
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (!entry.isSymbolicLink()) return entry
+        const entryPath = join(entry.parentPath, entry.name)
+        try {
+          const targetPath = await realpath(entryPath)
+          if (!targetPath.startsWith(canonicalRoot + "/")) {
+            warn("symlink target escapes root, skipping", {
+              path: relative(normalizedRoot, entryPath),
+            })
+            return null
+          }
+          const targetStat = await stat(targetPath)
+          if (!targetStat.isFile()) {
+            warn("symlink target is not a file, skipping", {
+              path: relative(normalizedRoot, entryPath),
+            })
+            return null
+          }
+          return entry
+        } catch (error) {
+          warn("broken symlink, skipping", {
+            path: relative(normalizedRoot, entryPath),
+            error: describeError(error),
+          })
+          return null
+        }
+      }),
+    )
+  ).filter((entry): entry is Dirent => entry !== null)

--- a/src/utils/filter-valid-symlinks.ts
+++ b/src/utils/filter-valid-symlinks.ts
@@ -6,13 +6,15 @@ import { realpath, stat } from "node:fs/promises"
 import { join, relative } from "node:path"
 import { describeError } from "./describe-error.js"
 
-type WarnFn = (message: string, meta: Record<string, unknown>) => void
+type SymlinkLogger = {
+  warn: (message: string, meta: Record<string, unknown>) => void
+}
 
 export const filterValidSymlinks = async (
   entries: ReadonlyArray<Dirent>,
   canonicalRoot: string,
   normalizedRoot: string,
-  warn: WarnFn,
+  logger: SymlinkLogger,
 ): Promise<Dirent[]> =>
   (
     await Promise.all(
@@ -22,21 +24,21 @@ export const filterValidSymlinks = async (
         try {
           const targetPath = await realpath(entryPath)
           if (!targetPath.startsWith(canonicalRoot + "/")) {
-            warn("symlink target escapes root, skipping", {
+            logger.warn("symlink target escapes root, skipping", {
               path: relative(normalizedRoot, entryPath),
             })
             return null
           }
           const targetStat = await stat(targetPath)
           if (!targetStat.isFile()) {
-            warn("symlink target is not a file, skipping", {
+            logger.warn("symlink target is not a file, skipping", {
               path: relative(normalizedRoot, entryPath),
             })
             return null
           }
           return entry
         } catch (error) {
-          warn("broken symlink, skipping", {
+          logger.warn("broken symlink, skipping", {
             path: relative(normalizedRoot, entryPath),
             error: describeError(error),
           })

--- a/src/utils/filter-valid-symlinks.ts
+++ b/src/utils/filter-valid-symlinks.ts
@@ -5,6 +5,9 @@ import type { Dirent } from "node:fs"
 import { realpath, stat } from "node:fs/promises"
 import { join, relative } from "node:path"
 import { describeError } from "./describe-error.js"
+import { mapWithConcurrency } from "./map-with-concurrency.js"
+
+const SYMLINK_VALIDATION_CONCURRENCY = 16
 
 type SymlinkLogger = {
   warn: (message: string, meta: Record<string, unknown>) => void
@@ -17,8 +20,10 @@ export const filterValidSymlinks = async (params: {
 }): Promise<Dirent[]> => {
   const { entries, roots, logger } = params
   return (
-    await Promise.all(
-      entries.map(async (entry) => {
+    await mapWithConcurrency({
+      items: [...entries],
+      concurrency: SYMLINK_VALIDATION_CONCURRENCY,
+      mapper: async (entry) => {
         if (!entry.isSymbolicLink()) return entry
         const entryPath = join(entry.parentPath, entry.name)
         try {
@@ -44,7 +49,7 @@ export const filterValidSymlinks = async (params: {
           })
           return null
         }
-      }),
-    )
+      },
+    })
   ).filter((entry): entry is Dirent => entry !== null)
 }

--- a/src/utils/filter-valid-symlinks.ts
+++ b/src/utils/filter-valid-symlinks.ts
@@ -8,13 +8,13 @@ import { mapWithConcurrency } from "./map-with-concurrency.js"
 const SYMLINK_VALIDATION_CONCURRENCY = 16
 
 /** Filters directory entries, excluding symlinks whose resolved targets are
- *  broken (dangling), escape the given root directory, or are not regular files. */
+ *  broken (dangling) or are not regular files. */
 export const filterValidSymlinks = async (params: {
   entries: ReadonlyArray<Dirent>
-  roots: { canonical: string; normalized: string }
+  normalizedRoot: string
   logger: Logger
 }): Promise<Dirent[]> => {
-  const { entries, roots, logger } = params
+  const { entries, normalizedRoot, logger } = params
   return (
     await mapWithConcurrency({
       items: [...entries],
@@ -24,23 +24,17 @@ export const filterValidSymlinks = async (params: {
         const entryPath = join(entry.parentPath, entry.name)
         try {
           const targetPath = await realpath(entryPath)
-          if (!targetPath.startsWith(roots.canonical + "/")) {
-            logger.warn("symlink target escapes root, skipping", {
-              path: relative(roots.normalized, entryPath),
-            })
-            return null
-          }
           const targetStat = await stat(targetPath)
           if (!targetStat.isFile()) {
             logger.warn("symlink target is not a file, skipping", {
-              path: relative(roots.normalized, entryPath),
+              path: relative(normalizedRoot, entryPath),
             })
             return null
           }
           return entry
         } catch (error) {
           logger.warn("broken symlink, skipping", {
-            path: relative(roots.normalized, entryPath),
+            path: relative(normalizedRoot, entryPath),
             error: describeError(error),
           })
           return null

--- a/src/utils/filter-valid-symlinks.ts
+++ b/src/utils/filter-valid-symlinks.ts
@@ -1,6 +1,3 @@
-/** Filters directory entries, excluding symlinks whose resolved targets are
- *  broken (dangling), escape the given root directory, or are not regular files. */
-
 import type { Dirent } from "node:fs"
 import { realpath, stat } from "node:fs/promises"
 import { join, relative } from "node:path"
@@ -10,6 +7,8 @@ import { mapWithConcurrency } from "./map-with-concurrency.js"
 
 const SYMLINK_VALIDATION_CONCURRENCY = 16
 
+/** Filters directory entries, excluding symlinks whose resolved targets are
+ *  broken (dangling), escape the given root directory, or are not regular files. */
 export const filterValidSymlinks = async (params: {
   entries: ReadonlyArray<Dirent>
   roots: { canonical: string; normalized: string }

--- a/src/utils/filter-valid-symlinks.ts
+++ b/src/utils/filter-valid-symlinks.ts
@@ -4,19 +4,16 @@
 import type { Dirent } from "node:fs"
 import { realpath, stat } from "node:fs/promises"
 import { join, relative } from "node:path"
+import type { Logger } from "../logger.js"
 import { describeError } from "./describe-error.js"
 import { mapWithConcurrency } from "./map-with-concurrency.js"
 
 const SYMLINK_VALIDATION_CONCURRENCY = 16
 
-type SymlinkLogger = {
-  warn: (message: string, meta: Record<string, unknown>) => void
-}
-
 export const filterValidSymlinks = async (params: {
   entries: ReadonlyArray<Dirent>
   roots: { canonical: string; normalized: string }
-  logger: SymlinkLogger
+  logger: Logger
 }): Promise<Dirent[]> => {
   const { entries, roots, logger } = params
   return (

--- a/src/vault-mcp/search/__tests__/file-watcher.test.ts
+++ b/src/vault-mcp/search/__tests__/file-watcher.test.ts
@@ -7,7 +7,14 @@ import {
   vi,
   onTestFinished,
 } from "vitest"
-import { mkdtemp, rm, writeFile, mkdir, unlink } from "node:fs/promises"
+import {
+  mkdtemp,
+  rm,
+  writeFile,
+  mkdir,
+  unlink,
+  symlink,
+} from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { watch } from "chokidar"
@@ -147,6 +154,27 @@ describe("file-watcher", () => {
 
     const hiddenResults = index.fullTextSearch({ query: "hidden" }, logger)
     expect(hiddenResults).toHaveLength(0)
+  })
+
+  it("indexes a symlinked .md file", { timeout: 15000 }, async () => {
+    await writeFile(join(vault, "real.md"), "symlink watcher target\n", "utf8")
+
+    await startFileWatcher(vault, index, {
+      stabilityThreshold: 200,
+      pollInterval: 50,
+    })
+
+    await symlink("real.md", join(vault, "linked.md"))
+
+    await waitFor(() =>
+      index
+        .fullTextSearch({ query: "symlink watcher" }, logger)
+        .some((result) => result.path === "linked.md"),
+    )
+    const paths = index
+      .fullTextSearch({ query: "symlink watcher" }, logger)
+      .map((result) => result.path)
+    expect(paths).toContain("linked.md")
   })
 
   // Polling is the Windows-mode path (inotify doesn't cross the Docker Desktop ↔

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -1770,25 +1770,26 @@ describe("rebuildFromVault", () => {
     ])
   })
 
-  it("skips a symlink whose target escapes the vault root", async () => {
-    // A valid internal symlink proves the system indexes symlinks —
-    // without it, the test passes trivially even if all symlinks are ignored
-    await symlink("root.md", join(vaultDir, "valid-link.md"))
-
+  it("indexes a symlink whose target is outside the vault root", async () => {
+    // Obsidian supports symlinks to files outside the vault (e.g. repo files
+    // symlinked into the vault for browsing), so vault-cortex follows suit
     const outsideDir = await mkdtemp(join(tmpdir(), "vault-outside-"))
     onTestFinished(async () => rm(outsideDir, { recursive: true }))
     await writeFile(
-      join(outsideDir, "secret.md"),
-      "# Secret\n\nExternal content.\n",
+      join(outsideDir, "external.md"),
+      "# External\n\nExternal content.\n",
       "utf8",
     )
-    await symlink(join(outsideDir, "secret.md"), join(vaultDir, "escape.md"))
+    await symlink(
+      join(outsideDir, "external.md"),
+      join(vaultDir, "linked-external.md"),
+    )
 
     const count = await index.rebuildFromVault(vaultDir)
-    expect(count).toBe(3) // 2 baseline + valid-link.md (escape.md filtered)
+    expect(count).toBe(3)
 
     const results = index.fullTextSearch({ query: "external content" }, logger)
-    expect(results).toHaveLength(0)
+    expect(results.map((result) => result.path)).toEqual(["linked-external.md"])
   })
 
   it("skips a broken symlink without crashing the rebuild", async () => {

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -1766,6 +1766,33 @@ describe("rebuildFromVault", () => {
     expect(asset!.exists).toBe(true)
     expect(asset!.kind).toBe("asset")
   })
+
+  it("skips a symlink whose target escapes the vault root", async () => {
+    const outsideDir = await mkdtemp(join(tmpdir(), "vault-outside-"))
+    onTestFinished(async () => rm(outsideDir, { recursive: true }))
+    await writeFile(
+      join(outsideDir, "secret.md"),
+      "# Secret\n\nExternal content.\n",
+      "utf8",
+    )
+    await symlink(join(outsideDir, "secret.md"), join(vaultDir, "escape.md"))
+
+    const count = await index.rebuildFromVault(vaultDir)
+    expect(count).toBe(2)
+
+    const results = index.fullTextSearch({ query: "external content" }, logger)
+    expect(results).toHaveLength(0)
+  })
+
+  it("skips a broken symlink without crashing the rebuild", async () => {
+    await symlink("nonexistent/target.md", join(vaultDir, "broken.md"))
+
+    const count = await index.rebuildFromVault(vaultDir)
+    expect(count).toBe(2)
+
+    const results = index.fullTextSearch({ query: "burnout" }, logger)
+    expect(results).toHaveLength(1)
+  })
 })
 
 // ── Link query methods ───────────────────────────────────────────

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -1761,10 +1761,13 @@ describe("rebuildFromVault", () => {
     await index.rebuildFromVault(vaultDir)
 
     const outgoing = index.getOutgoingLinks({ path: "source.md" }, logger)
-    expect(outgoing).toHaveLength(1)
-    expect(outgoing[0]!.path).toBe("Board.canvas")
-    expect(outgoing[0]!.exists).toBe(true)
-    expect(outgoing[0]!.kind).toBe("asset")
+    expect(outgoing).toEqual([
+      expect.objectContaining({
+        path: "Board.canvas",
+        exists: true,
+        kind: "asset",
+      }),
+    ])
   })
 
   it("skips a symlink whose target escapes the vault root", async () => {
@@ -1813,8 +1816,7 @@ describe("rebuildFromVault", () => {
     expect(count).toBe(4) // 2 baseline + valid-link.md + inner.md (dirlink.md filtered)
 
     const results = index.fullTextSearch({ query: "inner" }, logger)
-    expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("realdir/inner.md")
+    expect(results.map((result) => result.path)).toEqual(["realdir/inner.md"])
   })
 })
 

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -6,7 +6,7 @@ import {
   afterEach,
   onTestFinished,
 } from "vitest"
-import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
+import { mkdtemp, rm, writeFile, mkdir, symlink } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import Database from "better-sqlite3"
@@ -1725,6 +1725,46 @@ describe("rebuildFromVault", () => {
     expect(outgoing[0]!.kind).toBe("note")
     expect(outgoing[0]!.exists).toBe(true)
     expect(index.brokenLinkCount({}, logger).count).toBe(0)
+  })
+
+  it("indexes a symlinked .md file", async () => {
+    await mkdir(join(vaultDir, "real"), { recursive: true })
+    await writeFile(
+      join(vaultDir, "real/original.md"),
+      "# Original\n\nSymlink target content.\n",
+      "utf8",
+    )
+    await symlink("real/original.md", join(vaultDir, "linked.md"))
+
+    const count = await index.rebuildFromVault(vaultDir)
+    expect(count).toBe(4)
+
+    const results = index.fullTextSearch(
+      { query: "symlink target content" },
+      logger,
+    )
+    expect(results).toHaveLength(2)
+    const paths = results.map((result) => result.path).sort()
+    expect(paths).toEqual(["linked.md", "real/original.md"])
+  })
+
+  it("indexes a symlinked non-.md file for link resolution", async () => {
+    await mkdir(join(vaultDir, "boards"), { recursive: true })
+    await writeFile(join(vaultDir, "boards/real-board.canvas"), "{}", "utf8")
+    await symlink("boards/real-board.canvas", join(vaultDir, "Board.canvas"))
+    await writeFile(
+      join(vaultDir, "source.md"),
+      "# Source\n\nSee [[Board]].\n",
+      "utf8",
+    )
+
+    await index.rebuildFromVault(vaultDir)
+
+    const outgoing = index.getOutgoingLinks({ path: "source.md" }, logger)
+    const asset = outgoing.find((link) => link.path === "Board.canvas")
+    expect(asset).toBeDefined()
+    expect(asset!.exists).toBe(true)
+    expect(asset!.kind).toBe("asset")
   })
 })
 

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -1793,6 +1793,19 @@ describe("rebuildFromVault", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
     expect(results).toHaveLength(1)
   })
+
+  it("skips a symlink whose target is a directory, not a file", async () => {
+    await mkdir(join(vaultDir, "realdir"), { recursive: true })
+    await writeFile(join(vaultDir, "realdir/inner.md"), "inner\n", "utf8")
+    await symlink(join(vaultDir, "realdir"), join(vaultDir, "dirlink.md"))
+
+    const count = await index.rebuildFromVault(vaultDir)
+    expect(count).toBe(3)
+
+    const results = index.fullTextSearch({ query: "inner" }, logger)
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe("realdir/inner.md")
+  })
 })
 
 // ── Link query methods ───────────────────────────────────────────

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -1761,13 +1761,17 @@ describe("rebuildFromVault", () => {
     await index.rebuildFromVault(vaultDir)
 
     const outgoing = index.getOutgoingLinks({ path: "source.md" }, logger)
-    const asset = outgoing.find((link) => link.path === "Board.canvas")
-    expect(asset).toBeDefined()
-    expect(asset!.exists).toBe(true)
-    expect(asset!.kind).toBe("asset")
+    expect(outgoing).toHaveLength(1)
+    expect(outgoing[0]!.path).toBe("Board.canvas")
+    expect(outgoing[0]!.exists).toBe(true)
+    expect(outgoing[0]!.kind).toBe("asset")
   })
 
   it("skips a symlink whose target escapes the vault root", async () => {
+    // A valid internal symlink proves the system indexes symlinks —
+    // without it, the test passes trivially even if all symlinks are ignored
+    await symlink("root.md", join(vaultDir, "valid-link.md"))
+
     const outsideDir = await mkdtemp(join(tmpdir(), "vault-outside-"))
     onTestFinished(async () => rm(outsideDir, { recursive: true }))
     await writeFile(
@@ -1778,29 +1782,35 @@ describe("rebuildFromVault", () => {
     await symlink(join(outsideDir, "secret.md"), join(vaultDir, "escape.md"))
 
     const count = await index.rebuildFromVault(vaultDir)
-    expect(count).toBe(2)
+    expect(count).toBe(3) // 2 baseline + valid-link.md (escape.md filtered)
 
     const results = index.fullTextSearch({ query: "external content" }, logger)
     expect(results).toHaveLength(0)
   })
 
   it("skips a broken symlink without crashing the rebuild", async () => {
+    // A valid internal symlink proves the system indexes symlinks —
+    // without it, the test passes trivially even if all symlinks are ignored
+    await symlink("root.md", join(vaultDir, "valid-link.md"))
     await symlink("nonexistent/target.md", join(vaultDir, "broken.md"))
 
     const count = await index.rebuildFromVault(vaultDir)
-    expect(count).toBe(2)
+    expect(count).toBe(3) // 2 baseline + valid-link.md (broken.md filtered)
 
     const results = index.fullTextSearch({ query: "burnout" }, logger)
     expect(results).toHaveLength(1)
   })
 
   it("skips a symlink whose target is a directory, not a file", async () => {
+    // A valid internal symlink proves the system indexes symlinks —
+    // without it, the test passes trivially even if all symlinks are ignored
+    await symlink("root.md", join(vaultDir, "valid-link.md"))
     await mkdir(join(vaultDir, "realdir"), { recursive: true })
     await writeFile(join(vaultDir, "realdir/inner.md"), "inner\n", "utf8")
     await symlink(join(vaultDir, "realdir"), join(vaultDir, "dirlink.md"))
 
     const count = await index.rebuildFromVault(vaultDir)
-    expect(count).toBe(3)
+    expect(count).toBe(4) // 2 baseline + valid-link.md + inner.md (dirlink.md filtered)
 
     const results = index.fullTextSearch({ query: "inner" }, logger)
     expect(results).toHaveLength(1)

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -650,7 +650,7 @@ export const createSearchIndex = (dbPath: string) => {
       allEntries,
       canonicalVault,
       normalizedVault,
-      logger.warn.bind(logger),
+      logger,
     )
 
     // Filter directory entries to visible .md files, then load their content

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -434,6 +434,7 @@ export const createSearchIndex = (dbPath: string) => {
   const indexNonMarkdownFiles = (
     entries: ReadonlyArray<{
       isFile: () => boolean
+      isSymbolicLink: () => boolean
       name: string
       parentPath: string
     }>,
@@ -441,7 +442,10 @@ export const createSearchIndex = (dbPath: string) => {
   ): number => {
     let filesIndexed = 0
     for (const directoryEntry of entries) {
-      if (!directoryEntry.isFile() || directoryEntry.name.endsWith(".md"))
+      if (
+        (!directoryEntry.isFile() && !directoryEntry.isSymbolicLink()) ||
+        directoryEntry.name.endsWith(".md")
+      )
         continue
       const absolutePath = join(directoryEntry.parentPath, directoryEntry.name)
       const relativePath = relative(normalizedVault, absolutePath)
@@ -640,7 +644,10 @@ export const createSearchIndex = (dbPath: string) => {
     const markdownFiles = entries.reduce<
       { relativePath: string; absolutePath: string }[]
     >((filteredFiles, directoryEntry) => {
-      if (!directoryEntry.isFile() || !directoryEntry.name.endsWith(".md"))
+      if (
+        (!directoryEntry.isFile() && !directoryEntry.isSymbolicLink()) ||
+        !directoryEntry.name.endsWith(".md")
+      )
         return filteredFiles
       const absolutePath = join(directoryEntry.parentPath, directoryEntry.name)
       const relativePath = relative(normalizedVault, absolutePath)

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -659,6 +659,13 @@ export const createSearchIndex = (dbPath: string) => {
               })
               return null
             }
+            const targetStat = await stat(targetPath)
+            if (!targetStat.isFile()) {
+              logger.warn("symlink target is not a file, skipping", {
+                path: relative(normalizedVault, entryPath),
+              })
+              return null
+            }
             return entry
           } catch (error) {
             logger.warn("broken symlink, skipping", {

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3"
 import { DateTime } from "luxon"
-import { readFile, readdir, realpath, stat } from "node:fs/promises"
+import { readFile, readdir, stat } from "node:fs/promises"
 import { join, basename, posix, relative, resolve } from "node:path"
 import { logger, type Logger } from "../../logger.js"
 import { parseNote } from "../obsidian-markdown/frontmatter.js"
@@ -636,19 +636,15 @@ export const createSearchIndex = (dbPath: string) => {
     db.exec("DELETE FROM non_md_files")
 
     const normalizedVault = resolve(vaultPath)
-    // Canonical vault root for symlink target comparison — realpath resolves
-    // platform symlinks (e.g. macOS /var → /private/var) that resolve() misses
-    const canonicalVault = await realpath(normalizedVault)
     const allEntries = await readdir(vaultPath, {
       recursive: true,
       withFileTypes: true,
     })
 
-    // Validate symlink targets: exclude broken symlinks, targets escaping
-    // the vault root, and targets that aren't regular files
+    // Validate symlink targets: exclude broken symlinks and non-file targets
     const entries = await filterValidSymlinks({
       entries: allEntries,
-      roots: { canonical: canonicalVault, normalized: normalizedVault },
+      normalizedRoot: normalizedVault,
       logger,
     })
 

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3"
 import { DateTime } from "luxon"
-import { readFile, readdir, stat } from "node:fs/promises"
+import { readFile, readdir, realpath, stat } from "node:fs/promises"
 import { join, basename, posix, relative, resolve } from "node:path"
 import { logger, type Logger } from "../../logger.js"
 import { parseNote } from "../obsidian-markdown/frontmatter.js"
@@ -635,10 +635,41 @@ export const createSearchIndex = (dbPath: string) => {
     db.exec("DELETE FROM non_md_files")
 
     const normalizedVault = resolve(vaultPath)
-    const entries = await readdir(vaultPath, {
+    // Canonical vault root for symlink target comparison — realpath resolves
+    // platform symlinks (e.g. macOS /var → /private/var) that resolve() misses
+    const canonicalVault = await realpath(normalizedVault)
+    const allEntries = await readdir(vaultPath, {
       recursive: true,
       withFileTypes: true,
     })
+
+    // Validate symlink targets: exclude broken symlinks and those whose
+    // resolved target escapes the vault root (prevents directory traversal
+    // via a symlink planted inside the vault pointing to /etc/passwd etc.)
+    const entries = (
+      await Promise.all(
+        allEntries.map(async (entry) => {
+          if (!entry.isSymbolicLink()) return entry
+          const entryPath = join(entry.parentPath, entry.name)
+          try {
+            const targetPath = await realpath(entryPath)
+            if (!targetPath.startsWith(canonicalVault + "/")) {
+              logger.warn("symlink target escapes vault root, skipping", {
+                path: relative(normalizedVault, entryPath),
+              })
+              return null
+            }
+            return entry
+          } catch (error) {
+            logger.warn("broken symlink, skipping", {
+              path: relative(normalizedVault, entryPath),
+              error: describeError(error),
+            })
+            return null
+          }
+        }),
+      )
+    ).filter((entry): entry is NonNullable<typeof entry> => entry !== null)
 
     // Filter directory entries to visible .md files, then load their content
     const markdownFiles = entries.reduce<

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -651,25 +651,20 @@ export const createSearchIndex = (dbPath: string) => {
     })
 
     // Filter directory entries to visible .md files, then load their content
-    const markdownFiles = entries
-      .filter(
-        (entry) =>
-          (entry.isFile() || entry.isSymbolicLink()) &&
-          entry.name.endsWith(".md"),
+    const markdownFiles = entries.reduce<
+      { relativePath: string; absolutePath: string }[]
+    >((filteredFiles, directoryEntry) => {
+      if (
+        (!directoryEntry.isFile() && !directoryEntry.isSymbolicLink()) ||
+        !directoryEntry.name.endsWith(".md")
       )
-      .map((entry) => {
-        const absolutePath = join(entry.parentPath, entry.name)
-        return {
-          relativePath: relative(normalizedVault, absolutePath),
-          absolutePath,
-        }
-      })
-      .filter(
-        (file) =>
-          !file.relativePath
-            .split("/")
-            .some((segment) => segment.startsWith(".")),
-      )
+        return filteredFiles
+      const absolutePath = join(directoryEntry.parentPath, directoryEntry.name)
+      const relativePath = relative(normalizedVault, absolutePath)
+      if (relativePath.split("/").some((segment) => segment.startsWith(".")))
+        return filteredFiles
+      return [...filteredFiles, { relativePath, absolutePath }]
+    }, [])
 
     const noteContents = await Promise.all(
       markdownFiles.map(async (file) => {

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -641,7 +641,9 @@ export const createSearchIndex = (dbPath: string) => {
       withFileTypes: true,
     })
 
-    // Validate symlink targets: exclude broken symlinks and non-file targets
+    // Symlinks may point outside the vault (e.g. ARCHITECTURE.md →
+    // ~/Code/repo/ARCHITECTURE.md) — Obsidian supports this natively, so we
+    // follow suit. Only broken symlinks and non-file targets are excluded.
     const entries = await filterValidSymlinks({
       entries: allEntries,
       normalizedRoot: normalizedVault,

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -646,12 +646,11 @@ export const createSearchIndex = (dbPath: string) => {
 
     // Validate symlink targets: exclude broken symlinks, targets escaping
     // the vault root, and targets that aren't regular files
-    const entries = await filterValidSymlinks(
-      allEntries,
-      canonicalVault,
-      normalizedVault,
+    const entries = await filterValidSymlinks({
+      entries: allEntries,
+      roots: { canonical: canonicalVault, normalized: normalizedVault },
       logger,
-    )
+    })
 
     // Filter directory entries to visible .md files, then load their content
     const markdownFiles = entries

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -10,6 +10,7 @@ import { links } from "../obsidian-markdown/links.js"
 import { splitIntoLines } from "../obsidian-markdown/lines.js"
 import { describeError } from "../../utils/describe-error.js"
 import { assertPathHasExtension } from "../../utils/assert-path-has-extension.js"
+import { filterValidSymlinks } from "../../utils/filter-valid-symlinks.js"
 // ── Type guards ─────────────────────────────────────────────────
 
 const isString = (value: unknown): value is string => typeof value === "string"
@@ -643,40 +644,14 @@ export const createSearchIndex = (dbPath: string) => {
       withFileTypes: true,
     })
 
-    // Validate symlink targets: exclude broken symlinks and those whose
-    // resolved target escapes the vault root (prevents directory traversal
-    // via a symlink planted inside the vault pointing to /etc/passwd etc.)
-    const entries = (
-      await Promise.all(
-        allEntries.map(async (entry) => {
-          if (!entry.isSymbolicLink()) return entry
-          const entryPath = join(entry.parentPath, entry.name)
-          try {
-            const targetPath = await realpath(entryPath)
-            if (!targetPath.startsWith(canonicalVault + "/")) {
-              logger.warn("symlink target escapes vault root, skipping", {
-                path: relative(normalizedVault, entryPath),
-              })
-              return null
-            }
-            const targetStat = await stat(targetPath)
-            if (!targetStat.isFile()) {
-              logger.warn("symlink target is not a file, skipping", {
-                path: relative(normalizedVault, entryPath),
-              })
-              return null
-            }
-            return entry
-          } catch (error) {
-            logger.warn("broken symlink, skipping", {
-              path: relative(normalizedVault, entryPath),
-              error: describeError(error),
-            })
-            return null
-          }
-        }),
-      )
-    ).filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    // Validate symlink targets: exclude broken symlinks, targets escaping
+    // the vault root, and targets that aren't regular files
+    const entries = await filterValidSymlinks(
+      allEntries,
+      canonicalVault,
+      normalizedVault,
+      logger.warn.bind(logger),
+    )
 
     // Filter directory entries to visible .md files, then load their content
     const markdownFiles = entries

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -679,20 +679,25 @@ export const createSearchIndex = (dbPath: string) => {
     ).filter((entry): entry is NonNullable<typeof entry> => entry !== null)
 
     // Filter directory entries to visible .md files, then load their content
-    const markdownFiles = entries.reduce<
-      { relativePath: string; absolutePath: string }[]
-    >((filteredFiles, directoryEntry) => {
-      if (
-        (!directoryEntry.isFile() && !directoryEntry.isSymbolicLink()) ||
-        !directoryEntry.name.endsWith(".md")
+    const markdownFiles = entries
+      .filter(
+        (entry) =>
+          (entry.isFile() || entry.isSymbolicLink()) &&
+          entry.name.endsWith(".md"),
       )
-        return filteredFiles
-      const absolutePath = join(directoryEntry.parentPath, directoryEntry.name)
-      const relativePath = relative(normalizedVault, absolutePath)
-      if (relativePath.split("/").some((segment) => segment.startsWith(".")))
-        return filteredFiles
-      return [...filteredFiles, { relativePath, absolutePath }]
-    }, [])
+      .map((entry) => {
+        const absolutePath = join(entry.parentPath, entry.name)
+        return {
+          relativePath: relative(normalizedVault, absolutePath),
+          absolutePath,
+        }
+      })
+      .filter(
+        (file) =>
+          !file.relativePath
+            .split("/")
+            .some((segment) => segment.startsWith(".")),
+      )
 
     const noteContents = await Promise.all(
       markdownFiles.map(async (file) => {

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -680,6 +680,26 @@ describe("listNotes", () => {
     const files = await listNotes({ vaultPath: vault }, logger)
     expect(files).toEqual(["notes/a.md", "notes/b.md", "root.md"])
   })
+
+  it("excludes a symlink whose target is a directory, not a file", async () => {
+    await mkdir(join(vault, "realdir"), { recursive: true })
+    await symlink(join(vault, "realdir"), join(vault, "dirlink.md"))
+    const files = await listNotes({ vaultPath: vault }, logger)
+    expect(files).toEqual(["notes/a.md", "notes/b.md", "root.md"])
+  })
+
+  it("returns empty when folder is a symlink escaping the vault", async () => {
+    const outsideDir = await mkdtemp(join(tmpdir(), "vault-outside-"))
+    onTestFinished(async () => rm(outsideDir, { recursive: true }))
+    await writeFile(join(outsideDir, "secret.md"), "leaked", "utf8")
+    await symlink(outsideDir, join(vault, "escape-dir"))
+
+    const files = await listNotes(
+      { vaultPath: vault, folder: "escape-dir" },
+      logger,
+    )
+    expect(files).toEqual([])
+  })
 })
 
 describe("readNoteProperties", () => {

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -664,6 +664,22 @@ describe("listNotes", () => {
     const files = await listNotes({ vaultPath: vault }, logger)
     expect(files).toEqual(["notes/a.md", "notes/b.md", "root.md", "sym.md"])
   })
+
+  it("excludes a symlink whose target escapes the vault root", async () => {
+    const outsideDir = await mkdtemp(join(tmpdir(), "vault-outside-"))
+    onTestFinished(async () => rm(outsideDir, { recursive: true }))
+    await writeFile(join(outsideDir, "secret.md"), "leaked", "utf8")
+    await symlink(join(outsideDir, "secret.md"), join(vault, "escape.md"))
+
+    const files = await listNotes({ vaultPath: vault }, logger)
+    expect(files).toEqual(["notes/a.md", "notes/b.md", "root.md"])
+  })
+
+  it("excludes a broken symlink without crashing", async () => {
+    await symlink("nonexistent/target.md", join(vault, "broken.md"))
+    const files = await listNotes({ vaultPath: vault }, logger)
+    expect(files).toEqual(["notes/a.md", "notes/b.md", "root.md"])
+  })
 })
 
 describe("readNoteProperties", () => {

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -665,22 +665,23 @@ describe("listNotes", () => {
     expect(files).toEqual(["notes/a.md", "notes/b.md", "root.md", "sym.md"])
   })
 
-  it("excludes a symlink whose target escapes the vault root", async () => {
-    // A valid internal symlink proves symlinks are listed —
-    // without it, the test passes trivially even if all symlinks are ignored
-    await symlink("notes/a.md", join(vault, "valid-link.md"))
-
+  it("includes a symlink whose target is outside the vault root", async () => {
+    // Obsidian supports symlinks to external files (e.g. repo files
+    // symlinked into the vault for browsing) — vault-cortex follows suit
     const outsideDir = await mkdtemp(join(tmpdir(), "vault-outside-"))
     onTestFinished(async () => rm(outsideDir, { recursive: true }))
-    await writeFile(join(outsideDir, "secret.md"), "leaked", "utf8")
-    await symlink(join(outsideDir, "secret.md"), join(vault, "escape.md"))
+    await writeFile(join(outsideDir, "external.md"), "external", "utf8")
+    await symlink(
+      join(outsideDir, "external.md"),
+      join(vault, "linked-external.md"),
+    )
 
     const files = await listNotes({ vaultPath: vault }, logger)
     expect(files).toEqual([
+      "linked-external.md",
       "notes/a.md",
       "notes/b.md",
       "root.md",
-      "valid-link.md",
     ])
   })
 
@@ -711,23 +712,6 @@ describe("listNotes", () => {
       "root.md",
       "valid-link.md",
     ])
-  })
-
-  it("returns empty when folder is a symlink escaping the vault", async () => {
-    const outsideDir = await mkdtemp(join(tmpdir(), "vault-outside-"))
-    onTestFinished(async () => rm(outsideDir, { recursive: true }))
-    await writeFile(join(outsideDir, "secret.md"), "leaked", "utf8")
-    await symlink(outsideDir, join(vault, "escape-dir"))
-
-    // Verify the vault itself has notes (the empty result is the guard, not an empty vault)
-    const allNotes = await listNotes({ vaultPath: vault }, logger)
-    expect(allNotes.length).toBeGreaterThan(0)
-
-    const files = await listNotes(
-      { vaultPath: vault, folder: "escape-dir" },
-      logger,
-    )
-    expect(files).toEqual([])
   })
 })
 

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -719,6 +719,10 @@ describe("listNotes", () => {
     await writeFile(join(outsideDir, "secret.md"), "leaked", "utf8")
     await symlink(outsideDir, join(vault, "escape-dir"))
 
+    // Verify the vault itself has notes (the empty result is the guard, not an empty vault)
+    const allNotes = await listNotes({ vaultPath: vault }, logger)
+    expect(allNotes.length).toBeGreaterThan(0)
+
     const files = await listNotes(
       { vaultPath: vault, folder: "escape-dir" },
       logger,

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -666,26 +666,51 @@ describe("listNotes", () => {
   })
 
   it("excludes a symlink whose target escapes the vault root", async () => {
+    // A valid internal symlink proves symlinks are listed —
+    // without it, the test passes trivially even if all symlinks are ignored
+    await symlink("notes/a.md", join(vault, "valid-link.md"))
+
     const outsideDir = await mkdtemp(join(tmpdir(), "vault-outside-"))
     onTestFinished(async () => rm(outsideDir, { recursive: true }))
     await writeFile(join(outsideDir, "secret.md"), "leaked", "utf8")
     await symlink(join(outsideDir, "secret.md"), join(vault, "escape.md"))
 
     const files = await listNotes({ vaultPath: vault }, logger)
-    expect(files).toEqual(["notes/a.md", "notes/b.md", "root.md"])
+    expect(files).toEqual([
+      "notes/a.md",
+      "notes/b.md",
+      "root.md",
+      "valid-link.md",
+    ])
   })
 
   it("excludes a broken symlink without crashing", async () => {
+    // A valid internal symlink proves symlinks are listed —
+    // without it, the test passes trivially even if all symlinks are ignored
+    await symlink("notes/a.md", join(vault, "valid-link.md"))
     await symlink("nonexistent/target.md", join(vault, "broken.md"))
     const files = await listNotes({ vaultPath: vault }, logger)
-    expect(files).toEqual(["notes/a.md", "notes/b.md", "root.md"])
+    expect(files).toEqual([
+      "notes/a.md",
+      "notes/b.md",
+      "root.md",
+      "valid-link.md",
+    ])
   })
 
   it("excludes a symlink whose target is a directory, not a file", async () => {
+    // A valid internal symlink proves symlinks are listed —
+    // without it, the test passes trivially even if all symlinks are ignored
+    await symlink("notes/a.md", join(vault, "valid-link.md"))
     await mkdir(join(vault, "realdir"), { recursive: true })
     await symlink(join(vault, "realdir"), join(vault, "dirlink.md"))
     const files = await listNotes({ vaultPath: vault }, logger)
-    expect(files).toEqual(["notes/a.md", "notes/b.md", "root.md"])
+    expect(files).toEqual([
+      "notes/a.md",
+      "notes/b.md",
+      "root.md",
+      "valid-link.md",
+    ])
   })
 
   it("returns empty when folder is a symlink escaping the vault", async () => {

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -15,6 +15,7 @@ import {
   readFile,
   readdir,
   stat,
+  symlink,
 } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
@@ -656,6 +657,12 @@ describe("listNotes", () => {
     await writeFile(join(vault, "notes/z.md"), "z", "utf8")
     const files = await listNotes({ vaultPath: vault, folder: "notes" }, logger)
     expect(files).toEqual(["notes/a.md", "notes/b.md", "notes/z.md"])
+  })
+
+  it("includes a symlinked .md file in the listing", async () => {
+    await symlink("notes/a.md", join(vault, "sym.md"))
+    const files = await listNotes({ vaultPath: vault }, logger)
+    expect(files).toEqual(["notes/a.md", "notes/b.md", "root.md", "sym.md"])
   })
 })
 

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -7,7 +7,6 @@ import {
   link,
   rm,
   rmdir,
-  realpath,
 } from "node:fs/promises"
 import { randomUUID } from "node:crypto"
 import { join, dirname, relative, resolve, posix } from "node:path"
@@ -410,35 +409,20 @@ const listNotes = async (
   params: { vaultPath: string; folder?: string; glob?: string },
   logger: Logger,
 ): Promise<string[]> => {
-  const normalizedVault = resolve(params.vaultPath)
-  const canonicalVault = await realpath(normalizedVault)
-
-  // Canonicalize the search root so a symlinked folder inside the vault
-  // can't redirect readdirOrNull to a directory outside the vault root.
-  // Validate with canonical paths, but read with the original so
-  // entry.parentPath stays consistent with normalizedVault for relative().
   const searchRoot = params.folder
     ? resolveSafePath(params.vaultPath, params.folder)
     : resolve(params.vaultPath)
-  const canonicalSearchRoot = await realpath(searchRoot).catch(() => searchRoot)
-  if (
-    canonicalSearchRoot !== canonicalVault &&
-    !canonicalSearchRoot.startsWith(canonicalVault + "/")
-  ) {
-    logger.warn("search root escapes vault root, skipping", {
-      folder: params.folder,
-    })
-    return []
-  }
-
   const allEntries = await readdirOrNull(searchRoot)
   if (!allEntries) return []
 
-  // Validate symlink targets: exclude broken symlinks, targets escaping
-  // the vault root, and targets that aren't regular files
+  const normalizedVault = resolve(params.vaultPath)
+
+  // Symlinks may point outside the vault (e.g. ARCHITECTURE.md →
+  // ~/Code/repo/ARCHITECTURE.md) — Obsidian supports this natively, so we
+  // follow suit. Only broken symlinks and non-file targets are excluded.
   const entries = await filterValidSymlinks({
     entries: allEntries,
-    roots: { canonical: canonicalVault, normalized: normalizedVault },
+    normalizedRoot: normalizedVault,
     logger,
   })
 

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -7,6 +7,7 @@ import {
   link,
   rm,
   rmdir,
+  realpath,
 } from "node:fs/promises"
 import { randomUUID } from "node:crypto"
 import { join, dirname, relative, resolve, posix } from "node:path"
@@ -411,10 +412,37 @@ const listNotes = async (
   const searchRoot = params.folder
     ? resolveSafePath(params.vaultPath, params.folder)
     : resolve(params.vaultPath)
-  const entries = await readdirOrNull(searchRoot)
-  if (!entries) return []
+  const allEntries = await readdirOrNull(searchRoot)
+  if (!allEntries) return []
 
   const normalizedVault = resolve(params.vaultPath)
+  const canonicalVault = await realpath(normalizedVault)
+
+  // Validate symlink targets: exclude broken symlinks and those escaping the vault
+  const entries = (
+    await Promise.all(
+      allEntries.map(async (entry) => {
+        if (!entry.isSymbolicLink()) return entry
+        const entryPath = join(entry.parentPath, entry.name)
+        try {
+          const targetPath = await realpath(entryPath)
+          if (!targetPath.startsWith(canonicalVault + "/")) {
+            logger.warn("symlink target escapes vault root, skipping", {
+              path: relative(normalizedVault, entryPath),
+            })
+            return null
+          }
+          return entry
+        } catch (error) {
+          logger.warn("broken symlink, skipping", {
+            path: relative(normalizedVault, entryPath),
+            error: describeError(error),
+          })
+          return null
+        }
+      }),
+    )
+  ).filter((entry): entry is NonNullable<typeof entry> => entry !== null)
 
   const paths = entries
     .filter(

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -436,12 +436,11 @@ const listNotes = async (
 
   // Validate symlink targets: exclude broken symlinks, targets escaping
   // the vault root, and targets that aren't regular files
-  const entries = await filterValidSymlinks(
-    allEntries,
-    canonicalVault,
-    normalizedVault,
+  const entries = await filterValidSymlinks({
+    entries: allEntries,
+    roots: { canonical: canonicalVault, normalized: normalizedVault },
     logger,
-  )
+  })
 
   const paths = entries
     .filter(

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -8,12 +8,12 @@ import {
   rm,
   rmdir,
   realpath,
-  stat,
 } from "node:fs/promises"
 import { randomUUID } from "node:crypto"
 import { join, dirname, relative, resolve, posix } from "node:path"
 import picomatch from "picomatch"
 import { describeError } from "../../utils/describe-error.js"
+import { filterValidSymlinks } from "../../utils/filter-valid-symlinks.js"
 import { readFileOrNull, readdirOrNull } from "../../utils/fs.js"
 import {
   parseNote,
@@ -434,38 +434,14 @@ const listNotes = async (
   const allEntries = await readdirOrNull(searchRoot)
   if (!allEntries) return []
 
-  // Validate symlink targets: exclude broken symlinks and those escaping the vault
-  const entries = (
-    await Promise.all(
-      allEntries.map(async (entry) => {
-        if (!entry.isSymbolicLink()) return entry
-        const entryPath = join(entry.parentPath, entry.name)
-        try {
-          const targetPath = await realpath(entryPath)
-          if (!targetPath.startsWith(canonicalVault + "/")) {
-            logger.warn("symlink target escapes vault root, skipping", {
-              path: relative(normalizedVault, entryPath),
-            })
-            return null
-          }
-          const targetStat = await stat(targetPath)
-          if (!targetStat.isFile()) {
-            logger.warn("symlink target is not a file, skipping", {
-              path: relative(normalizedVault, entryPath),
-            })
-            return null
-          }
-          return entry
-        } catch (error) {
-          logger.warn("broken symlink, skipping", {
-            path: relative(normalizedVault, entryPath),
-            error: describeError(error),
-          })
-          return null
-        }
-      }),
-    )
-  ).filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+  // Validate symlink targets: exclude broken symlinks, targets escaping
+  // the vault root, and targets that aren't regular files
+  const entries = await filterValidSymlinks(
+    allEntries,
+    canonicalVault,
+    normalizedVault,
+    logger.warn.bind(logger),
+  )
 
   const paths = entries
     .filter(

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -8,6 +8,7 @@ import {
   rm,
   rmdir,
   realpath,
+  stat,
 } from "node:fs/promises"
 import { randomUUID } from "node:crypto"
 import { join, dirname, relative, resolve, posix } from "node:path"
@@ -409,14 +410,29 @@ const listNotes = async (
   params: { vaultPath: string; folder?: string; glob?: string },
   logger: Logger,
 ): Promise<string[]> => {
+  const normalizedVault = resolve(params.vaultPath)
+  const canonicalVault = await realpath(normalizedVault)
+
+  // Canonicalize the search root so a symlinked folder inside the vault
+  // can't redirect readdirOrNull to a directory outside the vault root.
+  // Validate with canonical paths, but read with the original so
+  // entry.parentPath stays consistent with normalizedVault for relative().
   const searchRoot = params.folder
     ? resolveSafePath(params.vaultPath, params.folder)
     : resolve(params.vaultPath)
+  const canonicalSearchRoot = await realpath(searchRoot).catch(() => searchRoot)
+  if (
+    canonicalSearchRoot !== canonicalVault &&
+    !canonicalSearchRoot.startsWith(canonicalVault + "/")
+  ) {
+    logger.warn("search root escapes vault root, skipping", {
+      folder: params.folder,
+    })
+    return []
+  }
+
   const allEntries = await readdirOrNull(searchRoot)
   if (!allEntries) return []
-
-  const normalizedVault = resolve(params.vaultPath)
-  const canonicalVault = await realpath(normalizedVault)
 
   // Validate symlink targets: exclude broken symlinks and those escaping the vault
   const entries = (
@@ -428,6 +444,13 @@ const listNotes = async (
           const targetPath = await realpath(entryPath)
           if (!targetPath.startsWith(canonicalVault + "/")) {
             logger.warn("symlink target escapes vault root, skipping", {
+              path: relative(normalizedVault, entryPath),
+            })
+            return null
+          }
+          const targetStat = await stat(targetPath)
+          if (!targetStat.isFile()) {
+            logger.warn("symlink target is not a file, skipping", {
               path: relative(normalizedVault, entryPath),
             })
             return null

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -440,7 +440,7 @@ const listNotes = async (
     allEntries,
     canonicalVault,
     normalizedVault,
-    logger.warn.bind(logger),
+    logger,
   )
 
   const paths = entries

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -418,7 +418,11 @@ const listNotes = async (
 
   const paths = entries
     .reduce<string[]>((acc, entry) => {
-      if (!entry.isFile() || !entry.name.endsWith(".md")) return acc
+      if (
+        (!entry.isFile() && !entry.isSymbolicLink()) ||
+        !entry.name.endsWith(".md")
+      )
+        return acc
       const rel = relative(normalizedVault, join(entry.parentPath, entry.name))
       if (rel.split("/").some((seg) => seg.startsWith("."))) return acc
       acc.push(rel)

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -417,21 +417,22 @@ const listNotes = async (
   const normalizedVault = resolve(params.vaultPath)
 
   const paths = entries
-    .reduce<string[]>((acc, entry) => {
-      if (
-        (!entry.isFile() && !entry.isSymbolicLink()) ||
-        !entry.name.endsWith(".md")
-      )
-        return acc
-      const rel = relative(normalizedVault, join(entry.parentPath, entry.name))
-      if (rel.split("/").some((seg) => seg.startsWith("."))) return acc
-      acc.push(rel)
-      return acc
-    }, [])
+    .filter(
+      (entry) =>
+        (entry.isFile() || entry.isSymbolicLink()) &&
+        entry.name.endsWith(".md"),
+    )
+    .map((entry) =>
+      relative(normalizedVault, join(entry.parentPath, entry.name)),
+    )
+    .filter(
+      (relativePath) =>
+        !relativePath.split("/").some((segment) => segment.startsWith(".")),
+    )
     .sort()
 
   const isMatch = params.glob ? picomatch(params.glob) : undefined
-  const result = isMatch ? paths.filter((p) => isMatch(p)) : paths
+  const result = isMatch ? paths.filter((notePath) => isMatch(notePath)) : paths
   logger.info("listed notes", { folder: params.folder, count: result.length })
   return result
 }


### PR DESCRIPTION
## Summary

- `Dirent.isFile()` returns `false` for symbolic links, silently excluding symlinked `.md` and non-`.md` files from search, backlinks, orphan detection, and note listing
- Added `|| isSymbolicLink()` checks in `rebuildFromVault`, `indexNonMarkdownFiles`, and `listNotes`
- **Symlink target validation:** broken symlinks (dangling targets) are skipped with a warn log; symlinks to non-file targets (directories) are rejected via `stat().isFile()`
- **External symlinks supported:** symlinks whose targets are outside the vault root are indexed — Obsidian supports this natively (e.g. repo files symlinked into the vault for browsing), so vault-cortex follows suit
- **Shared `filterValidSymlinks` util** extracted to `src/utils/filter-valid-symlinks.ts` with bounded concurrency (`mapWithConcurrency`)
- **File watcher:** already symlink-compatible via chokidar's `followSymlinks: true` default — added integration test to prove it
- **AGENTS.md:** clarified that `import type` from infrastructure modules is fine in utils
- Not a production issue (Obsidian Sync resolves symlinks into real files on Lightsail), but a bug for local dev and any OSS user whose vault contains symlinks

## Test plan

- [x] Symlinked `.md` file indexed by `rebuildFromVault`
- [x] Symlinked non-`.md` file resolves wikilinks
- [x] Symlinked `.md` file appears in `listNotes`
- [x] Symlink to file outside vault root is indexed (not blocked)
- [x] Broken symlink skipped gracefully (no crash)
- [x] Symlink to directory skipped (not treated as file)
- [x] File watcher indexes symlinked `.md` file via chokidar
- [x] Two-bar controls: valid internal symlink sentinel in exclusion tests
- [x] Mutation-tested: reverted production fix, confirmed tests fail
- [x] All 1077 tests pass
- [x] Build and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPDgHMKBvJ51V2YrrMYZET