### PR TITLE
fix(search): cascade sort uses per-field default directions + add position sort

### DIFF
--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -740,6 +740,7 @@ Example: vault_list_tasks({ due: { before: "2026-07-04" } }) — overdue triage;
 Example: vault_list_tasks({ folder: "Code Projects/vault-cortex", heading: "Active" }) — one project's Active Kanban lane
 Example: vault_list_tasks({ status: "done", done: { after: "2026-06-26" } }) — what got completed this week
 Example: vault_list_tasks({ priority: ["highest", "high"], sort_by: "priority" }) — most urgent open work first
+Example: vault_list_tasks({ path: "TASKS.md", sort_by: "position" }) — tasks in file order (Kanban card position)
 
 When to use: Any vault-wide task triage question — "what's overdue?", "what's open per project?", "what did I finish this week?" — in one call instead of per-board reads.
 Prefer vault_read_note (heading mode) to read one specific board lane verbatim. Prefer vault_search for full-text queries over note content.
@@ -749,7 +750,7 @@ Parameters:
 - due / scheduled / start / done / created / cancelled: date filters, each { before, on, after } in YYYY-MM-DD — before/after are exclusive, on is exact. A date filter only matches tasks that HAVE that date.
 - priority: array of "highest" | "high" | "medium" | "low" | "lowest" | "none", OR-combined ("none" = tasks with no priority signifier).
 - folder: note path prefix (e.g. "Code Projects/vault-cortex"). tag: bare inline-task-tag name; a parent tag matches children ("errand" matches "errand/groceries"). heading: exact heading text, case-sensitive (a Kanban lane name). path: one note, must end in ".md".
-- sort_by: "due" (default) | "scheduled" | "start" | "created" | "done" | "priority" | "note_mtime". Date sorts put dateless tasks last in both directions and cascade through related dates when the primary date is null — due falls through to scheduled → start → created, so a task with no due date but a scheduled date still sorts meaningfully. Fully dateless tasks tie-break by note modified time (most recent first), then file position. Priority sorts highest→lowest with unprioritized between medium and low. sort_direction defaults to "asc" for due and scheduled (soonest deadline first), "desc" for start, created, done, and note_mtime (most recent first).
+- sort_by: "due" (default) | "scheduled" | "start" | "created" | "done" | "priority" | "note_mtime" | "position". Date sorts put dateless tasks last in both directions and cascade through related dates when the primary is absent — due falls through to scheduled → start → created. Each cascade step uses its own natural direction (due/scheduled ascending, start/created descending), so a task with no due date but a created date sorts newest-first rather than inheriting due's ascending order. An explicit sort_direction overrides all cascade steps uniformly. Fully dateless tasks tie-break by note modified time (most recent first), then file position. Priority sorts highest→lowest with unprioritized between medium and low. "position" sorts by file path then line number — the natural order for Kanban boards where card position IS priority.
 - limit: max results (default 50). The total field always reports the full match count, so "50 of 338" is distinguishable from "all 50".
 
 Errors:
@@ -823,16 +824,17 @@ Returns: JSON { total, tasks }. Each task carries: path, line (1-based file line
             "done",
             "priority",
             "note_mtime",
+            "position",
           ])
           .optional()
           .describe(
-            'Sort key (default "due" — ascending, dateless tasks last)',
+            'Sort key (default "due"). Date sorts cascade through related fields when the primary is absent; each fallback uses its own natural direction. "position" sorts by file path then line number — the natural order for Kanban boards.',
           ),
         sort_direction: z
           .enum(["asc", "desc"])
           .optional()
           .describe(
-            'Sort direction (default "asc" for due/scheduled, "desc" for start/created/done/note_mtime)',
+            'Sort direction. Default per field: "asc" for due/scheduled/position, "desc" for start/created/done/note_mtime. Within a date cascade, each fallback uses its own default; an explicit value overrides all fields uniformly.',
           ),
       },
       annotations: {

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -750,7 +750,7 @@ Parameters:
 - due / scheduled / start / done / created / cancelled: date filters, each { before, on, after } in YYYY-MM-DD — before/after are exclusive, on is exact. A date filter only matches tasks that HAVE that date.
 - priority: array of "highest" | "high" | "medium" | "low" | "lowest" | "none", OR-combined ("none" = tasks with no priority signifier).
 - folder: note path prefix (e.g. "Code Projects/vault-cortex"). tag: bare inline-task-tag name; a parent tag matches children ("errand" matches "errand/groceries"). heading: exact heading text, case-sensitive (a Kanban lane name). path: one note, must end in ".md".
-- sort_by: "due" (default) | "scheduled" | "start" | "created" | "done" | "priority" | "note_mtime" | "position". Date sorts put dateless tasks last in both directions and cascade through related dates when the primary is absent — due falls through to scheduled → start → created. Each cascade step uses its own natural direction (due/scheduled ascending, start/created descending), so a task with no due date but a created date sorts newest-first rather than inheriting due's ascending order. An explicit sort_direction overrides all cascade steps uniformly. Fully dateless tasks tie-break by note modified time (most recent first), then file position. Priority sorts highest→lowest with unprioritized between medium and low. "position" sorts by file path then line number — the natural order for Kanban boards where card position IS priority.
+- sort_by: "due" (default) | "scheduled" | "start" | "created" | "done" | "priority" | "note_mtime" | "position". Date sorts put dateless tasks last in both directions and cascade through related dates when the primary is absent — due falls through to scheduled → start → created; scheduled, start, and created cascade similarly through the remaining date fields. Each cascade step uses its own natural direction (due/scheduled ascending, start/created descending), so a task with no due date but a created date sorts newest-first rather than inheriting due's ascending order. An explicit sort_direction overrides all cascade steps uniformly. "done" does not cascade — it sorts by done date alone, with a modified-time tiebreaker for undated tasks. Fully dateless tasks tie-break by note modified time (most recent first), then file position. Priority sorts highest→lowest with unprioritized between medium and low. "position" sorts by file path then line number — the natural order for Kanban boards where card position IS priority.
 - limit: max results (default 50). The total field always reports the full match count, so "50 of 338" is distinguishable from "all 50".
 
 Errors:
@@ -834,7 +834,7 @@ Returns: JSON { total, tasks }. Each task carries: path, line (1-based file line
           .enum(["asc", "desc"])
           .optional()
           .describe(
-            'Sort direction. Default per field: "asc" for due/scheduled/position, "desc" for start/created/done/note_mtime. Within a date cascade, each fallback uses its own default; an explicit value overrides all fields uniformly.',
+            'Sort direction. Default per field: "asc" for due/scheduled/priority/position, "desc" for start/created/done/note_mtime. Within a date cascade, each fallback uses its own default; an explicit value overrides all fields uniformly.',
           ),
       },
       annotations: {

--- a/src/vault-mcp/search/__tests__/task-queries.test.ts
+++ b/src/vault-mcp/search/__tests__/task-queries.test.ts
@@ -71,11 +71,12 @@ describe("task indexing lifecycle", () => {
 
     const result = index.listTasks({ status: "all" }, logger)
     expect(result.total).toBe(4)
+    // Due-dated first (ASC), then scheduled, then created-only (DESC — newest first).
     expect(result.tasks.map((entry) => entry.description)).toEqual([
       "Fix login bug",
       "Write tests",
-      "Ship release",
       "Old idea",
+      "Ship release",
     ])
   })
 
@@ -334,11 +335,12 @@ describe("listTasks status filter", () => {
   it("returns every status with status: all", () => {
     const index = indexWithBoard()
     const result = index.listTasks({ status: "all" }, logger)
+    // Created-only tasks sort DESC (newest first): Old idea (2026-06-02) before Ship release (2026-06-01).
     expect(result.tasks.map((entry) => entry.status)).toEqual([
       "todo",
       "in_progress",
-      "done",
       "cancelled",
+      "done",
     ])
   })
 })
@@ -621,9 +623,10 @@ describe("listTasks scope filters", () => {
   it("filters by heading (Kanban lane), excluding other lanes", () => {
     const index = indexWithBoardAndPlain()
     const result = index.listTasks({ status: "all", heading: "Done" }, logger)
+    // Created-only tasks sort DESC (newest first): Old idea (2026-06-02) before Ship release (2026-06-01).
     expect(result.tasks.map((entry) => entry.description)).toEqual([
-      "Ship release",
       "Old idea",
+      "Ship release",
     ])
   })
 
@@ -857,5 +860,206 @@ describe("listTasks sorting and paging", () => {
       "Due middle",
     ])
     expect(result.total).toBe(4)
+  })
+
+  it("cascade uses each fallback field's own default direction when sort_direction is omitted", () => {
+    const index = createTestIndex()
+    index.upsertNote(
+      {
+        filePath: "cascade-dir.md",
+        rawContent: [
+          "- [ ] Old created only ➕ 2026-01-15",
+          "- [ ] New created only ➕ 2026-07-06",
+          "- [ ] Has due 📅 2026-08-01 ➕ 2026-06-01",
+        ].join("\n"),
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    // Default sort_by: "due", no explicit direction.
+    // Due-dated tasks sort first (ASC — due's default).
+    // Created-only tasks sort second, but DESC (created's default) — newest first.
+    const result = index.listTasks({}, logger)
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Has due",
+      "New created only",
+      "Old created only",
+    ])
+  })
+
+  it("explicit sort_direction overrides cascade to a uniform direction", () => {
+    const index = createTestIndex()
+    index.upsertNote(
+      {
+        filePath: "cascade-explicit.md",
+        rawContent: [
+          "- [ ] Old created only ➕ 2026-01-15",
+          "- [ ] New created only ➕ 2026-07-06",
+          "- [ ] Has due 📅 2026-08-01 ➕ 2026-06-01",
+        ].join("\n"),
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    // Explicit ASC overrides all cascade steps — created-only tasks sort ASC (oldest first).
+    const result = index.listTasks({ sortDirection: "asc" }, logger)
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Has due",
+      "Old created only",
+      "New created only",
+    ])
+  })
+
+  it("cascade direction applies to start fallback (DESC default) within a due cascade", () => {
+    const index = createTestIndex()
+    index.upsertNote(
+      {
+        filePath: "start-cascade.md",
+        rawContent: [
+          "- [ ] Old start 🛫 2026-06-01",
+          "- [ ] New start 🛫 2026-07-05",
+          "- [ ] Has due 📅 2026-07-10",
+        ].join("\n"),
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    // Due-dated first (ASC), then start-only tasks sort DESC (start's default) — newest first.
+    const result = index.listTasks({}, logger)
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Has due",
+      "New start",
+      "Old start",
+    ])
+  })
+
+  it("start cascade uses per-field defaults (both start and created default DESC)", () => {
+    const index = createTestIndex()
+    index.upsertNote(
+      {
+        filePath: "start-sort.md",
+        rawContent: [
+          "- [ ] Has start 🛫 2026-07-01",
+          "- [ ] Old created only ➕ 2026-01-01",
+          "- [ ] New created only ➕ 2026-07-06",
+        ].join("\n"),
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    // sort_by: "start" cascades to [due, scheduled, created].
+    // start defaults DESC — most recently started first.
+    // created also defaults DESC — newest created first.
+    const result = index.listTasks({ sortBy: "start" }, logger)
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Has start",
+      "New created only",
+      "Old created only",
+    ])
+  })
+
+  it("sorts by position (file path then line number) within a single note", () => {
+    const index = createTestIndex()
+    index.upsertNote(
+      {
+        filePath: "board.md",
+        rawContent: [
+          "## Active",
+          "- [ ] First card ➕ 2026-07-06",
+          "- [ ] Second card ➕ 2026-07-01",
+          "## Done",
+          "- [x] Third card ➕ 2026-06-01 ✅ 2026-06-28",
+        ].join("\n"),
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    const result = index.listTasks(
+      { path: "board.md", status: "all", sortBy: "position" },
+      logger,
+    )
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "First card",
+      "Second card",
+      "Third card",
+    ])
+  })
+
+  it("position sort groups by file path across multiple notes", () => {
+    const index = createTestIndex()
+    index.upsertNote(
+      {
+        filePath: "b-note.md",
+        rawContent: "- [ ] B task",
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    index.upsertNote(
+      {
+        filePath: "a-note.md",
+        rawContent: "- [ ] A task",
+        fileStat: testStat(2000),
+      },
+      logger,
+    )
+    // Position sort orders by path ASC, so a-note before b-note regardless of mtime.
+    const result = index.listTasks({ sortBy: "position" }, logger)
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "A task",
+      "B task",
+    ])
+  })
+
+  it("position sort with explicit desc reverses file and line order", () => {
+    const index = createTestIndex()
+    index.upsertNote(
+      {
+        filePath: "board.md",
+        rawContent: ["- [ ] First line", "- [ ] Second line"].join("\n"),
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    const result = index.listTasks(
+      { path: "board.md", sortBy: "position", sortDirection: "desc" },
+      logger,
+    )
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Second line",
+      "First line",
+    ])
+  })
+
+  it("position sort with heading filter returns lane tasks in file order", () => {
+    const index = createTestIndex()
+    index.upsertNote(
+      {
+        filePath: "kanban.md",
+        rawContent: [
+          "---",
+          "kanban-plugin: board",
+          "---",
+          "## Active",
+          "- [ ] Third priority ➕ 2026-07-01",
+          "- [ ] First priority ➕ 2026-07-06",
+          "- [ ] Second priority ➕ 2026-07-03",
+          "## Done",
+          "- [x] Completed ➕ 2026-06-01 ✅ 2026-06-28",
+        ].join("\n"),
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    // Position sort preserves the file order — the user arranged these cards intentionally.
+    const result = index.listTasks(
+      { heading: "Active", sortBy: "position" },
+      logger,
+    )
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Third priority",
+      "First priority",
+      "Second priority",
+    ])
   })
 })

--- a/src/vault-mcp/search/__tests__/task-queries.test.ts
+++ b/src/vault-mcp/search/__tests__/task-queries.test.ts
@@ -960,13 +960,16 @@ describe("listTasks sorting and paging", () => {
 
   it("sorts by position (file path then line number) within a single note", () => {
     const index = createTestIndex()
+    // Created dates intentionally disagree with line order — Second card is
+    // newest, so a created-DESC fallback would produce [Second, First, Third],
+    // proving the sort is genuinely by line number.
     index.upsertNote(
       {
         filePath: "board.md",
         rawContent: [
           "## Active",
-          "- [ ] First card ➕ 2026-07-06",
-          "- [ ] Second card ➕ 2026-07-01",
+          "- [ ] First card ➕ 2026-07-01",
+          "- [ ] Second card ➕ 2026-07-06",
           "## Done",
           "- [x] Third card ➕ 2026-06-01 ✅ 2026-06-28",
         ].join("\n"),
@@ -987,11 +990,14 @@ describe("listTasks sorting and paging", () => {
 
   it("position sort groups by file path across multiple notes", () => {
     const index = createTestIndex()
+    // b-note has a higher mtime so the default due-cascade tiebreaker (mtime
+    // DESC) would put it first — position ASC puts a-note first instead,
+    // proving the sort is genuinely by path.
     index.upsertNote(
       {
         filePath: "b-note.md",
         rawContent: "- [ ] B task",
-        fileStat: testStat(1000),
+        fileStat: testStat(5000),
       },
       logger,
     )
@@ -999,11 +1005,10 @@ describe("listTasks sorting and paging", () => {
       {
         filePath: "a-note.md",
         rawContent: "- [ ] A task",
-        fileStat: testStat(2000),
+        fileStat: testStat(1000),
       },
       logger,
     )
-    // Position sort orders by path ASC, so a-note before b-note regardless of mtime.
     const result = index.listTasks({ sortBy: "position" }, logger)
     expect(result.tasks.map((entry) => entry.description)).toEqual([
       "A task",

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -171,7 +171,12 @@ export type TaskEntry = {
  *  todo + in_progress — the Tasks plugin's own `not done` semantics, which
  *  exclude cancelled tasks. */
 export type TaskStatusFilter =
-  "not_done" | "todo" | "in_progress" | "done" | "cancelled" | "all"
+  | "not_done"
+  | "todo"
+  | "in_progress"
+  | "done"
+  | "cancelled"
+  | "all"
 
 /** Date bounds for one task date field. before/after are exclusive and on is
  *  an exact match — the Tasks plugin's query vocabulary. Dates are
@@ -189,7 +194,14 @@ export type TaskPriorityFilter = TaskPriority | "none"
 /** Sort keys for listTasks. The five task dates and priority sort on the
  *  task's own metadata; note_mtime sorts on the owning note's modified time. */
 export type TaskSortKey =
-  "due" | "scheduled" | "start" | "created" | "done" | "priority" | "note_mtime"
+  | "due"
+  | "scheduled"
+  | "start"
+  | "created"
+  | "done"
+  | "priority"
+  | "note_mtime"
+  | "position"
 
 /** listTasks response: tasks is the limit-capped page, total the full match
  *  count — so callers can tell "50 of 338" from "all 50". */

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -192,7 +192,8 @@ export type TaskDateFilter = {
 export type TaskPriorityFilter = TaskPriority | "none"
 
 /** Sort keys for listTasks. The five task dates and priority sort on the
- *  task's own metadata; note_mtime sorts on the owning note's modified time. */
+ *  task's own metadata; note_mtime sorts on the owning note's modified time;
+ *  position sorts by file path then line number (Kanban card order). */
 export type TaskSortKey =
   | "due"
   | "scheduled"

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -171,12 +171,7 @@ export type TaskEntry = {
  *  todo + in_progress — the Tasks plugin's own `not done` semantics, which
  *  exclude cancelled tasks. */
 export type TaskStatusFilter =
-  | "not_done"
-  | "todo"
-  | "in_progress"
-  | "done"
-  | "cancelled"
-  | "all"
+  "not_done" | "todo" | "in_progress" | "done" | "cancelled" | "all"
 
 /** Date bounds for one task date field. before/after are exclusive and on is
  *  an exact match — the Tasks plugin's query vocabulary. Dates are

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -717,10 +717,9 @@ export const listTasks = (
   const limit = Math.max(0, Math.floor(params.limit ?? 50))
 
   const countRow = context.db
-    .prepare<
-      unknown[],
-      { total: number }
-    >(`SELECT COUNT(*) as total FROM tasks t JOIN notes n ON n.path = t.note_path ${whereClause}`)
+    .prepare<unknown[], { total: number }>(
+      `SELECT COUNT(*) as total FROM tasks t JOIN notes n ON n.path = t.note_path ${whereClause}`,
+    )
     .get(...queryParams)
   const total = countRow === undefined ? 0 : countRow.total
 

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -579,8 +579,8 @@ const TASK_ORDER_BY: Record<
     `CASE t.priority WHEN 'highest' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 4 WHEN 'lowest' THEN 5 ELSE 3 END ${direction ?? "ASC"}`,
   note_mtime: (direction) => `n.mtime ${direction ?? "DESC"}`,
   position: (direction) => {
-    const d = direction ?? "ASC"
-    return `n.path ${d}, t.line ${d}`
+    const sortDirection = direction ?? "ASC"
+    return `n.path ${sortDirection}, t.line ${sortDirection}`
   },
 }
 

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -522,18 +522,26 @@ const DATE_CASCADE: Record<string, readonly string[]> = {
 
 /** Builds a cascaded ORDER BY for a date sort key: primary date column, then
  *  each fallback date column (all with NULL-last), then note mtime descending
- *  as a recency tiebreaker for fully dateless tasks. */
+ *  as a recency tiebreaker for fully dateless tasks.
+ *
+ *  When explicitDirection is provided the caller asked for a uniform direction
+ *  — every column sorts that way. When undefined each column uses its own
+ *  natural default so the cascade doesn't force ASC-defaulting fields onto
+ *  DESC-defaulting fallbacks (or vice-versa). */
 const buildDateOrderBy = (
   column: string,
-  direction: "ASC" | "DESC",
+  explicitDirection: "ASC" | "DESC" | undefined,
 ): string => {
+  const directionFor = (col: string): "ASC" | "DESC" =>
+    explicitDirection ?? (DESCENDING_BY_DEFAULT.has(col) ? "DESC" : "ASC")
+
   const cascade = DATE_CASCADE[column]
-  const primary = `t.${column} IS NULL, t.${column} ${direction}`
+  const primary = `t.${column} IS NULL, t.${column} ${directionFor(column)}`
   if (cascade === undefined) {
     return `${primary}, n.mtime DESC`
   }
   const fallbacks = cascade
-    .map((col) => `t.${col} IS NULL, t.${col} ${direction}`)
+    .map((col) => `t.${col} IS NULL, t.${col} ${directionFor(col)}`)
     .join(", ")
   return `${primary}, ${fallbacks}, n.mtime DESC`
 }
@@ -552,12 +560,15 @@ const DESCENDING_BY_DEFAULT: ReadonlySet<string> = new Set([
 /** ORDER BY fragment per sort key. Values are trusted SQL assembled from the
  *  whitelisted TaskSortKey union — never raw user input. Date keys cascade
  *  through related date columns so dateless tasks sort by the next available
- *  date rather than falling to arbitrary file-path order; priority maps levels
+ *  date rather than falling to arbitrary file-path order; when direction is
+ *  omitted each cascade column uses its own default so the primary field's
+ *  direction doesn't bleed into unrelated fallbacks. Priority maps levels
  *  to the plugin's numeric order (highest=0 … lowest=5, none=3 between medium
- *  and low, the ELSE arm since none is stored as NULL). */
+ *  and low, the ELSE arm since none is stored as NULL). Position sorts by file
+ *  path then line number — the natural order for Kanban boards. */
 const TASK_ORDER_BY: Record<
   TaskSortKey,
-  (direction: "ASC" | "DESC") => string
+  (explicitDirection: "ASC" | "DESC" | undefined) => string
 > = {
   due: (direction) => buildDateOrderBy("due", direction),
   scheduled: (direction) => buildDateOrderBy("scheduled", direction),
@@ -565,8 +576,12 @@ const TASK_ORDER_BY: Record<
   created: (direction) => buildDateOrderBy("created", direction),
   done: (direction) => buildDateOrderBy("done", direction),
   priority: (direction) =>
-    `CASE t.priority WHEN 'highest' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 4 WHEN 'lowest' THEN 5 ELSE 3 END ${direction}`,
-  note_mtime: (direction) => `n.mtime ${direction}`,
+    `CASE t.priority WHEN 'highest' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 4 WHEN 'lowest' THEN 5 ELSE 3 END ${direction ?? "ASC"}`,
+  note_mtime: (direction) => `n.mtime ${direction ?? "DESC"}`,
+  position: (direction) => {
+    const d = direction ?? "ASC"
+    return `n.path ${d}, t.line ${d}`
+  },
 }
 
 /** Lists indexed tasks with structured filters and sorting. All filters
@@ -686,20 +701,23 @@ export const listTasks = (
     conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
 
   const sortBy = params.sortBy ?? "due"
-  const sortDirection =
-    params.sortDirection ?? (DESCENDING_BY_DEFAULT.has(sortBy) ? "desc" : "asc")
-  const orderBy = TASK_ORDER_BY[sortBy](
-    sortDirection === "desc" ? "DESC" : "ASC",
-  )
+  const explicitSqlDirection: "ASC" | "DESC" | undefined =
+    params.sortDirection === undefined
+      ? undefined
+      : params.sortDirection === "desc"
+        ? "DESC"
+        : "ASC"
+  const orderBy = TASK_ORDER_BY[sortBy](explicitSqlDirection)
 
   // Math.floor: SQLite rejects a non-integer LIMIT binding with a cryptic
   // "datatype mismatch" error, so a fractional limit is floored instead.
   const limit = Math.max(0, Math.floor(params.limit ?? 50))
 
   const countRow = context.db
-    .prepare<unknown[], { total: number }>(
-      `SELECT COUNT(*) as total FROM tasks t JOIN notes n ON n.path = t.note_path ${whereClause}`,
-    )
+    .prepare<
+      unknown[],
+      { total: number }
+    >(`SELECT COUNT(*) as total FROM tasks t JOIN notes n ON n.path = t.note_path ${whereClause}`)
     .get(...queryParams)
   const total = countRow === undefined ? 0 : countRow.total
 

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -523,6 +523,11 @@ const DATE_CASCADE: Record<string, readonly string[]> = {
   created: ["due", "scheduled", "start"],
 }
 
+const toSqlDirection = (
+  direction: "asc" | "desc" | undefined,
+): "ASC" | "DESC" | undefined =>
+  direction === undefined ? undefined : direction === "desc" ? "DESC" : "ASC"
+
 /** Builds a cascaded ORDER BY for a date sort key: primary date column, then
  *  each fallback date column (all with NULL-last), then note mtime descending
  *  as a recency tiebreaker for fully dateless tasks.
@@ -704,13 +709,8 @@ export const listTasks = (
     conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
 
   const sortBy = params.sortBy ?? "due"
-  const explicitSqlDirection: "ASC" | "DESC" | undefined =
-    params.sortDirection === undefined
-      ? undefined
-      : params.sortDirection === "desc"
-        ? "DESC"
-        : "ASC"
-  const orderBy = TASK_ORDER_BY[sortBy](explicitSqlDirection)
+  const explicitDirection = toSqlDirection(params.sortDirection)
+  const orderBy = TASK_ORDER_BY[sortBy](explicitDirection)
 
   // Math.floor: SQLite rejects a non-integer LIMIT binding with a cryptic
   // "datatype mismatch" error, so a fractional limit is floored instead.


### PR DESCRIPTION
## Summary

- **Bug fix:** Date cascade sorts (due → scheduled → start → created) were applying the primary field's default direction to all fallback columns. A `sort_by: "due"` query (default ASC) cascading to `created` would sort ASC — surfacing the oldest, least relevant tasks first instead of newest. Each cascade column now uses its own natural direction when `sort_direction` is omitted (due/scheduled ASC, start/created DESC). An explicit `sort_direction` still overrides all columns uniformly.
- **New sort option:** `sort_by: "position"` sorts by file path then line number — the natural order for Kanban boards where card position IS priority.

## Changes

| File | What |
|---|---|
| `search-index.ts` | Add `"position"` to `TaskSortKey` union |
| `search-queries.ts` | `buildDateOrderBy` accepts optional direction — each cascade column uses its own default when omitted; add `position` to `TASK_ORDER_BY` |
| `search-tools.ts` | Add `"position"` to `sort_by` enum; update `sort_by`, `sort_direction`, and main tool description |
| `task-queries.test.ts` | 8 new tests (cascade direction fix, explicit override, start cascade, position sort variants); 3 existing test expectations updated for correct new ordering |

## Test plan

- [x] Cascade with implicit direction: created-only tasks sort DESC (newest first) when cascading from due
- [x] Explicit sort_direction overrides cascade to uniform direction
- [x] Start fallback within due cascade sorts DESC
- [x] Start cascade with both fields DESC (empty ASC group)
- [x] Position sort within a single note preserves file order
- [x] Position sort across notes groups by path
- [x] Position DESC reverses file and line order
- [x] Position sort with heading filter (Kanban lane + position)
- [x] Mutation-tested: reverting the fix breaks 8 tests (3 new + 5 existing)
- [x] Full suite: 1492 tests pass, 0 lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust task search sorting defaults and add support for position-based ordering.

New Features:
- Add a new "position" sort key that orders tasks by file path then line number for Kanban-style boards.

Bug Fixes:
- Fix date cascade sorts so each fallback date field uses its own default direction when sort_direction is omitted instead of inheriting the primary field's direction.

Enhancements:
- Update task listing tool metadata and descriptions to document per-field sort defaults, date cascades, and the new position sort key.
- Refine sort direction handling so priority and note modified time have sensible built-in defaults when sort_direction is not provided.

Tests:
- Extend task query tests to cover date cascade direction behavior, explicit sort overrides, start-field cascades, and multiple variants of the new position sort ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task lists now support sorting by natural Kanban/card order using a new `position` option.
  * Sorting behavior now better follows each field’s default direction when no sort direction is specified.

* **Bug Fixes**
  * Improved date-based sorting cascades so fallback fields keep the expected order when primary dates are missing.
  * Task ordering is now more consistent when filtering by status, headings, and across multiple notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->