### PR TITLE
refactor: replace `as NodeJS.ErrnoException` casts with runtime type guard

### DIFF
--- a/src/utils/__tests__/is-errno-exception.test.ts
+++ b/src/utils/__tests__/is-errno-exception.test.ts
@@ -2,11 +2,8 @@ import { describe, it, expect } from "vitest"
 import { isErrnoException } from "../is-errno-exception.js"
 
 /** Creates a minimal ErrnoException-shaped error for testing. */
-const makeErrno = (code: string): Error => {
-  const error = new Error(`fake ${code}`)
-  ;(error as NodeJS.ErrnoException).code = code
-  return error
-}
+const makeErrno = (code: string): NodeJS.ErrnoException =>
+  Object.assign(new Error(`fake ${code}`), { code })
 
 describe("isErrnoException", () => {
   describe("with code argument", () => {

--- a/src/utils/__tests__/is-errno-exception.test.ts
+++ b/src/utils/__tests__/is-errno-exception.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest"
+import { isErrnoException } from "../is-errno-exception.js"
+
+/** Creates a minimal ErrnoException-shaped error for testing. */
+const makeErrno = (code: string): Error => {
+  const error = new Error(`fake ${code}`)
+  ;(error as NodeJS.ErrnoException).code = code
+  return error
+}
+
+describe("isErrnoException", () => {
+  describe("with code argument", () => {
+    it("returns true when the error code matches", () => {
+      expect(isErrnoException(makeErrno("ENOENT"), "ENOENT")).toBe(true)
+    })
+
+    it("returns false when the error code does not match", () => {
+      expect(isErrnoException(makeErrno("EACCES"), "ENOENT")).toBe(false)
+    })
+
+    it("narrows error.code to the literal type", () => {
+      const error: unknown = makeErrno("ENOENT")
+      if (isErrnoException(error, "ENOENT")) {
+        const code: "ENOENT" = error.code
+        expect(code).toBe("ENOENT")
+      } else {
+        expect.unreachable("guard should have matched")
+      }
+    })
+  })
+
+  describe("without code argument", () => {
+    it("returns true for any errno error", () => {
+      expect(isErrnoException(makeErrno("EEXIST"))).toBe(true)
+    })
+
+    it("narrows error.code to string", () => {
+      const error: unknown = makeErrno("EEXIST")
+      if (isErrnoException(error)) {
+        const code: string = error.code
+        expect(code).toBe("EEXIST")
+      } else {
+        expect.unreachable("guard should have matched")
+      }
+    })
+  })
+
+  describe("rejects non-errno values", () => {
+    it("returns false for a plain Error without a code property", () => {
+      expect(isErrnoException(new Error("plain"))).toBe(false)
+    })
+
+    it("returns false for a string", () => {
+      expect(isErrnoException("ENOENT")).toBe(false)
+    })
+
+    it("returns false for null", () => {
+      expect(isErrnoException(null)).toBe(false)
+    })
+
+    it("returns false for undefined", () => {
+      expect(isErrnoException(undefined)).toBe(false)
+    })
+
+    it("returns false for a plain object with a code property", () => {
+      expect(isErrnoException({ code: "ENOENT" })).toBe(false)
+    })
+  })
+})

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir, stat } from "node:fs/promises"
 import type { Dirent } from "node:fs"
+import { isErrnoException } from "./is-errno-exception.js"
 
 /** Reads a UTF-8 file, returning null instead of throwing when it does not exist
  *  (ENOENT). Any other error propagates. */
@@ -7,7 +8,7 @@ export const readFileOrNull = async (path: string): Promise<string | null> => {
   try {
     return await readFile(path, "utf8")
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null
+    if (isErrnoException(error, "ENOENT")) return null
     throw error
   }
 }
@@ -19,7 +20,7 @@ export const readdirOrNull = async (path: string): Promise<Dirent[] | null> => {
   try {
     return await readdir(path, { recursive: true, withFileTypes: true })
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null
+    if (isErrnoException(error, "ENOENT")) return null
     throw error
   }
 }
@@ -31,7 +32,7 @@ export const fileExists = async (path: string): Promise<boolean> => {
     await stat(path)
     return true
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false
+    if (isErrnoException(error, "ENOENT")) return false
     throw error
   }
 }

--- a/src/utils/is-errno-exception.ts
+++ b/src/utils/is-errno-exception.ts
@@ -8,4 +8,5 @@ export const isErrnoException = <C extends string = string>(
 ): error is NodeJS.ErrnoException & { code: C } =>
   error instanceof Error &&
   "code" in error &&
+  typeof error.code === "string" &&
   (code === undefined || error.code === code)

--- a/src/utils/is-errno-exception.ts
+++ b/src/utils/is-errno-exception.ts
@@ -1,0 +1,11 @@
+/** Runtime type guard for Node.js filesystem errors (ENOENT, EEXIST, EACCES, etc.).
+ *  Narrows an unknown catch value to `NodeJS.ErrnoException`, optionally matching
+ *  a specific `code` literal. When `code` is supplied, the return type narrows
+ *  `error.code` to that literal — so downstream branches don't need a second check. */
+export const isErrnoException = <C extends string = string>(
+  error: unknown,
+  code?: C,
+): error is NodeJS.ErrnoException & { code: C } =>
+  error instanceof Error &&
+  "code" in error &&
+  (code === undefined || error.code === code)

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -6,6 +6,7 @@ import { join, basename, dirname } from "node:path"
 import { parseNote, stringifyNote } from "../obsidian-markdown/frontmatter.js"
 import { atomicWriteFile } from "./vault-filesystem.js"
 import { readFileOrNull } from "../../utils/fs.js"
+import { isErrnoException } from "../../utils/is-errno-exception.js"
 import { withFileLock } from "../../utils/file-write-lock.js"
 import { parseLeadingCallout } from "../obsidian-markdown/callouts.js"
 import type { LeadingCallout } from "../obsidian-markdown/callouts.js"
@@ -305,7 +306,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     try {
       return await readFile(memoryFilePath(vaultPath, file), "utf8")
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      if (isErrnoException(err, "ENOENT")) {
         throw new Error(`memory file not found: "${memoryDir}/${file}.md"`, {
           cause: err,
         })
@@ -363,7 +364,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       try {
         entries = await readdir(dir)
       } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        if (isErrnoException(err, "ENOENT")) {
           logger.info("get memory", { mode: "all", fileCount: 0 })
           return ""
         }
@@ -596,7 +597,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     try {
       entries = await readdir(dir)
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return []
+      if (isErrnoException(err, "ENOENT")) return []
       throw err
     }
 
@@ -651,7 +652,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     try {
       entries = await readdir(dir)
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return []
+      if (isErrnoException(err, "ENOENT")) return []
       throw err
     }
     const names = entries
@@ -751,7 +752,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       await access(dirPath, constants.F_OK)
       return
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+      if (!isErrnoException(err, "ENOENT")) throw err
     }
     await mkdir(dirPath, { recursive: true })
     const created = DateTime.now().toISO()!

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -35,6 +35,7 @@ import { mapWithConcurrency } from "../../utils/map-with-concurrency.js"
 import { describeError } from "../../utils/describe-error.js"
 import { fileExists } from "../../utils/fs.js"
 import { assertPathHasExtension } from "../../utils/assert-path-has-extension.js"
+import { isErrnoException } from "../../utils/is-errno-exception.js"
 import type { Logger } from "../../logger.js"
 
 // ── Types ───────────────────────────────────────────────────────
@@ -582,7 +583,7 @@ const moveNote = async (
         hardLinksSupported: !params.windowsBindMount,
       })
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      if (isErrnoException(error, "EEXIST")) {
         throw new Error(`destination exists: "${newPath}"`, { cause: error })
       }
       logger.error(

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises"
 import { parseNote, stringifyNote } from "../obsidian-markdown/frontmatter.js"
 import { resolveSafePath, atomicWriteFile } from "./vault-filesystem.js"
 import { assertPathHasExtension } from "../../utils/assert-path-has-extension.js"
+import { isErrnoException } from "../../utils/is-errno-exception.js"
 import { withExclusiveFileLock } from "../../utils/file-write-lock.js"
 import {
   parseHeadings,
@@ -81,7 +82,7 @@ const readNoteForPatch = async (
       beforeBytes: Buffer.byteLength(fileContent, "utf8"),
     }
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+    if (isErrnoException(err, "ENOENT")) {
       throw new Error(`note not found: "${path}"`, { cause: err })
     }
     throw err


### PR DESCRIPTION
## What does this PR do?

Adds a generic `isErrnoException<C>()` runtime type guard and replaces all 10 `(error as NodeJS.ErrnoException).code` assertion sites across 4 files with guard calls, aligning with AGENTS.md's no-`as` rule.

The guard uses the TypeScript type predicate pattern with a generic code parameter:

```typescript
export const isErrnoException = <C extends string = string>(
  error: unknown,
  code?: C,
): error is NodeJS.ErrnoException & { code: C } =>
  error instanceof Error &&
  "code" in error &&
  (code === undefined || error.code === code)
```

When called with a specific code (`isErrnoException(err, "ENOENT")`), the generic `C` infers the literal type, narrowing `error.code` to `"ENOENT"` — one call replaces the two-step cast + comparison at every site.

**Sites updated (10 total):**

| File | Sites | Codes |
|------|-------|-------|
| `src/utils/fs.ts` | 3 | `ENOENT` |
| `src/vault-mcp/vault-operations/vault-patcher.ts` | 1 | `ENOENT` |
| `src/vault-mcp/vault-operations/note-mover.ts` | 1 | `EEXIST` |
| `src/vault-mcp/vault-operations/memory-store.ts` | 5 | `ENOENT` (4 positive, 1 inverted) |

No behavioral changes — pure refactor replacing unsafe type assertions with runtime narrowing.

## Type of change

- [x] Refactoring

## Checklist

- [x] `npm test` passes (1462 tests)
- [x] `npm run lint` passes
- [x] `npm run prettier:check` passes
- [x] `npm run build` succeeds
- [ ] ~~New MCP tools follow the naming and description conventions in AGENTS.md~~ N/A
- [ ] ~~README or ARCHITECTURE.md updated (if user-facing behavior changed)~~ N/A — internal refactor

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEUiajRTdYWSYwE4tagwgn)_

## Summary by Sourcery

Introduce a shared runtime type guard for NodeJS.ErrnoException and use it to replace direct error.code casts in filesystem and vault operations.

Enhancements:
- Add isErrnoException utility for safely narrowing unknown errors to NodeJS.ErrnoException with optional code matching.
- Refactor filesystem helpers and vault memory/note operations to rely on the new type guard instead of unsafe type assertions.

Tests:
- Add unit tests validating isErrnoException behavior, including code matching, type narrowing, and rejection of non-errno values.