### PR TITLE
chore(cli): add cross-encoder and reranking npm keywords

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -38,6 +38,8 @@
     "second-brain",
     "hybrid-search",
     "semantic-search",
+    "cross-encoder",
+    "reranking",
     "cli"
   ],
   "dependencies": {


### PR DESCRIPTION
## Summary

- Add `cross-encoder` and `reranking` to CLI npm keywords for discoverability, matching the GitHub repo topics updated alongside PR #235

## Test plan

- [ ] No code changes — keyword-only update
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)