### PR TITLE
feat(search): add is_kanban_task to TaskEntry

### DIFF
--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -29,7 +29,9 @@ const formatTaskEntry = (entry: TaskEntry): Record<string, unknown> =>
   Object.fromEntries(
     Object.entries(entry).filter(
       ([, value]) =>
-        value !== null && !(Array.isArray(value) && value.length === 0),
+        value !== null &&
+        value !== false &&
+        !(Array.isArray(value) && value.length === 0),
     ),
   )
 
@@ -755,7 +757,7 @@ Errors:
 - path without the ".md" extension is rejected
 - No matches returns { total: 0, tasks: [] }, not an error — don't use as an existence check
 
-Returns: JSON { total, tasks }. Each task carries: path, line (1-based file line number), status, status_char (raw checkbox character, for custom-status vaults), description (inline #tags kept in the text), folder (the note's full parent folder), heading (nearest heading above the task, null-omitted above the first heading), plus whichever metadata the task has: created/scheduled/start/due/done/cancelled dates, priority, recurrence (rule text — parsed, never executed), on_completion, task_id, depends_on, tags (bare inline tag names), block_id. Null fields and empty arrays are omitted to keep responses lean.`,
+Returns: JSON { total, tasks }. Each task carries: path, line (1-based file line number), status, status_char (raw checkbox character, for custom-status vaults), description (inline #tags kept in the text), folder (the note's full parent folder), heading (nearest heading above the task — on a Kanban board this is the lane name, null-omitted above the first heading), plus whichever metadata the task has: created/scheduled/start/due/done/cancelled dates, priority, recurrence (rule text — parsed, never executed), on_completion, task_id, depends_on, tags (bare inline tag names), block_id, is_kanban_task (true when the task's parent note has kanban-plugin frontmatter — present only when true, omitted for regular tasks; when true, heading carries the Kanban lane name and completing the task requires a lane move, not just a checkbox toggle). Null fields, false booleans, and empty arrays are omitted to keep responses lean.`,
       inputSchema: {
         status: z
           .enum(["not_done", "todo", "in_progress", "done", "cancelled", "all"])

--- a/src/vault-mcp/search/__tests__/search-helpers.test.ts
+++ b/src/vault-mcp/search/__tests__/search-helpers.test.ts
@@ -162,6 +162,7 @@ const makeTaskRow = (overrides: Partial<TaskRow> = {}): TaskRow => ({
   block_id: null,
   heading: "Tasks",
   folder: "Projects/Alpha",
+  is_kanban_task: 0,
   ...overrides,
 })
 
@@ -245,6 +246,7 @@ describe("rowToTaskEntry", () => {
       depends_on: ["def456"],
       tags: ["bug"],
       block_id: null,
+      is_kanban_task: false,
     })
   })
 

--- a/src/vault-mcp/search/__tests__/task-queries.test.ts
+++ b/src/vault-mcp/search/__tests__/task-queries.test.ts
@@ -183,23 +183,25 @@ describe("task indexing lifecycle", () => {
     expect(result.tasks.map((entry) => entry.folder)).toEqual([""])
   })
 
-  it("marks tasks from kanban-plugin notes as is_kanban_task", () => {
-    const index = indexWithBoardAndPlain()
-
-    const result = index.listTasks({ status: "all" }, logger)
+  it("marks tasks from kanban-plugin notes as is_kanban_task true", () => {
+    const result = indexWithBoardAndPlain().listTasks({ status: "all" }, logger)
     const boardTasks = result.tasks.filter(
       (entry) => entry.path === "Projects/board.md",
     )
+
+    expect(boardTasks).toHaveLength(4)
+    expect(boardTasks.every((entry) => entry.is_kanban_task === true)).toBe(
+      true,
+    )
+  })
+
+  it("marks tasks from plain notes as is_kanban_task false", () => {
+    const result = indexWithBoardAndPlain().listTasks({ status: "all" }, logger)
     const plainTasks = result.tasks.filter(
       (entry) => entry.path === "Inbox/notes.md",
     )
 
-    expect(boardTasks.length).toBe(4)
-    expect(boardTasks.every((entry) => entry.is_kanban_task === true)).toBe(
-      true,
-    )
-
-    expect(plainTasks.length).toBe(2)
+    expect(plainTasks).toHaveLength(2)
     expect(plainTasks.every((entry) => entry.is_kanban_task === false)).toBe(
       true,
     )

--- a/src/vault-mcp/search/__tests__/task-queries.test.ts
+++ b/src/vault-mcp/search/__tests__/task-queries.test.ts
@@ -107,6 +107,7 @@ describe("task indexing lifecycle", () => {
       depends_on: [],
       tags: [],
       block_id: "fix-login",
+      is_kanban_task: true,
     }
     expect(fixLoginTask).toEqual(expectedEntry)
   })
@@ -145,6 +146,7 @@ describe("task indexing lifecycle", () => {
       depends_on: ["id-1", "id-2"],
       tags: ["home", "home/kitchen"],
       block_id: null,
+      is_kanban_task: false,
     }
     expect(result.tasks).toEqual([expectedEntry])
   })
@@ -179,6 +181,28 @@ describe("task indexing lifecycle", () => {
 
     const result = index.listTasks({}, logger)
     expect(result.tasks.map((entry) => entry.folder)).toEqual([""])
+  })
+
+  it("marks tasks from kanban-plugin notes as is_kanban_task", () => {
+    const index = indexWithBoardAndPlain()
+
+    const result = index.listTasks({ status: "all" }, logger)
+    const boardTasks = result.tasks.filter(
+      (entry) => entry.path === "Projects/board.md",
+    )
+    const plainTasks = result.tasks.filter(
+      (entry) => entry.path === "Inbox/notes.md",
+    )
+
+    expect(boardTasks.length).toBe(4)
+    expect(boardTasks.every((entry) => entry.is_kanban_task === true)).toBe(
+      true,
+    )
+
+    expect(plainTasks.length).toBe(2)
+    expect(plainTasks.every((entry) => entry.is_kanban_task === false)).toBe(
+      true,
+    )
   })
 
   it("replaces a note's tasks on re-upsert instead of accumulating them", () => {

--- a/src/vault-mcp/search/search-helpers.ts
+++ b/src/vault-mcp/search/search-helpers.ts
@@ -151,6 +151,7 @@ export const rowToTaskEntry = (row: TaskRow): TaskEntry => ({
   depends_on: parseStringArray(row.depends_on),
   tags: parseStringArray(row.tags),
   block_id: row.block_id,
+  is_kanban_task: Boolean(row.is_kanban_task),
 })
 
 /** Builds a SearchResult from a NoteRow and caller-provided snippet + score.

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -137,6 +137,7 @@ export type TaskRow = {
   block_id: string | null
   heading: string | null
   folder: string
+  is_kanban_task: number
 }
 
 /** One task on the wire — snake_case multi-word fields match the JSON
@@ -163,6 +164,7 @@ export type TaskEntry = {
   depends_on: string[]
   tags: string[]
   block_id: string | null
+  is_kanban_task: boolean
 }
 
 /** Status filter vocabulary for listTasks. "not_done" (the default) covers

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -683,6 +683,8 @@ export const listTasks = (
     .get(...queryParams)
   const total = countRow === undefined ? 0 : countRow.total
 
+  // Kanban detection: notes with kanban-plugin in frontmatter are Kanban boards,
+  // so their tasks need lane moves (not checkbox toggles) to complete.
   const sql = `
     SELECT t.note_path, t.line, t.status_char, t.status, t.description,
            t.created, t.scheduled, t.start, t.due, t.done, t.cancelled,

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -687,7 +687,9 @@ export const listTasks = (
     SELECT t.note_path, t.line, t.status_char, t.status, t.description,
            t.created, t.scheduled, t.start, t.due, t.done, t.cancelled,
            t.priority, t.recurrence, t.on_completion, t.task_id, t.depends_on,
-           t.tags, t.block_id, t.heading, t.folder
+           t.tags, t.block_id, t.heading, t.folder,
+           CASE WHEN json_extract(n.properties, '$.kanban-plugin') IS NOT NULL
+                THEN 1 ELSE 0 END AS is_kanban_task
     FROM tasks t
     JOIN notes n ON n.path = t.note_path
     ${whereClause}


### PR DESCRIPTION
## Summary

- Add `is_kanban_task: boolean` to `TaskEntry` so agents know whether completing a task requires a Kanban lane move or a simple checkbox toggle
- Detected at query time via `json_extract(n.properties, '$.kanban-plugin')` on the existing `notes.properties` column — zero schema changes
- `formatTaskEntry` now also strips `false` values (alongside `null` and empty arrays), so `is_kanban_task` is omitted for regular tasks
- Tool description updated to document `is_kanban_task` and clarify that `heading` carries the Kanban lane name

## Changes

| File | What |
|------|------|
| `search-index.ts` | `TaskRow.is_kanban_task: number`, `TaskEntry.is_kanban_task: boolean` |
| `search-queries.ts` | `CASE WHEN json_extract(n.properties, '$.kanban-plugin') IS NOT NULL THEN 1 ELSE 0 END` in `listTasks` SELECT |
| `search-helpers.ts` | `rowToTaskEntry` maps `Boolean(row.is_kanban_task)` |
| `search-tools.ts` | `formatTaskEntry` strips `false`; `vault_list_tasks` description documents the new field |
| `task-queries.test.ts` | New test + updated existing full-entry assertions with `is_kanban_task` |

## Test plan

- [x] New test: tasks from `kanban-plugin: board` notes have `is_kanban_task: true`, plain notes have `false`
- [x] Existing full-entry assertions updated — both board task (`true`) and plain task (`false`)
- [x] Full suite: 1453 tests pass
- [x] Type check: `tsc --noEmit` clean
- [x] Lint: `eslint .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199AQqNtbaTrxDPPCVLGynr

---
_Generated by [Claude Code](https://claude.ai/code/session_0199AQqNtbaTrxDPPCVLGynr)_

## Summary by Sourcery

Add a kanban-awareness flag to task search results and document its behavior for tools.

New Features:
- Expose an is_kanban_task boolean on TaskEntry to indicate tasks originating from kanban-plugin notes.

Enhancements:
- Derive the kanban flag at query time from existing note properties without changing storage schema.
- Filter out false boolean values alongside nulls and empty arrays when formatting task entries for tool responses.
- Clarify tool documentation that heading represents the Kanban lane name and describe the is_kanban_task field semantics.

Tests:
- Extend task indexing tests to cover kanban-plugin notes and verify correct is_kanban_task values for board versus plain tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task listings now include Kanban-specific status, making board tasks distinguishable from regular tasks.
  * Task metadata responses now include a bit more detail while keeping output concise.

* **Bug Fixes**
  * Improved task field formatting so empty arrays, `false` values, and other unset fields are omitted from responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->