### PR TITLE
build: enable noUncheckedIndexedAccess

### DIFF
--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -52,6 +52,7 @@ export const verifyJwt = (token: string, secret: string): JwtPayload | null => {
   const parts = token.split(".")
   if (parts.length !== 3) return null
   const [header, payload, sig] = parts
+  if (!header || !payload || !sig) return null
 
   const expected = hmac(`${header}.${payload}`, secret)
 

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -347,7 +347,7 @@ describe("error handling", () => {
       isError?: boolean
     }
     expect(result.isError).toBe(true)
-    expect(result.content[0].text).toBe('note not found: "nonexistent.md"')
+    expect(result.content[0]?.text).toBe('note not found: "nonexistent.md"')
   })
 
   it("error text does not contain stack traces", async () => {
@@ -355,8 +355,8 @@ describe("error handling", () => {
     const result = (await handler({ path: "nonexistent.md" }, mockExtra)) as {
       content: Array<{ text: string }>
     }
-    expect(result.content[0].text).not.toContain("    at ")
-    expect(result.content[0].text).not.toContain("node:internal")
+    expect(result.content[0]?.text).not.toContain("    at ")
+    expect(result.content[0]?.text).not.toContain("node:internal")
   })
 
   it("vault_get_memory rejects section without file", async () => {
@@ -369,7 +369,7 @@ describe("error handling", () => {
       isError?: boolean
     }
     expect(result.isError).toBe(true)
-    expect(result.content[0].text).toBe("section requires a file")
+    expect(result.content[0]?.text).toBe("section requires a file")
   })
 
   it("vault_get_memory handler returns isError on failure", async () => {
@@ -382,7 +382,7 @@ describe("error handling", () => {
       isError?: boolean
     }
     expect(result.isError).toBe(true)
-    expect(result.content[0].text).toBe(
+    expect(result.content[0]?.text).toBe(
       'memory file not found: "About Me/Nonexistent.md"',
     )
   })
@@ -397,7 +397,7 @@ describe("error handling", () => {
       isError?: boolean
     }
     expect(result.isError).toBe(true)
-    expect(result.content[0].text).toBe(
+    expect(result.content[0]?.text).toBe(
       "outline, heading, and properties_only are mutually exclusive — set at most one",
     )
   })
@@ -412,7 +412,7 @@ describe("error handling", () => {
       isError?: boolean
     }
     expect(result.isError).toBe(true)
-    expect(result.content[0].text).toBe("heading_level requires a heading")
+    expect(result.content[0]?.text).toBe("heading_level requires a heading")
   })
 })
 
@@ -438,15 +438,15 @@ describe("vault_update_memory input schema", () => {
     "$field rejects an empty string and accepts a non-empty one",
     ({ field, validValue }) => {
       const schema = requireUpdateMemorySchema()
-      expect(schema[field].safeParse("").success).toBe(false)
-      expect(schema[field].safeParse(validValue).success).toBe(true)
+      expect(schema[field]?.safeParse("").success).toBe(false)
+      expect(schema[field]?.safeParse(validValue).success).toBe(true)
     },
   )
 
   it("options.date rejects an empty string and accepts a date", () => {
     const schema = requireUpdateMemorySchema()
-    expect(schema.options.safeParse({ date: "" }).success).toBe(false)
-    expect(schema.options.safeParse({ date: "2026-07-02" }).success).toBe(true)
+    expect(schema.options?.safeParse({ date: "" }).success).toBe(false)
+    expect(schema.options?.safeParse({ date: "2026-07-02" }).success).toBe(true)
   })
 })
 
@@ -493,7 +493,7 @@ describe("vault_update_memory handler", () => {
       isError?: boolean
     }
     expect(firstResult.isError).toBeUndefined()
-    expect(firstResult.content[0].text).toBe(
+    expect(firstResult.content[0]?.text).toBe(
       "Added entry to About Me/Principles.md → ## Decision heuristics (newest first)",
     )
 
@@ -503,7 +503,7 @@ describe("vault_update_memory handler", () => {
       isError?: boolean
     }
     expect(retryResult.isError).toBeUndefined()
-    expect(retryResult.content[0].text).toBe(
+    expect(retryResult.content[0]?.text).toBe(
       "Entry already exists in About Me/Principles.md → ## Decision heuristics (newest first) — nothing was written.",
     )
   })
@@ -657,7 +657,7 @@ describe("vault_list_tasks handler", () => {
       isError?: boolean
     }
     expect(result.isError).toBeUndefined()
-    const payload = JSON.parse(result.content[0].text) as {
+    const payload = JSON.parse(result.content[0]?.text ?? "") as {
       total: number
       tasks: Array<Record<string, unknown>>
     }
@@ -682,7 +682,7 @@ describe("vault_list_tasks handler", () => {
     const result = (await handler({}, mockExtra)) as {
       content: Array<{ text: string }>
     }
-    const payload = JSON.parse(result.content[0].text) as {
+    const payload = JSON.parse(result.content[0]?.text ?? "") as {
       tasks: Array<Record<string, unknown>>
     }
     // The whole-object match proves the empty/null-field filter drops only
@@ -707,7 +707,7 @@ describe("vault_list_tasks handler", () => {
       { status: "all", sort_by: "done", sort_direction: "desc" },
       mockExtra,
     )) as { content: Array<{ text: string }> }
-    const payload = JSON.parse(result.content[0].text) as {
+    const payload = JSON.parse(result.content[0]?.text ?? "") as {
       tasks: Array<{ description: string }>
     }
     // done DESC with dateless last: the completed card leads.
@@ -727,7 +727,7 @@ describe("vault_list_tasks handler", () => {
       isError?: boolean
     }
     expect(result.isError).toBe(true)
-    expect(result.content[0].text).toBe(
+    expect(result.content[0]?.text).toBe(
       'invalid due.before date: "not-a-date". Use YYYY-MM-DD (e.g. 2026-07-03).',
     )
   })
@@ -739,6 +739,9 @@ describe("vault_list_tasks handler", () => {
       isError?: boolean
     }
     expect(result.isError).toBeUndefined()
-    expect(JSON.parse(result.content[0].text)).toEqual({ total: 0, tasks: [] })
+    expect(JSON.parse(result.content[0]?.text ?? "")).toEqual({
+      total: 0,
+      tasks: [],
+    })
   })
 })

--- a/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
@@ -88,7 +88,7 @@ describe("parseHeadings", () => {
     ]
     // bodyEndLine absorbs the blank line before %% → ends at line 2.
     const headings = parseHeadings(lines)
-    expect(headings[0].bodyEndLine).toBe(2)
+    expect(headings[0]?.bodyEndLine).toBe(2)
   })
 
   it("returns an empty array when there are no headings", () => {

--- a/src/vault-mcp/obsidian-markdown/callouts.ts
+++ b/src/vault-mcp/obsidian-markdown/callouts.ts
@@ -45,6 +45,7 @@ const firstBodyLineIndex = (
 ): number => {
   if (index >= lines.length) return index
   const line = lines[index]
+  if (line === undefined) return index
   if (line.trim() === "") return firstBodyLineIndex(lines, index + 1, skippedH1)
   if (!skippedH1 && H1_REGEX.test(line))
     return firstBodyLineIndex(lines, index + 1, true)
@@ -75,14 +76,16 @@ export const parseLeadingCallout = (
   // Find where the first real body content begins (past blank lines + one H1).
   const cursor = firstBodyLineIndex(normalizedLines)
 
+  const openerLine = normalizedLines[cursor]
   const openerMatch =
-    cursor < normalizedLines.length
-      ? CALLOUT_OPENER_REGEX.exec(normalizedLines[cursor])
-      : null
+    openerLine !== undefined ? CALLOUT_OPENER_REGEX.exec(openerLine) : null
   if (!openerMatch) return null
 
-  const type = openerMatch[1].toLowerCase()
-  const title = openerMatch[3].trim()
+  const capturedType = openerMatch[1]
+  const capturedTitle = openerMatch[3]
+  if (capturedType === undefined || capturedTitle === undefined) return null
+  const type = capturedType.toLowerCase()
+  const title = capturedTitle.trim()
 
   // Body = consecutive `>` lines after the opener, until the next callout
   // opener (stacked callout), a non-blockquote line (incl. a blank line), or EOF.

--- a/src/vault-mcp/obsidian-markdown/callouts.ts
+++ b/src/vault-mcp/obsidian-markdown/callouts.ts
@@ -81,11 +81,11 @@ export const parseLeadingCallout = (
     openerLine !== undefined ? CALLOUT_OPENER_REGEX.exec(openerLine) : null
   if (!openerMatch) return null
 
-  const capturedType = openerMatch[1]
-  const capturedTitle = openerMatch[3]
-  if (capturedType === undefined || capturedTitle === undefined) return null
-  const type = capturedType.toLowerCase()
-  const title = capturedTitle.trim()
+  const matchedType = openerMatch[1]
+  const matchedTitle = openerMatch[3]
+  if (matchedType === undefined || matchedTitle === undefined) return null
+  const type = matchedType.toLowerCase()
+  const title = matchedTitle.trim()
 
   // Body = consecutive `>` lines after the opener, until the next callout
   // opener (stacked callout), a non-blockquote line (incl. a blank line), or EOF.

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -65,6 +65,7 @@ export const findTrailingCommentBlockStart = (
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
+    if (line === undefined) continue
 
     // Fence state advances only outside comments: inside a `%%` comment, `%%`
     // takes precedence and fence delimiters are just comment text (matching
@@ -88,7 +89,7 @@ export const findTrailingCommentBlockStart = (
       if (comment) {
         // Validate that the closer ends its own line — otherwise the block
         // isn't cleanly separable from body text and can't be preserved.
-        const validCloser = lines[i].trimEnd().endsWith(COMMENT_DELIMITER)
+        const validCloser = line.trimEnd().endsWith(COMMENT_DELIMITER)
         lastClosedBlock = validCloser
           ? { startLine: comment.openLine, endLine: i }
           : null
@@ -113,8 +114,10 @@ export const findTrailingCommentBlockStart = (
   if (!trailingBlock) return lines.length
 
   // The opener must start its own line.
+  const blockOpenerLine = lines[trailingBlock.startLine]
   if (
-    !lines[trailingBlock.startLine].trimStart().startsWith(COMMENT_DELIMITER)
+    blockOpenerLine === undefined ||
+    !blockOpenerLine.trimStart().startsWith(COMMENT_DELIMITER)
   ) {
     return lines.length
   }
@@ -154,14 +157,16 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
       }
 
       const match = HEADING_REGEX.exec(line)
-      if (match) {
+      const matchedHashes = match?.[1]
+      const matchedText = match?.[2]
+      if (matchedHashes !== undefined && matchedText !== undefined) {
         return {
           headings: [
             ...state.headings,
             {
               // Strip trailing closing hashes (e.g. "## Title ##" → "Title")
-              text: match[2].replace(/\s+#+\s*$/, "").trim(),
-              level: match[1].length,
+              text: matchedText.replace(/\s+#+\s*$/, "").trim(),
+              level: matchedHashes.length,
               startLine: i,
             },
           ],
@@ -224,7 +229,10 @@ export const findHeading = (
     const matchedHeadings = matches
       .map((h) => `${"#".repeat(h.level)} ${h.text} (line ${h.startLine + 1})`)
       .join(", ")
-    const allSameLevel = matches.every((h) => h.level === matches[0].level)
+    const firstMatch = matches[0]
+    const allSameLevel =
+      firstMatch !== undefined &&
+      matches.every((h) => h.level === firstMatch.level)
     const hint = allSameLevel
       ? "Rename one heading to make it unique, or use vault_replace_in_note to target by text."
       : "Use heading_level to disambiguate."
@@ -233,5 +241,9 @@ export const findHeading = (
     )
   }
 
-  return matches[0]
+  const result = matches[0]
+  if (result === undefined) {
+    throw new Error(`heading not found: "${searchText}"`)
+  }
+  return result
 }

--- a/src/vault-mcp/obsidian-markdown/tasks.ts
+++ b/src/vault-mcp/obsidian-markdown/tasks.ts
@@ -252,11 +252,6 @@ type TaskMetadata = Pick<
  *  well-formed line finishes in one pass; 20 covers any field permutation. */
 const MAX_STRIPPING_PASSES = 20
 
-/** Strips metadata fields off the end of a task body, mirroring the plugin's
- *  deserialize(): each pass tries every field regex (all `$`-anchored) and
- *  removes what matches; the loop repeats until a pass matches nothing. Tags
- *  interleaved with signifiers are stripped too, then re-appended, so they
- *  stay part of the description without blocking fields to their left. */
 /** Extracts a regex capture group, throwing if absent. Capture groups are
  *  guaranteed by the engine when the regex matches, but noUncheckedIndexedAccess
  *  adds `| undefined` to all indexed access. */
@@ -268,6 +263,11 @@ const matchedText = (match: RegExpExecArray, index: number): string => {
   return value
 }
 
+/** Strips metadata fields off the end of a task body, mirroring the plugin's
+ *  deserialize(): each pass tries every field regex (all `$`-anchored) and
+ *  removes what matches; the loop repeats until a pass matches nothing. Tags
+ *  interleaved with signifiers are stripped too, then re-appended, so they
+ *  stay part of the description without blocking fields to their left. */
 const parseTaskMetadata = (taskBody: string): TaskMetadata => {
   // The stripping loop is inherently sequential — every match shortens the
   // line and later passes depend on it — so mutable locals thread the parser

--- a/src/vault-mcp/obsidian-markdown/tasks.ts
+++ b/src/vault-mcp/obsidian-markdown/tasks.ts
@@ -257,6 +257,17 @@ const MAX_STRIPPING_PASSES = 20
  *  removes what matches; the loop repeats until a pass matches nothing. Tags
  *  interleaved with signifiers are stripped too, then re-appended, so they
  *  stay part of the description without blocking fields to their left. */
+/** Extracts a regex capture group, throwing if absent. Capture groups are
+ *  guaranteed by the engine when the regex matches, but noUncheckedIndexedAccess
+ *  adds `| undefined` to all indexed access. */
+const matchedText = (match: RegExpExecArray, index: number): string => {
+  const value = match[index]
+  if (value === undefined) {
+    throw new Error(`expected capture group ${index}`)
+  }
+  return value
+}
+
 const parseTaskMetadata = (taskBody: string): TaskMetadata => {
   // The stripping loop is inherently sequential — every match shortens the
   // line and later passes depend on it — so mutable locals thread the parser
@@ -295,7 +306,7 @@ const parseTaskMetadata = (taskBody: string): TaskMetadata => {
     key: (typeof DATE_FIELDS)[number]["key"],
   ): void => {
     extractField(regex, (match) => {
-      dates[key] = match[1]
+      dates[key] = matchedText(match, 1)
     })
   }
 
@@ -303,10 +314,10 @@ const parseTaskMetadata = (taskBody: string): TaskMetadata => {
     matchedThisPass = false
 
     extractField(EMOJI_PRIORITY_RE, (match) => {
-      priority = PRIORITY_BY_EMOJI[match[1]] ?? priority
+      priority = PRIORITY_BY_EMOJI[matchedText(match, 1)] ?? priority
     })
     extractField(DATAVIEW_PRIORITY_RE, (match) => {
-      priority = PRIORITY_BY_WORD[match[1]] ?? priority
+      priority = PRIORITY_BY_WORD[matchedText(match, 1)] ?? priority
     })
 
     for (const field of DATE_FIELDS) {
@@ -315,17 +326,17 @@ const parseTaskMetadata = (taskBody: string): TaskMetadata => {
     }
 
     extractField(EMOJI_RECURRENCE_RE, (match) => {
-      recurrence = match[1].trim()
+      recurrence = matchedText(match, 1).trim()
     })
     extractField(DATAVIEW_RECURRENCE_RE, (match) => {
-      recurrence = match[1].trim()
+      recurrence = matchedText(match, 1).trim()
     })
 
     extractField(EMOJI_ON_COMPLETION_RE, (match) => {
-      onCompletion = match[1]
+      onCompletion = matchedText(match, 1)
     })
     extractField(DATAVIEW_ON_COMPLETION_RE, (match) => {
-      onCompletion = match[1]
+      onCompletion = matchedText(match, 1)
     })
 
     // Tags may be mixed among the signifiers (`desc #a 📅 2026-01-01 #b`);
@@ -333,23 +344,23 @@ const parseTaskMetadata = (taskBody: string): TaskMetadata => {
     // them to the description after the loop. Right-to-left matching means
     // each stripped tag is prepended to keep the original order.
     extractField(HASHTAG_FROM_END_RE, (match) => {
-      const tagText = match[0].trim()
+      const tagText = matchedText(match, 0).trim()
       trailingTags =
         trailingTags === "" ? tagText : `${tagText} ${trailingTags}`
     })
 
     extractField(EMOJI_ID_RE, (match) => {
-      taskId = match[1].trim()
+      taskId = matchedText(match, 1).trim()
     })
     extractField(DATAVIEW_ID_RE, (match) => {
-      taskId = match[1].trim()
+      taskId = matchedText(match, 1).trim()
     })
 
     extractField(EMOJI_DEPENDS_ON_RE, (match) => {
-      dependsOn = splitIdSequence(match[1])
+      dependsOn = splitIdSequence(matchedText(match, 1))
     })
     extractField(DATAVIEW_DEPENDS_ON_RE, (match) => {
-      dependsOn = splitIdSequence(match[1])
+      dependsOn = splitIdSequence(matchedText(match, 1))
     })
 
     if (!matchedThisPass) break
@@ -430,6 +441,7 @@ const extractTasks = (rawContent: string): ParsedTask[] => {
   let openFence: OpenFence = null
   for (let lineIndex = 0; lineIndex < bodyLines.length; lineIndex++) {
     const lineText = bodyLines[lineIndex]
+    if (lineText === undefined) continue
     const fenceResult = advanceFence(lineText, openFence)
     const lineIsCode = fenceResult.isFenceDelimiter || openFence !== null
     openFence = fenceResult.openFence
@@ -438,12 +450,12 @@ const extractTasks = (rawContent: string): ParsedTask[] => {
     const taskLineMatch = TASK_LINE_RE.exec(lineText)
     if (taskLineMatch === null) continue
 
-    const statusChar = taskLineMatch[1]
+    const statusChar = matchedText(taskLineMatch, 1)
     // The block link sits at the absolute end of the line — strip it before
     // metadata parsing, exactly as the plugin does.
-    const bodyWithBlockLink = taskLineMatch[2]
+    const bodyWithBlockLink = matchedText(taskLineMatch, 2)
     const blockLinkMatch = BLOCK_LINK_RE.exec(bodyWithBlockLink)
-    const blockId = blockLinkMatch === null ? null : blockLinkMatch[1]
+    const blockId = blockLinkMatch === null ? null : (blockLinkMatch[1] ?? null)
     const taskBody =
       blockLinkMatch === null
         ? bodyWithBlockLink

--- a/src/vault-mcp/search/__tests__/chunker.test.ts
+++ b/src/vault-mcp/search/__tests__/chunker.test.ts
@@ -18,7 +18,7 @@ describe("chunkNoteContent", () => {
     it("prefixes the chunk with the note title", () => {
       const chunks = chunkNoteContent("Title", "Body content.")
 
-      expect(chunks[0].text).toBe("Title\n\nBody content.")
+      expect(chunks[0]?.text).toBe("Title\n\nBody content.")
     })
 
     it("returns a single chunk for exactly 499 tokens", () => {
@@ -41,7 +41,7 @@ describe("chunkNoteContent", () => {
       const chunks = chunkNoteContent("Title", "")
 
       expect(chunks).toHaveLength(1)
-      expect(chunks[0].text).toBe("Title")
+      expect(chunks[0]?.text).toBe("Title")
     })
   })
 
@@ -81,8 +81,8 @@ describe("chunkNoteContent", () => {
 
       // Total tokens > 500 → heading-based path, preamble becomes its own chunk
       expect(chunks).toHaveLength(2)
-      expect(chunks[0].text).toContain("preamble0")
-      expect(chunks[0].text).toContain("preamble299")
+      expect(chunks[0]?.text).toContain("preamble0")
+      expect(chunks[0]?.text).toContain("preamble299")
     })
   })
 
@@ -142,18 +142,18 @@ describe("chunkNoteContent", () => {
       const body = `Some text with [[Target|display text]] and more ${generateTokens(10)}`
       const chunks = chunkNoteContent("Note", body)
 
-      expect(chunks[0].text).toContain("display text")
-      expect(chunks[0].text).not.toContain("[[")
+      expect(chunks[0]?.text).toContain("display text")
+      expect(chunks[0]?.text).not.toContain("[[")
     })
 
     it("strips bold/italic markers in chunk text", () => {
       const body = `This has **bold** and *italic* text ${generateTokens(10)}`
       const chunks = chunkNoteContent("Note", body)
 
-      expect(chunks[0].text).toContain("bold")
-      expect(chunks[0].text).toContain("italic")
-      expect(chunks[0].text).not.toContain("**")
-      expect(chunks[0].text).not.toContain("*italic*")
+      expect(chunks[0]?.text).toContain("bold")
+      expect(chunks[0]?.text).toContain("italic")
+      expect(chunks[0]?.text).not.toContain("**")
+      expect(chunks[0]?.text).not.toContain("*italic*")
     })
 
     it("strips heading markers in chunk text", () => {

--- a/src/vault-mcp/search/__tests__/file-watcher.test.ts
+++ b/src/vault-mcp/search/__tests__/file-watcher.test.ts
@@ -73,7 +73,7 @@ describe("file-watcher", () => {
     )
     const results = index.fullTextSearch({ query: "watcher" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("test.md")
+    expect(results[0]?.path).toBe("test.md")
   })
 
   it("re-indexes a modified file", { timeout: 15000 }, async () => {
@@ -221,7 +221,7 @@ describe("file-watcher", () => {
     )
     const results = index.fullTextSearch({ query: "polled" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("polled.md")
+    expect(results[0]?.path).toBe("polled.md")
   })
 })
 
@@ -256,7 +256,7 @@ describe("startFileWatcher — chokidar watch options", () => {
     onTestFinished(() => watchMock.mockRestore())
     await startFileWatcher("/vault", index, watcherOptions)
     expect(watchMock).toHaveBeenCalledTimes(1)
-    return watchMock.mock.calls[0][1] as Record<string, unknown>
+    return watchMock.mock.calls[0]?.[1] as Record<string, unknown>
   }
 
   it("defaults to native events (usePolling false) with no interval when unset", async () => {

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -461,14 +461,9 @@ describe("fullTextSearch", () => {
       { query: "burnout", filters: { snippet_tokens: 60 } },
       logger,
     )
-    expect(short).toHaveLength(1)
-    expect(long).toHaveLength(1)
-    const shortEntry = short[0]
-    const longEntry = long[0]
-    if (shortEntry === undefined || longEntry === undefined) {
-      throw new Error("expected search results")
-    }
-    expect(longEntry.snippet.length).toBeGreaterThan(shortEntry.snippet.length)
+    expect(long[0]?.snippet?.length).toBeGreaterThan(
+      short[0]?.snippet?.length ?? 0,
+    )
   })
 
   it("respects folder filter", () => {
@@ -1129,9 +1124,7 @@ describe("listPropertyKeys", () => {
     for (let i = 1; i < keys.length; i++) {
       const prev = keys[i - 1]
       const curr = keys[i]
-      if (prev === undefined || curr === undefined) {
-        throw new Error(`unexpected undefined at index ${i}`)
-      }
+      if (prev === undefined || curr === undefined) continue
       expect(prev.count).toBeGreaterThanOrEqual(curr.count)
     }
   })
@@ -1218,9 +1211,7 @@ describe("listPropertyValues", () => {
     for (let i = 1; i < values.length; i++) {
       const prev = values[i - 1]
       const curr = values[i]
-      if (prev === undefined || curr === undefined) {
-        throw new Error(`unexpected undefined at index ${i}`)
-      }
+      if (prev === undefined || curr === undefined) continue
       expect(prev.count).toBeGreaterThanOrEqual(curr.count)
     }
   })
@@ -3058,14 +3049,9 @@ the Lightsail budget estimates for next quarter.
 
       expect(search_mode).toBe("hybrid")
       expect(results).toHaveLength(2)
-      const firstResult = results[0]
-      const secondResult = results[1]
-      if (firstResult === undefined || secondResult === undefined) {
-        throw new Error("expected 2 hybrid results")
-      }
       // a.md appears in both FTS and vector → higher RRF score → ranked first
-      expect(firstResult.path).toBe("a.md")
-      expect(firstResult.score).toBeGreaterThan(secondResult.score)
+      expect(results[0]?.path).toBe("a.md")
+      expect(results[0]?.score).toBeGreaterThan(results[1]?.score ?? 0)
     })
 
     it("includes vector-only results with full metadata", async () => {

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -104,7 +104,7 @@ describe("leading callout", () => {
       logger,
     )
     const results = index.searchByFolder({ folder: "About Me" }, logger)
-    expect(results[0].leading_callout).toEqual({
+    expect(results[0]?.leading_callout).toEqual({
       type: "info",
       title: "Scope of this file",
       body: "**Contains:** identity facts.\n**Convention:** append newest first.",
@@ -121,7 +121,7 @@ describe("leading callout", () => {
       logger,
     )
     const results = index.searchByFolder({ folder: "notes" }, logger)
-    expect(results[0].leading_callout).toBeNull()
+    expect(results[0]?.leading_callout).toBeNull()
   })
 
   it("omits the callout from fullTextSearch by default, includes it on request", () => {
@@ -136,13 +136,13 @@ describe("leading callout", () => {
 
     const withoutFlag = index.fullTextSearch({ query: "burnout" }, logger)
     expect(withoutFlag).toHaveLength(1)
-    expect(withoutFlag[0].leading_callout).toBeUndefined()
+    expect(withoutFlag[0]?.leading_callout).toBeUndefined()
 
     const withFlag = index.fullTextSearch(
       { query: "burnout", filters: { include_leading_callout: true } },
       logger,
     )
-    expect(withFlag[0].leading_callout?.title).toBe("Scope of this file")
+    expect(withFlag[0]?.leading_callout?.title).toBe("Scope of this file")
   })
 
   it("adds the leading_callout column to a pre-existing notes table (warm-DB migration)", async () => {
@@ -178,8 +178,8 @@ describe("leading callout", () => {
       ),
     ).not.toThrow()
     const results = warmIndex.searchByFolder({ folder: "About Me" }, logger)
-    expect(results[0].leading_callout?.title).toBe("Scope of this file")
-    expect(results[0].bytes).toBe(100)
+    expect(results[0]?.leading_callout?.title).toBe("Scope of this file")
+    expect(results[0]?.bytes).toBe(100)
   })
 })
 
@@ -194,7 +194,7 @@ describe("bytes", () => {
       logger,
     )
     const results = index.searchByFolder({ folder: "notes" }, logger)
-    expect(results[0].bytes).toBe(42)
+    expect(results[0]?.bytes).toBe(42)
   })
 
   it("includes bytes in full text search results", () => {
@@ -207,7 +207,7 @@ describe("bytes", () => {
       logger,
     )
     const results = index.fullTextSearch({ query: "searchable" }, logger)
-    expect(results[0].bytes).toBe(256)
+    expect(results[0]?.bytes).toBe(256)
   })
 
   it("includes bytes in recent notes results", () => {
@@ -220,7 +220,7 @@ describe("bytes", () => {
       logger,
     )
     const results = index.recentNotes({}, logger)
-    expect(results[0].bytes).toBe(128)
+    expect(results[0]?.bytes).toBe(128)
   })
 
   it("stores and retrieves a bytes value of 0", () => {
@@ -233,7 +233,7 @@ describe("bytes", () => {
       logger,
     )
     const results = index.searchByFolder({ folder: "notes" }, logger)
-    expect(results[0].bytes).toBe(0)
+    expect(results[0]?.bytes).toBe(0)
   })
 })
 
@@ -249,9 +249,9 @@ describe("upsertNote", () => {
     )
     const results = index.fullTextSearch({ query: "burnout" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("About Me/Principles.md")
-    expect(results[0].title).toBe("Principles")
-    expect(results[0].tags).toEqual(["principles", "self"])
+    expect(results[0]?.path).toBe("About Me/Principles.md")
+    expect(results[0]?.title).toBe("Principles")
+    expect(results[0]?.tags).toEqual(["principles", "self"])
   })
 
   it("extracts title from frontmatter", () => {
@@ -264,7 +264,7 @@ describe("upsertNote", () => {
       logger,
     )
     const results = index.searchByFolder({ folder: "About Me" }, logger)
-    expect(results[0].title).toBe("Principles")
+    expect(results[0]?.title).toBe("Principles")
   })
 
   it("falls back to filename for title when no frontmatter title", () => {
@@ -277,7 +277,7 @@ describe("upsertNote", () => {
       logger,
     )
     const results = index.searchByFolder({ folder: "notes" }, logger)
-    expect(results[0].title).toBe("random")
+    expect(results[0]?.title).toBe("random")
   })
 
   it("stores folder as first path segment", () => {
@@ -290,7 +290,7 @@ describe("upsertNote", () => {
       logger,
     )
     const results = index.searchByFolder({ folder: "About Me" }, logger)
-    expect(results[0].folder).toBe("About Me")
+    expect(results[0]?.folder).toBe("About Me")
   })
 
   it("stores empty folder for root-level notes", () => {
@@ -303,7 +303,7 @@ describe("upsertNote", () => {
       logger,
     )
     const recent = index.recentNotes({}, logger)
-    expect(recent[0].folder).toBe("")
+    expect(recent[0]?.folder).toBe("")
   })
 
   it("updates existing note on re-index", () => {
@@ -325,7 +325,7 @@ describe("upsertNote", () => {
     )
     const results = index.fullTextSearch({ query: "new content" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].title).toBe("V2")
+    expect(results[0]?.title).toBe("V2")
   })
 
   it("handles notes with no frontmatter", () => {
@@ -339,7 +339,7 @@ describe("upsertNote", () => {
     )
     const results = index.fullTextSearch({ query: "plain text" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].tags).toEqual([])
+    expect(results[0]?.tags).toEqual([])
   })
 
   it("normalizes tags to array when given as string", () => {
@@ -408,7 +408,7 @@ describe("fullTextSearch", () => {
   it("finds notes by content keyword", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("About Me/Principles.md")
+    expect(results[0]?.path).toBe("About Me/Principles.md")
   })
 
   it("finds notes by title", () => {
@@ -418,19 +418,20 @@ describe("fullTextSearch", () => {
 
   it("returns snippets without HTML markup", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
-    expect(results[0].snippet).not.toContain("<mark>")
-    expect(results[0].snippet).toContain("burnout")
+    expect(results[0]?.snippet).not.toContain("<mark>")
+    expect(results[0]?.snippet).toContain("burnout")
   })
 
   it("includes type in search results", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
-    expect(results[0].type).toBe("about-me")
+    expect(results[0]?.type).toBe("about-me")
   })
 
   it("rounds score to at most 4 significant figures", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
-    const score = results[0].score
-    expect(score).toBe(Number(score.toPrecision(4)))
+    const score = results[0]?.score
+    expect(score).toBeDefined()
+    expect(score).toBe(Number(score?.toPrecision(4)))
   })
 
   it("omits created when null", () => {
@@ -442,13 +443,13 @@ describe("fullTextSearch", () => {
   it("includes created when present", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
     expect(results[0]).toHaveProperty("created")
-    expect(results[0].created).toContain("2025")
+    expect(results[0]?.created).toContain("2025")
   })
 
   it("returns modified as ISO 8601 string", () => {
     const results = index.fullTextSearch({ query: "burnout" }, logger)
-    expect(typeof results[0].modified).toBe("string")
-    expect(results[0].modified).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(typeof results[0]?.modified).toBe("string")
+    expect(results[0]?.modified).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 
   it("respects custom snippet_tokens", () => {
@@ -460,7 +461,9 @@ describe("fullTextSearch", () => {
       { query: "burnout", filters: { snippet_tokens: 60 } },
       logger,
     )
-    expect(long[0].snippet.length).toBeGreaterThan(short[0].snippet.length)
+    expect(long[0]?.snippet?.length).toBeGreaterThan(
+      short[0]?.snippet?.length ?? 0,
+    )
   })
 
   it("respects folder filter", () => {
@@ -469,7 +472,7 @@ describe("fullTextSearch", () => {
       logger,
     )
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("Projects/notes.md")
+    expect(results[0]?.path).toBe("Projects/notes.md")
   })
 
   it("strips trailing slashes from folder filter before matching", () => {
@@ -478,7 +481,7 @@ describe("fullTextSearch", () => {
       logger,
     )
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("Projects/notes.md")
+    expect(results[0]?.path).toBe("Projects/notes.md")
   })
 
   it("respects tags filter", () => {
@@ -487,7 +490,7 @@ describe("fullTextSearch", () => {
       logger,
     )
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("Projects/notes.md")
+    expect(results[0]?.path).toBe("Projects/notes.md")
   })
 
   it("respects type filter", () => {
@@ -531,7 +534,7 @@ describe("fullTextSearch", () => {
       logger,
     )
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("About Me/Principles.md")
+    expect(results[0]?.path).toBe("About Me/Principles.md")
   })
 
   it("multi-word query does not require exact phrase adjacency", () => {
@@ -545,7 +548,7 @@ describe("fullTextSearch", () => {
     )
     const results = index.fullTextSearch({ query: "alpha beta" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("spread.md")
+    expect(results[0]?.path).toBe("spread.md")
   })
 
   it("exact phrase match with quotes", () => {
@@ -597,7 +600,7 @@ describe("fullTextSearch", () => {
     )
     const results = index.fullTextSearch({ query: "flux-capacitor" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("project.md")
+    expect(results[0]?.path).toBe("project.md")
   })
 
   it("dotted query matches content containing the dotted term", () => {
@@ -619,7 +622,7 @@ describe("fullTextSearch", () => {
     )
     const results = index.fullTextSearch({ query: "mcpservers.org" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("directories.md")
+    expect(results[0]?.path).toBe("directories.md")
   })
 
   it("query with stray punctuation does not throw", () => {
@@ -696,39 +699,39 @@ describe("metadata search", () => {
   it("finds a note by a type value that appears only in frontmatter", () => {
     const results = index.fullTextSearch({ query: "blueprint" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("garden/layout.md")
+    expect(results[0]?.path).toBe("garden/layout.md")
   })
 
   it("finds a note by a status value that appears only in frontmatter", () => {
     const results = index.fullTextSearch({ query: "overdue" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("garden/fence.md")
+    expect(results[0]?.path).toBe("garden/fence.md")
   })
 
   it("finds a note by a tag that appears only in frontmatter", () => {
     const results = index.fullTextSearch({ query: "xeriscaping" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("garden/layout.md")
+    expect(results[0]?.path).toBe("garden/layout.md")
   })
 
   it("finds a note by a frontmatter key name", () => {
     const results = index.fullTextSearch({ query: "lifecycle" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("garden/layout.md")
+    expect(results[0]?.path).toBe("garden/layout.md")
   })
 
   it("cross-field query matches a frontmatter term + body term together", () => {
     const results = index.fullTextSearch({ query: "compost gypsum" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("garden/notes.md")
+    expect(results[0]?.path).toBe("garden/notes.md")
   })
 
   it("snippet contains body text, not metadata, for a frontmatter-only match", () => {
     const results = index.fullTextSearch({ query: "overdue" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].snippet).not.toContain("status")
-    expect(results[0].snippet).not.toContain("overdue")
-    expect(results[0].snippet).toContain("rotted posts")
+    expect(results[0]?.snippet).not.toContain("status")
+    expect(results[0]?.snippet).not.toContain("overdue")
+    expect(results[0]?.snippet).toContain("rotted posts")
   })
 
   it("does not match notes that lack the queried frontmatter term", () => {
@@ -769,7 +772,7 @@ describe("metadata search", () => {
 
     const results = warmIndex.fullTextSearch({ query: "xeriscaping" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("garden/layout.md")
+    expect(results[0]?.path).toBe("garden/layout.md")
   })
 })
 
@@ -820,7 +823,7 @@ describe("searchByTag", () => {
       logger,
     )
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("a.md")
+    expect(results[0]?.path).toBe("a.md")
   })
 
   it("returns empty for non-existent tag", () => {
@@ -895,7 +898,7 @@ describe("searchByFolder", () => {
       logger,
     )
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("About Me/Principles.md")
+    expect(results[0]?.path).toBe("About Me/Principles.md")
   })
 
   it("sorts results by most recently modified", () => {
@@ -957,7 +960,7 @@ describe("listAllTags", () => {
     expect(tags).toHaveLength(3)
     const results = index.fullTextSearch({ query: "no tags" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("bare.md")
+    expect(results[0]?.path).toBe("bare.md")
   })
 })
 
@@ -991,20 +994,20 @@ describe("recentNotes", () => {
 
   it("sorts by modified by default", () => {
     const results = index.recentNotes({}, logger)
-    expect(results[0].path).toBe("new.md")
-    expect(results[1].path).toBe("no-created.md")
-    expect(results[2].path).toBe("old.md")
+    expect(results[0]?.path).toBe("new.md")
+    expect(results[1]?.path).toBe("no-created.md")
+    expect(results[2]?.path).toBe("old.md")
   })
 
   it("sorts by created date", () => {
     const results = index.recentNotes({ sort_by: "created" }, logger)
-    expect(results[0].path).toBe("new.md")
-    expect(results[1].path).toBe("old.md")
+    expect(results[0]?.path).toBe("new.md")
+    expect(results[1]?.path).toBe("old.md")
   })
 
   it("puts nulls last for created sort", () => {
     const results = index.recentNotes({ sort_by: "created" }, logger)
-    expect(results[results.length - 1].path).toBe("no-created.md")
+    expect(results[results.length - 1]?.path).toBe("no-created.md")
   })
 
   it("respects limit", () => {
@@ -1119,7 +1122,10 @@ describe("listPropertyKeys", () => {
   it("sorts by count descending", () => {
     const keys = index.listPropertyKeys({}, logger)
     for (let i = 1; i < keys.length; i++) {
-      expect(keys[i - 1].count).toBeGreaterThanOrEqual(keys[i].count)
+      const prev = keys[i - 1]
+      const curr = keys[i]
+      if (prev === undefined || curr === undefined) continue
+      expect(prev.count).toBeGreaterThanOrEqual(curr.count)
     }
   })
 
@@ -1203,7 +1209,10 @@ describe("listPropertyValues", () => {
   it("sorts by count descending", () => {
     const values = index.listPropertyValues({ key: "tags" }, logger)
     for (let i = 1; i < values.length; i++) {
-      expect(values[i - 1].count).toBeGreaterThanOrEqual(values[i].count)
+      const prev = values[i - 1]
+      const curr = values[i]
+      if (prev === undefined || curr === undefined) continue
+      expect(prev.count).toBeGreaterThanOrEqual(curr.count)
     }
   })
 
@@ -1270,7 +1279,7 @@ describe("searchByProperty", () => {
       logger,
     )
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("Projects/active.md")
+    expect(results[0]?.path).toBe("Projects/active.md")
   })
 
   it("finds notes by array property value", () => {
@@ -1279,7 +1288,7 @@ describe("searchByProperty", () => {
       logger,
     )
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("Projects/active.md")
+    expect(results[0]?.path).toBe("Projects/active.md")
   })
 
   it("returns NoteMetadata with all fields", () => {
@@ -1289,13 +1298,14 @@ describe("searchByProperty", () => {
     )
     expect(results).toHaveLength(1)
     const result = results[0]
-    expect(result.path).toBe("Projects/done.md")
-    expect(result.title).toBe("Done Project")
-    expect(result.tags).toEqual(["project", "done"])
-    expect(result.folder).toBe("Projects")
-    expect(result.type).toBe("project")
-    expect(result.bytes).toBe(100)
-    expect(result.properties).toEqual(
+    expect(result).toBeDefined()
+    expect(result?.path).toBe("Projects/done.md")
+    expect(result?.title).toBe("Done Project")
+    expect(result?.tags).toEqual(["project", "done"])
+    expect(result?.folder).toBe("Projects")
+    expect(result?.type).toBe("project")
+    expect(result?.bytes).toBe(100)
+    expect(result?.properties).toEqual(
       expect.objectContaining({ status: "done", priority: "low" }),
     )
   })
@@ -1330,7 +1340,7 @@ describe("searchByProperty", () => {
       logger,
     )
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("Projects/active.md")
+    expect(results[0]?.path).toBe("Projects/active.md")
   })
 
   it("respects limit", () => {
@@ -1363,7 +1373,7 @@ describe("searchByProperty", () => {
       logger,
     )
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("dated.md")
+    expect(results[0]?.path).toBe("dated.md")
   })
 })
 
@@ -1437,7 +1447,7 @@ describe("rebuildFromVault", () => {
     await index.rebuildFromVault({ vaultPath: vaultDir }, logger)
     const results = index.fullTextSearch({ query: "burnout" }, logger)
     expect(results).toHaveLength(1)
-    expect(results[0].path).toBe("About Me/Principles.md")
+    expect(results[0]?.path).toBe("About Me/Principles.md")
   })
 
   it("resolves a frontmatter wikilink whose target is indexed later (forward reference)", async () => {
@@ -1457,7 +1467,7 @@ describe("rebuildFromVault", () => {
     await index.rebuildFromVault({ vaultPath: vaultDir }, logger)
     const backlinks = index.getBacklinks({ path: "z-target.md" }, logger)
     expect(backlinks).toHaveLength(1)
-    expect(backlinks[0].path).toBe("a-source.md")
+    expect(backlinks[0]?.path).toBe("a-source.md")
   })
 
   it("does not count extensionless wikilinks to non-md files as broken", async () => {
@@ -1780,13 +1790,13 @@ describe("getBacklinks", () => {
   it("finds notes linking to the target", () => {
     const backlinks = index.getBacklinks({ path: "spoke-a.md" }, logger)
     expect(backlinks).toHaveLength(1)
-    expect(backlinks[0].path).toBe("hub.md")
+    expect(backlinks[0]?.path).toBe("hub.md")
   })
 
   it("finds backlinks from notes that link to the target", () => {
     const backlinks = index.getBacklinks({ path: "hub.md" }, logger)
     expect(backlinks).toHaveLength(1)
-    expect(backlinks[0].path).toBe("spoke-a.md")
+    expect(backlinks[0]?.path).toBe("spoke-a.md")
   })
 
   it("returns empty for notes with no backlinks", () => {
@@ -1796,12 +1806,12 @@ describe("getBacklinks", () => {
 
   it("includes title in results", () => {
     const backlinks = index.getBacklinks({ path: "spoke-a.md" }, logger)
-    expect(backlinks[0].title).toBe("hub")
+    expect(backlinks[0]?.title).toBe("hub")
   })
 
   it("includes bytes in results", () => {
     const backlinks = index.getBacklinks({ path: "spoke-a.md" }, logger)
-    expect(backlinks[0].bytes).toBe(100)
+    expect(backlinks[0]?.bytes).toBe(100)
   })
 })
 
@@ -2024,7 +2034,7 @@ describe("forward reference resolution", () => {
 
     const backlinks = index.getBacklinks({ path: "target.md" }, logger)
     expect(backlinks).toHaveLength(1)
-    expect(backlinks[0].path).toBe("source.md")
+    expect(backlinks[0]?.path).toBe("source.md")
   })
 
   it("re-resolves a full-path forward reference when the target is created later", () => {
@@ -2056,7 +2066,7 @@ describe("forward reference resolution", () => {
     )
     const backlinks = index.getBacklinks({ path: "folder/target.md" }, logger)
     expect(backlinks).toHaveLength(1)
-    expect(backlinks[0].path).toBe("source.md")
+    expect(backlinks[0]?.path).toBe("source.md")
   })
 
   it("re-resolves a relative ../ forward reference when the target is created later", () => {
@@ -2118,9 +2128,9 @@ describe("frontmatter links in the graph", () => {
     )
     const links = index.getOutgoingLinks({ path: "session.md" }, logger)
     expect(links).toHaveLength(1)
-    expect(links[0].path).toBe("task-board.md")
-    expect(links[0].exists).toBe(true)
-    expect(links[0].kind).toBe("note")
+    expect(links[0]?.path).toBe("task-board.md")
+    expect(links[0]?.exists).toBe(true)
+    expect(links[0]?.kind).toBe("note")
   })
 
   it("surfaces a frontmatter-only source in getBacklinks", () => {
@@ -2143,7 +2153,7 @@ describe("frontmatter links in the graph", () => {
     )
     const backlinks = index.getBacklinks({ path: "task-board.md" }, logger)
     expect(backlinks).toHaveLength(1)
-    expect(backlinks[0].path).toBe("session.md")
+    expect(backlinks[0]?.path).toBe("session.md")
   })
 
   it("does not flag a frontmatter-referenced note as an orphan, but still flags a truly unreferenced one", () => {
@@ -2201,7 +2211,7 @@ describe("frontmatter links in the graph", () => {
     )
     const backlinks = index.getBacklinks({ path: "shared.md" }, logger)
     expect(backlinks).toHaveLength(1)
-    expect(backlinks[0].path).toBe("double.md")
+    expect(backlinks[0]?.path).toBe("double.md")
   })
 })
 
@@ -3040,8 +3050,8 @@ the Lightsail budget estimates for next quarter.
       expect(search_mode).toBe("hybrid")
       expect(results).toHaveLength(2)
       // a.md appears in both FTS and vector → higher RRF score → ranked first
-      expect(results[0].path).toBe("a.md")
-      expect(results[0].score).toBeGreaterThan(results[1].score)
+      expect(results[0]?.path).toBe("a.md")
+      expect(results[0]?.score).toBeGreaterThan(results[1]?.score ?? 0)
     })
 
     it("includes vector-only results with full metadata", async () => {
@@ -3682,7 +3692,9 @@ This is a note with many words that should be truncated when using a small snipp
       await rerankIndex.hybridSearch({ query: "career goals" }, logger)
 
       expect(mockReranker.rerankPairs).toHaveBeenCalledOnce()
-      const [query, documents] = mockReranker.rerankPairs.mock.calls[0]
+      const callArgs = mockReranker.rerankPairs.mock.calls[0]
+      expect(callArgs).toBeDefined()
+      const [query, documents] = callArgs ?? []
       expect(query).toBe("career goals")
       expect(documents).toHaveLength(2)
       // Each document text should be non-empty (chunk text from vector hits)

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -461,9 +461,14 @@ describe("fullTextSearch", () => {
       { query: "burnout", filters: { snippet_tokens: 60 } },
       logger,
     )
-    expect(long[0]?.snippet?.length).toBeGreaterThan(
-      short[0]?.snippet?.length ?? 0,
-    )
+    expect(short).toHaveLength(1)
+    expect(long).toHaveLength(1)
+    const shortEntry = short[0]
+    const longEntry = long[0]
+    if (shortEntry === undefined || longEntry === undefined) {
+      throw new Error("expected search results")
+    }
+    expect(longEntry.snippet.length).toBeGreaterThan(shortEntry.snippet.length)
   })
 
   it("respects folder filter", () => {
@@ -1124,7 +1129,9 @@ describe("listPropertyKeys", () => {
     for (let i = 1; i < keys.length; i++) {
       const prev = keys[i - 1]
       const curr = keys[i]
-      if (prev === undefined || curr === undefined) continue
+      if (prev === undefined || curr === undefined) {
+        throw new Error(`unexpected undefined at index ${i}`)
+      }
       expect(prev.count).toBeGreaterThanOrEqual(curr.count)
     }
   })
@@ -1211,7 +1218,9 @@ describe("listPropertyValues", () => {
     for (let i = 1; i < values.length; i++) {
       const prev = values[i - 1]
       const curr = values[i]
-      if (prev === undefined || curr === undefined) continue
+      if (prev === undefined || curr === undefined) {
+        throw new Error(`unexpected undefined at index ${i}`)
+      }
       expect(prev.count).toBeGreaterThanOrEqual(curr.count)
     }
   })
@@ -3049,9 +3058,14 @@ the Lightsail budget estimates for next quarter.
 
       expect(search_mode).toBe("hybrid")
       expect(results).toHaveLength(2)
+      const firstResult = results[0]
+      const secondResult = results[1]
+      if (firstResult === undefined || secondResult === undefined) {
+        throw new Error("expected 2 hybrid results")
+      }
       // a.md appears in both FTS and vector → higher RRF score → ranked first
-      expect(results[0]?.path).toBe("a.md")
-      expect(results[0]?.score).toBeGreaterThan(results[1]?.score ?? 0)
+      expect(firstResult.path).toBe("a.md")
+      expect(firstResult.score).toBeGreaterThan(secondResult.score)
     })
 
     it("includes vector-only results with full metadata", async () => {

--- a/src/vault-mcp/search/chunker.ts
+++ b/src/vault-mcp/search/chunker.ts
@@ -106,7 +106,11 @@ export const chunkNoteContent = (
   }
 
   // Content before the first heading (preamble)
-  const preambleLines = bodyLines.slice(0, headings[0].startLine)
+  const firstHeading = headings[0]
+  if (firstHeading === undefined) {
+    return toChunks(splitLargeText(strippedBody), noteTitle)
+  }
+  const preambleLines = bodyLines.slice(0, firstHeading.startLine)
   const preambleText = stripMarkdownSyntax(preambleLines.join("\n")).trim()
 
   const rawSections: string[] = []

--- a/src/vault-mcp/search/reranker.ts
+++ b/src/vault-mcp/search/reranker.ts
@@ -160,6 +160,9 @@ export const blendScores = (params: {
   return normalizedRrf.map((rrfNorm, index) => {
     const rerankNorm = normalizedRerank[index]
     const rank = params.rrfRanks[index]
+    if (rerankNorm === undefined || rank === undefined) {
+      throw new Error(`score array length mismatch at index ${index}`)
+    }
 
     const rrfWeight = rank <= 3 ? 0.75 : rank <= 10 ? 0.5 : 0.4
     const rerankWeight = 1 - rrfWeight

--- a/src/vault-mcp/search/reranker.ts
+++ b/src/vault-mcp/search/reranker.ts
@@ -108,8 +108,13 @@ export const createReranker = (logger: Logger) => {
       })
       const output = await crossEncoder.model(inputs)
       // output.logits is a Tensor [1, 1] — a single relevance score per pair.
-      const logit = Number(output.logits.data[0])
-      scores.push(logit)
+      // Number() accepts `any`, so it would silently convert an undefined
+      // indexed access to NaN — extract and guard explicitly.
+      const logitValue = output.logits.data[0]
+      if (logitValue === undefined) {
+        throw new Error("reranker output tensor has no data")
+      }
+      scores.push(Number(logitValue))
     }
 
     return scores

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -397,10 +397,13 @@ const tryRerank = async (params: {
 
     const blendedScores = blendScores({ rrfScores, rerankScores, rrfRanks })
 
-    const scoredResults = params.mergedResults.map((result, index) => ({
-      ...result,
-      score: blendedScores[index],
-    }))
+    const scoredResults = params.mergedResults.map((result, index) => {
+      const score = blendedScores[index]
+      if (score === undefined) {
+        throw new Error(`blended score missing at index ${index}`)
+      }
+      return { ...result, score }
+    })
 
     return {
       results: scoredResults.sort(

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -1076,8 +1076,8 @@ describe("listMemoryFiles", () => {
   it("returns outlines sorted by filename", async () => {
     const outlines = await listMemoryFiles({ vaultPath: vault }, logger)
     expect(outlines).toHaveLength(2)
-    expect(outlines[0].file).toBe("Opinions")
-    expect(outlines[1].file).toBe("Principles")
+    expect(outlines[0]?.file).toBe("Opinions")
+    expect(outlines[1]?.file).toBe("Principles")
   })
 
   it("includes byte size per file", async () => {
@@ -1090,8 +1090,8 @@ describe("listMemoryFiles", () => {
 
   it("uses frontmatter title", async () => {
     const outlines = await listMemoryFiles({ vaultPath: vault }, logger)
-    expect(outlines[0].title).toBe("Opinions — About Me")
-    expect(outlines[1].title).toBe("Principles — About Me")
+    expect(outlines[0]?.title).toBe("Opinions — About Me")
+    expect(outlines[1]?.title).toBe("Principles — About Me")
   })
 
   it("surfaces each file's leading scope callout (null when absent)", async () => {
@@ -1180,7 +1180,7 @@ describe("listMemoryFiles", () => {
     const h1s = principles.headings.filter((heading) => heading.level === 1)
     const h2s = principles.headings.filter((heading) => heading.level === 2)
     expect(h1s).toHaveLength(1)
-    expect(h1s[0].text).toBe("Principles")
+    expect(h1s[0]?.text).toBe("Principles")
     expect(h2s).toHaveLength(3)
   })
 

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -121,7 +121,8 @@ const countDatedEntries = (
 ): number => {
   let count = 0
   for (let lineIndex = start; lineIndex < end; lineIndex++) {
-    if (ENTRY_PATTERN.test(lines[lineIndex])) count += 1
+    const entryLine = lines[lineIndex]
+    if (entryLine !== undefined && ENTRY_PATTERN.test(entryLine)) count += 1
   }
   return count
 }
@@ -725,9 +726,13 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         }
 
         // Remove the single matched line, preserving everything before and after it
+        const matchIndex = matchingIndices[0]
+        if (matchIndex === undefined) {
+          throw new Error("expected at least one matching index")
+        }
         const updatedLines = [
-          ...lines.slice(0, matchingIndices[0]),
-          ...lines.slice(matchingIndices[0] + 1),
+          ...lines.slice(0, matchIndex),
+          ...lines.slice(matchIndex + 1),
         ]
 
         const newContent = updatedLines.join("\n")

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -139,7 +139,13 @@ const resolveAnchorLine = (params: {
       `ambiguous ${role} anchor in "${path}": "${truncateForMessage(anchor)}" matches ${matchingLineIndices.length} lines${regionSuffix}. Use a longer, unique anchor, or set first_match: true.`,
     )
   }
-  return matchingLineIndices[0]
+  const matchedIndex = matchingLineIndices[0]
+  if (matchedIndex === undefined) {
+    throw new Error(
+      `${role} anchor not found in "${path}"${regionSuffix}: "${truncateForMessage(anchor)}"`,
+    )
+  }
+  return matchedIndex
 }
 
 // ── Exported functions ──────────────────────────────────────────

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "isolatedModules": true,
     "declaration": true,
     "noImplicitOverride": true,
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*.ts", "scripts/**/*.ts", "sst-env.d.ts"],
   "exclude": ["node_modules", "dist", ".sst"]


### PR DESCRIPTION
## Summary

- Enable `noUncheckedIndexedAccess` — every `array[index]` and `obj[key]` now returns `T | undefined`, forcing explicit narrowing before use
- Fixes 167 errors across 16 files (9 production, 7 test)
- Production: runtime guards on array access after length checks TS can't track, regex capture group access, and parallel-array map indexing
- Tests: optional chaining on indexed array access in assertions (`results[0]?.path`)
- `matchedText()` helper in tasks.ts centralizes regex capture group narrowing for 14 extraction callbacks

## Test plan

- [x] `tsc --noEmit` passes clean (0 errors)
- [x] All 1484 tests pass
- [x] Lint clean (0 errors, 300 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable stricter TypeScript indexed access checking and update code and tests for safer handling of potentially missing array and object elements.

New Features:
- Require noUncheckedIndexedAccess in the TypeScript compiler configuration to treat indexed access results as potentially undefined.

Enhancements:
- Introduce a matchedText helper to enforce presence of regex capture groups when parsing task metadata.
- Add defensive checks around array and string access in markdown parsing, search reranking, memory operations, and vault patching to avoid undefined-index usage.
- Tighten JWT verification by validating all token segments before computing the HMAC.

Tests:
- Update search, chunking, markdown parsing, tool-definition, memory-store, and file-watcher tests to use optional chaining and guard against undefined results where arrays are indexed.