### PR TITLE
fix: pass MEMORY_ENABLED through docker-compose to container

### DIFF
--- a/cli/src/env.ts
+++ b/cli/src/env.ts
@@ -25,6 +25,9 @@ const LOCAL_OPTIONAL_BLOCK = `# Optional ─────────────
 # Your IANA timezone — affects daily note resolution and memory timestamps.
 # TZ=America/New_York
 
+# Enable or disable the memory layer (default: true).
+# Set to false to hide memory tools and skip About Me/ creation.
+# MEMORY_ENABLED=true
 # Memory folder name in your vault (default: About Me).
 # MEMORY_DIR=About Me
 
@@ -50,6 +53,9 @@ const REMOTE_OPTIONAL_BLOCK = `# Optional ────────────�
 # Your IANA timezone — affects daily note resolution and memory timestamps.
 # TZ=America/New_York
 
+# Enable or disable the memory layer (default: true).
+# Set to false to hide memory tools and skip About Me/ creation.
+# MEMORY_ENABLED=true
 # Memory folder name in your vault (default: About Me).
 # MEMORY_DIR=About Me
 

--- a/cli/templates/local/docker-compose.yml
+++ b/cli/templates/local/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       INDEX_DB_PATH: /data/index.db
       MCP_AUTH_TOKEN: "${MCP_AUTH_TOKEN:?Set MCP_AUTH_TOKEN in .env — see .env.example}"
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:8000}
+      MEMORY_ENABLED: ${MEMORY_ENABLED:-true}
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       LOG_DIR: ${LOG_DIR:-}

--- a/cli/templates/remote/docker-compose.yml
+++ b/cli/templates/remote/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       INDEX_DB_PATH: /data/index.db
       MCP_AUTH_TOKEN: "${MCP_AUTH_TOKEN:?Set MCP_AUTH_TOKEN in .env — see .env.example}"
       PUBLIC_URL: "${PUBLIC_URL:?Set PUBLIC_URL to your server's public URL}"
+      MEMORY_ENABLED: ${MEMORY_ENABLED:-true}
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       LOG_DIR: ${LOG_DIR:-/data/logs}

--- a/deploy/local/.env.example
+++ b/deploy/local/.env.example
@@ -16,7 +16,8 @@ VAULT_PATH=
 # Your IANA timezone — affects daily note resolution and memory timestamps.
 # TZ=America/New_York
 
-# Disable the memory layer (hides memory tools; skips About Me/ creation).
+# Enable or disable the memory layer (default: true).
+# Set to false to hide memory tools and skip About Me/ creation.
 # MEMORY_ENABLED=true
 # Memory folder name in your vault (default: About Me).
 # MEMORY_DIR=About Me

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       INDEX_DB_PATH: /data/index.db
       MCP_AUTH_TOKEN: "${MCP_AUTH_TOKEN:?Set MCP_AUTH_TOKEN in .env — see .env.example}"
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:8000}
+      MEMORY_ENABLED: ${MEMORY_ENABLED:-true}
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       LOG_DIR: ${LOG_DIR:-}

--- a/deploy/remote/.env.example
+++ b/deploy/remote/.env.example
@@ -28,7 +28,8 @@ VAULT_NAME=
 # Your IANA timezone — affects daily note resolution and memory timestamps.
 # TZ=America/New_York
 
-# Disable the memory layer (hides memory tools; skips About Me/ creation).
+# Enable or disable the memory layer (default: true).
+# Set to false to hide memory tools and skip About Me/ creation.
 # MEMORY_ENABLED=true
 # Memory folder name in your vault (default: About Me).
 # MEMORY_DIR=About Me

--- a/deploy/remote/docker-compose.yml
+++ b/deploy/remote/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       INDEX_DB_PATH: /data/index.db
       MCP_AUTH_TOKEN: "${MCP_AUTH_TOKEN:?Set MCP_AUTH_TOKEN in .env — see .env.example}"
       PUBLIC_URL: "${PUBLIC_URL:?Set PUBLIC_URL to your server's public URL}"
+      MEMORY_ENABLED: ${MEMORY_ENABLED:-true}
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       LOG_DIR: ${LOG_DIR:-/data/logs}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -20,6 +20,7 @@ services:
       MCP_AUTH_TOKEN: local-dev-token
       PUBLIC_URL: http://localhost:8000
       LOG_LEVEL: debug
+      MEMORY_ENABLED: ${MEMORY_ENABLED:-true}
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
       TZ: ${TZ:-UTC}
       # Windows: set WINDOWS_MODE=true when developing against a vault on a C: drive

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       LOG_DIR: /data/logs
       LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-30}
       TZ: ${TZ:-UTC}
+      MEMORY_ENABLED: ${MEMORY_ENABLED:-true}
       MEMORY_DIR: ${MEMORY_DIR:-About Me}
       # Left empty = the server applies smart defaults
       # (<MEMORY_DIR> below is the resolved MEMORY_DIR value, default "About Me"):


### PR DESCRIPTION
## Summary

- `MEMORY_ENABLED` was documented in `.env.example` but never passed through docker-compose to the container — setting it to `false` had no effect in Docker deployments
- Added `MEMORY_ENABLED: ${MEMORY_ENABLED:-true}` to all 6 docker-compose files

## Test plan

- [x] Verified `MEMORY_DIR` (which does pass through) uses the same `:-` default pattern
- [ ] Deploy with `MEMORY_ENABLED=false` and confirm memory tools are hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)