### PR TITLE
fix(memory): make vault_update_memory idempotent on exact duplicate entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,16 @@ throughout the codebase.
 - `type` over `interface` unless `interface` is specifically required.
 - TypeScript strict mode. `node:` prefix for built-ins.
 - Explicit return types on exports. Zod for MCP tool schemas.
+- Tool input schemas stay at `.min(1)` — no `.refine`. Rich validation
+  (format, date validity, mutual exclusivity) lives in the data layer or
+  handler, where failures flow through `safeHandler` as structured tool
+  errors with remediation text and get logged as `tool_error`. Zod
+  schema failures surface as protocol-level invalid-params errors that
+  bypass both, and a `.refine` predicate can't be serialized into the
+  JSON schema clients see anyway — so it adds no discoverability, only a
+  second copy of a guard the data layer must enforce regardless (drift
+  risk). `.min(1)` is the floor because it does serialize (`minLength`)
+  and its default failure message is self-explanatory.
 - No `any`. No `as` or `!` (non-null assertion) — both are type
   assertions that bypass the compiler. Use runtime guards (`if (x ===
 undefined) return`) or schema validation to narrow types instead.

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -133,26 +133,26 @@ describe("registerTools", () => {
   it.each(WRITE_TOOLS)(
     "%s description includes Obsidian syntax guidance",
     (name) => {
-      const [, config] = findCall(name)!
+      const [, config] = requireCall(name)
       expect(config.description).toContain("Obsidian syntax:")
     },
   )
 
   it("vault_replace_in_note description clarifies in-place scope", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_REPLACE_IN_NOTE)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_REPLACE_IN_NOTE)
     expect(config.description).toContain("in place")
     expect(config.description).toContain("vault_read_note")
   })
 
   it("vault_patch_note description includes cross-section move guidance", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_PATCH_NOTE)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_PATCH_NOTE)
     expect(config.description).toContain("Cross-section move")
   })
 
   it.each([TOOL_NAMES.VAULT_UPDATE_MEMORY, TOOL_NAMES.VAULT_DELETE_MEMORY])(
     "%s description documents the shrink-guard error",
     (name) => {
-      const [, config] = findCall(name)!
+      const [, config] = requireCall(name)
       expect(config.description).toContain("Errors:")
       expect(config.description).toContain("refusing memory write")
     },
@@ -176,62 +176,62 @@ describe("registerTools", () => {
   })
 
   it("vault_update_properties description documents null-deletes-key contract", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_UPDATE_PROPERTIES)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_UPDATE_PROPERTIES)
     expect(config.description).toContain("null deletes a key")
   })
 
   it("vault_write_note description documents null-deletes-key contract", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_WRITE_NOTE)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_WRITE_NOTE)
     expect(config.description).toContain("keys set to null removed")
   })
 
   it("vault_recent_notes description documents sorting behavior", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_RECENT_NOTES)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_RECENT_NOTES)
     expect(config.description).toContain("filesystem mtime")
     expect(config.description).toContain("sort last")
   })
 
   it("vault_read_note description cross-references graph tools", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_READ_NOTE)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_READ_NOTE)
     expect(config.description).toContain("vault_get_backlinks")
     expect(config.description).toContain("vault_get_outgoing_links")
   })
 
   it("vault_search_by_property parameters cross-reference discovery tools", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_SEARCH_BY_PROPERTY)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_SEARCH_BY_PROPERTY)
     expect(config.description).toContain("vault_list_property_keys")
     expect(config.description).toContain("vault_list_property_values")
   })
 
   it("vault_list_notes description cross-references vault_read_note", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_LIST_NOTES)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_LIST_NOTES)
     expect(config.description).toContain("vault_read_note")
   })
 
   it("vault_get_daily_note description cross-references vault_recent_notes", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_GET_DAILY_NOTE)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_GET_DAILY_NOTE)
     expect(config.description).toContain("vault_recent_notes")
   })
 
   it("vault_list_tags description documents frontmatter-only tag counting", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_LIST_TAGS)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_LIST_TAGS)
     expect(config.description).toContain("frontmatter tags")
     expect(config.description).toContain("unique notes")
   })
 
   it("vault_get_daily_note description documents future date support", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_GET_DAILY_NOTE)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_GET_DAILY_NOTE)
     expect(config.description).toContain("future dates")
   })
 
   it("vault_list_notes description includes empty-result contract", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_LIST_NOTES)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_LIST_NOTES)
     expect(config.description).toContain("Errors:")
     expect(config.description).toContain("empty array, not an error")
   })
 
   it("vault_search_by_folder description cross-references graph tools", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_SEARCH_BY_FOLDER)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_SEARCH_BY_FOLDER)
     expect(config.description).toContain("vault_get_backlinks")
   })
 
@@ -248,19 +248,19 @@ describe("registerTools", () => {
 
 describe("annotations", () => {
   it.each(READ_ONLY_TOOLS)("%s has readOnlyHint: true", (name) => {
-    const [, config] = findCall(name)!
+    const [, config] = requireCall(name)
     expect(config.annotations?.readOnlyHint).toBe(true)
     expect(config.annotations?.destructiveHint).toBe(false)
   })
 
   it.each(DESTRUCTIVE_TOOLS)("%s has destructiveHint: true", (name) => {
-    const [, config] = findCall(name)!
+    const [, config] = requireCall(name)
     expect(config.annotations?.destructiveHint).toBe(true)
     expect(config.annotations?.readOnlyHint).toBe(false)
   })
 
   it.each(ADDITIVE_WRITE_TOOLS)("%s is a non-destructive write", (name) => {
-    const [, config] = findCall(name)!
+    const [, config] = requireCall(name)
     expect(config.annotations?.readOnlyHint).toBe(false)
     expect(config.annotations?.destructiveHint).toBe(false)
   })
@@ -292,8 +292,13 @@ describe("config interpolation in descriptions", () => {
     return server.registerTool.mock.calls as RegisterToolCall[]
   })()
 
-  const findCustomCall = (name: string): RegisterToolCall | undefined =>
-    customCalls.find(([toolName]) => toolName === name)
+  /** Like requireCall, but over the custom-config registration — throws
+   *  instead of returning undefined so call sites need no non-null assertion. */
+  const requireCustomCall = (name: string): RegisterToolCall => {
+    const call = customCalls.find(([toolName]) => toolName === name)
+    if (!call) throw new Error(`tool not registered: ${name}`)
+    return call
+  }
 
   const DEFAULT_MEMORY_REF = "About Me/"
 
@@ -311,20 +316,20 @@ describe("config interpolation in descriptions", () => {
   it.each(memoryDirTools)(
     "$name description references the configured memory dir",
     ({ toolName }) => {
-      const [, config] = findCustomCall(toolName)!
+      const [, config] = requireCustomCall(toolName)
       expect(config.description).toContain(`${CUSTOM_MEMORY_DIR}/`)
       expect(config.description).not.toContain(DEFAULT_MEMORY_REF)
     },
   )
 
   it("vault_delete_note description lists configured protected paths", () => {
-    const [, config] = findCustomCall(TOOL_NAMES.VAULT_DELETE_NOTE)!
+    const [, config] = requireCustomCall(TOOL_NAMES.VAULT_DELETE_NOTE)
     expect(config.description).toContain("Profile/")
     expect(config.description).not.toContain("About Me/")
   })
 
   it("vault_find_orphans description references configured exclusion folders", () => {
-    const [, config] = findCustomCall(TOOL_NAMES.VAULT_FIND_ORPHANS)!
+    const [, config] = requireCustomCall(TOOL_NAMES.VAULT_FIND_ORPHANS)
     expect(config.description).toContain(CUSTOM_MEMORY_DIR)
     expect(config.description).not.toContain("About Me")
   })
@@ -334,7 +339,7 @@ describe("error handling", () => {
   const mockExtra = { requestId: "test-1", sessionId: "session-1" }
 
   it("vault_read_note handler returns isError on failure", async () => {
-    const [, , handler] = findCall(TOOL_NAMES.VAULT_READ_NOTE)!
+    const [, , handler] = requireCall(TOOL_NAMES.VAULT_READ_NOTE)
     const result = (await handler({ path: "nonexistent.md" }, mockExtra)) as {
       content: Array<{ type: string; text: string }>
       isError?: boolean
@@ -344,7 +349,7 @@ describe("error handling", () => {
   })
 
   it("error text does not contain stack traces", async () => {
-    const [, , handler] = findCall(TOOL_NAMES.VAULT_READ_NOTE)!
+    const [, , handler] = requireCall(TOOL_NAMES.VAULT_READ_NOTE)
     const result = (await handler({ path: "nonexistent.md" }, mockExtra)) as {
       content: Array<{ text: string }>
     }
@@ -353,7 +358,7 @@ describe("error handling", () => {
   })
 
   it("vault_get_memory rejects section without file", async () => {
-    const [, , handler] = findCall(TOOL_NAMES.VAULT_GET_MEMORY)!
+    const [, , handler] = requireCall(TOOL_NAMES.VAULT_GET_MEMORY)
     const result = (await handler(
       { file: undefined, section: "Decision heuristics" },
       mockExtra,
@@ -366,7 +371,7 @@ describe("error handling", () => {
   })
 
   it("vault_get_memory handler returns isError on failure", async () => {
-    const [, , handler] = findCall(TOOL_NAMES.VAULT_GET_MEMORY)!
+    const [, , handler] = requireCall(TOOL_NAMES.VAULT_GET_MEMORY)
     const result = (await handler(
       { file: "Nonexistent", section: undefined },
       mockExtra,
@@ -381,7 +386,7 @@ describe("error handling", () => {
   })
 
   it("vault_read_note rejects combining outline with heading", async () => {
-    const [, , handler] = findCall(TOOL_NAMES.VAULT_READ_NOTE)!
+    const [, , handler] = requireCall(TOOL_NAMES.VAULT_READ_NOTE)
     const result = (await handler(
       { path: "note.md", outline: true, heading: "Active" },
       mockExtra,
@@ -396,7 +401,7 @@ describe("error handling", () => {
   })
 
   it("vault_read_note rejects heading_level without a heading", async () => {
-    const [, , handler] = findCall(TOOL_NAMES.VAULT_READ_NOTE)!
+    const [, , handler] = requireCall(TOOL_NAMES.VAULT_READ_NOTE)
     const result = (await handler(
       { path: "note.md", heading_level: 2 },
       mockExtra,

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -433,6 +433,20 @@ describe("vault_update_memory input schema", () => {
     expect(schema.entry.safeParse("a single-line entry").success).toBe(true)
   })
 
+  it("section rejects a multiline value and accepts a single-line one", () => {
+    const schema = requireUpdateMemorySchema()
+    const multilineResult = schema.section.safeParse("Heading\nsplit in two")
+    if (multilineResult.success) {
+      throw new Error("expected the multiline section to be rejected")
+    }
+    expect(multilineResult.error.issues.map((issue) => issue.message)).toEqual([
+      "section must be a single line",
+    ])
+    expect(
+      schema.section.safeParse("Decision heuristics (newest first)").success,
+    ).toBe(true)
+  })
+
   it("options.date rejects a calendar-impossible date and accepts a real one", () => {
     const schema = requireUpdateMemorySchema()
     const impossibleDateResult = schema.options.safeParse({

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -410,9 +410,11 @@ describe("error handling", () => {
 })
 
 describe("vault_update_memory input schema", () => {
-  // The data layer enforces the same guards, but the schema refines are the
-  // protocol-level defense — these tests catch the refine being dropped from
-  // the schema even though updateMemory would still reject the input deeper.
+  // Rich validation (single-line entries, calendar-valid dates) lives in the
+  // data layer, where failures flow through safeHandler as structured tool
+  // errors — by convention tool schemas stay at min(1). These tests catch an
+  // empty-string guard being dropped (an empty file name would silently
+  // create "About Me/.md").
   const requireUpdateMemorySchema = (): Record<string, z.ZodType> => {
     const [, config] = requireCall(TOOL_NAMES.VAULT_UPDATE_MEMORY)
     if (!config.inputSchema) {
@@ -421,45 +423,22 @@ describe("vault_update_memory input schema", () => {
     return config.inputSchema
   }
 
-  it("entry rejects a multiline value and accepts a single-line one", () => {
-    const schema = requireUpdateMemorySchema()
-    const multilineResult = schema.entry.safeParse("line one\nline two")
-    if (multilineResult.success) {
-      throw new Error("expected the multiline entry to be rejected")
-    }
-    expect(multilineResult.error.issues.map((issue) => issue.message)).toEqual([
-      "entry must be a single line",
-    ])
-    expect(schema.entry.safeParse("a single-line entry").success).toBe(true)
-  })
+  it.each([
+    { field: "file", validValue: "Principles" },
+    { field: "section", validValue: "Decision heuristics (newest first)" },
+    { field: "entry", validValue: "a single-line entry" },
+  ])(
+    "$field rejects an empty string and accepts a non-empty one",
+    ({ field, validValue }) => {
+      const schema = requireUpdateMemorySchema()
+      expect(schema[field].safeParse("").success).toBe(false)
+      expect(schema[field].safeParse(validValue).success).toBe(true)
+    },
+  )
 
-  it("section rejects a multiline value and accepts a single-line one", () => {
+  it("options.date rejects an empty string and accepts a date", () => {
     const schema = requireUpdateMemorySchema()
-    const multilineResult = schema.section.safeParse("Heading\nsplit in two")
-    if (multilineResult.success) {
-      throw new Error("expected the multiline section to be rejected")
-    }
-    expect(multilineResult.error.issues.map((issue) => issue.message)).toEqual([
-      "section must be a single line",
-    ])
-    expect(
-      schema.section.safeParse("Decision heuristics (newest first)").success,
-    ).toBe(true)
-  })
-
-  it("options.date rejects a calendar-impossible date and accepts a real one", () => {
-    const schema = requireUpdateMemorySchema()
-    const impossibleDateResult = schema.options.safeParse({
-      date: "2026-13-40",
-    })
-    if (impossibleDateResult.success) {
-      throw new Error("expected the calendar-impossible date to be rejected")
-    }
-    expect(
-      impossibleDateResult.error.issues.map((issue) => issue.message),
-    ).toEqual([
-      "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
-    ])
+    expect(schema.options.safeParse({ date: "" }).success).toBe(false)
     expect(schema.options.safeParse({ date: "2026-07-02" }).success).toBe(true)
   })
 })

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -145,6 +145,20 @@ describe("registerTools", () => {
     },
   )
 
+  it("vault_update_memory description documents the duplicate no-op contract", () => {
+    const [, config] = findCall(TOOL_NAMES.VAULT_UPDATE_MEMORY)!
+    expect(config.description).toContain("idempotent")
+    expect(config.description).toContain("no-op")
+  })
+
+  it("vault_delete_memory description documents duplicate-entry remediation", () => {
+    const [, config] = findCall(TOOL_NAMES.VAULT_DELETE_MEMORY)!
+    expect(config.description).toContain("ambiguous")
+    expect(config.description).toContain(
+      "vault_update_memory refuses to write exact duplicates",
+    )
+  })
+
   it("vault_update_properties description documents null-deletes-key contract", () => {
     const [, config] = findCall(TOOL_NAMES.VAULT_UPDATE_PROPERTIES)!
     expect(config.description).toContain("null deletes a key")
@@ -233,6 +247,11 @@ describe("annotations", () => {
     const [, config] = findCall(name)!
     expect(config.annotations?.readOnlyHint).toBe(false)
     expect(config.annotations?.destructiveHint).toBe(false)
+  })
+
+  it("vault_update_memory has idempotentHint: true (exact duplicates are no-ops)", () => {
+    const [, config] = findCall(TOOL_NAMES.VAULT_UPDATE_MEMORY)!
+    expect(config.annotations?.idempotentHint).toBe(true)
   })
 
   it("all tools have openWorldHint: false", () => {

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from "vitest"
+import { describe, it, expect, beforeEach, vi, onTestFinished } from "vitest"
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import type { z } from "zod"
 import { registerTools, TOOL_NAMES } from "../tool-definitions.js"
 import { loadConfig } from "../../config.js"
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
@@ -53,6 +57,7 @@ type RegisterToolCall = [
   config: {
     title?: string
     description?: string
+    inputSchema?: Record<string, z.ZodType>
     annotations?: Record<string, boolean>
   },
   handler: (...args: unknown[]) => Promise<unknown>,
@@ -75,6 +80,14 @@ beforeEach(() => {
 
 const findCall = (name: string): RegisterToolCall | undefined =>
   calls.find(([toolName]) => toolName === name)
+
+/** findCall for tests that assume the tool is registered — throws instead of
+ *  returning undefined so call sites need no non-null assertion. */
+const requireCall = (name: string): RegisterToolCall => {
+  const call = findCall(name)
+  if (!call) throw new Error(`tool not registered: ${name}`)
+  return call
+}
 
 describe("registerTools", () => {
   it(`registers exactly ${ALL_TOOL_NAMES.length} tools`, () => {
@@ -146,13 +159,16 @@ describe("registerTools", () => {
   )
 
   it("vault_update_memory description documents the duplicate no-op contract", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_UPDATE_MEMORY)!
-    expect(config.description).toContain("idempotent")
-    expect(config.description).toContain("no-op")
+    const [, config] = requireCall(TOOL_NAMES.VAULT_UPDATE_MEMORY)
+    // Assert the full contract fragment — a bare "idempotent" check would
+    // also pass on a reworded "not idempotent" description.
+    expect(config.description).toContain(
+      "idempotent — an exact duplicate (same date + text in the same section) is a no-op",
+    )
   })
 
   it("vault_delete_memory description documents duplicate-entry remediation", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_DELETE_MEMORY)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_DELETE_MEMORY)
     expect(config.description).toContain("ambiguous")
     expect(config.description).toContain(
       "vault_update_memory refuses to write exact duplicates",
@@ -250,7 +266,7 @@ describe("annotations", () => {
   })
 
   it("vault_update_memory has idempotentHint: true (exact duplicates are no-ops)", () => {
-    const [, config] = findCall(TOOL_NAMES.VAULT_UPDATE_MEMORY)!
+    const [, config] = requireCall(TOOL_NAMES.VAULT_UPDATE_MEMORY)
     expect(config.annotations?.idempotentHint).toBe(true)
   })
 
@@ -390,6 +406,106 @@ describe("error handling", () => {
     }
     expect(result.isError).toBe(true)
     expect(result.content[0].text).toBe("heading_level requires a heading")
+  })
+})
+
+describe("vault_update_memory input schema", () => {
+  // The data layer enforces the same guards, but the schema refines are the
+  // protocol-level defense — these tests catch the refine being dropped from
+  // the schema even though updateMemory would still reject the input deeper.
+  const requireUpdateMemorySchema = (): Record<string, z.ZodType> => {
+    const [, config] = requireCall(TOOL_NAMES.VAULT_UPDATE_MEMORY)
+    if (!config.inputSchema) {
+      throw new Error("vault_update_memory has no input schema")
+    }
+    return config.inputSchema
+  }
+
+  it("entry rejects a multiline value and accepts a single-line one", () => {
+    const schema = requireUpdateMemorySchema()
+    const multilineResult = schema.entry.safeParse("line one\nline two")
+    if (multilineResult.success) {
+      throw new Error("expected the multiline entry to be rejected")
+    }
+    expect(multilineResult.error.issues.map((issue) => issue.message)).toEqual([
+      "entry must be a single line",
+    ])
+    expect(schema.entry.safeParse("a single-line entry").success).toBe(true)
+  })
+
+  it("options.date rejects a calendar-impossible date and accepts a real one", () => {
+    const schema = requireUpdateMemorySchema()
+    const impossibleDateResult = schema.options.safeParse({
+      date: "2026-13-40",
+    })
+    if (impossibleDateResult.success) {
+      throw new Error("expected the calendar-impossible date to be rejected")
+    }
+    expect(
+      impossibleDateResult.error.issues.map((issue) => issue.message),
+    ).toEqual([
+      "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
+    ])
+    expect(schema.options.safeParse({ date: "2026-07-02" }).success).toBe(true)
+  })
+})
+
+describe("vault_update_memory handler", () => {
+  const mockExtra = { requestId: "test-1", sessionId: "session-1" }
+
+  it("reports the duplicate no-op instead of the append confirmation when retried", async () => {
+    // A real temp vault so the handler exercises the actual memory store —
+    // the global harness registers against a nonexistent path.
+    const tempVault = await mkdtemp(join(tmpdir(), "tool-definitions-memory-"))
+    onTestFinished(() => rm(tempVault, { recursive: true, force: true }))
+    await mkdir(join(tempVault, "About Me"), { recursive: true })
+    await writeFile(
+      join(tempVault, "About Me/Principles.md"),
+      "# Principles\n\n## Decision heuristics (newest first)\n- **2026-05-06**: seeded entry\n",
+      "utf8",
+    )
+    const server = { registerTool: vi.fn() }
+    registerTools({
+      server: server as unknown as McpServer,
+      vaultPath: tempVault,
+      search: {} as SearchIndex,
+      logger,
+      config: loadConfig({}),
+    })
+    const registeredCalls = server.registerTool.mock.calls as RegisterToolCall[]
+    const updateMemoryCall = registeredCalls.find(
+      ([toolName]) => toolName === TOOL_NAMES.VAULT_UPDATE_MEMORY,
+    )
+    if (!updateMemoryCall) throw new Error("vault_update_memory not registered")
+    const [, , handler] = updateMemoryCall
+
+    const args = {
+      file: "Principles",
+      section: "Decision heuristics (newest first)",
+      entry: "retry entry",
+      options: { date: "2026-07-02" },
+    }
+
+    // First call appends and confirms — proves the entry actually landed
+    // before the retry, so the no-op can't be a silent failure.
+    const firstResult = (await handler(args, mockExtra)) as {
+      content: Array<{ text: string }>
+      isError?: boolean
+    }
+    expect(firstResult.isError).toBeUndefined()
+    expect(firstResult.content[0].text).toBe(
+      "Added entry to About Me/Principles.md → ## Decision heuristics (newest first)",
+    )
+
+    // Identical retry succeeds but reports the no-op instead of "Added entry".
+    const retryResult = (await handler(args, mockExtra)) as {
+      content: Array<{ text: string }>
+      isError?: boolean
+    }
+    expect(retryResult.isError).toBeUndefined()
+    expect(retryResult.content[0].text).toBe(
+      "Entry already exists in About Me/Principles.md → ## Decision heuristics (newest first) — nothing was written.",
+    )
   })
 })
 

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -103,7 +103,7 @@ Returns: Raw markdown text.`,
 Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
 
 When to use: Recording a new preference, principle, opinion, or fact about the user. Call vault_list_memory_files first and reuse existing file and section names so entries stay grouped.
-Prefer vault_write_note for creating non-memory notes. A missing file or section is created automatically (new sections get "(newest first)" appended; new files get a placeholder scope callout to fill in via vault_patch_note).
+Prefer vault_write_note for creating non-memory notes. A missing file or section is created automatically (new sections get "(newest first)" appended; new files get a placeholder scope callout to fill in via vault_replace_in_note).
 
 Parameters:
 - options.date — ISO YYYY-MM-DD, defaults to today (server timezone).
@@ -114,6 +114,7 @@ Obsidian syntax: Entry text is Obsidian Flavored Markdown. Watch for: #word = ta
 Errors:
 - "refusing memory write: … would shrink content" — safety guard for diverged on-disk content. Re-read with vault_get_memory before retrying.
 - "entry must be a single line" — memory entries are single dated bullets; collapse newlines or append multiple entries.
+- "section must be a single line" — section names become H2 headings; remove line breaks.
 - "date must be a real ISO calendar date" — options.date only accepts an existing calendar date in bare YYYY-MM-DD form (e.g. "2026-07-02"), not a timestamp.
 - An exact duplicate entry is not an error — the call succeeds and reports that the entry already exists, without writing.
 
@@ -121,9 +122,15 @@ Returns: Confirmation message (notes when an identical entry already existed and
       inputSchema: {
         file: z
           .string()
+          .min(1)
           .describe('Memory file name without .md (e.g. "Principles")'),
         section: z
           .string()
+          .min(1)
+          .refine(
+            (sectionName) => !MEMORY_ENTRY_LINE_BREAK_PATTERN.test(sectionName),
+            { error: "section must be a single line" },
+          )
           .describe(
             'H2 section heading (e.g. "Decision heuristics (newest first)"). Matched case-insensitively, with or without the "(newest first)" suffix.',
           ),
@@ -198,7 +205,7 @@ Returns: Confirmation message (notes when an identical entry already existed and
           // Nudge the caller to author the scope callout the new file was
           // seeded with, so the file self-documents what belongs in it.
           return outcome === "created-file"
-            ? `${confirmation}. Created a new memory file with a placeholder scope callout — fill in its "Contains"/"Does NOT contain" via vault_patch_note (operation "prepend", no heading) so other agents know what this file is for.`
+            ? `${confirmation}. Created a new memory file with a placeholder scope callout — use vault_replace_in_note to replace its "(describe what belongs in this file — and what doesn't)" placeholder with what the file contains, so other agents know what it is for.`
             : confirmation
         },
       )
@@ -261,16 +268,18 @@ Parameters:
 
 Errors:
 - "no entry matching …" — no bullet matched the given date and entry text; verify exact text via vault_get_memory(file, section).
-- "ambiguous: N entries match …" — more than one identical bullet exists in the section (e.g. from hand edits, sync conflicts, or entries predating duplicate protection; vault_update_memory refuses to write exact duplicates). Remove the extra copy with vault_delete_span or a manual edit, then retry.
+- "ambiguous: N entries match …" — more than one identical bullet exists in the section (e.g. from hand edits, sync conflicts, or entries predating duplicate protection; vault_update_memory refuses to write exact duplicates). Remove the extra copy with vault_delete_span (pass first_match: true — identical lines make every anchor ambiguous) or a manual edit, then retry.
 - "refusing memory write: … would shrink content" — safety guard blocked a write that would remove more than half the file. Re-read with vault_get_memory to confirm current content before retrying.
 
 Returns: Confirmation message.`,
       inputSchema: {
         file: z
           .string()
+          .min(1)
           .describe('Memory file name without .md (e.g. "Principles")'),
         section: z
           .string()
+          .min(1)
           .describe(
             'H2 section heading containing the entry. Matched case-insensitively, with or without the "(newest first)" suffix.',
           ),

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -3,7 +3,7 @@
 import { z } from "zod"
 import {
   createMemoryStore,
-  MEMORY_ENTRY_DATE_PATTERN,
+  isValidMemoryEntryDate,
   MEMORY_ENTRY_LINE_BREAK_PATTERN,
 } from "../../vault-operations/memory-store.js"
 import type { ToolRegistrationContext } from "./tool-helpers.js"
@@ -114,7 +114,7 @@ Obsidian syntax: Entry text is Obsidian Flavored Markdown. Watch for: #word = ta
 Errors:
 - "refusing memory write: … would shrink content" — safety guard for diverged on-disk content. Re-read with vault_get_memory before retrying.
 - "entry must be a single line" — memory entries are single dated bullets; collapse newlines or append multiple entries.
-- "date must be ISO YYYY-MM-DD" — options.date only accepts a bare calendar date (e.g. "2026-07-02"), not a timestamp.
+- "date must be a real ISO calendar date" — options.date only accepts an existing calendar date in bare YYYY-MM-DD form (e.g. "2026-07-02"), not a timestamp.
 - An exact duplicate entry is not an error — the call succeeds and reports that the entry already exists, without writing.
 
 Returns: Confirmation message (notes when an identical entry already existed and nothing was written).`,
@@ -141,8 +141,9 @@ Returns: Confirmation message (notes when an identical entry already existed and
           .object({
             date: z
               .string()
-              .refine((dateText) => MEMORY_ENTRY_DATE_PATTERN.test(dateText), {
-                error: "date must be ISO YYYY-MM-DD",
+              .refine((dateText) => isValidMemoryEntryDate(dateText), {
+                error:
+                  "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
               })
               .optional()
               .describe("ISO YYYY-MM-DD date (defaults to today)"),

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -94,7 +94,7 @@ Returns: Raw markdown text.`,
     TOOL_NAMES.VAULT_UPDATE_MEMORY,
     {
       title: "Update Memory",
-      description: `Append a dated entry to a section of a ${config.memoryDir}/ memory file. The server prefixes the date automatically ("- **YYYY-MM-DD**: entry text") and inserts newest-first by default. Append-only — repeat calls add duplicates; when a preference changes, append the new state (newest wins) rather than deleting the old one.
+      description: `Append a dated entry to a section of a ${config.memoryDir}/ memory file. The server prefixes the date automatically ("- **YYYY-MM-DD**: entry text") and inserts newest-first by default. Append-only and idempotent — an exact duplicate (same date + text in the same section) is a no-op, so retrying a timed-out call is safe; when a preference changes, append the new state (newest wins) rather than deleting the old one.
 
 Example: vault_update_memory({ file: "Opinions", section: "Code patterns (newest first)", entry: "Prefer immutable data structures" })
 
@@ -109,8 +109,9 @@ Obsidian syntax: Entry text is Obsidian Flavored Markdown. Watch for: #word = ta
 
 Errors:
 - "refusing memory write: … would shrink content" — safety guard for diverged on-disk content. Re-read with vault_get_memory before retrying.
+- An exact duplicate entry is not an error — the call succeeds and reports that the entry already exists, without writing.
 
-Returns: Confirmation message.`,
+Returns: Confirmation message (notes when an identical entry already existed and nothing was written).`,
       inputSchema: {
         file: z
           .string()
@@ -145,8 +146,12 @@ Returns: Confirmation message.`,
         // Append-only: entries are inserted, never overwritten or deleted
         // (see memoryStore.updateMemory) — additive, not destructive.
         destructiveHint: false,
-        // Repeat calls add a duplicate dated entry, so not idempotent.
-        idempotentHint: false,
+        // An exact duplicate (same date + text in the same section) is a
+        // no-op, so replayed calls are safe. Nuance: `date` defaults to
+        // today, so identical args replayed across a date boundary append a
+        // second, differently-dated entry — real client retries happen
+        // within seconds, so the hint reflects the retry-safety contract.
+        idempotentHint: true,
         openWorldHint: false,
       },
     },
@@ -172,6 +177,9 @@ Returns: Confirmation message.`,
           ),
         (outcome) => {
           reqLogger.info("tool_result", { outcome })
+          if (outcome === "unchanged") {
+            return `Entry already exists in ${config.memoryDir}/${file}.md → ## ${section} — nothing was written.`
+          }
           const confirmation = `Added entry to ${config.memoryDir}/${file}.md → ## ${section}`
           // Nudge the caller to author the scope callout the new file was
           // seeded with, so the file self-documents what belongs in it.
@@ -239,7 +247,7 @@ Parameters:
 
 Errors:
 - "no entry matching …" — no bullet matched the given date and entry text; verify exact text via vault_get_memory(file, section).
-- "ambiguous: N entries match …" — more than one bullet matched; the entry text is not unique within the section.
+- "ambiguous: N entries match …" — more than one identical bullet exists in the section (possible only via hand edits; vault_update_memory refuses to write exact duplicates). Remove the extra copy with vault_delete_span or a manual edit, then retry.
 - "refusing memory write: … would shrink content" — safety guard blocked a write that would remove more than half the file. Re-read with vault_get_memory to confirm current content before retrying.
 
 Returns: Confirmation message.`,

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -141,7 +141,7 @@ Returns: Confirmation message (notes when an identical entry already existed and
           .object({
             date: z
               .string()
-              .refine((dateText) => isValidMemoryEntryDate(dateText), {
+              .refine(isValidMemoryEntryDate, {
                 error:
                   "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
               })

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -109,6 +109,7 @@ Obsidian syntax: Entry text is Obsidian Flavored Markdown. Watch for: #word = ta
 
 Errors:
 - "refusing memory write: … would shrink content" — safety guard for diverged on-disk content. Re-read with vault_get_memory before retrying.
+- "entry must be a single line" — memory entries are single dated bullets; collapse newlines or append multiple entries.
 - An exact duplicate entry is not an error — the call succeeds and reports that the entry already exists, without writing.
 
 Returns: Confirmation message (notes when an identical entry already existed and nothing was written).`,
@@ -124,8 +125,11 @@ Returns: Confirmation message (notes when an identical entry already existed and
         entry: z
           .string()
           .min(1)
+          .refine((entryText) => !/[\r\n]/.test(entryText), {
+            message: "entry must be a single line",
+          })
           .describe(
-            'Raw entry text — the server prepends "- **YYYY-MM-DD**: " automatically. Do not include the date or bullet prefix.',
+            'Raw entry text — a single line (newlines are rejected); the server prepends "- **YYYY-MM-DD**: " automatically. Do not include the date or bullet prefix.',
           ),
         options: z
           .object({

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -1,7 +1,11 @@
 /** Memory tool registrations — read, update, list, and delete About Me/ entries. */
 
 import { z } from "zod"
-import { createMemoryStore } from "../../vault-operations/memory-store.js"
+import {
+  createMemoryStore,
+  MEMORY_ENTRY_DATE_PATTERN,
+  MEMORY_ENTRY_LINE_BREAK_PATTERN,
+} from "../../vault-operations/memory-store.js"
 import type { ToolRegistrationContext } from "./tool-helpers.js"
 import { safeHandler } from "./tool-helpers.js"
 
@@ -110,6 +114,7 @@ Obsidian syntax: Entry text is Obsidian Flavored Markdown. Watch for: #word = ta
 Errors:
 - "refusing memory write: … would shrink content" — safety guard for diverged on-disk content. Re-read with vault_get_memory before retrying.
 - "entry must be a single line" — memory entries are single dated bullets; collapse newlines or append multiple entries.
+- "date must be ISO YYYY-MM-DD" — options.date only accepts a bare calendar date (e.g. "2026-07-02"), not a timestamp.
 - An exact duplicate entry is not an error — the call succeeds and reports that the entry already exists, without writing.
 
 Returns: Confirmation message (notes when an identical entry already existed and nothing was written).`,
@@ -125,9 +130,10 @@ Returns: Confirmation message (notes when an identical entry already existed and
         entry: z
           .string()
           .min(1)
-          .refine((entryText) => !/[\r\n]/.test(entryText), {
-            message: "entry must be a single line",
-          })
+          .refine(
+            (entryText) => !MEMORY_ENTRY_LINE_BREAK_PATTERN.test(entryText),
+            { error: "entry must be a single line" },
+          )
           .describe(
             'Raw entry text — a single line (newlines are rejected); the server prepends "- **YYYY-MM-DD**: " automatically. Do not include the date or bullet prefix.',
           ),
@@ -135,6 +141,9 @@ Returns: Confirmation message (notes when an identical entry already existed and
           .object({
             date: z
               .string()
+              .refine((dateText) => MEMORY_ENTRY_DATE_PATTERN.test(dateText), {
+                error: "date must be ISO YYYY-MM-DD",
+              })
               .optional()
               .describe("ISO YYYY-MM-DD date (defaults to today)"),
             position: z

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -252,6 +252,7 @@ Parameters:
 - section scopes the match — an identical entry under a different heading is not found. Section matching is case-insensitive, with or without the "(newest first)" suffix.
 
 Errors:
+- "date must be a real ISO calendar date" — date only accepts an existing calendar date in bare YYYY-MM-DD form. A hand-edited bullet carrying an impossible date cannot be targeted by this tool — remove it with vault_delete_span or a manual edit.
 - "no entry matching …" — no bullet matched the given date and entry text; verify exact text via vault_get_memory(file, section).
 - "ambiguous: N entries match …" — more than one identical bullet exists in the section (e.g. from hand edits, sync conflicts, or entries predating duplicate protection; vault_update_memory refuses to write exact duplicates). Remove the extra copy with vault_delete_span (pass first_match: true — identical lines make every anchor ambiguous) or a manual edit, then retry.
 - "refusing memory write: … would shrink content" — safety guard blocked a write that would remove more than half the file. Re-read with vault_get_memory to confirm current content before retrying.

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -1,11 +1,7 @@
 /** Memory tool registrations — read, update, list, and delete About Me/ entries. */
 
 import { z } from "zod"
-import {
-  createMemoryStore,
-  isValidMemoryEntryDate,
-  MEMORY_ENTRY_LINE_BREAK_PATTERN,
-} from "../../vault-operations/memory-store.js"
+import { createMemoryStore } from "../../vault-operations/memory-store.js"
 import type { ToolRegistrationContext } from "./tool-helpers.js"
 import { safeHandler } from "./tool-helpers.js"
 
@@ -127,20 +123,12 @@ Returns: Confirmation message (notes when an identical entry already existed and
         section: z
           .string()
           .min(1)
-          .refine(
-            (sectionName) => !MEMORY_ENTRY_LINE_BREAK_PATTERN.test(sectionName),
-            { error: "section must be a single line" },
-          )
           .describe(
             'H2 section heading (e.g. "Decision heuristics (newest first)"). Matched case-insensitively, with or without the "(newest first)" suffix.',
           ),
         entry: z
           .string()
           .min(1)
-          .refine(
-            (entryText) => !MEMORY_ENTRY_LINE_BREAK_PATTERN.test(entryText),
-            { error: "entry must be a single line" },
-          )
           .describe(
             'Raw entry text — a single line (newlines are rejected); the server prepends "- **YYYY-MM-DD**: " automatically. Do not include the date or bullet prefix.',
           ),
@@ -148,10 +136,7 @@ Returns: Confirmation message (notes when an identical entry already existed and
           .object({
             date: z
               .string()
-              .refine(isValidMemoryEntryDate, {
-                error:
-                  "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
-              })
+              .min(1)
               .optional()
               .describe("ISO YYYY-MM-DD date (defaults to today)"),
             position: z

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -261,7 +261,7 @@ Parameters:
 
 Errors:
 - "no entry matching …" — no bullet matched the given date and entry text; verify exact text via vault_get_memory(file, section).
-- "ambiguous: N entries match …" — more than one identical bullet exists in the section (possible only via hand edits; vault_update_memory refuses to write exact duplicates). Remove the extra copy with vault_delete_span or a manual edit, then retry.
+- "ambiguous: N entries match …" — more than one identical bullet exists in the section (e.g. from hand edits, sync conflicts, or entries predating duplicate protection; vault_update_memory refuses to write exact duplicates). Remove the extra copy with vault_delete_span or a manual edit, then retry.
 - "refusing memory write: … would shrink content" — safety guard blocked a write that would remove more than half the file. Re-read with vault_get_memory to confirm current content before retrying.
 
 Returns: Confirmation message.`,

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -502,11 +502,17 @@ describe("updateMemory idempotency", () => {
     expect(raw).toBe(PRINCIPLES_MD)
   })
 
-  it("rejects a date that is not a bare ISO calendar date", async () => {
+  it("rejects a date that is not a real bare ISO calendar date", async () => {
     // The date lands inside the same single-line bullet as the entry, so a
     // malformed or newline-bearing date corrupts the format the same way a
     // multiline entry does — it must be rejected before anything is written.
-    const malformedDates = ["2026-7-2", "2026-07-02T10:00:00", "today\n"]
+    // "2026-13-40" is shape-valid but calendar-impossible.
+    const malformedDates = [
+      "2026-7-2",
+      "2026-07-02T10:00:00",
+      "today\n",
+      "2026-13-40",
+    ]
     for (const malformedDate of malformedDates) {
       await expect(
         updateMemory(
@@ -519,7 +525,9 @@ describe("updateMemory idempotency", () => {
           },
           logger,
         ),
-      ).rejects.toThrow("date must be ISO YYYY-MM-DD (e.g. 2026-07-02)")
+      ).rejects.toThrow(
+        "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
+      )
     }
     // Nothing was written — the file is byte-identical to the fixture.
     const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -465,6 +465,39 @@ describe("updateMemory idempotency", () => {
     expect(bulletOccurrences - 1).toBe(1)
   })
 
+  it("rejects a multiline entry, which duplicate detection could never see", async () => {
+    // A multiline entry would write a block the line-based duplicate guard
+    // (and deleteMemory's exact line match) can never detect — it must be
+    // rejected before anything is written.
+    await expect(
+      updateMemory(
+        {
+          vaultPath: vault,
+          file: "Principles",
+          section: "Decision heuristics (newest first)",
+          entry: "line one\nline two",
+          date: "2026-07-02",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("entry must be a single line")
+    await expect(
+      updateMemory(
+        {
+          vaultPath: vault,
+          file: "Principles",
+          section: "Decision heuristics (newest first)",
+          entry: "carriage\rreturn",
+          date: "2026-07-02",
+        },
+        logger,
+      ),
+    ).rejects.toThrow("entry must be a single line")
+    // Nothing was written — the file is byte-identical to the fixture.
+    const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")
+    expect(raw).toBe(PRINCIPLES_MD)
+  })
+
   it("appends when the same text arrives with a different date", async () => {
     await updateMemory(
       {

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -948,6 +948,31 @@ describe("deleteMemory", () => {
     ).rejects.toThrow('no entry matching (2026-05-05, "nonexistent text")')
   })
 
+  // Server-written bullets only carry real calendar dates, so a malformed
+  // date can never match — the guard turns a guaranteed "no entry matching"
+  // miss into an actionable format error before any file read.
+  it("rejects a calendar-impossible date and leaves the file unchanged", async () => {
+    await expect(
+      deleteMemory(
+        {
+          vaultPath: vault,
+          file: "Principles",
+          section: "Decision heuristics (newest first)",
+          date: "2026-13-40",
+          entry: "Least-privilege for AI agents",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
+    )
+    const fileContent = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+    expect(fileContent).toBe(PRINCIPLES_MD)
+  })
+
   it("throws on ambiguous match", async () => {
     const dupeContent = `---
 title: Dupe

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -439,10 +439,10 @@ describe("updateMemory idempotency", () => {
       "utf8",
     )
     expect(contentAfterSecondCall).toBe(contentAfterFirstCall)
-    const bulletOccurrences = contentAfterSecondCall.split(
-      "- **2026-07-02**: retry-safe entry",
-    ).length
-    expect(bulletOccurrences - 1).toBe(1)
+    const bulletOccurrenceCount =
+      contentAfterSecondCall.split("- **2026-07-02**: retry-safe entry")
+        .length - 1
+    expect(bulletOccurrenceCount).toBe(1)
   })
 
   it("treats an entry already present from a hand edit as unchanged", async () => {
@@ -458,80 +458,77 @@ describe("updateMemory idempotency", () => {
       logger,
     )
     expect(outcome).toBe("unchanged")
-    const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")
-    const bulletOccurrences = raw.split(
-      "- **2026-05-06**: Secrets invisible at every layer",
-    ).length
-    expect(bulletOccurrences - 1).toBe(1)
+    // The no-op left the file byte-identical to the fixture — the entry was
+    // neither duplicated nor was anything else touched.
+    const fileContent = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+    expect(fileContent).toBe(PRINCIPLES_MD)
   })
 
-  it("rejects a multiline entry, which duplicate detection could never see", async () => {
-    // A multiline entry would write a block the line-based duplicate guard
-    // (and deleteMemory's exact line match) can never detect — it must be
-    // rejected before anything is written.
-    await expect(
-      updateMemory(
-        {
-          vaultPath: vault,
-          file: "Principles",
-          section: "Decision heuristics (newest first)",
-          entry: "line one\nline two",
-          date: "2026-07-02",
-        },
-        logger,
-      ),
-    ).rejects.toThrow(
-      "entry must be a single line: memory entries are single dated bullets — collapse newlines or append multiple entries",
-    )
-    await expect(
-      updateMemory(
-        {
-          vaultPath: vault,
-          file: "Principles",
-          section: "Decision heuristics (newest first)",
-          entry: "carriage\rreturn",
-          date: "2026-07-02",
-        },
-        logger,
-      ),
-    ).rejects.toThrow(
-      "entry must be a single line: memory entries are single dated bullets — collapse newlines or append multiple entries",
-    )
-    // Nothing was written — the file is byte-identical to the fixture.
-    const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")
-    expect(raw).toBe(PRINCIPLES_MD)
-  })
-
-  it("rejects a date that is not a real bare ISO calendar date", async () => {
-    // The date lands inside the same single-line bullet as the entry, so a
-    // malformed or newline-bearing date corrupts the format the same way a
-    // multiline entry does — it must be rejected before anything is written.
-    // "2026-13-40" is shape-valid but calendar-impossible.
-    const malformedDates = [
-      "2026-7-2",
-      "2026-07-02T10:00:00",
-      "today\n",
-      "2026-13-40",
-    ]
-    for (const malformedDate of malformedDates) {
+  // A multiline entry would write a block the line-based duplicate guard
+  // (and deleteMemory's exact line match) can never detect — it must be
+  // rejected before anything is written.
+  it.each([
+    { lineBreakKind: "a line feed", entry: "line one\nline two" },
+    { lineBreakKind: "a carriage return", entry: "carriage\rreturn" },
+  ])(
+    "rejects an entry containing $lineBreakKind, which duplicate detection could never see",
+    async ({ entry }) => {
       await expect(
         updateMemory(
           {
             vaultPath: vault,
             file: "Principles",
             section: "Decision heuristics (newest first)",
-            entry: "valid entry",
-            date: malformedDate,
+            entry,
+            date: "2026-07-02",
           },
           logger,
         ),
       ).rejects.toThrow(
-        "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
+        "entry must be a single line: memory entries are single dated bullets — collapse newlines or append multiple entries",
       )
-    }
+      // Nothing was written — the file is byte-identical to the fixture.
+      const fileContent = await readFile(
+        join(vault, "About Me/Principles.md"),
+        "utf8",
+      )
+      expect(fileContent).toBe(PRINCIPLES_MD)
+    },
+  )
+
+  // The date lands inside the same single-line bullet as the entry, so a
+  // malformed or newline-bearing date corrupts the format the same way a
+  // multiline entry does — it must be rejected before anything is written.
+  // "2026-13-40" is shape-valid but calendar-impossible.
+  it.each([
+    { dateKind: "a non-zero-padded date", date: "2026-7-2" },
+    { dateKind: "a timestamp", date: "2026-07-02T10:00:00" },
+    { dateKind: "free text with a line break", date: "today\n" },
+    { dateKind: "a calendar-impossible date", date: "2026-13-40" },
+  ])("rejects $dateKind as the entry date", async ({ date }) => {
+    await expect(
+      updateMemory(
+        {
+          vaultPath: vault,
+          file: "Principles",
+          section: "Decision heuristics (newest first)",
+          entry: "valid entry",
+          date,
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
+    )
     // Nothing was written — the file is byte-identical to the fixture.
-    const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")
-    expect(raw).toBe(PRINCIPLES_MD)
+    const fileContent = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+    expect(fileContent).toBe(PRINCIPLES_MD)
   })
 
   it("appends when the same text arrives with a different date", async () => {
@@ -603,7 +600,7 @@ describe("updateMemory idempotency", () => {
   })
 
   it("an identical bullet in a different section does not suppress the append", async () => {
-    await updateMemory(
+    const firstOutcome = await updateMemory(
       {
         vaultPath: vault,
         file: "Principles",
@@ -613,6 +610,9 @@ describe("updateMemory idempotency", () => {
       },
       logger,
     )
+    // The duplicate must actually be on disk before the cross-section call —
+    // otherwise the second "appended" proves nothing about section scoping.
+    expect(firstOutcome).toBe("appended")
     const outcome = await updateMemory(
       {
         vaultPath: vault,

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -480,7 +480,9 @@ describe("updateMemory idempotency", () => {
         },
         logger,
       ),
-    ).rejects.toThrow("entry must be a single line")
+    ).rejects.toThrow(
+      "entry must be a single line: memory entries are single dated bullets — collapse newlines or append multiple entries",
+    )
     await expect(
       updateMemory(
         {
@@ -492,7 +494,33 @@ describe("updateMemory idempotency", () => {
         },
         logger,
       ),
-    ).rejects.toThrow("entry must be a single line")
+    ).rejects.toThrow(
+      "entry must be a single line: memory entries are single dated bullets — collapse newlines or append multiple entries",
+    )
+    // Nothing was written — the file is byte-identical to the fixture.
+    const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")
+    expect(raw).toBe(PRINCIPLES_MD)
+  })
+
+  it("rejects a date that is not a bare ISO calendar date", async () => {
+    // The date lands inside the same single-line bullet as the entry, so a
+    // malformed or newline-bearing date corrupts the format the same way a
+    // multiline entry does — it must be rejected before anything is written.
+    const malformedDates = ["2026-7-2", "2026-07-02T10:00:00", "today\n"]
+    for (const malformedDate of malformedDates) {
+      await expect(
+        updateMemory(
+          {
+            vaultPath: vault,
+            file: "Principles",
+            section: "Decision heuristics (newest first)",
+            entry: "valid entry",
+            date: malformedDate,
+          },
+          logger,
+        ),
+      ).rejects.toThrow("date must be ISO YYYY-MM-DD (e.g. 2026-07-02)")
+    }
     // Nothing was written — the file is byte-identical to the fixture.
     const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")
     expect(raw).toBe(PRINCIPLES_MD)

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -402,6 +402,171 @@ describe("updateMemory", () => {
   })
 })
 
+describe("updateMemory idempotency", () => {
+  it("returns 'unchanged' and writes nothing when the exact entry already exists in the section", async () => {
+    const firstOutcome = await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+        entry: "retry-safe entry",
+        date: "2026-07-02",
+      },
+      logger,
+    )
+    expect(firstOutcome).toBe("appended")
+    const contentAfterFirstCall = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+
+    const secondOutcome = await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+        entry: "retry-safe entry",
+        date: "2026-07-02",
+      },
+      logger,
+    )
+    expect(secondOutcome).toBe("unchanged")
+
+    // The file is byte-identical to the state after the first call — the
+    // retry neither duplicated the entry nor touched anything else.
+    const contentAfterSecondCall = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+    expect(contentAfterSecondCall).toBe(contentAfterFirstCall)
+    const bulletOccurrences = contentAfterSecondCall.split(
+      "- **2026-07-02**: retry-safe entry",
+    ).length
+    expect(bulletOccurrences - 1).toBe(1)
+  })
+
+  it("treats an entry already present from a hand edit as unchanged", async () => {
+    // Duplicates the fixture line that exists in PRINCIPLES_MD verbatim.
+    const outcome = await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+        entry: "Secrets invisible at every layer",
+        date: "2026-05-06",
+      },
+      logger,
+    )
+    expect(outcome).toBe("unchanged")
+    const raw = await readFile(join(vault, "About Me/Principles.md"), "utf8")
+    const bulletOccurrences = raw.split(
+      "- **2026-05-06**: Secrets invisible at every layer",
+    ).length
+    expect(bulletOccurrences - 1).toBe(1)
+  })
+
+  it("appends when the same text arrives with a different date", async () => {
+    await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+        entry: "same text",
+        date: "2026-07-01",
+      },
+      logger,
+    )
+    const outcome = await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+        entry: "same text",
+        date: "2026-07-02",
+      },
+      logger,
+    )
+    expect(outcome).toBe("appended")
+    const result = await getMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+      },
+      logger,
+    )
+    expect(result).toContain("- **2026-07-01**: same text")
+    expect(result).toContain("- **2026-07-02**: same text")
+  })
+
+  it("appends when the same date arrives with different text", async () => {
+    await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+        entry: "first entry of the day",
+        date: "2026-07-02",
+      },
+      logger,
+    )
+    const outcome = await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+        entry: "second entry of the day",
+        date: "2026-07-02",
+      },
+      logger,
+    )
+    expect(outcome).toBe("appended")
+    const result = await getMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+      },
+      logger,
+    )
+    expect(result).toContain("- **2026-07-02**: first entry of the day")
+    expect(result).toContain("- **2026-07-02**: second entry of the day")
+  })
+
+  it("an identical bullet in a different section does not suppress the append", async () => {
+    await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Decision heuristics (newest first)",
+        entry: "cross-section entry",
+        date: "2026-07-02",
+      },
+      logger,
+    )
+    const outcome = await updateMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Working style (newest first)",
+        entry: "cross-section entry",
+        date: "2026-07-02",
+      },
+      logger,
+    )
+    expect(outcome).toBe("appended")
+    const workingStyle = await getMemory(
+      {
+        vaultPath: vault,
+        file: "Principles",
+        section: "Working style (newest first)",
+      },
+      logger,
+    )
+    expect(workingStyle).toContain("- **2026-07-02**: cross-section entry")
+  })
+})
+
 describe("updateMemory auto-creation", () => {
   it("auto-creates directory and file when neither exist", async () => {
     const emptyVault = await mkdtemp(join(tmpdir(), "no-dir-"))

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -184,6 +184,19 @@ describe("getMemory", () => {
     expect(result).toBe("")
     await rm(emptyVault, { recursive: true })
   })
+
+  // A memory file is a bare name, never a path — a separator would let
+  // "../.." read notes outside the memory directory (or the vault).
+  it("rejects a file name containing path separators instead of reading outside the memory directory", async () => {
+    // A real note one level above About Me/ — the guard, not a missing
+    // file, must be what rejects the read.
+    await writeFile(join(vault, "Outside.md"), "# Outside\n", "utf8")
+    await expect(
+      getMemory({ vaultPath: vault, file: "../Outside" }, logger),
+    ).rejects.toThrow(
+      'memory file must be a bare name without path separators: "../Outside"',
+    )
+  })
 })
 
 describe("updateMemory", () => {
@@ -530,6 +543,62 @@ describe("updateMemory idempotency", () => {
     )
     expect(fileContent).toBe(PRINCIPLES_MD)
   })
+
+  // A section name with a line break would write a corrupted multi-line
+  // "## heading" that findSection could never match again — every retry
+  // would append another broken section instead of hitting the duplicate
+  // guard, so it must be rejected before anything is written.
+  it("rejects a section name containing a line break, which would corrupt the heading", async () => {
+    await expect(
+      updateMemory(
+        {
+          vaultPath: vault,
+          file: "Principles",
+          section: "Decision heuristics\n(newest first)",
+          entry: "valid entry",
+          date: "2026-07-02",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      "section must be a single line: section names become H2 headings — remove line breaks",
+    )
+    // Nothing was written — the file is byte-identical to the fixture.
+    const fileContent = await readFile(
+      join(vault, "About Me/Principles.md"),
+      "utf8",
+    )
+    expect(fileContent).toBe(PRINCIPLES_MD)
+  })
+
+  // A memory file is a bare name, never a path — a separator would let
+  // "../.." escape the memory directory (and the vault) entirely.
+  it.each([
+    { separatorKind: "a forward slash", file: "../Escaped" },
+    { separatorKind: "a backslash", file: "..\\Escaped" },
+  ])(
+    "rejects a file name containing $separatorKind instead of writing outside the memory directory",
+    async ({ file }) => {
+      await expect(
+        updateMemory(
+          {
+            vaultPath: vault,
+            file,
+            section: "Decision heuristics (newest first)",
+            entry: "valid entry",
+            date: "2026-07-02",
+          },
+          logger,
+        ),
+      ).rejects.toThrow(
+        `memory file must be a bare name without path separators: "${file}"`,
+      )
+      // No file escaped the memory directory into the vault root.
+      await expect(
+        readFile(join(vault, "Escaped.md"), "utf8"),
+      ).rejects.toMatchObject({ code: "ENOENT" })
+    },
+  )
 
   it("appends when the same text arrives with a different date", async () => {
     await updateMemory(

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -394,141 +394,154 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       position?: "top" | "bottom"
     },
     logger: Logger,
-  ): Promise<UpdateMemoryOutcome> =>
+  ): Promise<UpdateMemoryOutcome> => {
+    // Memory entries are single dated bullets. A multiline entry would write
+    // a block that neither the duplicate guard below nor deleteMemory's
+    // exact line match can ever see — reject loudly at the boundary instead
+    // of writing an entry the memory tools can't detect or delete.
+    if (/[\r\n]/.test(params.entry)) {
+      throw new Error(
+        "entry must be a single line: memory entries are single dated bullets — collapse newlines or append multiple entries",
+      )
+    }
     // Serialize the read-modify-write so concurrent appends to the same file
     // don't clobber each other's entries (lost update).
-    withFileLock(memoryFilePath(params.vaultPath, params.file), async () => {
-      const date = params.date ?? DateTime.now().toISODate()
-      const position = params.position ?? "top"
-      const bullet = `- **${date}**: ${params.entry}`
+    return withFileLock(
+      memoryFilePath(params.vaultPath, params.file),
+      async () => {
+        const date = params.date ?? DateTime.now().toISODate()
+        const position = params.position ?? "top"
+        const bullet = `- **${date}**: ${params.entry}`
 
-      const existingContent = await readMemoryFileOrNull(
-        params.vaultPath,
-        params.file,
-      )
+        const existingContent = await readMemoryFileOrNull(
+          params.vaultPath,
+          params.file,
+        )
 
-      // File does not exist — create directory + file with section and entry
-      if (existingContent === null) {
-        const newSection = headingWithNewestFirstSuffix(params.section)
-        const filePath = memoryFilePath(params.vaultPath, params.file)
-        await mkdir(dirname(filePath), { recursive: true })
-        const content = buildNewMemoryFile({
-          fileName: params.file,
-          section: newSection,
+        // File does not exist — create directory + file with section and entry
+        if (existingContent === null) {
+          const newSection = headingWithNewestFirstSuffix(params.section)
+          const filePath = memoryFilePath(params.vaultPath, params.file)
+          await mkdir(dirname(filePath), { recursive: true })
+          const content = buildNewMemoryFile({
+            fileName: params.file,
+            section: newSection,
+            bullet,
+          })
+          await atomicWriteFile(filePath, content)
+          logger.info("created memory file", {
+            file: params.file,
+            section: newSection,
+            date,
+            outcome: "created-file",
+            beforeBytes: 0,
+            afterBytes: Buffer.byteLength(content, "utf8"),
+          })
+          return "created-file"
+        }
+
+        const parsed = parseNote(existingContent)
+        const contentLines = splitIntoLines(parsed.content)
+        const sections = parseSections(contentLines)
+        const match = findSection(sections, params.section, 2)
+
+        // File exists but section does not — append new H2 + entry at end
+        if (!match) {
+          const newSection = headingWithNewestFirstSuffix(params.section)
+          const appendedLines = [...contentLines, `## ${newSection}`, bullet]
+          const newContent = appendedLines.join("\n")
+          const serialized = stringifyNote(newContent, parsed.data)
+          const beforeBytes = Buffer.byteLength(existingContent, "utf8")
+          const afterBytes = Buffer.byteLength(serialized, "utf8")
+          guardAgainstShrink(beforeBytes, afterBytes, "creating memory section")
+          await atomicWriteFile(
+            memoryFilePath(params.vaultPath, params.file),
+            serialized,
+          )
+          logger.info("created memory section", {
+            file: params.file,
+            section: newSection,
+            date,
+            outcome: "created-section",
+            beforeBytes,
+            afterBytes,
+          })
+          return "created-section"
+        }
+
+        const bodyLines = contentLines.slice(
+          match.bodyStartLine,
+          match.bodyEndLine,
+        )
+
+        // Idempotency guard: if the exact bullet already exists in this section,
+        // the entry already landed — typically an MCP client retrying after a
+        // gateway timeout. Splicing again would create a duplicate that
+        // deleteMemory refuses to disambiguate, so no-op instead. Scoped to the
+        // target section: the same bullet under a different heading is a
+        // distinct entry and does not suppress the append.
+        if (bodyLines.includes(bullet)) {
+          logger.info("memory entry unchanged", {
+            file: params.file,
+            section: params.section,
+            date,
+            outcome: "unchanged",
+          })
+          return "unchanged"
+        }
+
+        // File + section exist — find the first and last dated bullet within the
+        // section body to determine where to insert. Offsets are relative to bodyStartLine.
+        const firstBulletOffset = bodyLines.findIndex((line) =>
+          ENTRY_PATTERN.test(line),
+        )
+        const lastBulletOffset = bodyLines.reduce(
+          (lastMatchIndex, line, index) =>
+            ENTRY_PATTERN.test(line) ? index : lastMatchIndex,
+          -1,
+        )
+
+        // Compute the absolute line index in the full content array for insertion.
+        // "top" inserts before the first existing bullet (newest-first ordering).
+        // "bottom" inserts after the last existing bullet.
+        // Empty sections (no bullets) fall back to bodyEndLine — appends at section end.
+        const insertIndex =
+          position === "top"
+            ? firstBulletOffset >= 0
+              ? match.bodyStartLine + firstBulletOffset
+              : match.bodyEndLine
+            : lastBulletOffset >= 0
+              ? match.bodyStartLine + lastBulletOffset + 1
+              : match.bodyEndLine
+
+        // Splice the new bullet into the content lines
+        const updatedLines = [
+          ...contentLines.slice(0, insertIndex),
           bullet,
-        })
-        await atomicWriteFile(filePath, content)
-        logger.info("created memory file", {
-          file: params.file,
-          section: newSection,
-          date,
-          outcome: "created-file",
-          beforeBytes: 0,
-          afterBytes: Buffer.byteLength(content, "utf8"),
-        })
-        return "created-file"
-      }
+          ...contentLines.slice(insertIndex),
+        ]
 
-      const parsed = parseNote(existingContent)
-      const contentLines = splitIntoLines(parsed.content)
-      const sections = parseSections(contentLines)
-      const match = findSection(sections, params.section, 2)
-
-      // File exists but section does not — append new H2 + entry at end
-      if (!match) {
-        const newSection = headingWithNewestFirstSuffix(params.section)
-        const appendedLines = [...contentLines, `## ${newSection}`, bullet]
-        const newContent = appendedLines.join("\n")
+        const newContent = updatedLines.join("\n")
         const serialized = stringifyNote(newContent, parsed.data)
         const beforeBytes = Buffer.byteLength(existingContent, "utf8")
         const afterBytes = Buffer.byteLength(serialized, "utf8")
-        guardAgainstShrink(beforeBytes, afterBytes, "creating memory section")
+        guardAgainstShrink(beforeBytes, afterBytes, "updating memory entry")
         await atomicWriteFile(
           memoryFilePath(params.vaultPath, params.file),
           serialized,
         )
-        logger.info("created memory section", {
-          file: params.file,
-          section: newSection,
-          date,
-          outcome: "created-section",
-          beforeBytes,
-          afterBytes,
-        })
-        return "created-section"
-      }
-
-      const bodyLines = contentLines.slice(
-        match.bodyStartLine,
-        match.bodyEndLine,
-      )
-
-      // Idempotency guard: if the exact bullet already exists in this section,
-      // the entry already landed — typically an MCP client retrying after a
-      // gateway timeout. Splicing again would create a duplicate that
-      // deleteMemory refuses to disambiguate, so no-op instead. Scoped to the
-      // target section: the same bullet under a different heading is a
-      // distinct entry and does not suppress the append.
-      if (bodyLines.includes(bullet)) {
-        logger.info("memory entry unchanged", {
+        logger.info("updated memory", {
           file: params.file,
           section: params.section,
           date,
-          outcome: "unchanged",
+          outcome: "appended",
+          beforeBytes,
+          afterBytes,
         })
-        return "unchanged"
-      }
-
-      // File + section exist — find the first and last dated bullet within the
-      // section body to determine where to insert. Offsets are relative to bodyStartLine.
-      const firstBulletOffset = bodyLines.findIndex((line) =>
-        ENTRY_PATTERN.test(line),
-      )
-      const lastBulletOffset = bodyLines.reduce(
-        (lastMatchIndex, line, index) =>
-          ENTRY_PATTERN.test(line) ? index : lastMatchIndex,
-        -1,
-      )
-
-      // Compute the absolute line index in the full content array for insertion.
-      // "top" inserts before the first existing bullet (newest-first ordering).
-      // "bottom" inserts after the last existing bullet.
-      // Empty sections (no bullets) fall back to bodyEndLine — appends at section end.
-      const insertIndex =
-        position === "top"
-          ? firstBulletOffset >= 0
-            ? match.bodyStartLine + firstBulletOffset
-            : match.bodyEndLine
-          : lastBulletOffset >= 0
-            ? match.bodyStartLine + lastBulletOffset + 1
-            : match.bodyEndLine
-
-      // Splice the new bullet into the content lines
-      const updatedLines = [
-        ...contentLines.slice(0, insertIndex),
-        bullet,
-        ...contentLines.slice(insertIndex),
-      ]
-
-      const newContent = updatedLines.join("\n")
-      const serialized = stringifyNote(newContent, parsed.data)
-      const beforeBytes = Buffer.byteLength(existingContent, "utf8")
-      const afterBytes = Buffer.byteLength(serialized, "utf8")
-      guardAgainstShrink(beforeBytes, afterBytes, "updating memory entry")
-      await atomicWriteFile(
-        memoryFilePath(params.vaultPath, params.file),
-        serialized,
-      )
-      logger.info("updated memory", {
-        file: params.file,
-        section: params.section,
-        date,
-        outcome: "appended",
-        beforeBytes,
-        afterBytes,
-      })
-      return "appended"
-    })
+        return "appended"
+      },
+    )
+  }
 
   const listMemoryFiles = async (
     params: { vaultPath: string },

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -46,12 +46,20 @@ const ENTRY_PATTERN = /^- \*\*\d{4}-\d{2}-\d{2}\*\*:/
  *  bullets, so any line break in an input would corrupt the format. */
 const MEMORY_ENTRY_LINE_BREAK_PATTERN = /[\r\n]/
 
-/** True when the text is a real ISO calendar date in bare YYYY-MM-DD form.
- *  fromFormat enforces both the exact shape (zero-padded, rejects timestamps
- *  and week/ordinal forms that the permissive fromISO would accept) and
- *  calendar validity ("2026-02-30" parses as out of range). */
-const isValidMemoryEntryDate = (dateText: string): boolean =>
-  DateTime.fromFormat(dateText, "yyyy-MM-dd").isValid
+/** True when the text is a real ISO calendar date in bare YYYY-MM-DD form —
+ *  or undefined, which callers treat as "not supplied" (updateMemory defaults
+ *  it to today). fromFormat enforces both the exact shape (zero-padded,
+ *  rejects timestamps and week/ordinal forms that the permissive fromISO
+ *  would accept) and calendar validity ("2026-02-30" parses as out of range). */
+const isValidMemoryEntryDate = (dateText: string | undefined): boolean => {
+  if (dateText === undefined) return true
+  return DateTime.fromFormat(dateText, "yyyy-MM-dd").isValid
+}
+
+/** Thrown by updateMemory and deleteMemory when a supplied date fails
+ *  isValidMemoryEntryDate — one string so the two sites can't drift. */
+const INVALID_MEMORY_ENTRY_DATE_MESSAGE =
+  "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)"
 
 const isString = (value: unknown): value is string => typeof value === "string"
 
@@ -424,14 +432,12 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         "entry must be a single line: memory entries are single dated bullets — collapse newlines or append multiple entries",
       )
     }
-    // The default date (today) is always valid, so only a caller-supplied
-    // date needs checking — anything that isn't a real bare YYYY-MM-DD date
-    // (a line break, a timestamp, free text, an impossible calendar value)
-    // would corrupt the bullet the same way a multiline entry does.
-    if (params.date !== undefined && !isValidMemoryEntryDate(params.date)) {
-      throw new Error(
-        "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
-      )
+    // An omitted date is fine (it defaults to today below); anything supplied
+    // that isn't a real bare YYYY-MM-DD date (a line break, a timestamp, free
+    // text, an impossible calendar value) would corrupt the bullet the same
+    // way a multiline entry does.
+    if (!isValidMemoryEntryDate(params.date)) {
+      throw new Error(INVALID_MEMORY_ENTRY_DATE_MESSAGE)
     }
     // A section name with a line break would write a corrupted multi-line
     // "## heading" that findSection can never match again — every subsequent
@@ -665,65 +671,75 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       entry: string
     },
     logger: Logger,
-  ): Promise<void> =>
+  ): Promise<void> => {
+    // Server-written bullets only ever carry real calendar dates, so a
+    // malformed date can never match — reject it up front with remediation
+    // instead of a guaranteed "no entry matching" miss.
+    if (!isValidMemoryEntryDate(params.date)) {
+      throw new Error(INVALID_MEMORY_ENTRY_DATE_MESSAGE)
+    }
     // Serialize with concurrent updates/deletes to the same file so the
     // read-modify-write can't be interleaved and lose a write.
-    withFileLock(memoryFilePath(params.vaultPath, params.file), async () => {
-      const raw = await readMemoryFile(params.vaultPath, params.file)
-      const parsed = parseNote(raw)
-      const lines = splitIntoLines(parsed.content)
-      const sections = parseSections(lines)
-      const match = findSection(sections, params.section, 2)
-      if (!match) {
-        throw new Error(
-          `section not found: "${params.section}" in ${memoryDir}/${params.file}.md`,
+    return withFileLock(
+      memoryFilePath(params.vaultPath, params.file),
+      async () => {
+        const raw = await readMemoryFile(params.vaultPath, params.file)
+        const parsed = parseNote(raw)
+        const lines = splitIntoLines(parsed.content)
+        const sections = parseSections(lines)
+        const match = findSection(sections, params.section, 2)
+        if (!match) {
+          throw new Error(
+            `section not found: "${params.section}" in ${memoryDir}/${params.file}.md`,
+          )
+        }
+
+        // Build the exact bullet string and find matching lines within the section
+        const targetBullet = `- **${params.date}**: ${params.entry}`
+        const matchingIndices = lines.flatMap((line, index) =>
+          index >= match.bodyStartLine &&
+          index < match.bodyEndLine &&
+          line === targetBullet
+            ? [index]
+            : [],
         )
-      }
 
-      // Build the exact bullet string and find matching lines within the section
-      const targetBullet = `- **${params.date}**: ${params.entry}`
-      const matchingIndices = lines.flatMap((line, index) =>
-        index >= match.bodyStartLine &&
-        index < match.bodyEndLine &&
-        line === targetBullet
-          ? [index]
-          : [],
-      )
+        if (matchingIndices.length === 0) {
+          throw new Error(
+            `no entry matching (${params.date}, "${params.entry}") under ## ${match.heading} in ${memoryDir}/${params.file}.md`,
+          )
+        }
+        if (matchingIndices.length > 1) {
+          throw new Error(
+            `ambiguous: ${matchingIndices.length} entries match (${params.date}, "${params.entry}") under ## ${match.heading} in ${memoryDir}/${params.file}.md`,
+          )
+        }
 
-      if (matchingIndices.length === 0) {
-        throw new Error(
-          `no entry matching (${params.date}, "${params.entry}") under ## ${match.heading} in ${memoryDir}/${params.file}.md`,
+        // Remove the single matched line, preserving everything before and after it
+        const updatedLines = [
+          ...lines.slice(0, matchingIndices[0]),
+          ...lines.slice(matchingIndices[0] + 1),
+        ]
+
+        const newContent = updatedLines.join("\n")
+        const serialized = stringifyNote(newContent, parsed.data)
+        const beforeBytes = Buffer.byteLength(raw, "utf8")
+        const afterBytes = Buffer.byteLength(serialized, "utf8")
+        guardAgainstShrink(beforeBytes, afterBytes, "deleting memory entry")
+        await atomicWriteFile(
+          memoryFilePath(params.vaultPath, params.file),
+          serialized,
         )
-      }
-      if (matchingIndices.length > 1) {
-        throw new Error(
-          `ambiguous: ${matchingIndices.length} entries match (${params.date}, "${params.entry}") under ## ${match.heading} in ${memoryDir}/${params.file}.md`,
-        )
-      }
-
-      // Remove the single matched line, preserving everything before and after it
-      const updatedLines = [
-        ...lines.slice(0, matchingIndices[0]),
-        ...lines.slice(matchingIndices[0] + 1),
-      ]
-
-      const newContent = updatedLines.join("\n")
-      const serialized = stringifyNote(newContent, parsed.data)
-      const beforeBytes = Buffer.byteLength(raw, "utf8")
-      const afterBytes = Buffer.byteLength(serialized, "utf8")
-      guardAgainstShrink(beforeBytes, afterBytes, "deleting memory entry")
-      await atomicWriteFile(
-        memoryFilePath(params.vaultPath, params.file),
-        serialized,
-      )
-      logger.info("deleted memory entry", {
-        file: params.file,
-        section: params.section,
-        date: params.date,
-        beforeBytes,
-        afterBytes,
-      })
-    })
+        logger.info("deleted memory entry", {
+          file: params.file,
+          section: params.section,
+          date: params.date,
+          beforeBytes,
+          afterBytes,
+        })
+      },
+    )
+  }
 
   /** Creates the memory directory with template files if it doesn't exist. Idempotent. */
   const bootstrapMemoryDir = async (

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -75,8 +75,10 @@ export type MemoryFileOutline = Readonly<{
 }>
 
 /** What an updateMemory call did — lets the tool layer tailor its confirmation
- *  (e.g. nudge the caller to fill in a new file's scope callout). */
-type UpdateMemoryOutcome = "created-file" | "created-section" | "appended"
+ *  (e.g. nudge the caller to fill in a new file's scope callout, or report
+ *  that an identical entry already existed and nothing was written). */
+type UpdateMemoryOutcome =
+  "created-file" | "created-section" | "appended" | "unchanged"
 
 type ParsedSection = Readonly<{
   heading: string
@@ -456,12 +458,29 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         return "created-section"
       }
 
-      // File + section exist — find the first and last dated bullet within the
-      // section body to determine where to insert. Offsets are relative to bodyStartLine.
       const bodyLines = contentLines.slice(
         match.bodyStartLine,
         match.bodyEndLine,
       )
+
+      // Idempotency guard: if the exact bullet already exists in this section,
+      // the entry already landed — typically an MCP client retrying after a
+      // gateway timeout. Splicing again would create a duplicate that
+      // deleteMemory refuses to disambiguate, so no-op instead. Scoped to the
+      // target section: the same bullet under a different heading is a
+      // distinct entry and does not suppress the append.
+      if (bodyLines.includes(bullet)) {
+        logger.info("memory entry unchanged", {
+          file: params.file,
+          section: params.section,
+          date,
+          outcome: "unchanged",
+        })
+        return "unchanged"
+      }
+
+      // File + section exist — find the first and last dated bullet within the
+      // section body to determine where to insert. Offsets are relative to bodyStartLine.
       const firstBulletOffset = bodyLines.findIndex((line) =>
         ENTRY_PATTERN.test(line),
       )

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -43,9 +43,8 @@ const guardAgainstShrink = (
 const ENTRY_PATTERN = /^- \*\*\d{4}-\d{2}-\d{2}\*\*:/
 
 /** Matches CR/LF anywhere in a string — memory entries are single-line dated
- *  bullets, so any line break in an input would corrupt the format. Shared
- *  with the tool-layer schema so the two guards can't drift. */
-export const MEMORY_ENTRY_LINE_BREAK_PATTERN = /[\r\n]/
+ *  bullets, so any line break in an input would corrupt the format. */
+const MEMORY_ENTRY_LINE_BREAK_PATTERN = /[\r\n]/
 
 /** Matches a bare ISO calendar date (YYYY-MM-DD) — the only date shape the
  *  dated-bullet format accepts. Shape only; calendar validity is checked by
@@ -54,9 +53,8 @@ const MEMORY_ENTRY_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 
 /** True when the text is a real ISO calendar date in bare YYYY-MM-DD form —
  *  the shape check rejects timestamps and free text, the Luxon parse rejects
- *  calendar-impossible values ("2026-13-40" is shape-valid but no date).
- *  Shared with the tool-layer schema so the two guards can't drift. */
-export const isValidMemoryEntryDate = (dateText: string): boolean =>
+ *  calendar-impossible values ("2026-13-40" is shape-valid but no date). */
+const isValidMemoryEntryDate = (dateText: string): boolean =>
   MEMORY_ENTRY_DATE_PATTERN.test(dateText) && DateTime.fromISO(dateText).isValid
 
 const isString = (value: unknown): value is string => typeof value === "string"

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -173,8 +173,17 @@ const findSection = (
 export const createMemoryStore = (options: { memoryDir: string }) => {
   const { memoryDir } = options
 
-  const memoryFilePath = (vaultPath: string, file: string): string =>
-    join(vaultPath, memoryDir, `${file}.md`)
+  // A memory file is a bare name, never a path — a separator would let a
+  // name like "../../outside" escape the memory directory (and the vault)
+  // entirely, so reject it at the single point every memory path goes through.
+  const memoryFilePath = (vaultPath: string, file: string): string => {
+    if (file.includes("/") || file.includes("\\")) {
+      throw new Error(
+        `memory file must be a bare name without path separators: "${file}"`,
+      )
+    }
+    return join(vaultPath, memoryDir, `${file}.md`)
+  }
 
   type MemoryTemplateSpec = {
     fileName: string
@@ -428,6 +437,15 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     if (params.date !== undefined && !isValidMemoryEntryDate(params.date)) {
       throw new Error(
         "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
+      )
+    }
+    // A section name with a line break would write a corrupted multi-line
+    // "## heading" that findSection can never match again — every subsequent
+    // call would append yet another broken section instead of reaching the
+    // duplicate guard, so reject it at the boundary like entry and date.
+    if (MEMORY_ENTRY_LINE_BREAK_PATTERN.test(params.section)) {
+      throw new Error(
+        "section must be a single line: section names become H2 headings — remove line breaks",
       )
     }
     // Serialize the read-modify-write so concurrent appends to the same file

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -46,16 +46,12 @@ const ENTRY_PATTERN = /^- \*\*\d{4}-\d{2}-\d{2}\*\*:/
  *  bullets, so any line break in an input would corrupt the format. */
 const MEMORY_ENTRY_LINE_BREAK_PATTERN = /[\r\n]/
 
-/** Matches a bare ISO calendar date (YYYY-MM-DD) — the only date shape the
- *  dated-bullet format accepts. Shape only; calendar validity is checked by
- *  isValidMemoryEntryDate. */
-const MEMORY_ENTRY_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
-
-/** True when the text is a real ISO calendar date in bare YYYY-MM-DD form —
- *  the shape check rejects timestamps and free text, the Luxon parse rejects
- *  calendar-impossible values ("2026-13-40" is shape-valid but no date). */
+/** True when the text is a real ISO calendar date in bare YYYY-MM-DD form.
+ *  fromFormat enforces both the exact shape (zero-padded, rejects timestamps
+ *  and week/ordinal forms that the permissive fromISO would accept) and
+ *  calendar validity ("2026-02-30" parses as out of range). */
 const isValidMemoryEntryDate = (dateText: string): boolean =>
-  MEMORY_ENTRY_DATE_PATTERN.test(dateText) && DateTime.fromISO(dateText).isValid
+  DateTime.fromFormat(dateText, "yyyy-MM-dd").isValid
 
 const isString = (value: unknown): value is string => typeof value === "string"
 

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -42,6 +42,15 @@ const guardAgainstShrink = (
 // The date portion is the reliable anchor — entry text after `: ` may contain its own **bold**
 const ENTRY_PATTERN = /^- \*\*\d{4}-\d{2}-\d{2}\*\*:/
 
+/** Matches CR/LF anywhere in a string — memory entries are single-line dated
+ *  bullets, so any line break in an input would corrupt the format. Shared
+ *  with the tool-layer schema so the two guards can't drift. */
+export const MEMORY_ENTRY_LINE_BREAK_PATTERN = /[\r\n]/
+
+/** Matches a bare ISO calendar date (YYYY-MM-DD) — the only date shape the
+ *  dated-bullet format accepts. Shared with the tool-layer schema. */
+export const MEMORY_ENTRY_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
 const isString = (value: unknown): value is string => typeof value === "string"
 
 /** Returns the heading name with the "(newest first)" suffix, appending it if absent (case-insensitive). */
@@ -399,10 +408,20 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     // a block that neither the duplicate guard below nor deleteMemory's
     // exact line match can ever see — reject loudly at the boundary instead
     // of writing an entry the memory tools can't detect or delete.
-    if (/[\r\n]/.test(params.entry)) {
+    if (MEMORY_ENTRY_LINE_BREAK_PATTERN.test(params.entry)) {
       throw new Error(
         "entry must be a single line: memory entries are single dated bullets — collapse newlines or append multiple entries",
       )
+    }
+    // The default date (today) is always valid, so only a caller-supplied
+    // date needs the shape check — anything that isn't a bare YYYY-MM-DD (a
+    // line break, a timestamp, free text) would corrupt the bullet the same
+    // way a multiline entry does.
+    if (
+      params.date !== undefined &&
+      !MEMORY_ENTRY_DATE_PATTERN.test(params.date)
+    ) {
+      throw new Error("date must be ISO YYYY-MM-DD (e.g. 2026-07-02)")
     }
     // Serialize the read-modify-write so concurrent appends to the same file
     // don't clobber each other's entries (lost update).

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -48,8 +48,16 @@ const ENTRY_PATTERN = /^- \*\*\d{4}-\d{2}-\d{2}\*\*:/
 export const MEMORY_ENTRY_LINE_BREAK_PATTERN = /[\r\n]/
 
 /** Matches a bare ISO calendar date (YYYY-MM-DD) — the only date shape the
- *  dated-bullet format accepts. Shared with the tool-layer schema. */
-export const MEMORY_ENTRY_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+ *  dated-bullet format accepts. Shape only; calendar validity is checked by
+ *  isValidMemoryEntryDate. */
+const MEMORY_ENTRY_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/** True when the text is a real ISO calendar date in bare YYYY-MM-DD form —
+ *  the shape check rejects timestamps and free text, the Luxon parse rejects
+ *  calendar-impossible values ("2026-13-40" is shape-valid but no date).
+ *  Shared with the tool-layer schema so the two guards can't drift. */
+export const isValidMemoryEntryDate = (dateText: string): boolean =>
+  MEMORY_ENTRY_DATE_PATTERN.test(dateText) && DateTime.fromISO(dateText).isValid
 
 const isString = (value: unknown): value is string => typeof value === "string"
 
@@ -414,14 +422,13 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       )
     }
     // The default date (today) is always valid, so only a caller-supplied
-    // date needs the shape check — anything that isn't a bare YYYY-MM-DD (a
-    // line break, a timestamp, free text) would corrupt the bullet the same
-    // way a multiline entry does.
-    if (
-      params.date !== undefined &&
-      !MEMORY_ENTRY_DATE_PATTERN.test(params.date)
-    ) {
-      throw new Error("date must be ISO YYYY-MM-DD (e.g. 2026-07-02)")
+    // date needs checking — anything that isn't a real bare YYYY-MM-DD date
+    // (a line break, a timestamp, free text, an impossible calendar value)
+    // would corrupt the bullet the same way a multiline entry does.
+    if (params.date !== undefined && !isValidMemoryEntryDate(params.date)) {
+      throw new Error(
+        "date must be a real ISO calendar date (YYYY-MM-DD, e.g. 2026-07-02)",
+      )
     }
     // Serialize the read-modify-write so concurrent appends to the same file
     // don't clobber each other's entries (lost update).


### PR DESCRIPTION
## What does this PR do?

Makes `vault_update_memory` idempotent on exact duplicates. Previously `updateMemory` spliced the new bullet unconditionally, so a retried call (e.g. an MCP client retry after a gateway timeout) duplicated the entry — and `vault_delete_memory` then refused to remove either copy ("ambiguous: N entries match"), leaving the file in a state the tools couldn't repair.

Changes:

- **`memory-store.ts`** — inside the existing per-file write lock, an exact duplicate (same date + text in the target section) is now a no-op reported as a new `"unchanged"` outcome. The guard is scoped to the target section, so the same bullet under a different heading still appends. The create-file/create-section paths are untouched (no existing content to duplicate); a retry landing after either takes the section-exists path and hits the guard.
- **`memory-tools.ts`** — the tool description now documents the idempotency contract ("an exact duplicate … is a no-op, so retrying a timed-out call is safe"), the `"unchanged"` outcome returns "Entry already exists … — nothing was written." instead of "Added entry", and `idempotentHint` flips to `true` (with a comment noting the date-defaults-to-today nuance).
- **`vault_delete_memory` description** — the ambiguous-match error now carries remediation guidance: identical bullets can only arise from hand edits, and the extra copy is removed via `vault_delete_span` or a manual edit.
- `deleteMemory`'s ambiguity guard stays as defense in depth for hand-edited duplicates.

Tests: duplicate call returns `"unchanged"` with the file byte-identical to the first write; a hand-edited pre-existing entry is treated as unchanged; same text + different date appends; same date + different text appends; an identical bullet in a different section does not suppress the append; description + annotation assertions for the new contract.

## Type of change

- [x] Bug fix

## Checklist

- [x] `npm test` passes (1267 tests)
- [x] `npm run lint` passes
- [x] `npm run prettier:check` passes
- [x] `npm run build` succeeds
- [x] New MCP tools follow the naming and description conventions in AGENTS.md (no new tools)
- [x] README or ARCHITECTURE.md updated (no user-facing surface change — tool description updates live in code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ty19MCbuGwUwGy7E1ixzsd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory updates are now idempotent for exact duplicates, so re-sending the same entry won’t create duplicate bullets.
  * Update results can now clearly report when nothing was written because the entry already existed.

* **Bug Fixes**
  * Entry input now rejects multiline text to prevent malformed memory items.
  * Duplicate-handling messages were clarified to better explain ambiguous cases and expected manual edits.

* **Tests**
  * Added coverage for duplicate detection, unchanged writes, section/date behavior, and multiline entry rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->