### PR TITLE
ci: add PR-Agent automated code review

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,0 +1,24 @@
+name: PR-Agent Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event.pull_request.user.login == 'aliasunder'
+    runs-on: ubuntu-latest
+    name: AI code review
+    steps:
+      - uses: docker://ghcr.io/the-pr-agent/pr-agent:latest
+        env:
+          OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/deepseek/deepseek-v3.2' }}
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_improve: "false"

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -3,6 +3,8 @@ name: PR-Agent Review
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -11,7 +13,12 @@ permissions:
 
 jobs:
   review:
-    if: github.event.pull_request.user.login == github.repository_owner
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.user.login == github.repository_owner) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.comment.user.login == github.repository_owner)
     runs-on: ubuntu-latest
     name: AI code review
     steps:

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -18,7 +18,8 @@ jobs:
        github.event.pull_request.user.login == github.repository_owner) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       github.event.comment.user.login == github.repository_owner)
+       github.event.comment.user.login == github.repository_owner &&
+       startsWith(github.event.comment.body, '/review'))
     runs-on: ubuntu-latest
     name: AI code review
     steps:

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  issues: write
+  issues: write # persistent_comment posts to the PR conversation thread (issue comments API)
   pull-requests: write
 
 jobs:

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -6,15 +6,16 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
   review:
-    if: github.event.pull_request.user.login == 'aliasunder'
+    if: github.event.pull_request.user.login == github.repository_owner
     runs-on: ubuntu-latest
     name: AI code review
     steps:
-      - uses: docker://ghcr.io/the-pr-agent/pr-agent:latest
+      - uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
         env:
           OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/deepseek/deepseek-v3.2' }}
+          config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/anthropic/claude-sonnet-4-6' }}
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "false"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,3 @@
-[config]
-fallback_models = ["openrouter/deepseek/deepseek-chat-v3.1"]
-
 [pr_reviewer]
 extra_instructions = """\
 Read AGENTS.md in the repo root for this project's coding conventions, \

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,26 @@
+[config]
+fallback_models = ["openrouter/deepseek/deepseek-chat-v3.1"]
+
+[pr_reviewer]
+extra_instructions = """\
+Read AGENTS.md in the repo root for this project's coding conventions, \
+code style rules, naming conventions, test conventions, and module layering. \
+Review against those conventions — they take priority over general best practices. \
+Flag violations of the AGENTS.md rules explicitly.\
+"""
+num_code_suggestions = 4
+require_can_be_reviewed = true
+persistent_comment = true
+remove_previous_review_comment = true
+
+[pr_description]
+enable_pr_description = false
+
+[pr_code_suggestions]
+enable = false
+
+[pr_commands]
+/ask = false
+/improve = false
+/describe = false
+/review = true


### PR DESCRIPTION
## What does this PR do?

Adds automated AI code review using [PR-Agent](https://github.com/The-PR-Agent/pr-agent) routed through OpenRouter. Reviews fire on PR open/reopen, and the repo owner can manually trigger with a `/review` comment.

**Design decisions:**
- **Read-only** — `contents: read` permission; the bot cannot push code or modify files
- **Owner-only** — job condition checks `github.repository_owner`, skipping Dependabot and collaborator PRs
- **`issue_comment` guarded** — only the repo owner's comments trigger the workflow, and only `/review` is enabled (mitigates prompt injection via PR comments, CVE-2024-51355/51356)
- **Model via variable** — `vars.PR_AGENT_MODEL` overrides the default from Settings > Variables, no code change needed
- **AGENTS.md-aware** — `extra_instructions` tells the model to read AGENTS.md for project conventions, so reviews stay relevant as conventions evolve
- **Review + suggestions only** — `/ask`, `/improve`, `/describe` disabled; code suggestions posted as review comments (not code pushes)

**Setup required** (after merge):
1. Add `OPENROUTER_KEY` as a repository **secret** (Settings > Secrets and variables > Actions)
2. Optionally set `PR_AGENT_MODEL` as a repository **variable** to override the default model

## Type of change

- [ ] New MCP tool
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [x] CI / workflow change
- [ ] Infrastructure (SST, Docker)
- [ ] Other

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run prettier:check` passes
- [x] `npm run build` succeeds
- [ ] New MCP tools follow the naming and description conventions in AGENTS.md
- [ ] README or ARCHITECTURE.md updated (if user-facing behavior changed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgsmCAepVKYHWtGpUwSH23)_