### PR TITLE
build: enable noImplicitOverride + exactOptionalPropertyTypes

### DIFF
--- a/src/vault-mcp/mcp-core/mcp-router.ts
+++ b/src/vault-mcp/mcp-core/mcp-router.ts
@@ -123,6 +123,9 @@ Vault content is Obsidian Flavored Markdown. Write tools pass content through wi
           config,
         })
 
+        // @ts-expect-error — SDK type bug: StreamableHTTPServerTransport
+        // declares onclose as optional, but Transport requires it. onclose
+        // is assigned above; remove this when the SDK fixes the type.
         await server.connect(transport)
         await transport.handleRequest(req, res, body)
         if (transport.sessionId) {

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -90,14 +90,14 @@ export type VaultStats = {
 }
 
 export type SearchFilters = {
-  folder?: string
-  tags?: string[]
-  related?: string[]
-  type?: string
-  properties?: Record<string, string | number | boolean>
-  limit?: number
-  snippet_tokens?: number
-  include_leading_callout?: boolean
+  folder?: string | undefined
+  tags?: string[] | undefined
+  related?: string[] | undefined
+  type?: string | undefined
+  properties?: Record<string, string | number | boolean> | undefined
+  limit?: number | undefined
+  snippet_tokens?: number | undefined
+  include_leading_callout?: boolean | undefined
 }
 
 export type NoteRow = {
@@ -171,12 +171,21 @@ export type TaskEntry = {
  *  todo + in_progress — the Tasks plugin's own `not done` semantics, which
  *  exclude cancelled tasks. */
 export type TaskStatusFilter =
-  "not_done" | "todo" | "in_progress" | "done" | "cancelled" | "all"
+  | "not_done"
+  | "todo"
+  | "in_progress"
+  | "done"
+  | "cancelled"
+  | "all"
 
 /** Date bounds for one task date field. before/after are exclusive and on is
  *  an exact match — the Tasks plugin's query vocabulary. Dates are
  *  YYYY-MM-DD, so bounds compare lexicographically. */
-export type TaskDateFilter = { before?: string; on?: string; after?: string }
+export type TaskDateFilter = {
+  before?: string | undefined
+  on?: string | undefined
+  after?: string | undefined
+}
 
 /** Priority filter value — the five explicit levels plus "none" for tasks
  *  with no priority signifier. */
@@ -185,7 +194,13 @@ export type TaskPriorityFilter = TaskPriority | "none"
 /** Sort keys for listTasks. The five task dates and priority sort on the
  *  task's own metadata; note_mtime sorts on the owning note's modified time. */
 export type TaskSortKey =
-  "due" | "scheduled" | "start" | "created" | "done" | "priority" | "note_mtime"
+  | "due"
+  | "scheduled"
+  | "start"
+  | "created"
+  | "done"
+  | "priority"
+  | "note_mtime"
 
 /** listTasks response: tasks is the limit-capped page, total the full match
  *  count — so callers can tell "50 of 338" from "all 50". */

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -171,12 +171,7 @@ export type TaskEntry = {
  *  todo + in_progress — the Tasks plugin's own `not done` semantics, which
  *  exclude cancelled tasks. */
 export type TaskStatusFilter =
-  | "not_done"
-  | "todo"
-  | "in_progress"
-  | "done"
-  | "cancelled"
-  | "all"
+  "not_done" | "todo" | "in_progress" | "done" | "cancelled" | "all"
 
 /** Date bounds for one task date field. before/after are exclusive and on is
  *  an exact match — the Tasks plugin's query vocabulary. Dates are
@@ -194,13 +189,7 @@ export type TaskPriorityFilter = TaskPriority | "none"
 /** Sort keys for listTasks. The five task dates and priority sort on the
  *  task's own metadata; note_mtime sorts on the owning note's modified time. */
 export type TaskSortKey =
-  | "due"
-  | "scheduled"
-  | "start"
-  | "created"
-  | "done"
-  | "priority"
-  | "note_mtime"
+  "due" | "scheduled" | "start" | "created" | "done" | "priority" | "note_mtime"
 
 /** listTasks response: tasks is the limit-capped page, total the full match
  *  count — so callers can tell "50 of 338" from "all 50". */

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -111,7 +111,7 @@ const vectorSearch = async (
 
 export const fullTextSearch = (
   context: SearchQueryContext,
-  params: { query: string; filters?: SearchFilters },
+  params: { query: string; filters?: SearchFilters | undefined },
   logger: Logger,
 ): SearchResult[] => {
   // Build WHERE clause dynamically: each filter appends a condition + its bind params
@@ -229,7 +229,7 @@ export const fullTextSearch = (
  *  embeddings are available. */
 export const hybridSearch = async (
   context: SearchQueryContext,
-  params: { query: string; filters?: SearchFilters },
+  params: { query: string; filters?: SearchFilters | undefined },
   logger: Logger,
 ): Promise<HybridSearchResult> => {
   const userLimit = Math.max(0, Math.floor(params.filters?.limit ?? 20))
@@ -420,7 +420,11 @@ const tryRerank = async (params: {
 /** Finds notes with a specific tag. Supports hierarchical prefix matching. */
 export const searchByTag = (
   context: SearchQueryContext,
-  params: { tag: string; exactMatch?: boolean; limit?: number },
+  params: {
+    tag: string
+    exactMatch?: boolean | undefined
+    limit?: number | undefined
+  },
   logger: Logger,
 ): NoteMetadata[] => {
   const limit = Math.max(0, Math.floor(params.limit ?? 20))
@@ -453,7 +457,11 @@ export const searchByTag = (
 /** Lists notes in a folder, optionally including subfolders. */
 export const searchByFolder = (
   context: SearchQueryContext,
-  params: { folder: string; recursive?: boolean; limit?: number },
+  params: {
+    folder: string
+    recursive?: boolean | undefined
+    limit?: number | undefined
+  },
   logger: Logger,
 ): NoteMetadata[] => {
   const recursive = params.recursive ?? true
@@ -558,21 +566,21 @@ const TASK_ORDER_BY: Record<
 export const listTasks = (
   context: SearchQueryContext,
   params: {
-    status?: TaskStatusFilter
-    due?: TaskDateFilter
-    scheduled?: TaskDateFilter
-    start?: TaskDateFilter
-    done?: TaskDateFilter
-    created?: TaskDateFilter
-    cancelled?: TaskDateFilter
-    priority?: TaskPriorityFilter[]
-    folder?: string
-    tag?: string
-    heading?: string
-    path?: string
-    limit?: number
-    sortBy?: TaskSortKey
-    sortDirection?: "asc" | "desc"
+    status?: TaskStatusFilter | undefined
+    due?: TaskDateFilter | undefined
+    scheduled?: TaskDateFilter | undefined
+    start?: TaskDateFilter | undefined
+    done?: TaskDateFilter | undefined
+    created?: TaskDateFilter | undefined
+    cancelled?: TaskDateFilter | undefined
+    priority?: TaskPriorityFilter[] | undefined
+    folder?: string | undefined
+    tag?: string | undefined
+    heading?: string | undefined
+    path?: string | undefined
+    limit?: number | undefined
+    sortBy?: TaskSortKey | undefined
+    sortDirection?: "asc" | "desc" | undefined
   },
   logger: Logger,
 ): ListTasksResult => {
@@ -687,9 +695,10 @@ export const listTasks = (
   const limit = Math.max(0, Math.floor(params.limit ?? 50))
 
   const countRow = context.db
-    .prepare<unknown[], { total: number }>(
-      `SELECT COUNT(*) as total FROM tasks t JOIN notes n ON n.path = t.note_path ${whereClause}`,
-    )
+    .prepare<
+      unknown[],
+      { total: number }
+    >(`SELECT COUNT(*) as total FROM tasks t JOIN notes n ON n.path = t.note_path ${whereClause}`)
     .get(...queryParams)
   const total = countRow === undefined ? 0 : countRow.total
 
@@ -742,7 +751,10 @@ export const listAllTags = (
 /** Returns recently modified or created notes, sorted by chosen timestamp. */
 export const recentNotes = (
   context: SearchQueryContext,
-  params: { sort_by?: "created" | "modified"; limit?: number },
+  params: {
+    sort_by?: "created" | "modified" | undefined
+    limit?: number | undefined
+  },
   logger: Logger,
 ): NoteMetadata[] => {
   const sortBy = params.sort_by ?? "modified"
@@ -772,7 +784,7 @@ export const recentNotes = (
 /** Returns all frontmatter property keys with note counts and top 3 sample values. */
 export const listPropertyKeys = (
   context: SearchQueryContext,
-  params: { folder?: string },
+  params: { folder?: string | undefined },
   logger: Logger,
 ): PropertyKeyInfo[] => {
   const escapedFolder = params.folder
@@ -844,7 +856,11 @@ export const listPropertyKeys = (
 /** Returns distinct values for a given property key with note counts. */
 export const listPropertyValues = (
   context: SearchQueryContext,
-  params: { key: string; folder?: string; limit?: number },
+  params: {
+    key: string
+    folder?: string | undefined
+    limit?: number | undefined
+  },
   logger: Logger,
 ): PropertyValueCount[] => {
   const limit = Math.max(0, Math.floor(params.limit ?? 50))
@@ -898,7 +914,12 @@ export const listPropertyValues = (
 /** Finds notes where a frontmatter property matches a value (exact match). */
 export const searchByProperty = (
   context: SearchQueryContext,
-  params: { key: string; value: string; folder?: string; limit?: number },
+  params: {
+    key: string
+    value: string
+    folder?: string | undefined
+    limit?: number | undefined
+  },
   logger: Logger,
 ): NoteMetadata[] => {
   const limit = Math.max(0, Math.floor(params.limit ?? 20))
@@ -1045,7 +1066,7 @@ export const getOutgoingLinks = (
 /** Finds notes with no incoming links (orphans). */
 export const findOrphans = (
   context: SearchQueryContext,
-  params: { excludeFolders?: string[]; limit?: number },
+  params: { excludeFolders?: string[] | undefined; limit?: number | undefined },
   logger: Logger,
 ): NoteMetadata[] => {
   const excludeFolders = params.excludeFolders ?? []

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -697,10 +697,9 @@ export const listTasks = (
   const limit = Math.max(0, Math.floor(params.limit ?? 50))
 
   const countRow = context.db
-    .prepare<
-      unknown[],
-      { total: number }
-    >(`SELECT COUNT(*) as total FROM tasks t JOIN notes n ON n.path = t.note_path ${whereClause}`)
+    .prepare<unknown[], { total: number }>(
+      `SELECT COUNT(*) as total FROM tasks t JOIN notes n ON n.path = t.note_path ${whereClause}`,
+    )
     .get(...queryParams)
   const total = countRow === undefined ? 0 : countRow.total
 

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -1164,7 +1164,7 @@ export const brokenLinkCount = (
  *  (server-local day boundaries, governed by the TZ env var). */
 export const modifiedOnDate = (
   context: SearchQueryContext,
-  params: { date: string; limit?: number },
+  params: { date: string; limit?: number | undefined },
   logger: Logger,
 ): NoteMetadata[] => {
   const limit = Math.max(0, Math.floor(params.limit ?? 50))

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -538,6 +538,17 @@ const buildDateOrderBy = (
   return `${primary}, ${fallbacks}, n.mtime DESC`
 }
 
+/** Sort keys that default to descending — "most recent first" is the natural
+ *  view for "what did I start/create/finish lately?". The remaining keys
+ *  ("due", "scheduled") default ascending — soonest deadline first (overdue
+ *  triage). "priority" also defaults ascending (highest priority first). */
+const DESCENDING_BY_DEFAULT: ReadonlySet<string> = new Set([
+  "start",
+  "created",
+  "done",
+  "note_mtime",
+])
+
 /** ORDER BY fragment per sort key. Values are trusted SQL assembled from the
  *  whitelisted TaskSortKey union — never raw user input. Date keys cascade
  *  through related date columns so dateless tasks sort by the next available
@@ -675,15 +686,6 @@ export const listTasks = (
     conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
 
   const sortBy = params.sortBy ?? "due"
-  // "due" and "scheduled" default ascending — soonest deadline first
-  // (overdue triage). "start", "created", "done", and "note_mtime" default
-  // descending — most recent first ("what did I start/create/finish lately?").
-  const DESCENDING_BY_DEFAULT: ReadonlySet<string> = new Set([
-    "start",
-    "created",
-    "done",
-    "note_mtime",
-  ])
   const sortDirection =
     params.sortDirection ?? (DESCENDING_BY_DEFAULT.has(sortBy) ? "desc" : "asc")
   const orderBy = TASK_ORDER_BY[sortBy](

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -143,7 +143,7 @@ type DailyNoteResult = {
 /** Reads a daily note by date. Returns the resolved path, content
  *  (if the note exists), and an exists flag. */
 export const getDailyNote = async (
-  params: { vaultPath: string; date?: string },
+  params: { vaultPath: string; date?: string | undefined },
   logger: Logger,
 ): Promise<DailyNoteResult> => {
   const path = await getDailyNotePath(params.vaultPath, params.date)

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -98,10 +98,7 @@ export type MemoryFileOutline = Readonly<{
  *  (e.g. nudge the caller to fill in a new file's scope callout, or report
  *  that an identical entry already existed and nothing was written). */
 type UpdateMemoryOutcome =
-  | "created-file"
-  | "created-section"
-  | "appended"
-  | "unchanged"
+  "created-file" | "created-section" | "appended" | "unchanged"
 
 type ParsedSection = Readonly<{
   heading: string

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -98,7 +98,10 @@ export type MemoryFileOutline = Readonly<{
  *  (e.g. nudge the caller to fill in a new file's scope callout, or report
  *  that an identical entry already existed and nothing was written). */
 type UpdateMemoryOutcome =
-  "created-file" | "created-section" | "appended" | "unchanged"
+  | "created-file"
+  | "created-section"
+  | "appended"
+  | "unchanged"
 
 type ParsedSection = Readonly<{
   heading: string
@@ -359,7 +362,11 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
   // ── Exported functions ──────────────────────────────────────────
 
   const getMemory = async (
-    params: { vaultPath: string; file?: string; section?: string },
+    params: {
+      vaultPath: string
+      file?: string | undefined
+      section?: string | undefined
+    },
     logger: Logger,
   ): Promise<string> => {
     if (!params.file) {
@@ -423,8 +430,8 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       file: string
       section: string
       entry: string
-      date?: string
-      position?: "top" | "bottom"
+      date?: string | undefined
+      position?: "top" | "bottom" | undefined
     },
     logger: Logger,
   ): Promise<UpdateMemoryOutcome> => {

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -276,7 +276,7 @@ const readNoteSection = async (
     vaultPath: string
     path: string
     heading: string
-    headingLevel?: number
+    headingLevel?: number | undefined
   },
   logger: Logger,
 ): Promise<string> => {
@@ -317,7 +317,7 @@ const writeNote = async (
     vaultPath: string
     path: string
     body: string
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown> | undefined
   },
   logger: Logger,
 ): Promise<void> => {
@@ -422,7 +422,11 @@ const deleteNote = async (
 
 /** Lists .md files under a folder (or vault root). Supports glob filtering. */
 const listNotes = async (
-  params: { vaultPath: string; folder?: string; glob?: string },
+  params: {
+    vaultPath: string
+    folder?: string | undefined
+    glob?: string | undefined
+  },
   logger: Logger,
 ): Promise<string[]> => {
   const searchRoot = params.folder

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -151,8 +151,8 @@ const patchNote = async (
     path: string
     operation: Operation
     content: string
-    heading?: string
-    headingLevel?: number
+    heading?: string | undefined
+    headingLevel?: number | undefined
   },
   logger: Logger,
 ): Promise<string> => {
@@ -236,7 +236,7 @@ const replaceInNote = async (
     path: string
     oldText: string
     newText: string
-    replaceAllOccurrences?: boolean
+    replaceAllOccurrences?: boolean | undefined
   },
   logger: Logger,
 ): Promise<{ message: string; count: number }> => {
@@ -301,8 +301,8 @@ const deleteSpan = async (
     vaultPath: string
     path: string
     startAnchor: string
-    endAnchor?: string
-    firstMatch?: boolean
+    endAnchor?: string | undefined
+    firstMatch?: boolean | undefined
   },
   logger: Logger,
 ): Promise<string> => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "declaration": true
+    "declaration": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src/**/*.ts", "scripts/**/*.ts", "sst-env.d.ts"],
   "exclude": ["node_modules", "dist", ".sst"]


### PR DESCRIPTION
## Summary

- Enable `noImplicitOverride` (0 existing violations — free safety net for subclass overrides)
- Enable `exactOptionalPropertyTypes` (26 violations fixed — distinguishes "key absent" from "key present with value `undefined`")
- All 26 errors came from one pattern: Zod's `.optional()` produces `T | undefined`, but data-layer functions declared optional params as `key?: T`. Fixed by widening to `key?: T | undefined` — a type-only change, no runtime behavior change
- One `@ts-expect-error` for an MCP SDK type mismatch (`StreamableHTTPServerTransport.onclose` declared optional but `Transport` requires it)

## Test plan

- [x] `tsc --noEmit` passes clean
- [x] All 1484 tests pass
- [x] Lint clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten TypeScript type safety by enabling stricter compiler options and aligning search and vault operation parameter types with exact optional semantics.

Enhancements:
- Update search filter and vault operation parameter types to treat optional values as potentially undefined without changing runtime behavior.
- Adjust various type definitions and unions for improved clarity and compatibility with stricter TypeScript settings.
- Annotate MCP router transport connection with a ts-expect-error to document and accommodate an upstream SDK type inconsistency.

Build:
- Enable noImplicitOverride and exactOptionalPropertyTypes in tsconfig to enforce safer subclassing and precise optional property behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened TypeScript checking across the project for more consistent optional-field handling.
  * Updated several public search, note, and vault operation inputs to accept omitted values more reliably.
  * Added a type-safety note for an existing transport setup issue without changing behavior.
  * No runtime functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->