### PR TITLE
ci: switch PR review to Umm-actually bot with 4-phase pipeline

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -8,8 +8,8 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
+  issues: read
+  pull-requests: read
 
 jobs:
   review:
@@ -25,13 +25,14 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.UMM_APP_ID }}
           private-key: ${{ secrets.UMM_PRIVATE_KEY }}
 
       # Phase 1 — Correctness & Security
       - name: "Phase 1: Correctness & security"
+        if: github.event_name == 'pull_request'
         uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
         env:
           OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
@@ -67,6 +68,7 @@ jobs:
 
       # Phase 2 — Code Quality & Conventions
       - name: "Phase 2: Code quality & conventions"
+        if: github.event_name == 'pull_request'
         uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
         env:
           OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
@@ -94,6 +96,7 @@ jobs:
 
       # Phase 3 — Test Quality
       - name: "Phase 3: Test quality"
+        if: github.event_name == 'pull_request'
         uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
         env:
           OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
@@ -121,6 +124,7 @@ jobs:
 
       # Phase 4 — Bug Patterns
       - name: "Phase 4: Bug patterns"
+        if: github.event_name == 'pull_request'
         uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
         env:
           OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -36,8 +36,14 @@ jobs:
         env:
           OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # PR-Agent only calls models in its hardcoded MAX_TOKENS table;
+          # models not listed (e.g. deepseek-v3.2 via OpenRouter) fail silently
+          # and fall back. custom_model_max_tokens tells PR-Agent the context
+          # window directly. Update alongside PR_AGENT_MODEL when switching.
           config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/anthropic/claude-sonnet-4-6' }}
           config.custom_model_max_tokens: ${{ vars.PR_AGENT_MAX_TOKENS || '200000' }}
+          # Default fallback is gpt-5.4-mini (hardcoded in PR-Agent), which
+          # routes through OpenRouter to OpenAI — unexpected model and charges.
           config.fallback_models: '["openrouter/anthropic/claude-sonnet-4-6"]'
           github_action_config.auto_review: "false"
           github_action_config.auto_describe: "false"
@@ -54,6 +60,9 @@ jobs:
 
             For each suggestion, explain the concrete failure scenario — what input or state
             triggers the bug and what goes wrong.
+          # Default (-1) posts suggestions only as conversation comments.
+          # Threshold >= 0 also posts them as inline review comments on the
+          # diff for suggestions at or above that score (0-10 scale).
           pr_code_suggestions.dual_publishing_score_threshold: ${{ vars.PR_AGENT_SUGGESTION_THRESHOLD || '3' }}
 
       # Phase 2 — Code Quality & Conventions

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           app-id: ${{ secrets.UMM_APP_ID }}
           private-key: ${{ secrets.UMM_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
+          permission-issues: write
 
       # Phase 1 — Correctness & Security
       - name: "Phase 1: Correctness & security"

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -157,6 +157,20 @@ jobs:
             7. Platform/encoding — path separator assumptions, Unicode normalization,
                locale-dependent string operations, timezone-naive date handling.
 
+            For CI/workflow files (.yml), also check:
+            8. Action pinning — third-party actions must be pinned to a full commit SHA,
+               not a mutable tag (v2, v3, latest). Pin to SHA with a version comment:
+               `uses: org/action@<sha> # v2.1.0`. First-party `actions/*` are lower risk
+               but should still be pinned in security-sensitive workflows.
+            9. Permissions least privilege — `permissions:` should grant only what the job
+               needs. If all steps use a GitHub App token (create-github-app-token), the
+               default GITHUB_TOKEN only needs `read`. Write permissions on an unused
+               GITHUB_TOKEN is unnecessary attack surface.
+            10. Multi-trigger event guards — when a workflow has multiple triggers in `on:`
+                (e.g. pull_request + issue_comment), check whether each step should run for
+                all triggers or only specific ones. Steps meant only for PRs need
+                `if: github.event_name == 'pull_request'` guards.
+
             For each finding, state the specific input or sequence that triggers the bug.
           pr_code_suggestions.dual_publishing_score_threshold: ${{ vars.PR_AGENT_SUGGESTION_THRESHOLD || '3' }}
 

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,4 +1,4 @@
-name: PR-Agent Review
+name: Umm Review
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  issues: write # persistent_comment posts to the PR conversation thread (issue comments API)
+  issues: write
   pull-requests: write
 
 jobs:
@@ -21,23 +21,143 @@ jobs:
        github.event.comment.user.login == github.repository_owner &&
        startsWith(github.event.comment.body, '/review'))
     runs-on: ubuntu-latest
-    name: AI code review
+    name: umm, actually
     steps:
-      - uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.UMM_APP_ID }}
+          private-key: ${{ secrets.UMM_PRIVATE_KEY }}
+
+      # Phase 1 — Correctness & Security
+      - name: "Phase 1: Correctness & security"
+        uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
         env:
           OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/anthropic/claude-sonnet-4-6' }}
-          # PR-Agent only calls models in its hardcoded MAX_TOKENS table;
-          # models not listed (e.g. deepseek-v3.2 via OpenRouter) fail silently
-          # and fall back. This tells PR-Agent the model's context window directly.
-          # Update alongside PR_AGENT_MODEL when switching models.
           config.custom_model_max_tokens: ${{ vars.PR_AGENT_MAX_TOKENS || '200000' }}
-          # Default fallback is gpt-5.4-mini (hardcoded in PR-Agent), which routes
-          # through OpenRouter to OpenAI — unexpected model and unexpected charges.
-          # Override to keep everything on the configured provider.
           config.fallback_models: '["openrouter/anthropic/claude-sonnet-4-6"]'
           github_action_config.auto_review: "false"
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_improve: "true"
+          pr_code_suggestions.extra_instructions: >-
+            FOCUS: Correctness and security only. Ignore style, naming, and test quality.
+
+            Read AGENTS.md in the repo root for project conventions.
+
+            Look for: logic errors, incorrect conditions, off-by-one errors, null/undefined
+            access, race conditions, unhandled error paths, missing edge cases, security
+            vulnerabilities (injection, path traversal, auth bypass), and performance issues
+            (unbounded queries, missing indices, O(n^2) in hot paths).
+
+            For each suggestion, explain the concrete failure scenario — what input or state
+            triggers the bug and what goes wrong.
+          pr_code_suggestions.dual_publishing_score_threshold: ${{ vars.PR_AGENT_SUGGESTION_THRESHOLD || '3' }}
+
+      # Phase 2 — Code Quality & Conventions
+      - name: "Phase 2: Code quality & conventions"
+        uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
+        env:
+          OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/anthropic/claude-sonnet-4-6' }}
+          config.custom_model_max_tokens: ${{ vars.PR_AGENT_MAX_TOKENS || '200000' }}
+          config.fallback_models: '["openrouter/anthropic/claude-sonnet-4-6"]'
+          github_action_config.auto_review: "false"
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_improve: "true"
+          pr_code_suggestions.extra_instructions: >-
+            FOCUS: Code quality and convention compliance only. Skip correctness bugs and
+            test files — other passes handle those.
+
+            Read AGENTS.md in the repo root. Review ONLY against its rules:
+            naming conventions (explicit names over abbreviations, descriptive function names),
+            structure (early returns over nested if/else, immutable by default, no disguised
+            mutation in reduce), module layering (dependency direction, export style),
+            comment conventions (comments above complex logic, regex doc comments),
+            and simplicity (simple code over clever code, no premature abstractions).
+
+            Only flag violations of AGENTS.md rules. Do not invent conventions the project
+            doesn't have.
+          pr_code_suggestions.dual_publishing_score_threshold: ${{ vars.PR_AGENT_SUGGESTION_THRESHOLD || '3' }}
+
+      # Phase 3 — Test Quality
+      - name: "Phase 3: Test quality"
+        uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
+        env:
+          OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/anthropic/claude-sonnet-4-6' }}
+          config.custom_model_max_tokens: ${{ vars.PR_AGENT_MAX_TOKENS || '200000' }}
+          config.fallback_models: '["openrouter/anthropic/claude-sonnet-4-6"]'
+          github_action_config.auto_review: "false"
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_improve: "true"
+          pr_code_suggestions.extra_instructions: >-
+            FOCUS: Test quality and coverage gaps only. Skip production code style and
+            correctness — other passes handle those.
+
+            Read AGENTS.md in the repo root for test conventions.
+
+            For test files: check that each it() tests what its name claims, assertions are
+            exact (toHaveLength(2) not toBeGreaterThanOrEqual(1)), tests include both positive
+            and negative cases, tests would fail if the behavior broke (not pass by coincidence),
+            and const-per-test is preferred over let+beforeEach.
+
+            For production files: check if new functions, branches, or error paths have
+            corresponding tests. Flag missing coverage with the specific untested scenario.
+          pr_code_suggestions.dual_publishing_score_threshold: ${{ vars.PR_AGENT_SUGGESTION_THRESHOLD || '3' }}
+
+      # Phase 4 — Bug Patterns
+      - name: "Phase 4: Bug patterns"
+        uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
+        env:
+          OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/anthropic/claude-sonnet-4-6' }}
+          config.custom_model_max_tokens: ${{ vars.PR_AGENT_MAX_TOKENS || '200000' }}
+          config.fallback_models: '["openrouter/anthropic/claude-sonnet-4-6"]'
+          github_action_config.auto_review: "false"
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_improve: "true"
+          pr_code_suggestions.extra_instructions: >-
+            FOCUS: Subtle bug patterns that survive normal code review. Skip style, naming,
+            and test quality — other passes handle those.
+
+            Read AGENTS.md in the repo root for project conventions.
+
+            Apply these 7 checks systematically:
+            1. Description-vs-implementation mismatch — do comments, tool descriptions, error
+               messages, and docstrings accurately describe what the code actually does?
+            2. SQL correctness — missing quotes around LIKE patterns, wrong JOIN type, missing
+               WHERE clauses, injection via string interpolation.
+            3. Type safety — JSON.parse without runtime validation, type assertions (as/!)
+               that bypass the compiler, implicit any from untyped library calls.
+            4. Boundary and off-by-one — fencepost errors in slicing, pagination, or loop
+               bounds; empty-input handling; integer overflow in arithmetic.
+            5. Behavioral asymmetry — create/update/delete paths that handle the same field
+               differently; format-on-write vs format-on-read inconsistency.
+            6. Input validation gaps — user inputs that reach data layer unchecked; path
+               traversal (../) in file paths; missing length/range bounds.
+            7. Platform/encoding — path separator assumptions, Unicode normalization,
+               locale-dependent string operations, timezone-naive date handling.
+
+            For each finding, state the specific input or sequence that triggers the bug.
+          pr_code_suggestions.dual_publishing_score_threshold: ${{ vars.PR_AGENT_SUGGESTION_THRESHOLD || '3' }}
+
+      # Manual /review — only runs when triggered by comment
+      - name: "Manual review (on /review command)"
+        if: github.event_name == 'issue_comment'
+        uses: The-PR-Agent/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
+        env:
+          OPENROUTER.KEY: ${{ secrets.OPENROUTER_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          config.model: ${{ vars.PR_AGENT_MODEL || 'openrouter/anthropic/claude-sonnet-4-6' }}
+          config.custom_model_max_tokens: ${{ vars.PR_AGENT_MAX_TOKENS || '200000' }}
+          config.fallback_models: '["openrouter/anthropic/claude-sonnet-4-6"]'
+          github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
           pr_reviewer.extra_instructions: >-
@@ -52,7 +172,4 @@ jobs:
             code style rules, naming conventions, test conventions, and module layering.
             Review against those conventions — they take priority over general best practices.
             Flag violations of the AGENTS.md rules explicitly.
-          # Default (-1) posts suggestions only as conversation comments.
-          # Threshold >= 0 also posts them as inline review comments on the diff
-          # for suggestions at or above that score (0-10 scale).
           pr_code_suggestions.dual_publishing_score_threshold: ${{ vars.PR_AGENT_SUGGESTION_THRESHOLD || '3' }}

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -49,8 +49,12 @@ jobs:
           # Default fallback is gpt-5.4-mini (hardcoded in PR-Agent), which
           # routes through OpenRouter to OpenAI — unexpected model and charges.
           config.fallback_models: '["openrouter/anthropic/claude-sonnet-4-6"]'
+          # Run /review — posts a summary comment ("PR Reviewer Guide").
+          # Off for phases (inline suggestions only); on for manual /review.
           github_action_config.auto_review: "false"
+          # Run /describe — auto-generates PR title + description.
           github_action_config.auto_describe: "false"
+          # Run /improve — posts inline code suggestions on the diff.
           github_action_config.auto_improve: "true"
           pr_code_suggestions.extra_instructions: >-
             FOCUS: Correctness and security only. Ignore style, naming, and test quality.


### PR DESCRIPTION
## Summary
- Replaces single-pass PR-Agent with a 4-phase ship-check-inspired pipeline, each running `/improve` with focused instructions:
  1. **Correctness & security** — logic errors, race conditions, injection, unhandled paths
  2. **Code quality & conventions** — AGENTS.md naming, structure, module layering
  3. **Test quality** — assertion quality, coverage gaps, const-per-test
  4. **Bug patterns** — 7-dimension checklist (description mismatch, SQL, type safety, boundaries, behavioral asymmetry, input validation, platform/encoding)
- All comments now post as `umm-actually[bot]` via GitHub App token (`UMM_APP_ID` + `UMM_PRIVATE_KEY` secrets)
- Disables auto-review summary comment ("PR Reviewer Guide"); keeps inline suggestions only
- Manual `/review` trigger preserved with both review summary and inline suggestions

## Test plan
- [ ] Verify `UMM_APP_ID` and `UMM_PRIVATE_KEY` secrets are set
- [ ] Open a test PR and confirm comments appear as `umm-actually[bot]`
- [ ] Verify all 4 phases run and post inline suggestions
- [ ] Comment `/review` on a PR and confirm the summary + inline suggestions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated pull request review handling.
  * Reviews now run in several focused passes, helping catch correctness, quality, testing, and subtle bug issues more consistently.
  * Manual `/review` requests are supported with the same enhanced review flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->