### PR TITLE
fix: quote slash-prefixed keys in .pr_agent.toml

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -17,7 +17,7 @@ enable_pr_description = false
 enable = false
 
 [pr_commands]
-/ask = false
-/improve = false
-/describe = false
-/review = true
+"/ask" = false
+"/improve" = false
+"/describe" = false
+"/review" = true


### PR DESCRIPTION
## What does this PR do?

Fixes a TOML parse error that broke PR-Agent on every PR. The `[pr_commands]` section used bare `/ask`, `/improve`, `/describe`, `/review` keys — but `/` is not valid in bare TOML keys (`[A-Za-z0-9_-]` only). The parser rejected them at line 20, causing the "AI code review" check to fail.

Quotes all four keys so the TOML is valid.

## Type of change

- [x] Bug fix

## Checklist

- [x] `npm test` passes — no test changes
- [x] `npm run lint` passes — no code changes
- [x] `npm run prettier:check` passes — no code changes
- [x] `npm run build` succeeds — no code changes
- [ ] ~~New MCP tools follow the naming and description conventions in AGENTS.md~~ — N/A
- [ ] ~~README or ARCHITECTURE.md updated~~ — N/A