### PR TITLE
docs(readme): update trip dogfooding stat to audited tool-call count

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 - **[Obsidian-native](#properties)** — understands frontmatter, wikilinks, tags, headings, and daily notes
 - **[Guided workflows](#prompts-3)** — three built-in prompts for vault health, memory review, and daily reconciliation — assembled from live vault data each time
 
-**Tested across a 15-day trip through Europe.** 30+ sessions from a phone, 70+ tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
+**Tested across a 15-day trip through Europe.** 30+ sessions from a phone, 216 tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
 
 ## Quick Start
 


### PR DESCRIPTION
The "70+ tool calls" figure in the dogfooding line was a pre-audit estimate taken from chat history. An audit of the persistent server logs on the deployed instance (May 22 – Jun 5 window) counted **216 tool calls** (89 reads, 79 surgical edits, 16 searches). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)