### PR TITLE
feat: enable PR-Agent inline code suggestions

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -31,4 +31,14 @@ jobs:
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
+          pr_reviewer.extra_instructions: >-
+            Read AGENTS.md in the repo root for this project's coding conventions,
+            code style rules, naming conventions, test conventions, and module layering.
+            Review against those conventions — they take priority over general best practices.
+            Flag violations of the AGENTS.md rules explicitly.
+          pr_reviewer.num_code_suggestions: "4"
+          pr_reviewer.require_can_be_reviewed: "true"
+          pr_reviewer.persistent_comment: "false"
+          pr_reviewer.remove_previous_review_comment: "false"
+          pr_description.enable_pr_description: "false"
           pr_code_suggestions.num_code_suggestions: "4"

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -36,9 +36,7 @@ jobs:
             code style rules, naming conventions, test conventions, and module layering.
             Review against those conventions — they take priority over general best practices.
             Flag violations of the AGENTS.md rules explicitly.
-          pr_reviewer.num_code_suggestions: "4"
           pr_reviewer.require_can_be_reviewed: "true"
           pr_reviewer.persistent_comment: "false"
           pr_reviewer.remove_previous_review_comment: "false"
           pr_description.enable_pr_description: "false"
-          pr_code_suggestions.num_code_suggestions: "4"

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -30,4 +30,5 @@ jobs:
           config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/anthropic/claude-sonnet-4-6' }}
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
-          github_action_config.auto_improve: "false"
+          github_action_config.auto_improve: "true"
+          pr_code_suggestions.num_code_suggestions: "4"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,26 +1,5 @@
-[pr_reviewer]
-extra_instructions = """\
-Read AGENTS.md in the repo root for this project's coding conventions, \
-code style rules, naming conventions, test conventions, and module layering. \
-Review against those conventions — they take priority over general best practices. \
-Flag violations of the AGENTS.md rules explicitly.\
-"""
-num_code_suggestions = 0
-require_can_be_reviewed = true
-# Disabled: Qodo GitHub App uses the same persistent-comment markers,
-# so enabling this causes our review to silently update Qodo's comment
-# instead of posting its own.
-persistent_comment = false
-remove_previous_review_comment = false
-
-[pr_description]
-enable_pr_description = false
-
-[pr_code_suggestions]
-enable = false
-
-[pr_commands]
-"/ask" = false
-"/improve" = false
-"/describe" = false
-"/review" = true
+# Minimal config — most settings live in the workflow env vars
+# (.github/workflows/pr_agent.yml) to avoid affecting the Qodo GitHub App,
+# which reads this file too.
+#
+# Only settings that MUST be repo-wide (affecting both bots) belong here.

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,7 +5,7 @@ code style rules, naming conventions, test conventions, and module layering. \
 Review against those conventions — they take priority over general best practices. \
 Flag violations of the AGENTS.md rules explicitly.\
 """
-num_code_suggestions = 4
+num_code_suggestions = 0
 require_can_be_reviewed = true
 # Disabled: Qodo GitHub App uses the same persistent-comment markers,
 # so enabling this causes our review to silently update Qodo's comment

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,5 +1,0 @@
-# Minimal config — most settings live in the workflow env vars
-# (.github/workflows/pr_agent.yml) to avoid affecting the Qodo GitHub App,
-# which reads this file too.
-#
-# Only settings that MUST be repo-wide (affecting both bots) belong here.


### PR DESCRIPTION
## What does this PR do?

Moves all PR-Agent configuration out of `.pr_agent.toml` and into workflow env vars, then deletes the TOML file entirely.

The TOML file was read by both our self-hosted PR-Agent workflow AND the Qodo GitHub App. Settings like `[pr_code_suggestions] enable = false` and `num_code_suggestions = 0` were suppressing Qodo's inline comments. With the file gone, Qodo reverts to its own defaults.

Changes:
- **Deleted `.pr_agent.toml`** — no longer needed
- **`pr_agent.yml`**: all settings moved to env vars — `extra_instructions`, `persistent_comment`, `require_can_be_reviewed`, `auto_improve`, etc.
- **Enabled `auto_improve`** so PR-Agent posts inline code suggestions on the diff
- **Removed `num_code_suggestions` caps** — PR-Agent decides how many suggestions are relevant

## Type of change

- [x] Bug fix
- [x] CI / workflow change

## Checklist

- [x] `npm test` passes — no test changes
- [x] `npm run lint` passes — no code changes
- [x] `npm run prettier:check` passes — no code changes
- [x] `npm run build` succeeds — no code changes
- [ ] ~~New MCP tools follow the naming and description conventions in AGENTS.md~~ — N/A
- [ ] ~~README or ARCHITECTURE.md updated~~ — N/A