### PR TITLE
fix: disable persistent comment to avoid Qodo collision

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -7,8 +7,7 @@ Flag violations of the AGENTS.md rules explicitly.\
 """
 num_code_suggestions = 4
 require_can_be_reviewed = true
-persistent_comment = true
-remove_previous_review_comment = true
+persistent_comment = false
 
 [pr_description]
 enable_pr_description = false


### PR DESCRIPTION
## What does this PR do?

Disables `persistent_comment` in `.pr_agent.toml` so the self-hosted PR-Agent workflow and the Qodo GitHub App stop colliding.

Both use the same PR-Agent codebase and share persistent-comment markers. With `persistent_comment = true` + `remove_previous_review_comment = true`, our workflow finds Qodo's existing review comment, treats it as "the" persistent review, and silently updates the link instead of posting its own review — which is why `/review` triggers produced only "Persistent review updated" one-liners with no actual code review.

With `persistent_comment = false`, each bot posts its own independent comment, so they can be compared side by side.

## Type of change

- [x] Bug fix

## Checklist

- [x] `npm test` passes — no test changes
- [x] `npm run lint` passes — no code changes
- [x] `npm run prettier:check` passes — no code changes
- [x] `npm run build` succeeds — no code changes
- [ ] ~~New MCP tools follow the naming and description conventions in AGENTS.md~~ — N/A
- [ ] ~~README or ARCHITECTURE.md updated~~ — N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgsmCAepVKYHWtGpUwSH23)_

## Summary by Sourcery

Enhancements:
- Update PR-Agent configuration to have each bot post independent review comments instead of sharing a single persistent comment.