### PR TITLE
chore(cli): update npm keywords for Phase 2 search

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -36,7 +36,8 @@
     "knowledge-base",
     "note-taking",
     "second-brain",
-    "full-text-search",
+    "hybrid-search",
+    "semantic-search",
     "cli"
   ],
   "dependencies": {

--- a/src/vault-mcp/mcp-core/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/mcp-router.test.ts
@@ -59,7 +59,7 @@ const SERVER_INFO = {
   name: "vault-cortex",
   title: "Vault Cortex",
   version: "1.0.0",
-  description: `Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (${DEFAULT_CONFIG.memoryDir}/) for personalization across conversations.`,
+  description: `Read, write, and search an Obsidian vault. Provides hybrid search, tag queries, and a structured memory layer (${DEFAULT_CONFIG.memoryDir}/) for personalization across conversations.`,
   icons: [
     {
       src: "https://raw.githubusercontent.com/aliasunder/vault-cortex/main/assets/icon-400.png",

--- a/src/vault-mcp/mcp-core/__tests__/vault-orientation-prompt.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/vault-orientation-prompt.test.ts
@@ -315,7 +315,7 @@ describe("vault-orientation full prompt output", () => {
         "",
         "---",
         "Go deeper with the vault tools:",
-        "- `vault_search` — full-text search across all notes",
+        "- `vault_search` — hybrid search across all notes",
         "- `vault_search_by_tag` — explore notes by tag",
         "- `vault_list_property_values` — explore values for any property key",
         "- `vault_find_orphans` — full orphan list with exclusion control",

--- a/src/vault-mcp/mcp-core/mcp-router.ts
+++ b/src/vault-mcp/mcp-core/mcp-router.ts
@@ -77,14 +77,17 @@ export const createMcpRouter = ({
             })
           }
         }
+        const searchDescription = config.embeddingEnabled
+          ? "hybrid search"
+          : "full-text search"
         const server = new McpServer(
           {
             name: "vault-cortex",
             title: "Vault Cortex",
             version: "1.0.0",
             description: config.memoryEnabled
-              ? `Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and a structured memory layer (${config.memoryDir}/) for personalization across conversations.`
-              : `Read, write, and search an Obsidian vault. Provides full-text search, tag queries, and property-based filtering.`,
+              ? `Read, write, and search an Obsidian vault. Provides ${searchDescription}, tag queries, and a structured memory layer (${config.memoryDir}/) for personalization across conversations.`
+              : `Read, write, and search an Obsidian vault. Provides ${searchDescription}, tag queries, and property-based filtering.`,
             icons: SERVER_ICONS,
             websiteUrl: SERVER_WEBSITE_URL,
           },

--- a/src/vault-mcp/mcp-core/prompts/vault-orientation-prompt.ts
+++ b/src/vault-mcp/mcp-core/prompts/vault-orientation-prompt.ts
@@ -241,7 +241,7 @@ export const registerVaultOrientationPrompt = ({
           ? "- `vault_get_memory` — read memory files in detail"
           : ""
         const goDeeper = [
-          "- `vault_search` — full-text search across all notes",
+          `- \`vault_search\` — ${config.embeddingEnabled ? "hybrid" : "full-text"} search across all notes`,
           "- `vault_search_by_tag` — explore notes by tag",
           "- `vault_list_property_values` — explore values for any property key",
           orphanTools,


### PR DESCRIPTION
## Summary
- Replace `full-text-search` with `hybrid-search` and `semantic-search` in CLI `package.json` keywords
- Make the MCP server description (`mcp-router.ts`) and vault-orientation prompt conditional on `config.embeddingEnabled` — says "hybrid search" when embedding is on, "full-text search" when off
- Update corresponding tests

## Test plan
- [x] `mcp-router.test.ts` — 22 tests pass
- [x] `vault-orientation-prompt.test.ts` — 19 tests pass
- [ ] Confirm keywords appear on npmjs.com after next CLI release

🤖 Generated with [Claude Code](https://claude.com/claude-code)