### PR TITLE
fix: normalize trailing slashes in folder filter inputs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,7 +149,7 @@ jobs:
           # page). Mirror the server.json / Dockerfile description here.
           annotations: |
             index:org.opencontainers.image.title=vault-cortex
-            index:org.opencontainers.image.description=Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1.
+            index:org.opencontainers.image.description=Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools, OAuth 2.1.
             index:org.opencontainers.image.source=https://github.com/aliasunder/vault-cortex
             index:org.opencontainers.image.licenses=MIT
           cache-from: type=gha

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,7 +149,7 @@ jobs:
           # page). Mirror the server.json / Dockerfile description here.
           annotations: |
             index:org.opencontainers.image.title=vault-cortex
-            index:org.opencontainers.image.description=Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools, OAuth 2.1.
+            index:org.opencontainers.image.description=Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools + 3 prompts, OAuth 2.1.
             index:org.opencontainers.image.source=https://github.com/aliasunder/vault-cortex
             index:org.opencontainers.image.licenses=MIT
           cache-from: type=gha

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,7 +532,7 @@ changed:
 | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `README.md`                          | Tool/prompt count changes, new deployment mode, new feature worth mentioning in the value prop                                                           |
 | `ARCHITECTURE.md`                    | New component, requirement, or design decision; component diagram changes                                                                                |
-| `server.json`                        | Tool/prompt count changes (the `tools` and `prompts` fields)                                                                                             |
+| `server.json`                        | Tool/prompt count changes (the `tools` and `prompts` fields), description changes. `description` has a 100-character limit per the MCP registry schema.  |
 | `assets/social-preview.svg` + `.png` | Tool count changes (rendered in the image); regenerate PNG after SVG edits                                                                               |
 | `.devin/wiki.json`                   | New architectural area (new page), module renamed/moved (update `repo_notes` or `purpose` references), significant tool count jump (update `repo_notes`) |
 | `deploy/local/` + `deploy/remote/`   | New env var, changed default, new deployment step, or Docker Compose service change — update `.env.example` and `README.md` in the affected directory    |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,6 +537,7 @@ changed:
 | `.devin/wiki.json`                   | New architectural area (new page), module renamed/moved (update `repo_notes` or `purpose` references), significant tool count jump (update `repo_notes`) |
 | `deploy/local/` + `deploy/remote/`   | New env var, changed default, new deployment step, or Docker Compose service change — update `.env.example` and `README.md` in the affected directory    |
 | `.env.example` (root)                | New env var or changed default for the Lightsail reference deployment                                                                                    |
+| `cli/README.md`                      | Feature description, tool/prompt count, or search capability changes — this is the npmjs.com landing page                                                |
 | `cli/src/env.ts`                     | New env var or changed default — the CLI generates `.env` files with optional blocks that must mirror `deploy/*/.env.example`                            |
 | `cli/templates/`                     | Docker Compose service change, new env var passthrough — templates must mirror `deploy/*/docker-compose.yml`                                             |
 | `CONTRIBUTING.md`                    | CI pipeline, repo settings, or release conventions change                                                                                                |

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0 VAULT_PATH=/vault INDEX_DB_PATH=/
 # set in deploy.yml — keep that description and the one here in sync.
 LABEL io.modelcontextprotocol.server.name="io.github.aliasunder/vault-cortex" \
       org.opencontainers.image.title="vault-cortex" \
-      org.opencontainers.image.description="Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1." \
+      org.opencontainers.image.description="Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools, OAuth 2.1." \
       org.opencontainers.image.source="https://github.com/aliasunder/vault-cortex" \
       org.opencontainers.image.licenses="MIT"
 COPY --from=deps  /app/node_modules ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0 VAULT_PATH=/vault INDEX_DB_PATH=/
 # set in deploy.yml — keep that description and the one here in sync.
 LABEL io.modelcontextprotocol.server.name="io.github.aliasunder/vault-cortex" \
       org.opencontainers.image.title="vault-cortex" \
-      org.opencontainers.image.description="Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools, OAuth 2.1." \
+      org.opencontainers.image.description="Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools + 3 prompts, OAuth 2.1." \
       org.opencontainers.image.source="https://github.com/aliasunder/vault-cortex" \
       org.opencontainers.image.licenses="MIT"
 COPY --from=deps  /app/node_modules ./node_modules

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 </div>
 
-**Vault Cortex** is a standalone MCP server that gives any AI agent **hybrid search, structured memory, and read/write access** to your [Obsidian](https://obsidian.md) vault. No plugins, no running Obsidian, no separate bridge. One Docker container, your vault folder, 25 tools. Deploy on a VPS with Obsidian Sync and the same vault is accessible from your phone, claude.ai, or any remote MCP client, secured with OAuth 2.1.
+**Vault Cortex** is a standalone MCP server that gives any AI agent **hybrid search, structured memory, and read/write access** to your [Obsidian](https://obsidian.md) vault. No plugins, no running Obsidian, no separate bridge. One Docker container, your vault folder, 25 tools + 3 guided prompts. Deploy on a VPS with Obsidian Sync and the same vault is accessible from your phone, claude.ai, or any remote MCP client, secured with OAuth 2.1.
 
 **Contents** — [What you get](#what-you-get) · [Quick Start](#quick-start) · [How It Works](#how-it-works) · [Hybrid Search](#hybrid-search) · [Tools](#tools-25) · [Prompts](#prompts-3) · [Config](#configuration) · [Auth](#authentication) · [Deployment](#deployment-options)
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -8,8 +8,8 @@ npx vault-cortex@latest init
 ```
 
 Vault Cortex is a plugin-free, remote-capable MCP server for Obsidian vaults —
-25 tools for search (SQLite FTS5), notes, frontmatter, links, daily notes, and
-a persistent memory layer, plus 3 guided prompts (orientation, memory review,
+25 tools for hybrid search (FTS5 + vector), notes, frontmatter, links, daily notes, and
+a structured memory layer, plus 3 guided prompts (orientation, memory review,
 daily review). It runs as a Docker container; this CLI scaffolds the config so
 you don't have to.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -7,7 +7,7 @@ for your Obsidian vault in one command:
 npx vault-cortex@latest init
 ```
 
-Vault Cortex is a plugin-free, remote-capable MCP server for Obsidian vaults —
+Vault Cortex is a standalone, remote-capable MCP server for Obsidian vaults —
 25 tools for hybrid search (FTS5 + vector), notes, frontmatter, links, daily notes, and
 a structured memory layer, plus 3 guided prompts (orientation, memory review,
 daily review). It runs as a Docker container; this CLI scaffolds the config so

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vault-cortex",
   "version": "0.23.12",
   "private": true,
-  "description": "Standalone MCP server for Obsidian vaults — plugin-free search, memory, link graph, and daily notes over Streamable HTTP",
+  "description": "Standalone MCP server for Obsidian vaults — hybrid search, structured memory, link graph, and daily notes over Streamable HTTP",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,10 +14,15 @@
   },
   "keywords": [
     "mcp",
+    "mcp-server",
     "model-context-protocol",
     "obsidian",
-    "vault",
-    "remote-mcp-server"
+    "obsidian-vault",
+    "hybrid-search",
+    "semantic-search",
+    "sqlite-vec",
+    "ai-memory",
+    "docker"
   ],
   "type": "module",
   "engines": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.aliasunder/vault-cortex",
   "title": "Vault Cortex",
-  "description": "Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools + 3 prompts, OAuth 2.1.",
+  "description": "Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools, OAuth 2.1.",
   "version": "0.23.12",
   "websiteUrl": "https://github.com/aliasunder/vault-cortex",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.aliasunder/vault-cortex",
   "title": "Vault Cortex",
-  "description": "Standalone MCP server for Obsidian vaults — plugin-free, 25 tools + 3 prompts, OAuth 2.1.",
+  "description": "Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools + 3 prompts, OAuth 2.1.",
   "version": "0.23.12",
   "websiteUrl": "https://github.com/aliasunder/vault-cortex",
   "repository": {

--- a/src/vault-mcp/search/__tests__/search-helpers.test.ts
+++ b/src/vault-mcp/search/__tests__/search-helpers.test.ts
@@ -195,6 +195,18 @@ describe("noteMatchesSearchFilters", () => {
       }),
     ).toBe(false)
   })
+
+  it("strips trailing slashes from folder filter before matching", () => {
+    expect(
+      noteMatchesSearchFilters(baseRow, { folder: "Projects/Alpha/" }),
+    ).toBe(true)
+    expect(noteMatchesSearchFilters(baseRow, { folder: "Projects/" })).toBe(
+      true,
+    )
+    expect(
+      noteMatchesSearchFilters(baseRow, { folder: "Projects/Beta/" }),
+    ).toBe(false)
+  })
 })
 
 // ── buildSnippetFromChunkText ─────────────────────────────────

--- a/src/vault-mcp/search/__tests__/search-helpers.test.ts
+++ b/src/vault-mcp/search/__tests__/search-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   noteMatchesSearchFilters,
   buildSnippetFromChunkText,
   escapeLikeWildcards,
+  stripTrailingSlashes,
 } from "../search-helpers.js"
 import type { NoteRow } from "../search-index.js"
 
@@ -237,5 +238,31 @@ describe("escapeLikeWildcards", () => {
 
   it("leaves normal text unchanged", () => {
     expect(escapeLikeWildcards("Projects/Alpha")).toBe("Projects/Alpha")
+  })
+})
+
+// ── stripTrailingSlashes ──────────────────────────────────────
+
+describe("stripTrailingSlashes", () => {
+  it("strips a single trailing slash", () => {
+    expect(stripTrailingSlashes("Projects/")).toBe("Projects")
+  })
+
+  it("strips multiple trailing slashes", () => {
+    expect(stripTrailingSlashes("Projects///")).toBe("Projects")
+  })
+
+  it("leaves paths without trailing slashes unchanged", () => {
+    expect(stripTrailingSlashes("Projects/Alpha")).toBe("Projects/Alpha")
+  })
+
+  it("preserves internal slashes", () => {
+    expect(stripTrailingSlashes("Projects/Alpha/Beta/")).toBe(
+      "Projects/Alpha/Beta",
+    )
+  })
+
+  it("handles a bare folder name", () => {
+    expect(stripTrailingSlashes("Projects")).toBe("Projects")
   })
 })

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -872,6 +872,14 @@ describe("searchByFolder", () => {
       "About Me/Principles.md",
     ])
   })
+
+  it("strips trailing slashes from folder before matching", () => {
+    const results = index.searchByFolder({ folder: "About Me/" }, logger)
+    expect(results.map((note) => note.path)).toEqual([
+      "About Me/sub/deep.md",
+      "About Me/Principles.md",
+    ])
+  })
 })
 
 describe("listAllTags", () => {
@@ -1912,6 +1920,16 @@ describe("findOrphans", () => {
     )
     const orphanPaths = orphans.map((orphan) => orphan.path)
     expect(orphanPaths).not.toContain("Daily Notes/2026-05-13.md")
+  })
+
+  it("strips trailing slashes from excludeFolders before matching", () => {
+    const orphans = index.findOrphans(
+      { excludeFolders: ["Daily Notes/"] },
+      logger,
+    )
+    const orphanPaths = orphans.map((orphan) => orphan.path)
+    expect(orphanPaths).not.toContain("Daily Notes/2026-05-13.md")
+    expect(orphanPaths).toContain("Projects/orphan.md")
   })
 
   it("respects limit", () => {

--- a/src/vault-mcp/search/search-helpers.ts
+++ b/src/vault-mcp/search/search-helpers.ts
@@ -22,6 +22,11 @@ export const coerceToArray = (value: unknown): string[] =>
 
 // ── LIKE escaping ─────────────────────────────────────────────
 
+/** Strips trailing slashes so folder paths produce clean LIKE patterns
+ *  (e.g. `"Projects/"` → `"Projects"`, avoiding `Projects//%`). */
+export const stripTrailingSlashes = (folder: string): string =>
+  folder.replace(/\/+$/, "")
+
 /** Escapes LIKE-wildcard characters (`\`, `%`, `_`) in a value so it is
  *  matched literally in a `LIKE ... ESCAPE '\'` clause. */
 export const escapeLikeWildcards = (value: string): string =>

--- a/src/vault-mcp/search/search-helpers.ts
+++ b/src/vault-mcp/search/search-helpers.ts
@@ -132,7 +132,10 @@ export const noteMatchesSearchFilters = (
   note: NoteRow,
   filters: SearchFilters,
 ): boolean => {
-  if (filters.folder && !note.path.startsWith(filters.folder + "/"))
+  if (
+    filters.folder &&
+    !note.path.startsWith(stripTrailingSlashes(filters.folder) + "/")
+  )
     return false
 
   if (filters.tags) {

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -13,6 +13,7 @@ import {
   noteMatchesSearchFilters,
   buildSnippetFromChunkText,
   escapeLikeWildcards,
+  stripTrailingSlashes,
 } from "./search-helpers.js"
 import type {
   VectorHit,
@@ -106,7 +107,9 @@ export const fullTextSearch = (
 
   if (params.filters?.folder) {
     conditions.push("n.path LIKE ? ESCAPE '\\'")
-    queryParams.push(`${escapeLikeWildcards(params.filters.folder)}/%`)
+    queryParams.push(
+      `${escapeLikeWildcards(stripTrailingSlashes(params.filters.folder))}/%`,
+    )
   }
 
   if (params.filters?.tags) {
@@ -348,7 +351,7 @@ export const searchByFolder = (
   const recursive = params.recursive ?? true
   const limit = Math.max(0, params.limit ?? 20)
 
-  const escapedFolder = escapeLikeWildcards(params.folder)
+  const escapedFolder = escapeLikeWildcards(stripTrailingSlashes(params.folder))
   const condition = recursive
     ? "path LIKE ? || '/%' ESCAPE '\\'"
     : "path LIKE ? || '/%' ESCAPE '\\' AND path NOT LIKE ? || '/%/%' ESCAPE '\\'"
@@ -428,7 +431,7 @@ export const listPropertyKeys = (
   logger: Logger,
 ): PropertyKeyInfo[] => {
   const escapedFolder = params.folder
-    ? escapeLikeWildcards(params.folder)
+    ? escapeLikeWildcards(stripTrailingSlashes(params.folder))
     : null
   const folderCondition = escapedFolder
     ? "WHERE n.path LIKE @folder || '/%' ESCAPE '\\'"
@@ -501,7 +504,7 @@ export const listPropertyValues = (
 ): PropertyValueCount[] => {
   const limit = Math.max(0, params.limit ?? 50)
   const escapedFolder = params.folder
-    ? escapeLikeWildcards(params.folder)
+    ? escapeLikeWildcards(stripTrailingSlashes(params.folder))
     : null
   const folderCondition = escapedFolder
     ? "AND path LIKE @folder || '/%' ESCAPE '\\'"
@@ -553,7 +556,7 @@ export const searchByProperty = (
 ): NoteMetadata[] => {
   const limit = Math.max(0, params.limit ?? 20)
   const escapedFolder = params.folder
-    ? escapeLikeWildcards(params.folder)
+    ? escapeLikeWildcards(stripTrailingSlashes(params.folder))
     : null
   const folderCondition = escapedFolder
     ? "AND n.path LIKE @folder || '/%' ESCAPE '\\'"

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -700,7 +700,9 @@ export const findOrphans = (
   const limit = Math.max(0, params.limit ?? 50)
 
   // One exclusion clause per folder, each bound to a positional parameter
-  const escapedExcludeFolders = excludeFolders.map(escapeLikeWildcards)
+  const escapedExcludeFolders = excludeFolders.map((folder) =>
+    escapeLikeWildcards(stripTrailingSlashes(folder)),
+  )
   const folderExclusions = Array(escapedExcludeFolders.length)
     .fill("path NOT LIKE ? || '/%' ESCAPE '\\'")
     .join(" AND ")


### PR DESCRIPTION
## Summary

- Folder inputs with trailing slashes (e.g. `"Projects/"`) produced a LIKE pattern with `//` (`Projects//%`) that silently returned zero results
- Added `stripTrailingSlashes` helper in search-helpers.ts, applied at all 5 folder filter sites in search-queries.ts
- 5 unit tests for the new helper

Found by qodo in PR #228 review.

## Test plan

- [x] `stripTrailingSlashes` unit tests (5 cases: single slash, multiple, no slash, internal slashes, bare name)
- [x] Full search test suite passes (298 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)