### PR TITLE
ci: switch PR review to Umm-actually bot with 4-phase pipeline

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -51,5 +51,5 @@ jobs:
           # Default (-1) posts suggestions only as conversation comments.
           # Threshold >= 0 also posts them as inline review comments on the diff
           # for suggestions at or above that score (0-10 scale).
-          pr_code_suggestions.dual_publishing_score_threshold: "4"
+          pr_code_suggestions.dual_publishing_score_threshold: ${{ vars.PR_AGENT_SUGGESTION_THRESHOLD || '3' }}
           pr_description.enable_pr_description: "false"

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -37,19 +37,15 @@ jobs:
           # through OpenRouter to OpenAI — unexpected model and unexpected charges.
           # Override to keep everything on the configured provider.
           config.fallback_models: '["openrouter/anthropic/claude-sonnet-4-6"]'
-          github_action_config.auto_review: "true"
+          github_action_config.auto_review: "false"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
-          pr_reviewer.extra_instructions: >-
+          pr_code_suggestions.extra_instructions: >-
             Read AGENTS.md in the repo root for this project's coding conventions,
             code style rules, naming conventions, test conventions, and module layering.
             Review against those conventions — they take priority over general best practices.
             Flag violations of the AGENTS.md rules explicitly.
-          pr_reviewer.require_can_be_reviewed: "true"
-          pr_reviewer.persistent_comment: "false"
-          pr_reviewer.remove_previous_review_comment: "false"
           # Default (-1) posts suggestions only as conversation comments.
           # Threshold >= 0 also posts them as inline review comments on the diff
           # for suggestions at or above that score (0-10 scale).
           pr_code_suggestions.dual_publishing_score_threshold: ${{ vars.PR_AGENT_SUGGESTION_THRESHOLD || '3' }}
-          pr_description.enable_pr_description: "false"

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -40,6 +40,13 @@ jobs:
           github_action_config.auto_review: "false"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
+          pr_reviewer.extra_instructions: >-
+            Read AGENTS.md in the repo root for this project's coding conventions,
+            code style rules, naming conventions, test conventions, and module layering.
+            Review against those conventions — they take priority over general best practices.
+            Flag violations of the AGENTS.md rules explicitly.
+          pr_reviewer.persistent_comment: "false"
+          pr_reviewer.remove_previous_review_comment: "false"
           pr_code_suggestions.extra_instructions: >-
             Read AGENTS.md in the repo root for this project's coding conventions,
             code style rules, naming conventions, test conventions, and module layering.


### PR DESCRIPTION
## Summary
- Replaces single-pass PR-Agent with a 4-phase ship-check-inspired pipeline, each running `/improve` with focused instructions:
  1. **Correctness & security** — logic errors, race conditions, injection, unhandled paths
  2. **Code quality & conventions** — AGENTS.md naming, structure, module layering
  3. **Test quality** — assertion quality, coverage gaps, const-per-test
  4. **Bug patterns** — 7-dimension checklist (description mismatch, SQL, type safety, boundaries, behavioral asymmetry, input validation, platform/encoding)
- All comments now post as `umm-actually[bot]` via GitHub App token (`UMM_APP_ID` + `UMM_PRIVATE_KEY` secrets)
- Disables auto-review summary comment ("PR Reviewer Guide"); keeps inline suggestions only
- Makes `dual_publishing_score_threshold` configurable via `PR_AGENT_SUGGESTION_THRESHOLD` variable (default lowered from 4 to 3)
- Manual `/review` trigger preserved with both review summary and inline suggestions

## Test plan
- [ ] Verify `UMM_APP_ID` and `UMM_PRIVATE_KEY` secrets are set
- [ ] Open a test PR and confirm comments appear as `umm-actually[bot]`
- [ ] Verify all 4 phases run and post inline suggestions
- [ ] Comment `/review` on a PR and confirm the summary comment + inline suggestions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)