### PR TITLE
chore: add inline comment + explicit remove_previous_review_comment

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -7,7 +7,11 @@ Flag violations of the AGENTS.md rules explicitly.\
 """
 num_code_suggestions = 4
 require_can_be_reviewed = true
+# Disabled: Qodo GitHub App uses the same persistent-comment markers,
+# so enabling this causes our review to silently update Qodo's comment
+# instead of posting its own.
 persistent_comment = false
+remove_previous_review_comment = false
 
 [pr_description]
 enable_pr_description = false


### PR DESCRIPTION
## What does this PR do?

Follow-up to #263 (Sourcery feedback). Adds an inline TOML comment explaining why `persistent_comment` is disabled (Qodo collision context for future maintainers) and explicitly sets `remove_previous_review_comment = false` instead of relying on the default after removing it.

## Type of change

- [x] CI / workflow change

## Checklist

- [x] `npm test` passes — no test changes
- [x] `npm run lint` passes — no code changes
- [x] `npm run prettier:check` passes — no code changes
- [x] `npm run build` succeeds — no code changes
- [ ] ~~New MCP tools follow the naming and description conventions in AGENTS.md~~ — N/A
- [ ] ~~README or ARCHITECTURE.md updated~~ — N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgsmCAepVKYHWtGpUwSH23)_

## Summary by Sourcery

CI:
- Document the rationale for disabling persistent comments in .pr_agent.toml and explicitly set remove_previous_review_comment to false.