### PR TITLE
feat(search): add hybrid search with RRF fusion

### DIFF
--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -405,6 +405,7 @@ describe("vault_search description reflects EMBEDDING_ENABLED", () => {
     expect(description).toContain("Reciprocal Rank Fusion")
     expect(description).toContain("semantic")
     expect(description).toContain("career aspirations")
+    expect(description).toContain("search_mode")
   })
 
   it("describes keyword-only search when EMBEDDING_ENABLED=false", () => {
@@ -416,6 +417,7 @@ describe("vault_search description reflects EMBEDDING_ENABLED", () => {
     expect(description).not.toContain("Reciprocal Rank Fusion")
     expect(description).not.toContain("semantic")
     expect(description).not.toContain("career aspirations")
+    expect(description).toContain("search_mode")
   })
 })
 

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -374,6 +374,51 @@ describe("error handling", () => {
   })
 })
 
+describe("vault_search description reflects EMBEDDING_ENABLED", () => {
+  const registerWithConfig = (
+    env: Record<string, string>,
+  ): RegisterToolCall[] => {
+    const server = { registerTool: vi.fn() }
+    registerTools({
+      server: server as unknown as McpServer,
+      vaultPath: "/test-vault",
+      search: {} as SearchIndex,
+      logger,
+      config: loadConfig(env),
+    })
+    const registeredCalls = server.registerTool.mock.calls as RegisterToolCall[]
+    return registeredCalls
+  }
+
+  const findSearchDescription = (
+    registeredCalls: RegisterToolCall[],
+  ): string => {
+    const searchCall = registeredCalls.find(
+      ([name]) => name === TOOL_NAMES.VAULT_SEARCH,
+    )
+    return searchCall![1].description!
+  }
+
+  it("describes hybrid search when EMBEDDING_ENABLED=true", () => {
+    const description = findSearchDescription(registerWithConfig({}))
+    expect(description).toContain("Hybrid search")
+    expect(description).toContain("Reciprocal Rank Fusion")
+    expect(description).toContain("semantic")
+    expect(description).toContain("career aspirations")
+  })
+
+  it("describes keyword-only search when EMBEDDING_ENABLED=false", () => {
+    const description = findSearchDescription(
+      registerWithConfig({ EMBEDDING_ENABLED: "false" }),
+    )
+    expect(description).toContain("Full-text search")
+    expect(description).not.toContain("Hybrid")
+    expect(description).not.toContain("Reciprocal Rank Fusion")
+    expect(description).not.toContain("semantic")
+    expect(description).not.toContain("career aspirations")
+  })
+})
+
 describe("MEMORY_ENABLED=false", () => {
   const MEMORY_TOOLS = [
     TOOL_NAMES.VAULT_GET_MEMORY,

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -30,7 +30,7 @@ export const registerSearchTools = ({
     TOOL_NAMES.VAULT_SEARCH,
     {
       title: "Search Notes",
-      description: `Full-text search across all vault notes, ranked by relevance. Combine a text query with structured filters to narrow results by metadata — the "narrow by metadata, search by text" pattern. Unquoted terms use implicit AND with porter stemming; wrap in double quotes for exact phrases; punctuated terms (vault-cortex, deploy/local) are matched as exact adjacent-word phrases automatically.
+      description: `Hybrid search across all vault notes, ranked by combined keyword and semantic relevance. When the embedding pipeline is active, results are ranked using Reciprocal Rank Fusion (RRF) — combining FTS5 keyword matching with vector similarity. When embeddings are unavailable, falls back to keyword-only (FTS5 BM25) transparently. Combine a text query with structured filters to narrow results by metadata — the "narrow by metadata, search by text" pattern. Unquoted terms use implicit AND with porter stemming; wrap in double quotes for exact phrases; punctuated terms (vault-cortex, deploy/local) are matched as exact adjacent-word phrases automatically.
 
 Filters — all conditions AND-combine with each other and the text query:
 - folder: path prefix (e.g. "Projects")
@@ -41,16 +41,16 @@ Filters — all conditions AND-combine with each other and the text query:
 
 Example: vault_search({ query: "kubernetes networking", filters: { tags: ["reference"] } })
 Example: vault_search({ query: "meeting notes", filters: { type: "meeting", folder: "Work" } })
-Example: vault_search({ query: "deployment", filters: { properties: { status: "active" } } })
+Example: vault_search({ query: "career aspirations", filters: { folder: "About Me" } })
 
-When to use: The primary discovery tool for content-based queries, optionally constrained by metadata.
+When to use: The primary discovery tool for content-based queries, optionally constrained by metadata. Semantic matching finds notes even when exact keywords differ — "career aspirations" finds notes about "goals" and "targets".
 Prefer vault_search_by_tag for tag-only queries without text. Prefer vault_search_by_folder for browsing a folder. Prefer vault_search_by_property for metadata-only queries. Prefer vault_recent_notes for time-based browsing.
 
 Errors:
 - No matches returns { results: [], total: 0 }, not an error
 - Malformed query syntax is sanitized automatically — the tool never throws a query syntax error
 
-Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified, bytes) and total count. created is omitted when null. bytes is the on-disk file size. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when present.`,
+Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified, bytes) and total count. score reflects combined relevance (higher = more relevant). created is omitted when null. bytes is the on-disk file size. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when present.`,
       inputSchema: {
         query: z
           .string()
@@ -123,7 +123,7 @@ Returns: JSON with results array (path, title, snippet, score, tags, folder, typ
       reqLogger.info("tool_call", { query, ...(filters ? { filters } : {}) })
       return safeHandler(
         reqLogger,
-        async () => search.fullTextSearch({ query, filters }, reqLogger),
+        async () => search.hybridSearch({ query, filters }, reqLogger),
         (results) => {
           reqLogger.info("tool_result", { resultCount: results.length })
           return JSON.stringify({ results, total: results.length })

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -42,7 +42,7 @@ Filters — all conditions AND-combine with each other and the text query:
 
 Example: vault_search({ query: "kubernetes networking", filters: { tags: ["reference"] } })
 Example: vault_search({ query: "meeting notes", filters: { type: "meeting", folder: "Work" } })
-Example: vault_search({ query: "dealing with burnout recovery" }) — semantic: finds notes about mental health and overwhelm even without the word "burnout"
+Example: vault_search({ query: "how the server watches for file changes" }) — semantic: finds notes about chokidar and file watchers even without those exact terms
 
 When to use: The primary discovery tool for content-based queries, optionally constrained by metadata. Semantic matching bridges vocabulary gaps — try natural-language queries, not just keywords.
 Prefer vault_search_by_tag for tag-only queries without text. Prefer vault_search_by_folder for browsing a folder. Prefer vault_search_by_property for metadata-only queries. Prefer vault_recent_notes for time-based browsing.

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -30,7 +30,8 @@ export const registerSearchTools = ({
     TOOL_NAMES.VAULT_SEARCH,
     {
       title: "Search Notes",
-      description: `Hybrid search across all vault notes, ranked by combined keyword and semantic relevance. When the embedding pipeline is active, results are ranked using Reciprocal Rank Fusion (RRF) — combining FTS5 keyword matching with vector similarity. When embeddings are unavailable, falls back to keyword-only (FTS5 BM25) transparently. Combine a text query with structured filters to narrow results by metadata — the "narrow by metadata, search by text" pattern. Unquoted terms use implicit AND with porter stemming; wrap in double quotes for exact phrases; punctuated terms (vault-cortex, deploy/local) are matched as exact adjacent-word phrases automatically.
+      description: config.embeddingEnabled
+        ? `Hybrid search across all vault notes, ranked by combined keyword and semantic relevance using Reciprocal Rank Fusion (RRF) — combining FTS5 keyword matching with vector similarity. Semantic matching finds notes even when exact keywords differ — "career aspirations" finds notes about "goals" and "targets". Falls back to keyword-only (FTS5 BM25) transparently while embeddings are being built. Combine a text query with structured filters to narrow results by metadata — the "narrow by metadata, search by text" pattern. Unquoted terms use implicit AND with porter stemming; wrap in double quotes for exact phrases; punctuated terms (vault-cortex, deploy/local) are matched as exact adjacent-word phrases automatically.
 
 Filters — all conditions AND-combine with each other and the text query:
 - folder: path prefix (e.g. "Projects")
@@ -43,14 +44,35 @@ Example: vault_search({ query: "kubernetes networking", filters: { tags: ["refer
 Example: vault_search({ query: "meeting notes", filters: { type: "meeting", folder: "Work" } })
 Example: vault_search({ query: "career aspirations", filters: { folder: "About Me" } })
 
-When to use: The primary discovery tool for content-based queries, optionally constrained by metadata. Semantic matching finds notes even when exact keywords differ — "career aspirations" finds notes about "goals" and "targets".
+When to use: The primary discovery tool for content-based queries, optionally constrained by metadata.
 Prefer vault_search_by_tag for tag-only queries without text. Prefer vault_search_by_folder for browsing a folder. Prefer vault_search_by_property for metadata-only queries. Prefer vault_recent_notes for time-based browsing.
 
 Errors:
 - No matches returns { results: [], total: 0 }, not an error
 - Malformed query syntax is sanitized automatically — the tool never throws a query syntax error
 
-Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified, bytes) and total count. score reflects combined relevance (higher = more relevant). created is omitted when null. bytes is the on-disk file size. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when present.`,
+Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified, bytes) and total count. score reflects combined relevance (higher = more relevant). created is omitted when null. bytes is the on-disk file size. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when present.`
+        : `Full-text search across all vault notes, ranked by relevance. Combine a text query with structured filters to narrow results by metadata — the "narrow by metadata, search by text" pattern. Unquoted terms use implicit AND with porter stemming; wrap in double quotes for exact phrases; punctuated terms (vault-cortex, deploy/local) are matched as exact adjacent-word phrases automatically.
+
+Filters — all conditions AND-combine with each other and the text query:
+- folder: path prefix (e.g. "Projects")
+- tags: require all listed tags (AND)
+- type: exact match on frontmatter type (e.g. "person", "session-log")
+- related: require all listed related links (AND)
+- properties: arbitrary frontmatter key-value pairs, supports string/number/boolean (e.g. { status: "active" })
+
+Example: vault_search({ query: "kubernetes networking", filters: { tags: ["reference"] } })
+Example: vault_search({ query: "meeting notes", filters: { type: "meeting", folder: "Work" } })
+Example: vault_search({ query: "deployment", filters: { properties: { status: "active" } } })
+
+When to use: The primary discovery tool for content-based queries, optionally constrained by metadata.
+Prefer vault_search_by_tag for tag-only queries without text. Prefer vault_search_by_folder for browsing a folder. Prefer vault_search_by_property for metadata-only queries. Prefer vault_recent_notes for time-based browsing.
+
+Errors:
+- No matches returns { results: [], total: 0 }, not an error
+- Malformed query syntax is sanitized automatically — the tool never throws a query syntax error
+
+Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified, bytes) and total count. created is omitted when null. bytes is the on-disk file size. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when present.`,
       inputSchema: {
         query: z
           .string()

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -51,7 +51,7 @@ Errors:
 - No matches returns { results: [], total: 0 }, not an error
 - Malformed query syntax is sanitized automatically — the tool never throws a query syntax error
 
-Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified, bytes) and total count. score reflects combined relevance (higher = more relevant). created is omitted when null. bytes is the on-disk file size. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when present.`
+Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified, bytes), total count, and search_mode ("hybrid" or "fts"). search_mode indicates which ranking was used — "hybrid" when vector embeddings contributed, "fts" when only keyword matching was available. score reflects combined relevance (higher = more relevant). created is omitted when null. bytes is the on-disk file size. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when present.`
         : `Full-text search across all vault notes, ranked by relevance. Combine a text query with structured filters to narrow results by metadata — the "narrow by metadata, search by text" pattern. Unquoted terms use implicit AND with porter stemming; wrap in double quotes for exact phrases; punctuated terms (vault-cortex, deploy/local) are matched as exact adjacent-word phrases automatically.
 
 Filters — all conditions AND-combine with each other and the text query:
@@ -72,7 +72,7 @@ Errors:
 - No matches returns { results: [], total: 0 }, not an error
 - Malformed query syntax is sanitized automatically — the tool never throws a query syntax error
 
-Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified, bytes) and total count. created is omitted when null. bytes is the on-disk file size. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when present.`,
+Returns: JSON with results array (path, title, snippet, score, tags, folder, type, created, modified, bytes), total count, and search_mode ("fts" — keyword-only ranking). created is omitted when null. bytes is the on-disk file size. With filters.include_leading_callout, each result also carries leading_callout ({ type, title, body }) when present.`,
       inputSchema: {
         query: z
           .string()
@@ -146,9 +146,15 @@ Returns: JSON with results array (path, title, snippet, score, tags, folder, typ
       return safeHandler(
         reqLogger,
         async () => search.hybridSearch({ query, filters }, reqLogger),
-        (results) => {
-          reqLogger.info("tool_result", { resultCount: results.length })
-          return JSON.stringify({ results, total: results.length })
+        (searchResult) => {
+          reqLogger.info("tool_result", {
+            resultCount: searchResult.results.length,
+            searchMode: searchResult.search_mode,
+          })
+          return JSON.stringify({
+            ...searchResult,
+            total: searchResult.results.length,
+          })
         },
       )
     },

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -42,9 +42,9 @@ Filters — all conditions AND-combine with each other and the text query:
 
 Example: vault_search({ query: "kubernetes networking", filters: { tags: ["reference"] } })
 Example: vault_search({ query: "meeting notes", filters: { type: "meeting", folder: "Work" } })
-Example: vault_search({ query: "career aspirations", filters: { folder: "About Me" } })
+Example: vault_search({ query: "dealing with burnout recovery" }) — semantic: finds notes about mental health and overwhelm even without the word "burnout"
 
-When to use: The primary discovery tool for content-based queries, optionally constrained by metadata.
+When to use: The primary discovery tool for content-based queries, optionally constrained by metadata. Semantic matching bridges vocabulary gaps — try natural-language queries, not just keywords.
 Prefer vault_search_by_tag for tag-only queries without text. Prefer vault_search_by_folder for browsing a folder. Prefer vault_search_by_property for metadata-only queries. Prefer vault_recent_notes for time-based browsing.
 
 Errors:

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -1,4 +1,4 @@
-/** Search tool registrations — full-text, tag, property, folder, and graph queries. */
+/** Search tool registrations — hybrid (FTS + vector), tag, property, folder, and graph queries. */
 
 import { z } from "zod"
 import type { ToolRegistrationContext } from "./tool-helpers.js"

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -2999,16 +2999,16 @@ It has multiple sentences to verify chunking works correctly.
 })
 
 describe("computeRrfScores", () => {
+  /** Rank-1 RRF score with default k=60: 1/(60+1) + 0.05 bonus */
+  const RANK_1_SCORE = Number((1 / 61 + 0.05).toPrecision(4))
+
   it("scores a path appearing in FTS only", () => {
     const result = computeRrfScores({
       ftsRanked: [{ path: "a.md" }],
       vectorRanked: [],
     })
 
-    expect(result).toHaveLength(1)
-    expect(result[0].path).toBe("a.md")
-    // rank 1: 1/(60+1) + 0.05 bonus = 0.06639...
-    expect(result[0].score).toBe(Number((1 / 61 + 0.05).toPrecision(4)))
+    expect(result).toEqual([{ path: "a.md", score: RANK_1_SCORE }])
   })
 
   it("scores a path appearing in vector only", () => {
@@ -3017,9 +3017,7 @@ describe("computeRrfScores", () => {
       vectorRanked: [{ path: "a.md" }],
     })
 
-    expect(result).toHaveLength(1)
-    expect(result[0].path).toBe("a.md")
-    expect(result[0].score).toBe(Number((1 / 61 + 0.05).toPrecision(4)))
+    expect(result).toEqual([{ path: "a.md", score: RANK_1_SCORE }])
   })
 
   it("combines scores when a path appears in both lists", () => {
@@ -3028,10 +3026,10 @@ describe("computeRrfScores", () => {
       vectorRanked: [{ path: "a.md" }],
     })
 
-    expect(result).toHaveLength(1)
-    // rank 1 in both: (1/61 + 0.05) * 2
-    const expectedScore = Number(((1 / 61 + 0.05) * 2).toPrecision(4))
-    expect(result[0].score).toBe(expectedScore)
+    // rank 1 in both lists: score doubles
+    expect(result).toEqual([
+      { path: "a.md", score: Number((RANK_1_SCORE * 2).toPrecision(4)) },
+    ])
   })
 
   it("applies +0.02 bonus for ranks 2-3", () => {
@@ -3044,11 +3042,12 @@ describe("computeRrfScores", () => {
       vectorRanked: [],
     })
 
-    expect(result).toHaveLength(3)
-    const secondResult = result.find((r) => r.path === "second.md")
-    const thirdResult = result.find((r) => r.path === "third.md")
-    expect(secondResult?.score).toBe(Number((1 / 62 + 0.02).toPrecision(4)))
-    expect(thirdResult?.score).toBe(Number((1 / 63 + 0.02).toPrecision(4)))
+    // Sorted by score descending — rank 1 has highest score
+    expect(result).toEqual([
+      { path: "first.md", score: RANK_1_SCORE },
+      { path: "second.md", score: Number((1 / 62 + 0.02).toPrecision(4)) },
+      { path: "third.md", score: Number((1 / 63 + 0.02).toPrecision(4)) },
+    ])
   })
 
   it("applies no bonus for rank 4 and beyond", () => {
@@ -3062,19 +3061,24 @@ describe("computeRrfScores", () => {
       vectorRanked: [],
     })
 
-    const fourthResult = result.find((r) => r.path === "4.md")
-    expect(fourthResult?.score).toBe(Number((1 / 64).toPrecision(4)))
+    // Fourth result has no bonus — raw RRF only
+    expect(result[3]).toEqual({
+      path: "4.md",
+      score: Number((1 / 64).toPrecision(4)),
+    })
   })
 
-  it("handles disjoint lists and sorts by score descending", () => {
+  it("handles disjoint lists with equal-rank paths", () => {
     const result = computeRrfScores({
       ftsRanked: [{ path: "fts-only.md" }],
       vectorRanked: [{ path: "vec-only.md" }],
     })
 
-    expect(result).toHaveLength(2)
-    // Both are rank 1 in their respective lists — same score, stable order
-    expect(result[0].score).toBe(result[1].score)
+    // Both are rank 1 in their respective lists — same score
+    expect(result).toEqual([
+      { path: "fts-only.md", score: RANK_1_SCORE },
+      { path: "vec-only.md", score: RANK_1_SCORE },
+    ])
   })
 
   it("returns empty array for empty inputs", () => {
@@ -3091,9 +3095,10 @@ describe("computeRrfScores", () => {
       vectorRanked: [{ path: "a.md" }],
     })
 
-    // "a.md" appears in both lists → higher score
+    // "a.md" appears in both lists → higher combined score → first
     expect(result[0].path).toBe("a.md")
     expect(result[0].score).toBeGreaterThan(result[1].score)
+    expect(result[1].path).toBe("b.md")
   })
 
   it("accepts a custom k value", () => {
@@ -3181,7 +3186,7 @@ the Lightsail budget estimates for next quarter.
         logger,
       )
 
-      expect(results.length).toBeGreaterThan(0)
+      expect(results).toHaveLength(1)
       expect(results[0].path).toBe("a.md")
     })
 
@@ -3199,7 +3204,7 @@ the Lightsail budget estimates for next quarter.
         logger,
       )
 
-      expect(results.length).toBeGreaterThan(0)
+      expect(results).toHaveLength(1)
       expect(results[0].path).toBe("a.md")
       // embedText called once for the query embedding, but KNN returns nothing
       expect(mockEmbedder.embedText).toHaveBeenCalled()
@@ -3214,19 +3219,19 @@ the Lightsail budget estimates for next quarter.
         logger,
       )
       const warnSpy = vi.spyOn(logger, "warn")
+      onTestFinished(() => warnSpy.mockRestore())
 
       const results = await hybridIndex.hybridSearch(
         { query: "career goals" },
         logger,
       )
 
-      expect(results.length).toBeGreaterThan(0)
+      expect(results).toHaveLength(1)
       expect(results[0].path).toBe("a.md")
       expect(warnSpy).toHaveBeenCalledWith(
         "vector search failed, falling back to FTS-only",
         expect.objectContaining({ error: "model unavailable" }),
       )
-      warnSpy.mockRestore()
     })
   })
 
@@ -3260,17 +3265,16 @@ the Lightsail budget estimates for next quarter.
         logger,
       )
 
-      expect(results.length).toBeGreaterThanOrEqual(1)
-      // a.md appears in both FTS and vector → higher RRF score
+      expect(results.length).toBeGreaterThanOrEqual(2)
+      // a.md appears in both FTS and vector → higher RRF score → ranked first
       expect(results[0].path).toBe("a.md")
+      expect(results[0].score).toBeGreaterThan(results[1].score)
     })
 
     it("includes vector-only results with full metadata", async () => {
       const mockEmbedder = createHybridMockEmbedder()
       const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
 
-      // NOTE_A has "aspire" and "targets" — a semantic match for "aspirations"
-      // but FTS won't find it via stemming alone for some queries
       hybridIndex.upsertNote(
         { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
         logger,
@@ -3295,18 +3299,26 @@ the Lightsail budget estimates for next quarter.
         logger,
       )
 
-      // Both should appear since both have vector results
-      expect(results.length).toBeGreaterThanOrEqual(1)
-      // All results should have full metadata
-      for (const result of results) {
-        expect(result.path).toBeTruthy()
-        expect(result.title).toBeTruthy()
-        expect(result.score).toBeGreaterThan(0)
-        expect(result.tags).toBeInstanceOf(Array)
-        expect(result.folder).toBeDefined()
-        expect(result.modified).toBeTruthy()
-        expect(typeof result.bytes).toBe("number")
-      }
+      expect(results.length).toBeGreaterThanOrEqual(2)
+      const paths = results.map((result) => result.path)
+      expect(paths).toContain("a.md")
+      expect(paths).toContain("b.md")
+
+      // Vector-only result (a.md — no FTS match for "project ideas CLI")
+      // should carry full metadata from the notes table
+      const vectorOnlyResult = results.find((result) => result.path === "a.md")
+      expect(vectorOnlyResult).toEqual(
+        expect.objectContaining({
+          path: "a.md",
+          title: "Career Goals",
+          tags: ["personal", "career"],
+          folder: "",
+          type: "reflection",
+        }),
+      )
+      expect(vectorOnlyResult?.score).toBeGreaterThan(0)
+      expect(vectorOnlyResult?.modified).toBeTruthy()
+      expect(typeof vectorOnlyResult?.bytes).toBe("number")
     })
 
     it("generates snippets from chunk text for vector-only results", async () => {
@@ -3346,9 +3358,11 @@ the Lightsail budget estimates for next quarter.
         logger,
       )
 
-      // Vector-only results should have snippet from chunk text
+      // Vector-only results should have non-empty snippet built from chunk text
+      expect(results.length).toBeGreaterThanOrEqual(1)
       for (const result of results) {
-        expect(typeof result.snippet).toBe("string")
+        expect(result.snippet).toBeTruthy()
+        expect(result.snippet.length).toBeGreaterThan(0)
       }
     })
   })
@@ -3435,8 +3449,9 @@ Content about deployment costs and infrastructure.
         logger,
       )
 
-      // Only c.md has the "work" tag
-      const paths = results.map((r) => r.path)
+      // Only c.md has the "work" tag — a.md (tags: personal, career) excluded
+      const paths = results.map((result) => result.path)
+      expect(paths).toContain("c.md")
       expect(paths).not.toContain("a.md")
     })
 
@@ -3467,7 +3482,9 @@ Content about deployment costs and infrastructure.
         logger,
       )
 
-      const paths = results.map((r) => r.path)
+      // Only c.md is type "meeting" — a.md (type: reflection) excluded
+      const paths = results.map((result) => result.path)
+      expect(paths).toContain("c.md")
       expect(paths).not.toContain("a.md")
     })
   })
@@ -3593,11 +3610,155 @@ The main content discusses RESTful API design and GraphQL alternatives.
         logger,
       )
 
-      const refResult = results.find((r) => r.path === "ref.md")
+      const refResult = results.find((result) => result.path === "ref.md")
       expect(refResult).toBeDefined()
-      if (refResult?.leading_callout) {
-        expect(refResult.leading_callout.type).toBe("info")
-      }
+      expect(refResult?.leading_callout).toEqual({
+        type: "info",
+        title: "Quick reference",
+        body: "This is a reference document about API design patterns.",
+      })
+    })
+  })
+
+  describe("filters — related and properties", () => {
+    it("applies related filter to vector-only results", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      hybridIndex.upsertNote(
+        { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
+        logger,
+      )
+      hybridIndex.upsertNote(
+        { filePath: "c.md", rawContent: NOTE_C, fileStat: testStat(1000) },
+        logger,
+      )
+
+      await hybridIndex.embedNote(
+        { notePath: "a.md", rawContent: NOTE_A },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "c.md", rawContent: NOTE_C },
+        logger,
+      )
+
+      const results = await hybridIndex.hybridSearch(
+        {
+          query: "deployment infrastructure",
+          filters: { related: ["[[Projects/alpha.md]]"] },
+        },
+        logger,
+      )
+
+      // Only c.md has the related link — a.md has no related field
+      const paths = results.map((result) => result.path)
+      expect(paths).toContain("c.md")
+      expect(paths).not.toContain("a.md")
+    })
+
+    it("applies properties filter to vector-only results", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      const noteWithProperty = `---
+title: Active Project
+tags: [project]
+status: active
+---
+
+This project is currently in development with active deployment work.
+`
+      const noteWithoutProperty = `---
+title: Archived Project
+tags: [project]
+status: archived
+---
+
+This project is no longer maintained but had deployment infrastructure.
+`
+
+      hybridIndex.upsertNote(
+        {
+          filePath: "active.md",
+          rawContent: noteWithProperty,
+          fileStat: testStat(1000),
+        },
+        logger,
+      )
+      hybridIndex.upsertNote(
+        {
+          filePath: "archived.md",
+          rawContent: noteWithoutProperty,
+          fileStat: testStat(1000),
+        },
+        logger,
+      )
+
+      await hybridIndex.embedNote(
+        { notePath: "active.md", rawContent: noteWithProperty },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "archived.md", rawContent: noteWithoutProperty },
+        logger,
+      )
+
+      const results = await hybridIndex.hybridSearch(
+        {
+          query: "deployment",
+          filters: { properties: { status: "active" } },
+        },
+        logger,
+      )
+
+      // Only active.md has status: active
+      const paths = results.map((result) => result.path)
+      expect(paths).toContain("active.md")
+      expect(paths).not.toContain("archived.md")
+    })
+  })
+
+  describe("snippet_tokens", () => {
+    it("truncates vector-only snippets to the specified token count", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      const verboseNote = `---
+title: Verbose Note
+tags: [test]
+---
+
+This is a note with many words that should be truncated when using a small snippet token limit for vector-only results.
+`
+
+      hybridIndex.upsertNote(
+        {
+          filePath: "verbose.md",
+          rawContent: verboseNote,
+          fileStat: testStat(1000),
+        },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "verbose.md", rawContent: verboseNote },
+        logger,
+      )
+
+      // Query that won't match via FTS — forces vector-only result path
+      const results = await hybridIndex.hybridSearch(
+        { query: "zzz_no_fts_match", filters: { snippet_tokens: 5 } },
+        logger,
+      )
+
+      const verboseResult = results.find(
+        (result) => result.path === "verbose.md",
+      )
+      expect(verboseResult).toBeDefined()
+      // Snippet should be truncated to ~5 words with trailing "..."
+      const wordCount = verboseResult?.snippet.split(/\s+/).length ?? 0
+      expect(wordCount).toBeLessThanOrEqual(6) // 5 words + "..." is 6 tokens
+      expect(verboseResult?.snippet).toContain("...")
     })
   })
 })

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -3181,13 +3181,14 @@ the Lightsail budget estimates for next quarter.
         logger,
       )
 
-      const results = await ftsIndex.hybridSearch(
+      const { results, search_mode } = await ftsIndex.hybridSearch(
         { query: "career goals" },
         logger,
       )
 
       expect(results).toHaveLength(1)
       expect(results[0].path).toBe("a.md")
+      expect(search_mode).toBe("fts")
     })
 
     it("returns FTS results when embedder exists but no vectors indexed", async () => {
@@ -3199,14 +3200,14 @@ the Lightsail budget estimates for next quarter.
       )
       // upsertNote doesn't embed — vectors are empty
 
-      const results = await hybridIndex.hybridSearch(
+      const { results, search_mode } = await hybridIndex.hybridSearch(
         { query: "career goals" },
         logger,
       )
 
       expect(results).toHaveLength(1)
       expect(results[0].path).toBe("a.md")
-      // embedText called once for the query embedding, but KNN returns nothing
+      expect(search_mode).toBe("fts")
       expect(mockEmbedder.embedText).toHaveBeenCalled()
     })
 
@@ -3221,13 +3222,14 @@ the Lightsail budget estimates for next quarter.
       const warnSpy = vi.spyOn(logger, "warn")
       onTestFinished(() => warnSpy.mockRestore())
 
-      const results = await hybridIndex.hybridSearch(
+      const { results, search_mode } = await hybridIndex.hybridSearch(
         { query: "career goals" },
         logger,
       )
 
       expect(results).toHaveLength(1)
       expect(results[0].path).toBe("a.md")
+      expect(search_mode).toBe("fts")
       expect(warnSpy).toHaveBeenCalledWith(
         "vector search failed, falling back to FTS-only",
         expect.objectContaining({ error: "model unavailable" }),
@@ -3260,11 +3262,12 @@ the Lightsail budget estimates for next quarter.
       )
 
       // Query that matches NOTE_A via FTS ("career goals") and both via vector
-      const results = await hybridIndex.hybridSearch(
+      const { results, search_mode } = await hybridIndex.hybridSearch(
         { query: "career goals" },
         logger,
       )
 
+      expect(search_mode).toBe("hybrid")
       expect(results.length).toBeGreaterThanOrEqual(2)
       // a.md appears in both FTS and vector → higher RRF score → ranked first
       expect(results[0].path).toBe("a.md")
@@ -3294,7 +3297,7 @@ the Lightsail budget estimates for next quarter.
       )
 
       // Query that matches b.md via FTS ("project ideas CLI") and both via vector
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         { query: "project ideas CLI" },
         logger,
       )
@@ -3354,7 +3357,7 @@ the Lightsail budget estimates for next quarter.
       )
 
       // Query that doesn't match any note via FTS — results are vector-only
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         { query: "zzz_no_fts_match" },
         logger,
       )
@@ -3411,7 +3414,7 @@ Content about deployment costs and infrastructure.
         logger,
       )
 
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         { query: "deployment costs", filters: { folder: "Work" } },
         logger,
       )
@@ -3444,7 +3447,7 @@ Content about deployment costs and infrastructure.
         logger,
       )
 
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         { query: "deployment infrastructure", filters: { tags: ["work"] } },
         logger,
       )
@@ -3477,7 +3480,7 @@ Content about deployment costs and infrastructure.
         logger,
       )
 
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         { query: "deployment timeline", filters: { type: "meeting" } },
         logger,
       )
@@ -3520,7 +3523,7 @@ Content about deployment costs and infrastructure.
         logger,
       )
 
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         { query: "project", filters: { limit: 1 } },
         logger,
       )
@@ -3563,7 +3566,7 @@ We should track latency and error rates across all services.
         logger,
       )
 
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         { query: "deployment" },
         logger,
       )
@@ -3602,7 +3605,7 @@ The main content discusses RESTful API design and GraphQL alternatives.
         logger,
       )
 
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         {
           query: "API design patterns",
           filters: { include_leading_callout: true },
@@ -3643,7 +3646,7 @@ The main content discusses RESTful API design and GraphQL alternatives.
         logger,
       )
 
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         {
           query: "deployment infrastructure",
           filters: { related: ["[[Projects/alpha.md]]"] },
@@ -3704,7 +3707,7 @@ This project is no longer maintained but had deployment infrastructure.
         logger,
       )
 
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         {
           query: "deployment",
           filters: { properties: { status: "active" } },
@@ -3746,7 +3749,7 @@ This is a note with many words that should be truncated when using a small snipp
       )
 
       // Query that won't match via FTS — forces vector-only result path
-      const results = await hybridIndex.hybridSearch(
+      const { results } = await hybridIndex.hybridSearch(
         { query: "zzz_no_fts_match", filters: { snippet_tokens: 5 } },
         logger,
       )

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -14,7 +14,11 @@ import Database from "better-sqlite3"
 import { DateTime } from "luxon"
 import * as sqliteVec from "sqlite-vec"
 vi.mock("sqlite-vec", { spy: true })
-import { createSearchIndex, sanitizeFtsQuery } from "../search-index.js"
+import {
+  createSearchIndex,
+  sanitizeFtsQuery,
+  computeRrfScores,
+} from "../search-index.js"
 import type { SearchIndex } from "../search-index.js"
 import { logger } from "../../../logger.js"
 
@@ -2990,6 +2994,610 @@ It has multiple sentences to verify chunking works correctly.
       // Both notes attempted embedding (first failed, second succeeded)
       expect(mockEmbedder.embedText).toHaveBeenCalledTimes(2)
       warnSpy.mockRestore()
+    })
+  })
+})
+
+describe("computeRrfScores", () => {
+  it("scores a path appearing in FTS only", () => {
+    const result = computeRrfScores({
+      ftsRanked: [{ path: "a.md" }],
+      vectorRanked: [],
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].path).toBe("a.md")
+    // rank 1: 1/(60+1) + 0.05 bonus = 0.06639...
+    expect(result[0].score).toBe(Number((1 / 61 + 0.05).toPrecision(4)))
+  })
+
+  it("scores a path appearing in vector only", () => {
+    const result = computeRrfScores({
+      ftsRanked: [],
+      vectorRanked: [{ path: "a.md" }],
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].path).toBe("a.md")
+    expect(result[0].score).toBe(Number((1 / 61 + 0.05).toPrecision(4)))
+  })
+
+  it("combines scores when a path appears in both lists", () => {
+    const result = computeRrfScores({
+      ftsRanked: [{ path: "a.md" }],
+      vectorRanked: [{ path: "a.md" }],
+    })
+
+    expect(result).toHaveLength(1)
+    // rank 1 in both: (1/61 + 0.05) * 2
+    const expectedScore = Number(((1 / 61 + 0.05) * 2).toPrecision(4))
+    expect(result[0].score).toBe(expectedScore)
+  })
+
+  it("applies +0.02 bonus for ranks 2-3", () => {
+    const result = computeRrfScores({
+      ftsRanked: [
+        { path: "first.md" },
+        { path: "second.md" },
+        { path: "third.md" },
+      ],
+      vectorRanked: [],
+    })
+
+    expect(result).toHaveLength(3)
+    const secondResult = result.find((r) => r.path === "second.md")
+    const thirdResult = result.find((r) => r.path === "third.md")
+    expect(secondResult?.score).toBe(Number((1 / 62 + 0.02).toPrecision(4)))
+    expect(thirdResult?.score).toBe(Number((1 / 63 + 0.02).toPrecision(4)))
+  })
+
+  it("applies no bonus for rank 4 and beyond", () => {
+    const result = computeRrfScores({
+      ftsRanked: [
+        { path: "1.md" },
+        { path: "2.md" },
+        { path: "3.md" },
+        { path: "4.md" },
+      ],
+      vectorRanked: [],
+    })
+
+    const fourthResult = result.find((r) => r.path === "4.md")
+    expect(fourthResult?.score).toBe(Number((1 / 64).toPrecision(4)))
+  })
+
+  it("handles disjoint lists and sorts by score descending", () => {
+    const result = computeRrfScores({
+      ftsRanked: [{ path: "fts-only.md" }],
+      vectorRanked: [{ path: "vec-only.md" }],
+    })
+
+    expect(result).toHaveLength(2)
+    // Both are rank 1 in their respective lists — same score, stable order
+    expect(result[0].score).toBe(result[1].score)
+  })
+
+  it("returns empty array for empty inputs", () => {
+    const result = computeRrfScores({
+      ftsRanked: [],
+      vectorRanked: [],
+    })
+    expect(result).toEqual([])
+  })
+
+  it("sorts results by score descending", () => {
+    const result = computeRrfScores({
+      ftsRanked: [{ path: "a.md" }, { path: "b.md" }],
+      vectorRanked: [{ path: "a.md" }],
+    })
+
+    // "a.md" appears in both lists → higher score
+    expect(result[0].path).toBe("a.md")
+    expect(result[0].score).toBeGreaterThan(result[1].score)
+  })
+
+  it("accepts a custom k value", () => {
+    const defaultResult = computeRrfScores({
+      ftsRanked: [{ path: "a.md" }],
+      vectorRanked: [],
+    })
+    const customResult = computeRrfScores({
+      ftsRanked: [{ path: "a.md" }],
+      vectorRanked: [],
+      k: 10,
+    })
+
+    // k=10 → 1/(10+1) + 0.05 vs k=60 → 1/(60+1) + 0.05
+    expect(customResult[0].score).toBeGreaterThan(defaultResult[0].score)
+  })
+})
+
+describe("hybridSearch", () => {
+  const EMBEDDING_DIMENSIONS = 384
+
+  /** Creates a mock embedder where all texts get the same embedding (distance 0
+   *  between any two notes). For tests that need differentiated distances, override
+   *  embedText after creation. */
+  const createHybridMockEmbedder = () => ({
+    embedText: vi
+      .fn()
+      .mockResolvedValue(new Float32Array(EMBEDDING_DIMENSIONS).fill(0.1)),
+    embedBatch: vi
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(
+          texts.map(() => new Float32Array(EMBEDDING_DIMENSIONS).fill(0.1)),
+        ),
+      ),
+  })
+
+  /** Generates a unique embedding by setting one dimension to 1.0 based on seed. */
+  const seededEmbedding = (seed: number): Float32Array => {
+    const embedding = new Float32Array(EMBEDDING_DIMENSIONS).fill(0)
+    embedding[seed % EMBEDDING_DIMENSIONS] = 1.0
+    return embedding
+  }
+
+  const NOTE_A = `---
+title: Career Goals
+tags: [personal, career]
+type: reflection
+---
+
+I aspire to build meaningful products and grow as a technical leader.
+My targets include shipping a major open source project.
+`
+
+  const NOTE_B = `---
+title: Project Ideas
+tags: [ideas]
+type: brainstorm
+---
+
+Some project ideas for the next quarter. Build a CLI tool for vault management.
+`
+
+  const NOTE_C = `---
+title: Meeting Notes
+tags: [work, meetings]
+type: meeting
+related: ["[[Projects/alpha.md]]"]
+---
+
+Discussed the deployment timeline and infrastructure costs. Need to follow up on
+the Lightsail budget estimates for next quarter.
+`
+
+  describe("fallback to FTS-only", () => {
+    it("returns FTS results when no embedder is provided", async () => {
+      const ftsIndex = createSearchIndex(":memory:")
+      ftsIndex.upsertNote(
+        { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
+        logger,
+      )
+
+      const results = await ftsIndex.hybridSearch(
+        { query: "career goals" },
+        logger,
+      )
+
+      expect(results.length).toBeGreaterThan(0)
+      expect(results[0].path).toBe("a.md")
+    })
+
+    it("returns FTS results when embedder exists but no vectors indexed", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+      hybridIndex.upsertNote(
+        { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
+        logger,
+      )
+      // upsertNote doesn't embed — vectors are empty
+
+      const results = await hybridIndex.hybridSearch(
+        { query: "career goals" },
+        logger,
+      )
+
+      expect(results.length).toBeGreaterThan(0)
+      expect(results[0].path).toBe("a.md")
+      // embedText called once for the query embedding, but KNN returns nothing
+      expect(mockEmbedder.embedText).toHaveBeenCalled()
+    })
+
+    it("returns FTS results when embedder fails", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      mockEmbedder.embedText.mockRejectedValue(new Error("model unavailable"))
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+      hybridIndex.upsertNote(
+        { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
+        logger,
+      )
+      const warnSpy = vi.spyOn(logger, "warn")
+
+      const results = await hybridIndex.hybridSearch(
+        { query: "career goals" },
+        logger,
+      )
+
+      expect(results.length).toBeGreaterThan(0)
+      expect(results[0].path).toBe("a.md")
+      expect(warnSpy).toHaveBeenCalledWith(
+        "vector search failed, falling back to FTS-only",
+        expect.objectContaining({ error: "model unavailable" }),
+      )
+      warnSpy.mockRestore()
+    })
+  })
+
+  describe("hybrid ranking", () => {
+    it("boosts results that appear in both FTS and vector search", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      hybridIndex.upsertNote(
+        { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
+        logger,
+      )
+      hybridIndex.upsertNote(
+        { filePath: "b.md", rawContent: NOTE_B, fileStat: testStat(1000) },
+        logger,
+      )
+
+      // Embed both notes (same embedding = both match any query equally)
+      await hybridIndex.embedNote(
+        { notePath: "a.md", rawContent: NOTE_A },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "b.md", rawContent: NOTE_B },
+        logger,
+      )
+
+      // Query that matches NOTE_A via FTS ("career goals") and both via vector
+      const results = await hybridIndex.hybridSearch(
+        { query: "career goals" },
+        logger,
+      )
+
+      expect(results.length).toBeGreaterThanOrEqual(1)
+      // a.md appears in both FTS and vector → higher RRF score
+      expect(results[0].path).toBe("a.md")
+    })
+
+    it("includes vector-only results with full metadata", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      // NOTE_A has "aspire" and "targets" — a semantic match for "aspirations"
+      // but FTS won't find it via stemming alone for some queries
+      hybridIndex.upsertNote(
+        { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
+        logger,
+      )
+      hybridIndex.upsertNote(
+        { filePath: "b.md", rawContent: NOTE_B, fileStat: testStat(1000) },
+        logger,
+      )
+
+      await hybridIndex.embedNote(
+        { notePath: "a.md", rawContent: NOTE_A },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "b.md", rawContent: NOTE_B },
+        logger,
+      )
+
+      // Query that matches b.md via FTS ("project ideas CLI") and both via vector
+      const results = await hybridIndex.hybridSearch(
+        { query: "project ideas CLI" },
+        logger,
+      )
+
+      // Both should appear since both have vector results
+      expect(results.length).toBeGreaterThanOrEqual(1)
+      // All results should have full metadata
+      for (const result of results) {
+        expect(result.path).toBeTruthy()
+        expect(result.title).toBeTruthy()
+        expect(result.score).toBeGreaterThan(0)
+        expect(result.tags).toBeInstanceOf(Array)
+        expect(result.folder).toBeDefined()
+        expect(result.modified).toBeTruthy()
+        expect(typeof result.bytes).toBe("number")
+      }
+    })
+
+    it("generates snippets from chunk text for vector-only results", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      // Return different embeddings so query matches a.md better semantically
+      let callCount = 0
+      mockEmbedder.embedText.mockImplementation(() => {
+        callCount++
+        // First two calls are during embedNote (for the notes' chunks)
+        // Third+ call is the query embedding — make it match a.md's embedding
+        return Promise.resolve(seededEmbedding(callCount <= 1 ? 0 : 1))
+      })
+
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      hybridIndex.upsertNote(
+        { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
+        logger,
+      )
+      hybridIndex.upsertNote(
+        { filePath: "c.md", rawContent: NOTE_C, fileStat: testStat(1000) },
+        logger,
+      )
+
+      await hybridIndex.embedNote(
+        { notePath: "a.md", rawContent: NOTE_A },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "c.md", rawContent: NOTE_C },
+        logger,
+      )
+
+      // Query that doesn't match any note via FTS keywords
+      const results = await hybridIndex.hybridSearch(
+        { query: "zzz_no_fts_match" },
+        logger,
+      )
+
+      // Vector-only results should have snippet from chunk text
+      for (const result of results) {
+        expect(typeof result.snippet).toBe("string")
+      }
+    })
+  })
+
+  describe("filters", () => {
+    it("applies folder filter to vector-only results", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      const noteInFolder = `---
+title: Inside Folder
+tags: [test]
+---
+Content about deployment costs and infrastructure.
+`
+      const noteOutsideFolder = `---
+title: Outside Folder
+tags: [test]
+---
+Content about deployment costs and infrastructure.
+`
+
+      hybridIndex.upsertNote(
+        {
+          filePath: "Work/inside.md",
+          rawContent: noteInFolder,
+          fileStat: testStat(1000),
+        },
+        logger,
+      )
+      hybridIndex.upsertNote(
+        {
+          filePath: "Personal/outside.md",
+          rawContent: noteOutsideFolder,
+          fileStat: testStat(1000),
+        },
+        logger,
+      )
+
+      await hybridIndex.embedNote(
+        { notePath: "Work/inside.md", rawContent: noteInFolder },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "Personal/outside.md", rawContent: noteOutsideFolder },
+        logger,
+      )
+
+      const results = await hybridIndex.hybridSearch(
+        { query: "deployment costs", filters: { folder: "Work" } },
+        logger,
+      )
+
+      // Only the note inside Work/ should appear
+      const paths = results.map((r) => r.path)
+      expect(paths).toContain("Work/inside.md")
+      expect(paths).not.toContain("Personal/outside.md")
+    })
+
+    it("applies tag filter to vector-only results", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      hybridIndex.upsertNote(
+        { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
+        logger,
+      )
+      hybridIndex.upsertNote(
+        { filePath: "c.md", rawContent: NOTE_C, fileStat: testStat(1000) },
+        logger,
+      )
+
+      await hybridIndex.embedNote(
+        { notePath: "a.md", rawContent: NOTE_A },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "c.md", rawContent: NOTE_C },
+        logger,
+      )
+
+      const results = await hybridIndex.hybridSearch(
+        { query: "deployment infrastructure", filters: { tags: ["work"] } },
+        logger,
+      )
+
+      // Only c.md has the "work" tag
+      const paths = results.map((r) => r.path)
+      expect(paths).not.toContain("a.md")
+    })
+
+    it("applies type filter to vector-only results", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      hybridIndex.upsertNote(
+        { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
+        logger,
+      )
+      hybridIndex.upsertNote(
+        { filePath: "c.md", rawContent: NOTE_C, fileStat: testStat(1000) },
+        logger,
+      )
+
+      await hybridIndex.embedNote(
+        { notePath: "a.md", rawContent: NOTE_A },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "c.md", rawContent: NOTE_C },
+        logger,
+      )
+
+      const results = await hybridIndex.hybridSearch(
+        { query: "deployment timeline", filters: { type: "meeting" } },
+        logger,
+      )
+
+      const paths = results.map((r) => r.path)
+      expect(paths).not.toContain("a.md")
+    })
+  })
+
+  describe("limit and deduplication", () => {
+    it("respects the user limit after fusion", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      hybridIndex.upsertNote(
+        { filePath: "a.md", rawContent: NOTE_A, fileStat: testStat(1000) },
+        logger,
+      )
+      hybridIndex.upsertNote(
+        { filePath: "b.md", rawContent: NOTE_B, fileStat: testStat(1000) },
+        logger,
+      )
+      hybridIndex.upsertNote(
+        { filePath: "c.md", rawContent: NOTE_C, fileStat: testStat(1000) },
+        logger,
+      )
+
+      await hybridIndex.embedNote(
+        { notePath: "a.md", rawContent: NOTE_A },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "b.md", rawContent: NOTE_B },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "c.md", rawContent: NOTE_C },
+        logger,
+      )
+
+      const results = await hybridIndex.hybridSearch(
+        { query: "project", filters: { limit: 1 } },
+        logger,
+      )
+
+      expect(results).toHaveLength(1)
+    })
+
+    it("deduplicates to one result per note", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      // A long note produces multiple chunks — each could match in KNN
+      const longNote = `---
+title: Long Document
+tags: [test]
+---
+
+## Section One
+
+This section discusses project management and team coordination.
+We need to ensure all stakeholders are aligned on the timeline.
+
+## Section Two
+
+This section covers deployment strategies and infrastructure.
+The deployment pipeline should be automated for efficiency.
+
+## Section Three
+
+This section is about monitoring and observability patterns.
+We should track latency and error rates across all services.
+`
+
+      hybridIndex.upsertNote(
+        { filePath: "long.md", rawContent: longNote, fileStat: testStat(1000) },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "long.md", rawContent: longNote },
+        logger,
+      )
+
+      const results = await hybridIndex.hybridSearch(
+        { query: "deployment" },
+        logger,
+      )
+
+      // Even with multiple chunks, the note appears only once
+      const longNoteResults = results.filter((r) => r.path === "long.md")
+      expect(longNoteResults).toHaveLength(1)
+    })
+  })
+
+  describe("include_leading_callout", () => {
+    it("includes leading callout for vector-only results when requested", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      const noteWithCallout = `---
+title: Reference Doc
+tags: [reference]
+---
+
+> [!info] Quick reference
+> This is a reference document about API design patterns.
+
+The main content discusses RESTful API design and GraphQL alternatives.
+`
+      hybridIndex.upsertNote(
+        {
+          filePath: "ref.md",
+          rawContent: noteWithCallout,
+          fileStat: testStat(1000),
+        },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "ref.md", rawContent: noteWithCallout },
+        logger,
+      )
+
+      const results = await hybridIndex.hybridSearch(
+        {
+          query: "API design patterns",
+          filters: { include_leading_callout: true },
+        },
+        logger,
+      )
+
+      const refResult = results.find((r) => r.path === "ref.md")
+      expect(refResult).toBeDefined()
+      if (refResult?.leading_callout) {
+        expect(refResult.leading_callout.type).toBe("info")
+      }
     })
   })
 })

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -3323,13 +3323,14 @@ the Lightsail budget estimates for next quarter.
 
     it("generates snippets from chunk text for vector-only results", async () => {
       const mockEmbedder = createHybridMockEmbedder()
-      // Return different embeddings so query matches a.md better semantically
-      let callCount = 0
+      // Embed call 1 (a.md chunk): seed 0
+      // Embed call 2 (c.md chunk): seed 1
+      // Embed call 3+ (query): seed 0 — matches a.md exactly (distance 0)
+      let embedCallIndex = 0
       mockEmbedder.embedText.mockImplementation(() => {
-        callCount++
-        // First two calls are during embedNote (for the notes' chunks)
-        // Third+ call is the query embedding — make it match a.md's embedding
-        return Promise.resolve(seededEmbedding(callCount <= 1 ? 0 : 1))
+        const seed = embedCallIndex === 1 ? 1 : 0
+        embedCallIndex++
+        return Promise.resolve(seededEmbedding(seed))
       })
 
       const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
@@ -3352,18 +3353,17 @@ the Lightsail budget estimates for next quarter.
         logger,
       )
 
-      // Query that doesn't match any note via FTS keywords
+      // Query that doesn't match any note via FTS — results are vector-only
       const results = await hybridIndex.hybridSearch(
         { query: "zzz_no_fts_match" },
         logger,
       )
 
-      // Vector-only results should have non-empty snippet built from chunk text
+      // a.md should appear (closest vector match) with a snippet from its chunk
       expect(results.length).toBeGreaterThanOrEqual(1)
-      for (const result of results) {
-        expect(result.snippet).toBeTruthy()
-        expect(result.snippet.length).toBeGreaterThan(0)
-      }
+      const noteA = results.find((r) => r.path === "a.md")
+      expect(noteA).toBeDefined()
+      expect(noteA!.snippet).toContain("aspire")
     })
   })
 
@@ -3755,10 +3755,9 @@ This is a note with many words that should be truncated when using a small snipp
         (result) => result.path === "verbose.md",
       )
       expect(verboseResult).toBeDefined()
-      // Snippet should be truncated to ~5 words with trailing "..."
-      const wordCount = verboseResult?.snippet.split(/\s+/).length ?? 0
-      expect(wordCount).toBeLessThanOrEqual(6) // 5 words + "..." is 6 tokens
-      expect(verboseResult?.snippet).toContain("...")
+      // buildSnippetFromChunkText takes first 5 words of the chunk text
+      // (title-prefixed body) and appends "..."
+      expect(verboseResult!.snippet).toBe("Verbose Note This is a...")
     })
   })
 })

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -158,6 +158,11 @@ type SearchResult = {
   leading_callout?: LeadingCallout
 }
 
+type HybridSearchResult = {
+  results: SearchResult[]
+  search_mode: "hybrid" | "fts"
+}
+
 type NoteMetadata = {
   path: string
   title: string
@@ -1252,7 +1257,7 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
   const hybridSearch = async (
     params: { query: string; filters?: SearchFilters },
     logger: Logger,
-  ): Promise<SearchResult[]> => {
+  ): Promise<HybridSearchResult> => {
     const userLimit = params.filters?.limit ?? 20
     const snippetTokens = params.filters?.snippet_tokens ?? 30
     const includeLeadingCallout =
@@ -1275,7 +1280,8 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
     )
 
     // FTS-only fallback when no vectors are available
-    if (vectorHits.length === 0) return ftsResults.slice(0, userLimit)
+    if (vectorHits.length === 0)
+      return { results: ftsResults.slice(0, userLimit), search_mode: "fts" }
 
     // Compute RRF scores from both ranked lists
     const rrfScores = computeRrfScores({
@@ -1340,7 +1346,10 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
       mergedResults: mergedResults.length,
       returnedResults: Math.min(mergedResults.length, userLimit),
     })
-    return mergedResults.slice(0, userLimit)
+    return {
+      results: mergedResults.slice(0, userLimit),
+      search_mode: "hybrid",
+    }
   }
 
   /** Finds notes with a specific tag. Supports hierarchical prefix matching. */

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -1310,7 +1310,7 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
         folder: noteRow.folder,
         type: noteRow.type,
         ...(noteRow.created !== null ? { created: noteRow.created } : {}),
-        modified: DateTime.fromMillis(Math.round(noteRow.mtime)).toISO()!,
+        modified: DateTime.fromMillis(Math.round(noteRow.mtime)).toISO() ?? "",
         bytes: noteRow.bytes ?? 0,
         ...(includeLeadingCallout && noteRow.leading_callout
           ? {
@@ -1908,8 +1908,8 @@ const notePassesFilters = (note: NoteRow, filters: SearchFilters): boolean => {
   return true
 }
 
-/** Truncates chunk text to a token-limited snippet, mirroring FTS5's
- *  snippet() behavior for vector-only results. */
+/** Truncates chunk text to the first N words for snippet display —
+ *  used for vector-only results that have no FTS5 snippet available. */
 const buildSnippetFromChunkText = (
   chunkText: string,
   snippetTokens: number,

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -821,7 +821,14 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
         const chunkRow = selectChunkIdStmt.get(notePath, chunk.index) as {
           id: number
         }
-        insertVectorStmt.run(BigInt(chunkRow.id), Buffer.from(embedding.buffer))
+        insertVectorStmt.run(
+          BigInt(chunkRow.id),
+          Buffer.from(
+            embedding.buffer,
+            embedding.byteOffset,
+            embedding.byteLength,
+          ),
+        )
       })()
       embeddedCount++
     }
@@ -862,7 +869,11 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
     try {
       const queryEmbedding = await embedder.embedText(params.query)
       const rows = knnSearchStmt.all(
-        Buffer.from(queryEmbedding.buffer),
+        Buffer.from(
+          queryEmbedding.buffer,
+          queryEmbedding.byteOffset,
+          queryEmbedding.byteLength,
+        ),
         params.limit,
       ) as Array<{ note_path: string; chunk_text: string; distance: number }>
 

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -1292,8 +1292,15 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
     )
 
     // FTS-only fallback when no vectors are available
-    if (vectorHits.length === 0)
-      return { results: ftsResults.slice(0, userLimit), search_mode: "fts" }
+    if (vectorHits.length === 0) {
+      const fallbackResults = ftsResults.slice(0, userLimit)
+      logger.info("hybrid search", {
+        query: params.query,
+        searchMode: "fts",
+        resultCount: fallbackResults.length,
+      })
+      return { results: fallbackResults, search_mode: "fts" }
+    }
 
     // Compute RRF scores from both ranked lists
     const rrfScores = computeRrfScores({
@@ -1353,6 +1360,7 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
 
     logger.info("hybrid search", {
       query: params.query,
+      searchMode: "hybrid",
       ftsResults: ftsResults.length,
       vectorHits: vectorHits.length,
       mergedResults: mergedResults.length,

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -100,7 +100,49 @@ export const sanitizeFtsQuery = (raw: string): string => {
   return parts.length === 0 ? '""' : parts.join(" ")
 }
 
+// ── RRF fusion ─────────────────────────────────────────────────
+
+/** Reciprocal Rank Fusion (RRF) — combines two ranked result lists into a
+ *  single scored ranking. Top-rank bonuses reward results that either system
+ *  placed highly: +0.05 for rank 1, +0.02 for ranks 2–3. */
+export const computeRrfScores = (params: {
+  ftsRanked: readonly { path: string }[]
+  vectorRanked: readonly { path: string }[]
+  k?: number
+}): { path: string; score: number }[] => {
+  const k = params.k ?? 60
+
+  const scoresByPath = new Map<string, number>()
+
+  const accumulateScores = (rankedItems: readonly { path: string }[]): void => {
+    for (const [index, item] of rankedItems.entries()) {
+      const rank = index + 1
+      const rrfScore = 1 / (k + rank)
+      const bonus = rank === 1 ? 0.05 : rank <= 3 ? 0.02 : 0
+      const previousScore = scoresByPath.get(item.path) ?? 0
+      scoresByPath.set(item.path, previousScore + rrfScore + bonus)
+    }
+  }
+
+  accumulateScores(params.ftsRanked)
+  accumulateScores(params.vectorRanked)
+
+  return [...scoresByPath.entries()]
+    .sort(([, scoreA], [, scoreB]) => scoreB - scoreA)
+    .map(([path, score]) => ({
+      path,
+      score: Number(score.toPrecision(4)),
+    }))
+}
+
 // ── Types ───────────────────────────────────────────────────────
+
+/** A note path with its best-chunk distance from a vector KNN query. */
+type VectorHit = Readonly<{
+  path: string
+  distance: number
+  chunkText: string
+}>
 
 type SearchResult = {
   path: string
@@ -439,6 +481,26 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
         `DELETE FROM note_vectors WHERE chunk_id IN (SELECT id FROM note_chunks WHERE note_path = ? AND chunk_index >= ?)`,
       )
     : null
+
+  // ── Vector query statements ─────────────────────────────────────
+  /** KNN search — finds the k nearest chunks to a query embedding. */
+  const knnSearchStmt = embedder
+    ? db.prepare(
+        `SELECT nc.note_path, nc.chunk_text, nv.distance
+         FROM note_vectors nv
+         JOIN note_chunks nc ON nc.id = nv.chunk_id
+         WHERE nv.embedding MATCH ?
+           AND nv.k = ?
+         ORDER BY nv.distance`,
+      )
+    : null
+
+  /** Metadata lookup for notes found only via vector search. */
+  const selectNoteMetadataStmt = db.prepare(
+    `SELECT path, title, tags, related, folder, type, created, mtime,
+            properties, leading_callout, bytes
+     FROM notes WHERE path = ?`,
+  )
 
   /** Strips the file extension from a path, or returns the path unchanged if
    *  it has no extension. Uses the last dot in the filename (not the path). */
@@ -788,6 +850,49 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
     await embedAndStoreChunks(params, logger)
   }
 
+  /** Embed a query and find the nearest notes via sqlite-vec KNN. Deduplicates
+   *  to the best (closest) chunk per note. Returns [] silently on any failure
+   *  so hybrid search degrades to FTS-only. */
+  const vectorSearch = async (
+    params: { query: string; limit: number },
+    logger: Logger,
+  ): Promise<VectorHit[]> => {
+    if (!embedder || !knnSearchStmt) return []
+
+    try {
+      const queryEmbedding = await embedder.embedText(params.query)
+      const rows = knnSearchStmt.all(
+        Buffer.from(queryEmbedding.buffer),
+        params.limit,
+      ) as Array<{ note_path: string; chunk_text: string; distance: number }>
+
+      // Deduplicate to best chunk per note — rows are ordered by distance
+      // ascending, so the first occurrence of each path is the closest match.
+      const bestPerNote = new Map<string, VectorHit>()
+      for (const row of rows) {
+        if (!bestPerNote.has(row.note_path)) {
+          bestPerNote.set(row.note_path, {
+            path: row.note_path,
+            distance: row.distance,
+            chunkText: row.chunk_text,
+          })
+        }
+      }
+
+      logger.info("vector search", {
+        query: params.query,
+        knnHits: rows.length,
+        uniqueNotes: bestPerNote.size,
+      })
+      return [...bestPerNote.values()]
+    } catch (error) {
+      logger.warn("vector search failed, falling back to FTS-only", {
+        error: describeError(error),
+      })
+      return []
+    }
+  }
+
   /** Removes a note from the notes table, FTS index, links, and vectors. */
   const removeNote = (filePath: string): void => {
     deleteFtsStmt.run(filePath)
@@ -1128,6 +1233,103 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
       })
       return []
     }
+  }
+
+  /** Hybrid search — combines FTS5 keyword search with sqlite-vec vector
+   *  similarity via RRF fusion. Falls back to FTS-only silently when no
+   *  embeddings are available. */
+  const hybridSearch = async (
+    params: { query: string; filters?: SearchFilters },
+    logger: Logger,
+  ): Promise<SearchResult[]> => {
+    const userLimit = params.filters?.limit ?? 20
+    const snippetTokens = params.filters?.snippet_tokens ?? 30
+    const includeLeadingCallout =
+      params.filters?.include_leading_callout ?? false
+    const candidateLimit = Math.min(userLimit * 3, 100)
+
+    // Run FTS with inflated limit to give RRF enough candidates
+    const ftsResults = fullTextSearch(
+      {
+        query: params.query,
+        filters: { ...params.filters, limit: candidateLimit },
+      },
+      logger,
+    )
+
+    // Attempt vector search — returns [] on any failure
+    const vectorHits = await vectorSearch(
+      { query: params.query, limit: candidateLimit },
+      logger,
+    )
+
+    // FTS-only fallback when no vectors are available
+    if (vectorHits.length === 0) return ftsResults.slice(0, userLimit)
+
+    // Compute RRF scores from both ranked lists
+    const rrfScores = computeRrfScores({
+      ftsRanked: ftsResults,
+      vectorRanked: vectorHits,
+    })
+
+    // Index FTS results and vector hits by path for O(1) lookup
+    const ftsResultsByPath = new Map(
+      ftsResults.map((result) => [result.path, result]),
+    )
+    const vectorHitsByPath = new Map(vectorHits.map((hit) => [hit.path, hit]))
+
+    // Build the merged result set, ordered by RRF score
+    const mergedResults: SearchResult[] = []
+    for (const { path, score } of rrfScores) {
+      const ftsResult = ftsResultsByPath.get(path)
+      if (ftsResult) {
+        // Path found via FTS — use its metadata and snippet, replace score
+        mergedResults.push({ ...ftsResult, score })
+        continue
+      }
+
+      // Vector-only result — look up metadata from the notes table
+      const noteRow = selectNoteMetadataStmt.get(path) as NoteRow | undefined
+      if (!noteRow) continue
+
+      // Apply filters that FTS would have applied via SQL
+      if (params.filters && !notePassesFilters(noteRow, params.filters))
+        continue
+
+      const vectorHit = vectorHitsByPath.get(path)
+      const snippet = vectorHit
+        ? buildSnippetFromChunkText(vectorHit.chunkText, snippetTokens)
+        : ""
+
+      mergedResults.push({
+        path: noteRow.path,
+        title: noteRow.title,
+        snippet,
+        score,
+        tags: JSON.parse(noteRow.tags) as string[],
+        folder: noteRow.folder,
+        type: noteRow.type,
+        ...(noteRow.created !== null ? { created: noteRow.created } : {}),
+        modified: DateTime.fromMillis(Math.round(noteRow.mtime)).toISO()!,
+        bytes: noteRow.bytes ?? 0,
+        ...(includeLeadingCallout && noteRow.leading_callout
+          ? {
+              leading_callout: JSON.parse(
+                noteRow.leading_callout,
+              ) as LeadingCallout,
+            }
+          : {}),
+      })
+    }
+
+    logger.info("hybrid search", {
+      query: params.query,
+      ftsResults: ftsResults.length,
+      vectorHits: vectorHits.length,
+      mergedResults: mergedResults.length,
+      returnedResults: Math.min(mergedResults.length, userLimit),
+    })
+    return mergedResults.slice(0, userLimit)
   }
 
   /** Finds notes with a specific tag. Supports hierarchical prefix matching. */
@@ -1638,6 +1840,7 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
     removeNonMdFile,
     setDailyNotesFolder,
     fullTextSearch,
+    hybridSearch,
     searchByTag,
     searchByFolder,
     listAllTags,
@@ -1672,5 +1875,48 @@ const rowToMetadata = (row: NoteRow): NoteMetadata => ({
     ? (JSON.parse(row.leading_callout) as LeadingCallout)
     : null,
 })
+
+/** Applies the same filter logic as fullTextSearch's SQL WHERE clause, but in
+ *  TypeScript — used for vector-only results that bypassed the FTS query. */
+const notePassesFilters = (note: NoteRow, filters: SearchFilters): boolean => {
+  if (filters.folder && !note.path.startsWith(filters.folder + "/"))
+    return false
+
+  if (filters.tags) {
+    const noteTags = JSON.parse(note.tags) as string[]
+    if (!filters.tags.every((tag) => noteTags.includes(tag))) return false
+  }
+
+  if (filters.type && note.type !== filters.type) return false
+
+  if (filters.related) {
+    const noteRelated = JSON.parse(note.related) as string[]
+    if (!filters.related.every((link) => noteRelated.includes(link)))
+      return false
+  }
+
+  if (filters.properties) {
+    const noteProperties = JSON.parse(note.properties) as Record<
+      string,
+      unknown
+    >
+    for (const [key, value] of Object.entries(filters.properties)) {
+      if (noteProperties[key] !== value) return false
+    }
+  }
+
+  return true
+}
+
+/** Truncates chunk text to a token-limited snippet, mirroring FTS5's
+ *  snippet() behavior for vector-only results. */
+const buildSnippetFromChunkText = (
+  chunkText: string,
+  snippetTokens: number,
+): string => {
+  const words = chunkText.split(/\s+/).filter((word) => word.length > 0)
+  if (words.length <= snippetTokens) return words.join(" ")
+  return words.slice(0, snippetTokens).join(" ") + "..."
+}
 
 export type SearchIndex = ReturnType<typeof createSearchIndex>

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -1230,25 +1230,14 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
         }
       >
 
-      const results: SearchResult[] = rows.map((row) => ({
-        path: row.path,
-        title: row.title,
-        snippet: row.snippet,
-        score: Number(row.score.toPrecision(4)),
-        tags: JSON.parse(row.tags) as string[],
-        folder: row.folder,
-        type: row.type,
-        ...(row.created !== null ? { created: row.created } : {}),
-        modified: DateTime.fromMillis(Math.round(row.mtime)).toISO()!,
-        bytes: row.bytes ?? 0,
-        ...(includeLeadingCallout && row.leading_callout
-          ? {
-              leading_callout: JSON.parse(
-                row.leading_callout,
-              ) as LeadingCallout,
-            }
-          : {}),
-      }))
+      const results: SearchResult[] = rows.map((row) =>
+        noteRowToSearchResult({
+          row,
+          snippet: row.snippet,
+          score: Number(row.score.toPrecision(4)),
+          includeLeadingCallout,
+        }),
+      )
       logger.info("full text search", {
         query: params.query,
         resultCount: results.length,
@@ -1337,25 +1326,14 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
         ? buildSnippetFromChunkText(vectorHit.chunkText, snippetTokens)
         : ""
 
-      mergedResults.push({
-        path: noteRow.path,
-        title: noteRow.title,
-        snippet,
-        score,
-        tags: JSON.parse(noteRow.tags) as string[],
-        folder: noteRow.folder,
-        type: noteRow.type,
-        ...(noteRow.created !== null ? { created: noteRow.created } : {}),
-        modified: DateTime.fromMillis(Math.round(noteRow.mtime)).toISO() ?? "",
-        bytes: noteRow.bytes ?? 0,
-        ...(includeLeadingCallout && noteRow.leading_callout
-          ? {
-              leading_callout: JSON.parse(
-                noteRow.leading_callout,
-              ) as LeadingCallout,
-            }
-          : {}),
-      })
+      mergedResults.push(
+        noteRowToSearchResult({
+          row: noteRow,
+          snippet,
+          score,
+          includeLeadingCallout,
+        }),
+      )
     }
 
     logger.info("hybrid search", {
@@ -1914,6 +1892,43 @@ const rowToMetadata = (row: NoteRow): NoteMetadata => ({
   leading_callout: row.leading_callout
     ? (JSON.parse(row.leading_callout) as LeadingCallout)
     : null,
+})
+
+/** Builds a SearchResult from a NoteRow and caller-provided snippet + score.
+ *  Shared by fullTextSearch (FTS rows) and hybridSearch (vector-only rows). */
+const noteRowToSearchResult = (params: {
+  row: Pick<
+    NoteRow,
+    | "path"
+    | "title"
+    | "tags"
+    | "folder"
+    | "type"
+    | "created"
+    | "mtime"
+    | "bytes"
+  > & { leading_callout?: string | null }
+  snippet: string
+  score: number
+  includeLeadingCallout: boolean
+}): SearchResult => ({
+  path: params.row.path,
+  title: params.row.title,
+  snippet: params.snippet,
+  score: params.score,
+  tags: JSON.parse(params.row.tags) as string[],
+  folder: params.row.folder,
+  type: params.row.type,
+  ...(params.row.created !== null ? { created: params.row.created } : {}),
+  modified: DateTime.fromMillis(Math.round(params.row.mtime)).toISO() ?? "",
+  bytes: params.row.bytes ?? 0,
+  ...(params.includeLeadingCallout && params.row.leading_callout
+    ? {
+        leading_callout: JSON.parse(
+          params.row.leading_callout,
+        ) as LeadingCallout,
+      }
+    : {}),
 })
 
 /** Applies the same filter logic as fullTextSearch's SQL WHERE clause, but in

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -102,9 +102,21 @@ export const sanitizeFtsQuery = (raw: string): string => {
 
 // ── RRF fusion ─────────────────────────────────────────────────
 
-/** Reciprocal Rank Fusion (RRF) — combines two ranked result lists into a
- *  single scored ranking. Top-rank bonuses reward results that either system
- *  placed highly: +0.05 for rank 1, +0.02 for ranks 2–3. */
+/** Reciprocal Rank Fusion (RRF) — merges two independently ranked result
+ *  lists (FTS keyword + vector semantic) into a single relevance score.
+ *
+ *  Algorithm:
+ *  1. For each result in each list, compute 1 / (k + rank) where rank is
+ *     1-indexed and k (default 60) dampens the influence of low ranks
+ *  2. Sum scores per path across both lists — a path in both gets a higher
+ *     combined score than one appearing in only one list
+ *  3. Add top-rank bonuses: +0.05 for rank 1, +0.02 for ranks 2–3 in either
+ *     list, rewarding results that either system placed highly
+ *  4. Sort by combined score descending
+ *
+ *  Reference: Cormack, Clarke & Butt (2009) "Reciprocal Rank Fusion
+ *  outperforms Condorcet and individual Rank Learning Methods"
+ *  https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf */
 export const computeRrfScores = (params: {
   ftsRanked: readonly { path: string }[]
   vectorRanked: readonly { path: string }[]

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -896,10 +896,10 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
 
       // Deduplicate to best chunk per note — rows are ordered by distance
       // ascending, so the first occurrence of each path is the closest match.
-      const bestPerNote = new Map<string, VectorHit>()
+      const bestChunkPerNote = new Map<string, VectorHit>()
       for (const row of rows) {
-        if (!bestPerNote.has(row.note_path)) {
-          bestPerNote.set(row.note_path, {
+        if (!bestChunkPerNote.has(row.note_path)) {
+          bestChunkPerNote.set(row.note_path, {
             path: row.note_path,
             distance: row.distance,
             chunkText: row.chunk_text,
@@ -910,9 +910,9 @@ export const createSearchIndex = (dbPath: string, embedder?: Embedder) => {
       logger.info("vector search", {
         query: params.query,
         knnHits: rows.length,
-        uniqueNotes: bestPerNote.size,
+        uniqueNotes: bestChunkPerNote.size,
       })
-      return [...bestPerNote.values()]
+      return [...bestChunkPerNote.values()]
     } catch (error) {
       logger.warn("vector search failed, falling back to FTS-only", {
         error: describeError(error),


### PR DESCRIPTION
## Summary
- Add hybrid search (FTS5 + sqlite-vec vector + RRF fusion) to `vault_search` tool
- Transparent upgrade: uses hybrid ranking when embeddings are available, falls back to FTS-only when they are not
- Three new functions: `computeRrfScores` (pure RRF), `vectorSearch` (KNN), `hybridSearch` (orchestrator)
- Updated `vault_search` tool description to reflect hybrid search capabilities

## Spike result
8/9 previously-failed queries fixed, 0 regressions, ~8ms latency (RRF-only mode).

## Test plan
- [x] 9 `computeRrfScores` unit tests (table-driven: single/both systems, bonuses, custom k, sort order)
- [x] 12 `hybridSearch` integration tests (fallback, hybrid ranking, filters, limits, dedup, callouts)
- [x] All 1177 tests pass
- [x] Build and lint clean
- [ ] Deploy to Lightsail and run 9-query eval against live vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZbaHwP28ASYTpQnZk6MqM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now uses a hybrid ranking approach that blends keyword and semantic matching for more relevant results.
  * Results can now fall back to keyword-only search when embeddings aren’t available.
  * Search snippets and result metadata are more complete for semantic matches, with improved relevance ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->