### PR TITLE
docs: add task queries to README intro feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 </div>
 
-**Vault Cortex** is a standalone MCP server that gives any AI agent **hybrid search, structured memory, and read/write access** to your [Obsidian](https://obsidian.md) vault. No plugins, no running Obsidian, no separate bridge. One Docker container, your vault folder, 26 tools + 3 guided prompts. Deploy on a VPS with Obsidian Sync and the same vault is accessible from your phone, claude.ai, or any remote MCP client, secured with OAuth 2.1.
+**Vault Cortex** is a standalone MCP server that gives any AI agent **hybrid search, task queries, structured memory, and read/write access** to your [Obsidian](https://obsidian.md) vault. No plugins, no running Obsidian, no separate bridge. One Docker container, your vault folder, 26 tools + 3 guided prompts. Deploy on a VPS with Obsidian Sync and the same vault is accessible from your phone, claude.ai, or any remote MCP client, secured with OAuth 2.1.
 
 **Contents** — [What you get](#what-you-get) · [Quick Start](#quick-start) · [How It Works](#how-it-works) · [Hybrid Search](#hybrid-search) · [Tools](#tools-26) · [Prompts](#prompts-3) · [Config](#configuration) · [Auth](#authentication) · [Deployment](#deployment-options)
 


### PR DESCRIPTION
## What does this PR do?

Adds "task queries" to the README intro paragraph's bold feature list. The intro is the first thing visitors see on the repo landing page, and the bold trio — "hybrid search, structured memory, and read/write access" — predated the task layer (PR #255). The "What you get" bullets already mention task queries, but the intro didn't.

**Before:** hybrid search, structured memory, and read/write access
**After:** hybrid search, task queries, structured memory, and read/write access

Task queries are placed next to hybrid search since both are query-type capabilities, before the two data-layer features (memory, CRUD).

## Type of change

- [x] Documentation
- [ ] New MCP tool
- [ ] Bug fix
- [ ] Refactoring
- [ ] CI / workflow change
- [ ] Infrastructure (SST, Docker)
- [ ] Other

## Checklist

- [x] `npm test` passes — docs-only change, no code touched
- [x] `npm run lint` passes — docs-only change
- [x] `npm run prettier:check` passes — docs-only change
- [x] `npm run build` succeeds — docs-only change
- [x] New MCP tools follow the naming and description conventions in AGENTS.md — N/A
- [x] README or ARCHITECTURE.md updated (if user-facing behavior changed) — this IS the README update

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgsmCAepVKYHWtGpUwSH23)_

## Summary by Sourcery

Documentation:
- Add task queries to the README intro feature list to align with existing documentation of capabilities.