### PR TITLE
fix(ci): PR-Agent model fallback + inline suggestions

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -32,7 +32,7 @@ jobs:
           # models not listed (e.g. deepseek-v3.2 via OpenRouter) fail silently
           # and fall back. This tells PR-Agent the model's context window directly.
           # Update alongside PR_AGENT_MODEL when switching models.
-          config.custom_model_max_tokens: ${{ vars.PR_AGENT_MAX_TOKENS || '128000' }}
+          config.custom_model_max_tokens: ${{ vars.PR_AGENT_MAX_TOKENS || '200000' }}
           # Default fallback is gpt-5.4-mini (hardcoded in PR-Agent), which routes
           # through OpenRouter to OpenAI — unexpected model and unexpected charges.
           # Override to keep everything on the configured provider.

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -28,7 +28,13 @@ jobs:
           OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/anthropic/claude-sonnet-4-6' }}
+          # PR-Agent only calls models in its hardcoded MAX_TOKENS table;
+          # models not listed (e.g. deepseek-v3.2 via OpenRouter) fail silently
+          # and fall back. This tells PR-Agent the model's context window directly.
           config.custom_model_max_tokens: "128000"
+          # Default fallback is gpt-5.4-mini (hardcoded in PR-Agent), which routes
+          # through OpenRouter to OpenAI — unexpected model and unexpected charges.
+          # Override to keep everything on the configured provider.
           config.fallback_models: '["openrouter/anthropic/claude-sonnet-4-6"]'
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
@@ -41,5 +47,8 @@ jobs:
           pr_reviewer.require_can_be_reviewed: "true"
           pr_reviewer.persistent_comment: "false"
           pr_reviewer.remove_previous_review_comment: "false"
+          # Default (-1) posts suggestions only as conversation comments.
+          # Threshold >= 0 also posts them as inline review comments on the diff
+          # for suggestions at or above that score (0-10 scale).
           pr_code_suggestions.dual_publishing_score_threshold: "5"
           pr_description.enable_pr_description: "false"

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -31,7 +31,8 @@ jobs:
           # PR-Agent only calls models in its hardcoded MAX_TOKENS table;
           # models not listed (e.g. deepseek-v3.2 via OpenRouter) fail silently
           # and fall back. This tells PR-Agent the model's context window directly.
-          config.custom_model_max_tokens: "128000"
+          # Update alongside PR_AGENT_MODEL when switching models.
+          config.custom_model_max_tokens: ${{ vars.PR_AGENT_MAX_TOKENS || '128000' }}
           # Default fallback is gpt-5.4-mini (hardcoded in PR-Agent), which routes
           # through OpenRouter to OpenAI — unexpected model and unexpected charges.
           # Override to keep everything on the configured provider.

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -28,6 +28,8 @@ jobs:
           OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/anthropic/claude-sonnet-4-6' }}
+          config.custom_model_max_tokens: "128000"
+          config.fallback_models: '["openrouter/anthropic/claude-sonnet-4-6"]'
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
@@ -39,4 +41,5 @@ jobs:
           pr_reviewer.require_can_be_reviewed: "true"
           pr_reviewer.persistent_comment: "false"
           pr_reviewer.remove_previous_review_comment: "false"
+          pr_code_suggestions.dual_publishing_score_threshold: "5"
           pr_description.enable_pr_description: "false"


### PR DESCRIPTION
## What does this PR do?

Fixes two PR-Agent issues discovered via OpenRouter dashboard and action logs on PR \#266:

1. **Model fallback to GPT-5.4 Mini** — `openrouter/deepseek/deepseek-v3.2` (set via `PR_AGENT_MODEL` repo variable) isn't in PR-Agent's hardcoded `MAX_TOKENS` lookup table. Both the review and improve steps fail with "Model not defined in MAX_TOKENS and no custom_model_max_tokens is set", then silently fall back to the hardcoded default `gpt-5.4-mini` — routing through OpenRouter to OpenAI with unexpected charges.

2. **Code suggestions not posting inline** — `dual_publishing_score_threshold` defaults to `-1` (disabled), so `auto_improve` suggestions only post as conversation comments, never as inline review comments on the diff.

**Changes:**

| Config | Value | Why |
|--------|-------|-----|
| `config.custom_model_max_tokens` | `128000` | Tells PR-Agent the model's context window so it stops rejecting models not in its `MAX_TOKENS` table |
| `config.fallback_models` | `["openrouter/anthropic/claude-sonnet-4-6"]` | Overrides the hardcoded `gpt-5.4-mini` fallback to keep everything on the configured provider |
| `pr_code_suggestions.dual_publishing_score_threshold` | `5` | Suggestions scoring >= 5 (out of 10) now also post as inline review comments on the diff |

Inline comments added to the workflow explaining why each non-obvious config value is set.

## Type of change

- [x] CI / workflow change

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run prettier:check` passes
- [x] `npm run build` succeeds
- [ ] ~~New MCP tools follow the naming and description conventions in AGENTS.md~~ N/A
- [ ] ~~README or ARCHITECTURE.md updated (if user-facing behavior changed)~~ N/A — CI-only change

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEMFJkQmheYE9bGzkD32DY)_

## Summary by Sourcery

Adjust PR-Agent CI workflow configuration to prevent unintended model fallbacks and enable inline code suggestions.

CI:
- Configure PR-Agent with an explicit custom model max tokens value to support models outside its built-in table.
- Override PR-Agent’s default fallback model to keep requests on the configured OpenRouter provider.
- Enable dual publishing of code suggestions so sufficiently high-scoring suggestions are posted as inline review comments on the diff.