### PR TITLE
ci: fix skip_deploy to build image but skip instance deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: v${{ inputs.version }}
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,15 @@ on:
         required: false
         default: false
         type: boolean
+      skip_instance:
+        description: >-
+          Skip SST deploy and Lightsail instance update (SSH, compose
+          restart, healthcheck). The image is still built and pushed to
+          GHCR. Use when the instance runs a different branch (e.g.
+          Phase 2) and restarting compose would overwrite it.
+        required: false
+        default: false
+        type: boolean
 
 # Top-level token is read-only; the job declares its writes. Callers'
 # job-level grants are the ceiling — they must cover the same set.
@@ -51,12 +60,14 @@ jobs:
       - run: npm ci
 
       - name: Configure AWS credentials (OIDC)
+        if: ${{ !inputs.skip_instance }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SST deploy
+        if: ${{ !inputs.skip_instance }}
         env:
           SSH_PUBKEY: ${{ secrets.SSH_PUBKEY }}
           SSH_CIDRS: ${{ secrets.SSH_CIDRS }}
@@ -67,7 +78,7 @@ jobs:
         run: npx sst deploy --stage "$SST_STAGE"
 
       - name: Connect to Tailscale
-        if: env.TAILSCALE_ENABLED == 'true'
+        if: ${{ !inputs.skip_instance && env.TAILSCALE_ENABLED == 'true' }}
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
@@ -79,6 +90,7 @@ jobs:
       # repo means public Actions logs. The static-ip name matches
       # sst.config.ts (`vault-cortex-ip-${stage}`).
       - name: Fetch Lightsail IP from AWS
+        if: ${{ !inputs.skip_instance }}
         id: sst
         run: |
           ip=$(aws lightsail get-static-ip \
@@ -94,6 +106,7 @@ jobs:
           echo "ip=$ip" >> "$GITHUB_OUTPUT"
 
       - name: Resolve SSH target
+        if: ${{ !inputs.skip_instance }}
         id: ssh
         env:
           TAILSCALE_HOST: ${{ secrets.TAILSCALE_SSH_HOST }}
@@ -142,10 +155,12 @@ jobs:
           cache-to: type=gha,mode=max
 
       - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
+        if: ${{ !inputs.skip_instance }}
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Wait for Docker on Lightsail
+        if: ${{ !inputs.skip_instance }}
         env:
           IP: ${{ steps.ssh.outputs.host }}
         run: |
@@ -159,6 +174,7 @@ jobs:
           done
 
       - name: Bootstrap deploy directory and GHCR login on instance
+        if: ${{ !inputs.skip_instance }}
         env:
           IP: ${{ steps.ssh.outputs.host }}
           GHCR_USER: ${{ vars.GHCR_USER }}
@@ -170,6 +186,7 @@ jobs:
             "docker login ghcr.io -u '$GHCR_USER' --password-stdin"
 
       - name: Write Lightsail .env from secrets
+        if: ${{ !inputs.skip_instance }}
         env:
           PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
           MCP_AUTH_TOKEN: ${{ secrets.MCP_AUTH_TOKEN }}
@@ -206,6 +223,7 @@ jobs:
           EOF
 
       - name: Ship compose + .env to instance
+        if: ${{ !inputs.skip_instance }}
         env:
           IP: ${{ steps.ssh.outputs.host }}
         run: |
@@ -213,6 +231,7 @@ jobs:
           scp -o StrictHostKeyChecking=accept-new "$RUNNER_TEMP/lightsail.env" ubuntu@"$IP":/opt/vault-cortex/.env
 
       - name: Pull and restart compose stack
+        if: ${{ !inputs.skip_instance }}
         env:
           IP: ${{ steps.ssh.outputs.host }}
         run: |
@@ -220,6 +239,7 @@ jobs:
             'cd /opt/vault-cortex && docker compose pull && docker compose up -d --wait --wait-timeout 180 && docker image prune -f'
 
       - name: Healthcheck
+        if: ${{ !inputs.skip_instance }}
         env:
           PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
         run: curl -fsS --retry 6 --retry-delay 5 "$PUBLIC_URL/healthz"

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -14,10 +14,10 @@ on:
           - major
       skip_deploy:
         description: >-
-          Skip image build, SST deploy, and Lightsail restart. Use when
-          Lightsail runs a different branch (e.g. Phase 2) and deploying
-          main would overwrite it. The version bump, tag, GitHub release,
-          changelog, and registry publish still run normally.
+          Skip SST deploy and Lightsail restart — the Docker image is
+          still built and pushed to GHCR. Use when the instance runs a
+          different branch (e.g. Phase 2) and restarting compose would
+          overwrite it.
         required: false
         type: boolean
         default: false
@@ -98,7 +98,6 @@ jobs:
 
   deploy:
     needs: bump-and-tag
-    if: ${{ !inputs.skip_deploy }}
     # Ceiling for the reusable workflow: AWS OIDC + GHCR push.
     permissions:
       id-token: write
@@ -107,16 +106,11 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       version: ${{ needs.bump-and-tag.outputs.version }}
+      skip_instance: ${{ inputs.skip_deploy }}
     secrets: inherit
 
   publish-registry:
     needs: [bump-and-tag, deploy]
-    # Runs even when deploy is skipped — the registry manifest (server.json)
-    # doesn't depend on the Docker image or Lightsail.
-    if: |-
-      always() &&
-      needs.bump-and-tag.result == 'success' &&
-      (needs.deploy.result == 'success' || needs.deploy.result == 'skipped')
     # Ceiling for the reusable workflow: MCP Registry OIDC.
     permissions:
       id-token: write
@@ -127,12 +121,6 @@ jobs:
 
   release:
     needs: [bump-and-tag, deploy]
-    # When deploy is skipped (skip_deploy), release still runs — the GitHub
-    # release and changelog don't depend on the Docker image or Lightsail.
-    if: |-
-      always() &&
-      needs.bump-and-tag.result == 'success' &&
-      (needs.deploy.result == 'success' || needs.deploy.result == 'skipped')
     runs-on: ubuntu-latest
     # gh release create uses GITHUB_TOKEN; the CHANGELOG push to main
     # authenticates as the release App, not this token. generate-notes.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,22 +14,6 @@
 
 
 
-
-## [0.23.12] — 2026-06-29
-
-### Bug Fixes
-
-- Serialize concurrent writes to prevent TOCTOU lost updates (#220)
-- Pass MEMORY_ENABLED through docker-compose to container (#219)
-
-### Documentation
-
-- Update CHANGELOG.md for v0.23.11
-
-### CI / Infrastructure
-
-- Add skip_deploy escape hatch to manual release workflow (#221)
-
 ## [0.23.11] — 2026-06-27
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vault-cortex",
-  "version": "0.23.12",
+  "version": "0.23.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vault-cortex",
-      "version": "0.23.12",
+      "version": "0.23.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-cortex",
-  "version": "0.23.12",
+  "version": "0.23.11",
   "private": true,
   "description": "Standalone MCP server for Obsidian vaults — plugin-free search, memory, link graph, and daily notes over Streamable HTTP",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.aliasunder/vault-cortex",
   "title": "Vault Cortex",
   "description": "Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1.",
-  "version": "0.23.12",
+  "version": "0.23.11",
   "websiteUrl": "https://github.com/aliasunder/vault-cortex",
   "repository": {
     "url": "https://github.com/aliasunder/vault-cortex",
@@ -13,7 +13,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/aliasunder/vault-mcp:0.23.12",
+      "identifier": "ghcr.io/aliasunder/vault-mcp:0.23.11",
       "runtimeHint": "docker",
       "runtimeArguments": [
         {


### PR DESCRIPTION
## Summary

- Redesigns `skip_deploy` so the Docker image is still built and pushed to GHCR — only the Lightsail instance update (SST, SSH, compose restart, healthcheck) is skipped
- Adds `skip_instance` input to `deploy.yml` — reusable by any caller, not just manual_release
- Removes the `always()` + result-check gymnastics from `manual_release.yml` — deploy always runs (just with `skip_instance`), so the dependency chain stays linear
- Reverts the orphaned v0.23.12 version bump and changelog from the failed release attempt
- Deletes the orphaned v0.23.12 tag from GitHub (done manually before this PR)

## Motivation

The initial `skip_deploy` (#221) skipped the entire deploy job, which meant no Docker image was built. This broke two things:
1. OSS users couldn't pull the versioned image from GHCR
2. The MCP Registry rejected the publish because it validates that the Docker image exists

## Test plan

- [ ] Dispatch Manual Release with `skip_deploy: true` — verify image is built+pushed to GHCR, SST/SSH/compose steps are skipped, registry publish succeeds
- [ ] Dispatch Manual Release with `skip_deploy: false` (default) — verify all steps run as before
- [ ] Verify version is back to 0.23.11 (reverted from orphaned 0.23.12)
- [ ] YAML validated locally with Ruby YAML parser


🤖 Generated with [Claude Code](https://claude.com/claude-code)