### PR TITLE
fix(parser): make fence state machine blockquote-aware

### DIFF
--- a/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
@@ -54,6 +54,31 @@ describe("parseHeadings", () => {
     expect(headingTexts).toEqual(["Real", "Also real"])
   })
 
+  it("ignores ATX headings inside a blockquoted fenced code block", () => {
+    const lines = [
+      "# Real",
+      "> ```",
+      "> ## Not a heading",
+      "> ```",
+      "## Also real",
+    ]
+    expect(parseHeadings(lines).map((heading) => heading.text)).toEqual([
+      "Real",
+      "Also real",
+    ])
+  })
+
+  it("recognizes a heading after a blockquoted fence implicitly closes", () => {
+    const lines = [
+      "> ```",
+      "> ## Hidden inside fence",
+      "## Visible after implicit close",
+    ]
+    expect(parseHeadings(lines).map((heading) => heading.text)).toEqual([
+      "Visible after implicit close",
+    ])
+  })
+
   it("ignores ATX headings inside an indented fenced code block (CommonMark §4.5)", () => {
     // The fence is indented 3 spaces — recognized via the shared lines.ts fence
     // grammar. The previous heading-local matcher required column 0, so it would

--- a/src/vault-mcp/obsidian-markdown/__tests__/lines.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/lines.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest"
-import { splitIntoLines, advanceFence, classifyLines } from "../lines.js"
+import {
+  splitIntoLines,
+  advanceFence,
+  classifyLines,
+  type OpenFence,
+} from "../lines.js"
 
 // ── splitIntoLines ───────────────────────────────────────────────
 
@@ -23,11 +28,20 @@ describe("splitIntoLines", () => {
 
 // ── advanceFence ─────────────────────────────────────────────────
 
+/** Shorthand for an open fence at a given depth (default 0). */
+const fence = (delimiter: string, quoteDepth = 0): OpenFence => ({
+  delimiter,
+  quoteDepth,
+})
+
 describe("advanceFence", () => {
+  // ── depth-0 (backward-compatible) ────────────────────────────
+
   it("opens a fence on a delimiter line outside a fence", () => {
     expect(advanceFence("```", null)).toEqual({
-      openFence: "```",
+      openFence: fence("```"),
       isFenceDelimiter: true,
+      lineIsCode: true,
     })
   })
 
@@ -35,55 +49,63 @@ describe("advanceFence", () => {
     expect(advanceFence("plain", null)).toEqual({
       openFence: null,
       isFenceDelimiter: false,
+      lineIsCode: false,
     })
   })
 
   it("keeps the fence open for an interior non-fence line", () => {
-    expect(advanceFence("code", "```")).toEqual({
-      openFence: "```",
+    expect(advanceFence("code", fence("```"))).toEqual({
+      openFence: fence("```"),
       isFenceDelimiter: false,
+      lineIsCode: true,
     })
   })
 
   it("closes the fence on a matching closer", () => {
-    expect(advanceFence("```", "```")).toEqual({
+    expect(advanceFence("```", fence("```"))).toEqual({
       openFence: null,
       isFenceDelimiter: true,
+      lineIsCode: true,
     })
   })
 
   it("does not close a backtick fence on a tilde delimiter", () => {
-    expect(advanceFence("~~~", "```")).toEqual({
-      openFence: "```",
+    expect(advanceFence("~~~", fence("```"))).toEqual({
+      openFence: fence("```"),
       isFenceDelimiter: true,
+      lineIsCode: true,
     })
   })
 
   it("does not close on a delimiter shorter than the opener", () => {
-    expect(advanceFence("```", "````")).toEqual({
-      openFence: "````",
+    expect(advanceFence("```", fence("````"))).toEqual({
+      openFence: fence("````"),
       isFenceDelimiter: true,
+      lineIsCode: true,
     })
   })
 
   it("closes on a delimiter longer than the opener", () => {
-    expect(advanceFence("`````", "```")).toEqual({
+    expect(advanceFence("`````", fence("```"))).toEqual({
       openFence: null,
       isFenceDelimiter: true,
+      lineIsCode: true,
     })
   })
 
   it("does not close on a delimiter carrying a trailing info string", () => {
-    expect(advanceFence("``` js", "```")).toEqual({
-      openFence: "```",
+    expect(advanceFence("``` js", fence("```"))).toEqual({
+      openFence: fence("```"),
       isFenceDelimiter: true,
+      lineIsCode: true,
     })
   })
 
   it("opens a fence indented up to three spaces (CommonMark §4.5)", () => {
     expect(advanceFence("   ```", null)).toEqual({
-      openFence: "```",
+      openFence: fence("```"),
       isFenceDelimiter: true,
+      lineIsCode: true,
     })
   })
 
@@ -91,6 +113,89 @@ describe("advanceFence", () => {
     expect(advanceFence("    ```", null)).toEqual({
       openFence: null,
       isFenceDelimiter: false,
+      lineIsCode: false,
+    })
+  })
+
+  // ── blockquote depth awareness ───────────────────────────────
+
+  it("opens a fence inside a blockquote at depth 1", () => {
+    expect(advanceFence("> ```", null)).toEqual({
+      openFence: fence("```", 1),
+      isFenceDelimiter: true,
+      lineIsCode: true,
+    })
+  })
+
+  it("recognizes content inside a blockquoted fence as code", () => {
+    expect(advanceFence("> code", fence("```", 1))).toEqual({
+      openFence: fence("```", 1),
+      isFenceDelimiter: false,
+      lineIsCode: true,
+    })
+  })
+
+  it("closes a blockquoted fence at matching depth", () => {
+    expect(advanceFence("> ```", fence("```", 1))).toEqual({
+      openFence: null,
+      isFenceDelimiter: true,
+      lineIsCode: true,
+    })
+  })
+
+  it("implicitly closes fence when blockquote depth drops", () => {
+    expect(advanceFence("plain text", fence("```", 1))).toEqual({
+      openFence: null,
+      isFenceDelimiter: false,
+      lineIsCode: false,
+    })
+  })
+
+  it("implicitly closes fence and opens a new one at lower depth", () => {
+    expect(advanceFence("```", fence("```", 1))).toEqual({
+      openFence: fence("```", 0),
+      isFenceDelimiter: true,
+      lineIsCode: true,
+    })
+  })
+
+  it("treats deeper-depth lines as content inside the fence", () => {
+    expect(advanceFence("> > text", fence("```", 1))).toEqual({
+      openFence: fence("```", 1),
+      isFenceDelimiter: false,
+      lineIsCode: true,
+    })
+  })
+
+  it("treats blockquoted lines inside a depth-0 fence as content", () => {
+    expect(advanceFence("> text", fence("```", 0))).toEqual({
+      openFence: fence("```", 0),
+      isFenceDelimiter: false,
+      lineIsCode: true,
+    })
+  })
+
+  it("opens a fence at depth 2 with nested blockquote markers", () => {
+    expect(advanceFence("> > ```", null)).toEqual({
+      openFence: fence("```", 2),
+      isFenceDelimiter: true,
+      lineIsCode: true,
+    })
+  })
+
+  it("opens a fence with an info string inside a blockquote", () => {
+    expect(advanceFence("> ```js", null)).toEqual({
+      openFence: fence("```", 1),
+      isFenceDelimiter: true,
+      lineIsCode: true,
+    })
+  })
+
+  it("opens a tilde fence inside a blockquote", () => {
+    expect(advanceFence("> ~~~", null)).toEqual({
+      openFence: fence("~~~", 1),
+      isFenceDelimiter: true,
+      lineIsCode: true,
     })
   })
 })
@@ -174,6 +279,34 @@ describe("classifyLines", () => {
       { text: "inside", inCode: true },
       { text: "  ```", inCode: true },
       { text: "after", inCode: false },
+    ])
+  })
+
+  // ── blockquote-aware classification ──────────────────────────
+
+  it("classifies lines inside a blockquoted fence as code", () => {
+    const content = [
+      "before",
+      "> ```",
+      "> inside fence",
+      "> ```",
+      "after",
+    ].join("\n")
+    expect([...classifyLines(content)]).toEqual([
+      { text: "before", inCode: false },
+      { text: "> ```", inCode: true },
+      { text: "> inside fence", inCode: true },
+      { text: "> ```", inCode: true },
+      { text: "after", inCode: false },
+    ])
+  })
+
+  it("implicitly closes the fence when the blockquote ends", () => {
+    const content = ["> ```", "> code", "not code anymore"].join("\n")
+    expect([...classifyLines(content)]).toEqual([
+      { text: "> ```", inCode: true },
+      { text: "> code", inCode: true },
+      { text: "not code anymore", inCode: false },
     ])
   })
 })

--- a/src/vault-mcp/obsidian-markdown/__tests__/lines.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/lines.test.ts
@@ -198,6 +198,14 @@ describe("advanceFence", () => {
       lineIsCode: true,
     })
   })
+
+  it("opens a fence when a tab follows the blockquote marker", () => {
+    expect(advanceFence(">\t```", null)).toEqual({
+      openFence: fence("```", 1),
+      isFenceDelimiter: true,
+      lineIsCode: true,
+    })
+  })
 })
 
 // ── classifyLines ────────────────────────────────────────────────

--- a/src/vault-mcp/obsidian-markdown/__tests__/tasks.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/tasks.test.ts
@@ -524,6 +524,51 @@ describe("tasks.extractTasks", () => {
         task({ line: 2, description: "Task under a horizontal rule" }),
       ])
     })
+
+    it("excludes task lines inside a fenced code block within a callout", () => {
+      const content = [
+        "> [!info] Example",
+        "> ```",
+        "> - [ ] not really a task",
+        "> ```",
+        "> - [ ] Real callout task",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 5, description: "Real callout task" }),
+      ])
+    })
+
+    it("still extracts real tasks inside callouts without fences", () => {
+      const content = [
+        "> [!todo] Board",
+        "> - [ ] Buy milk",
+        "> - [x] Walk dog",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toHaveLength(2)
+      expect(extracted[0]).toEqual(task({ line: 2, description: "Buy milk" }))
+      expect(extracted[1]).toEqual(
+        task({
+          line: 3,
+          statusChar: "x",
+          status: "done",
+          description: "Walk dog",
+        }),
+      )
+    })
+
+    it("extracts tasks after a blockquote-scoped fence implicitly closes", () => {
+      const content = [
+        "> ```",
+        "> - [ ] hidden in fence",
+        "- [ ] visible after blockquote ends",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 3, description: "visible after blockquote ends" }),
+      ])
+    })
   })
 
   describe("heading attribution", () => {

--- a/src/vault-mcp/obsidian-markdown/__tests__/tasks.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/tasks.test.ts
@@ -568,6 +568,34 @@ describe("tasks.extractTasks", () => {
         task({ line: 3, description: "visible after blockquote ends" }),
       ])
     })
+
+    it("excludes task lines inside a tilde fenced code block within a callout", () => {
+      const content = [
+        "> [!info] Example",
+        "> ~~~",
+        "> - [ ] not really a task",
+        "> ~~~",
+        "> - [ ] Real tilde callout task",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 5, description: "Real tilde callout task" }),
+      ])
+    })
+
+    it("excludes task lines inside a depth-2 fence that implicitly closes", () => {
+      const content = [
+        "> [!info] Example",
+        "> > ```",
+        "> > - [ ] nested task hidden in fence",
+        "> Back to depth 1, fence implicitly closed",
+        "> - [ ] Task after nested fence",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 5, description: "Task after nested fence" }),
+      ])
+    })
   })
 
   describe("heading attribution", () => {

--- a/src/vault-mcp/obsidian-markdown/__tests__/tasks.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/tasks.test.ts
@@ -546,16 +546,15 @@ describe("tasks.extractTasks", () => {
         "> - [x] Walk dog",
       ].join("\n")
       const extracted = tasks.extractTasks(content)
-      expect(extracted).toHaveLength(2)
-      expect(extracted[0]).toEqual(task({ line: 2, description: "Buy milk" }))
-      expect(extracted[1]).toEqual(
+      expect(extracted).toEqual([
+        task({ line: 2, description: "Buy milk" }),
         task({
           line: 3,
           statusChar: "x",
           status: "done",
           description: "Walk dog",
         }),
-      )
+      ])
     })
 
     it("extracts tasks after a blockquote-scoped fence implicitly closes", () => {

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -72,11 +72,8 @@ export const findTrailingCommentBlockStart = (
     // Obsidian's parser). A fence-delimiter line never toggles comment state.
     if (!comment) {
       const fenceResult = advanceFence(line, openFence)
-      if (fenceResult.lineIsCode) {
-        openFence = fenceResult.openFence
-        continue
-      }
       openFence = fenceResult.openFence
+      if (fenceResult.lineIsCode) continue
     }
 
     // Outside fences (or inside a comment): `%%` at the start or end of the

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -71,14 +71,12 @@ export const findTrailingCommentBlockStart = (
     // takes precedence and fence delimiters are just comment text (matching
     // Obsidian's parser). A fence-delimiter line never toggles comment state.
     if (!comment) {
-      const { openFence: nextFence, isFenceDelimiter } = advanceFence(
-        line,
-        openFence,
-      )
-      if (openFence !== null || isFenceDelimiter) {
-        openFence = nextFence
+      const fenceResult = advanceFence(line, openFence)
+      if (fenceResult.lineIsCode) {
+        openFence = fenceResult.openFence
         continue
       }
+      openFence = fenceResult.openFence
     }
 
     // Outside fences (or inside a comment): `%%` at the start or end of the
@@ -146,14 +144,10 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
     openFence: OpenFence
   }>(
     (state, line, i) => {
-      const { openFence, isFenceDelimiter } = advanceFence(
-        line,
-        state.openFence,
-      )
+      const fenceResult = advanceFence(line, state.openFence)
 
-      // A fence delimiter, or any line while a fence is open, is never a heading.
-      if (isFenceDelimiter || state.openFence !== null) {
-        return { headings: state.headings, openFence }
+      if (fenceResult.lineIsCode) {
+        return { headings: state.headings, openFence: fenceResult.openFence }
       }
 
       const match = HEADING_REGEX.exec(line)
@@ -170,11 +164,11 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
               startLine: i,
             },
           ],
-          openFence,
+          openFence: fenceResult.openFence,
         }
       }
 
-      return { headings: state.headings, openFence }
+      return { headings: state.headings, openFence: fenceResult.openFence }
     },
     { headings: [], openFence: null },
   )

--- a/src/vault-mcp/obsidian-markdown/lines.ts
+++ b/src/vault-mcp/obsidian-markdown/lines.ts
@@ -23,8 +23,8 @@ export const splitIntoLines = (content: string): string[] =>
 // ── Blockquote prefix stripping ─────────────────────────────────
 
 /** Matches one blockquote marker: up to 3 spaces indent + `>` + optional
- *  space (CommonMark §5.1). Applied iteratively to count nesting depth. */
-const BLOCKQUOTE_MARKER = /^ {0,3}> ?/
+ *  space or tab (CommonMark §5.1). Applied iteratively to count nesting depth. */
+const BLOCKQUOTE_MARKER = /^ {0,3}>[ \t]?/
 
 /** Counts the blockquote nesting depth of a line and returns the content
  *  after all markers are stripped, so fence matching runs on the inner

--- a/src/vault-mcp/obsidian-markdown/lines.ts
+++ b/src/vault-mcp/obsidian-markdown/lines.ts
@@ -20,46 +20,137 @@ export const splitIntoLines = (content: string): string[] =>
     .split("\n")
     .map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line))
 
+// ── Blockquote prefix stripping ─────────────────────────────────
+
+/** Matches one blockquote marker: up to 3 spaces indent + `>` + optional
+ *  space (CommonMark §5.1). Applied iteratively to count nesting depth. */
+const BLOCKQUOTE_MARKER = /^ {0,3}> ?/
+
+/** Counts the blockquote nesting depth of a line and returns the content
+ *  after all markers are stripped, so fence matching runs on the inner
+ *  content — a `> \`\`\`` line has depth 1 and inner content `\`\`\``. */
+const stripBlockquotePrefix = (
+  line: string,
+): { depth: number; innerContent: string } => {
+  let depth = 0
+  let remaining = line
+  for (;;) {
+    const match = BLOCKQUOTE_MARKER.exec(remaining)
+    if (match === null) break
+    depth++
+    remaining = remaining.slice(match[0].length)
+  }
+  return { depth, innerContent: remaining }
+}
+
 // ── Fenced-code state machine ───────────────────────────────────
 
 /** Matches fenced code block openers: 0-3 spaces indent + 3+ backticks or tildes
- *  (CommonMark §4.5). */
+ *  (CommonMark §4.5). Applied to the inner content after blockquote markers are
+ *  stripped. */
 const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/
 
-/** The currently-open fence's delimiter run (e.g. "```" or "~~~~"), or null when
- *  not inside a fenced code block. */
-export type OpenFence = string | null
+/** The currently-open fence: its delimiter run (e.g. "```") plus the blockquote
+ *  depth it opened at, or null when not inside a fenced code block. A fence
+ *  opened at depth N closes only at the same depth; a line at lower depth
+ *  closes it implicitly (the container ended per CommonMark §5.1). */
+export type OpenFence = { delimiter: string; quoteDepth: number } | null
+
+type FenceResult = {
+  openFence: OpenFence
+  isFenceDelimiter: boolean
+  /** Whether this line is inside a fenced code block — accounts for blockquote
+   *  depth, including implicit fence closure when the container ends. Consumers
+   *  should use this instead of computing `isFenceDelimiter || openFence !== null`. */
+  lineIsCode: boolean
+}
+
+/** Attempts to match a fence delimiter in `innerContent` and, if matched,
+ *  returns a new fence opened at `quoteDepth`. */
+const tryOpenFence = (
+  innerContent: string,
+  quoteDepth: number,
+): FenceResult | null => {
+  const fenceMatch = FENCE_OPEN.exec(innerContent)
+  const fenceChars = fenceMatch?.[1]
+  if (fenceChars === undefined) return null
+  return {
+    openFence: { delimiter: fenceChars, quoteDepth },
+    isFenceDelimiter: true,
+    lineIsCode: true,
+  }
+}
 
 /** Advances the fenced-code state machine by one line — the single CommonMark
  *  §4.5 fence transition shared by every fence-aware walk.
  *
- *  Given the fence open before this line (null outside a fence) and the line,
- *  returns the fence open after it plus whether the line is itself a fence
- *  delimiter (any line matching the opener grammar — an opener, a closer, or a
- *  fence-looking line inside a fence). Delimiter lines are always code, never
- *  heading- or link-bearing content, so callers skip them.
+ *  Blockquote-aware: the line's `> ` markers are stripped before fence matching,
+ *  so fences inside callouts/blockquotes (e.g. `> \`\`\``) are recognized. A
+ *  fence opened at blockquote depth N closes only at the same depth; a line at
+ *  lower depth closes it implicitly (the blockquote container ended), and a line
+ *  at higher depth is content inside the fence.
  *
- *  A closer must use the opener's character (backtick vs tilde), be at least as
- *  long, and once trimmed hold only fence characters (no trailing info string). */
+ *  Returns `lineIsCode` — whether this line is inside a fenced code block —
+ *  which accounts for depth changes. Callers should use it instead of the
+ *  previous `isFenceDelimiter || openFence !== null` pattern.
+ *
+ *  Lazy continuation (CommonMark allows omitting `> ` on continuation lines
+ *  inside a blockquote) is out of scope: Obsidian's own renderer does not fully
+ *  support it either, and real vaults almost always include the `> ` prefix on
+ *  every line. */
 export const advanceFence = (
   line: string,
   openFence: OpenFence,
-): { openFence: OpenFence; isFenceDelimiter: boolean } => {
-  const fenceMatch = FENCE_OPEN.exec(line)
-  const fenceChars = fenceMatch?.[1]
-  if (!fenceChars) return { openFence, isFenceDelimiter: false }
-  // Outside a fence: this line opens one.
-  if (openFence === null) {
-    return { openFence: fenceChars, isFenceDelimiter: true }
+): FenceResult => {
+  const { depth: lineQuoteDepth, innerContent } = stripBlockquotePrefix(line)
+
+  // Fence implicitly closed — this line's blockquote depth is below the fence's,
+  // so the container that held the fence has ended. The line itself is NOT code;
+  // check whether it opens a new fence at its own depth.
+  if (openFence !== null && lineQuoteDepth < openFence.quoteDepth) {
+    return (
+      tryOpenFence(innerContent, lineQuoteDepth) ?? {
+        openFence: null,
+        isFenceDelimiter: false,
+        lineIsCode: false,
+      }
+    )
   }
 
-  // Inside a fence: only a matching closer ends it; any other fence-looking line
-  // is code content and leaves the fence open.
+  // Deeper depth — content inside the fence, not a delimiter at this depth.
+  if (openFence !== null && lineQuoteDepth > openFence.quoteDepth) {
+    return { openFence, isFenceDelimiter: false, lineIsCode: true }
+  }
+
+  // Same depth (or no fence open) — normal fence matching on inner content.
+  const fenceMatch = FENCE_OPEN.exec(innerContent)
+  const fenceChars = fenceMatch?.[1]
+  if (fenceChars === undefined) {
+    return {
+      openFence,
+      isFenceDelimiter: false,
+      lineIsCode: openFence !== null,
+    }
+  }
+
+  if (openFence === null) {
+    return {
+      openFence: { delimiter: fenceChars, quoteDepth: lineQuoteDepth },
+      isFenceDelimiter: true,
+      lineIsCode: true,
+    }
+  }
+
+  // Inside a fence at the same depth: only a matching closer ends it.
   const closesFence =
-    fenceChars[0] === openFence[0] &&
-    fenceChars.length >= openFence.length &&
-    line.trim() === fenceChars
-  return { openFence: closesFence ? null : openFence, isFenceDelimiter: true }
+    fenceChars[0] === openFence.delimiter[0] &&
+    fenceChars.length >= openFence.delimiter.length &&
+    innerContent.trim() === fenceChars
+  return {
+    openFence: closesFence ? null : openFence,
+    isFenceDelimiter: true,
+    lineIsCode: true,
+  }
 }
 
 // ── Line classification ─────────────────────────────────────────
@@ -83,9 +174,7 @@ export const classifyLines = function* (
   let openFence: OpenFence = null
   for (const text of content.split("\n")) {
     const result = advanceFence(text, openFence)
-    // A fence delimiter is code; so is any line while a fence is already open.
-    const inCode = result.isFenceDelimiter || openFence !== null
     openFence = result.openFence
-    yield { text, inCode }
+    yield { text, inCode: result.lineIsCode }
   }
 }

--- a/src/vault-mcp/obsidian-markdown/lines.ts
+++ b/src/vault-mcp/obsidian-markdown/lines.ts
@@ -32,6 +32,8 @@ const BLOCKQUOTE_MARKER = /^ {0,3}> ?/
 const stripBlockquotePrefix = (
   line: string,
 ): { depth: number; innerContent: string } => {
+  // Iterative prefix stripping — depth and remaining track the cursor across
+  // successive `> ` markers.
   let depth = 0
   let remaining = line
   for (;;) {

--- a/src/vault-mcp/obsidian-markdown/tasks.ts
+++ b/src/vault-mcp/obsidian-markdown/tasks.ts
@@ -443,9 +443,8 @@ const extractTasks = (rawContent: string): ParsedTask[] => {
     const lineText = bodyLines[lineIndex]
     if (lineText === undefined) continue
     const fenceResult = advanceFence(lineText, openFence)
-    const lineIsCode = fenceResult.isFenceDelimiter || openFence !== null
     openFence = fenceResult.openFence
-    if (lineIsCode) continue
+    if (fenceResult.lineIsCode) continue
 
     const taskLineMatch = TASK_LINE_RE.exec(lineText)
     if (taskLineMatch === null) continue


### PR DESCRIPTION
## Summary
- `advanceFence` now strips `> ` blockquote markers before matching fence delimiters, tracks the blockquote depth at which a fence opened, and implicitly closes it when depth drops — fixing fenced code blocks inside callouts being invisible to the state machine
- `OpenFence` type changes from `string | null` to `{ delimiter: string; quoteDepth: number } | null`; new `lineIsCode` return field replaces the manual `isFenceDelimiter || openFence !== null` pattern in all 4 consumers (classifyLines, parseHeadings, findTrailingCommentBlockStart, extractTasks)
- Lazy continuation (omitting `> ` on blockquote continuation lines) is out of scope — Obsidian's own renderer doesn't fully support it either

## Test plan
- [x] 12 new `advanceFence` blockquote-depth tests (opener, closer, implicit close, depth transitions, info strings, tildes)
- [x] 2 new `classifyLines` integration tests (quoted fence sequence, implicit close)
- [x] 3 new `extractTasks` regression tests (callout fence exclusion, plain callout tasks, implicit close)
- [x] Mutation-verified: disabling `stripBlockquotePrefix` fails the callout-fence tests
- [x] All 1499 tests pass, lint clean, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the fenced code parser blockquote-aware so fences inside callouts/quotes are correctly detected and treated as code, and update all consumers to use the new fence state API.

New Features:
- Support fenced code blocks nested inside blockquotes and callouts by tracking blockquote depth in the fence state machine.

Bug Fixes:
- Prevent task extraction from treating checklist-like lines inside blockquoted fenced code blocks as real tasks.
- Ensure headings and trailing comment block detection ignore lines inside blockquoted fenced code blocks.
- Fix line classification so lines inside blockquoted fences are correctly marked as code and fences implicitly close when the blockquote ends.

Enhancements:
- Refine the fence state representation with a structured OpenFence type and a unified lineIsCode flag for downstream consumers.

Tests:
- Add unit and integration tests covering blockquote-depth behavior for fences, blockquoted line classification, and task extraction around callout fences.