### PR TITLE
feat(search): accept arrays for heading and status in vault_list_tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,8 +386,8 @@ undefined) return`) or schema validation to narrow types instead.
   normalized → expanded → deduplicated), keep a consistent prefix
   so every variable clearly belongs to the same chain:
   `statusInput` → `statusValues` → `statusValuesWithExpansions` →
-  `expandedStatuses`, not `input` → `values` → `withExpansions` →
-  `result`. A reader scanning the function should see the domain
+  `expandedStatusValues`, not `input` → `values` → `withExpansions`
+  → `expanded`. A reader scanning the function should see the domain
   noun on every intermediate, not just the first and last.
 - Lean toward named records over positional tuples, and named locals over
   inline expressions, where it helps a line read on its own — `{ start, end }`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,12 +378,23 @@ undefined) return`) or schema validation to narrow types instead.
   This applies everywhere: function params, callback params (`row`
   not `r`, `entry` not `e`, `orphan` not `o`), SQL aliases
   (`element` not `je`), destructured bindings, and loop variables.
+  For constants representing a category, name them for the domain
+  contrast they represent — `CONCRETE_STATUSES` communicates the
+  virtual/concrete distinction; `ALL_REAL_STATUSES` doesn't (what
+  makes a status "real"?).
 - Lean toward named records over positional tuples, and named locals over
   inline expressions, where it helps a line read on its own — `{ start, end }`
   over `[start, end] as const` destructured as `[spanStart, spanEnd]`;
   `const linkText = match[0]` over an inline `match[0].length`. Judgment,
   not a hard rule: an inline expression that's obvious in its context is
   fine. Optimize for readability in context, not mechanical extraction.
+- Break nested functional composition into named intermediate steps.
+  `[...new Set(items.flatMap(transform))]` nests three operations
+  (spread, Set, flatMap) — a reader has to unpack inside-out. Split into
+  `const withExpansions = items.flatMap(transform)` then
+  `const deduplicated = [...new Set(withExpansions)]` so each line reads
+  top-to-bottom. The threshold is ~2 nesting levels; a single
+  `items.map(f)` or `[...new Set(items)]` is fine inline.
 - Function and helper names state what they _do_, specifically — a reader
   should know what a function does without reading its body
   (`collectWikilinksFrom` not `collect`,
@@ -407,7 +418,10 @@ undefined) return`) or schema validation to narrow types instead.
 - Name booleans (params, flags, locals) for the affirmative state, and
   let the value carry the negation: `hardLinksSupported: false` reads
   clearer than `hardLinksUnsupported: true`, and a double negative like
-  `if (!notReady)` is a smell. A positively-named flag also keeps the
+  `if (!notReady)` is a smell. This extends to guard booleans: name
+  them for the action the guard controls — `needsStatusFilter` over
+  `!isUnfiltered`, because the guard's intent is "do we need a filter?"
+  not "is it not unfiltered?". A positively-named flag also keeps the
   guard's condition positive (`if (hardLinksSupported) { … return }`),
   so it pairs naturally with the early-return rule above — the common
   path returns, the fallback flows beneath it, no `else`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,13 @@ undefined) return`) or schema validation to narrow types instead.
   contrast they represent — `CONCRETE_STATUSES` communicates the
   virtual/concrete distinction; `ALL_REAL_STATUSES` doesn't (what
   makes a status "real"?).
+  When a value flows through a multi-step pipeline (input →
+  normalized → expanded → deduplicated), keep a consistent prefix
+  so every variable clearly belongs to the same chain:
+  `statusInput` → `statusValues` → `statusValuesWithExpansions` →
+  `expandedStatuses`, not `input` → `values` → `withExpansions` →
+  `result`. A reader scanning the function should see the domain
+  noun on every intermediate, not just the first and last.
 - Lean toward named records over positional tuples, and named locals over
   inline expressions, where it helps a line read on its own — `{ start, end }`
   over `[start, end] as const` destructured as `[spanStart, spanEnd]`;

--- a/src/vault-mcp/mcp-core/tools/search-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/search-tools.ts
@@ -738,7 +738,9 @@ Returns: JSON array of note metadata (path, title, tags, related, folder, type, 
 
 Example: vault_list_tasks({ due: { before: "2026-07-04" } }) — overdue triage; the default status (not_done) and sort (due ascending) make this the "what's overdue?" call
 Example: vault_list_tasks({ folder: "Code Projects/vault-cortex", heading: "Active" }) — one project's Active Kanban lane
+Example: vault_list_tasks({ folder: "Code Projects/vault-cortex", heading: ["Active", "Up Next", "Waiting On"] }) — one project's actionable Kanban lanes in one call
 Example: vault_list_tasks({ status: "done", done: { after: "2026-06-26" } }) — what got completed this week
+Example: vault_list_tasks({ status: ["todo", "in_progress"] }) — explicit equivalent of "not_done"
 Example: vault_list_tasks({ priority: ["highest", "high"], sort_by: "priority" }) — most urgent open work first
 Example: vault_list_tasks({ path: "TASKS.md", sort_by: "position" }) — tasks in file order (Kanban card position)
 
@@ -746,10 +748,10 @@ When to use: Any vault-wide task triage question — "what's overdue?", "what's 
 Prefer vault_read_note (heading mode) to read one specific board lane verbatim. Prefer vault_search for full-text queries over note content.
 
 Parameters:
-- status: "not_done" (default — todo + in_progress, excludes done AND cancelled), "todo", "in_progress", "done", "cancelled", or "all". Checkbox chars map to statuses the way the Tasks plugin maps them: " " todo, "/" in_progress, "x"/"X" done, "-" cancelled, any other char todo.
+- status: a single value or an array of values, OR-combined (default "not_done"). Values: "not_done" (todo + in_progress, excludes done AND cancelled), "todo", "in_progress", "done", "cancelled", "all". Virtual values expand in arrays: ["not_done", "done"] matches todo + in_progress + done. Checkbox chars map to statuses the way the Tasks plugin maps them: " " todo, "/" in_progress, "x"/"X" done, "-" cancelled, any other char todo.
 - due / scheduled / start / done / created / cancelled: date filters, each { before, on, after } in YYYY-MM-DD — before/after are exclusive, on is exact. A date filter only matches tasks that HAVE that date.
 - priority: array of "highest" | "high" | "medium" | "low" | "lowest" | "none", OR-combined ("none" = tasks with no priority signifier).
-- folder: note path prefix (e.g. "Code Projects/vault-cortex"). tag: bare inline-task-tag name; a parent tag matches children ("errand" matches "errand/groceries"). heading: exact heading text, case-sensitive (a Kanban lane name). path: one note, must end in ".md".
+- folder: note path prefix (e.g. "Code Projects/vault-cortex"). tag: bare inline-task-tag name; a parent tag matches children ("errand" matches "errand/groceries"). heading: exact heading text or array of headings, case-sensitive, OR-combined (e.g. ["Active", "Up Next"] returns tasks under either heading — useful for querying multiple Kanban lanes at once). path: one note, must end in ".md".
 - sort_by: "due" (default) | "scheduled" | "start" | "created" | "done" | "priority" | "note_mtime" | "position". Date sorts put dateless tasks last in both directions and cascade through related dates when the primary is absent — due falls through to scheduled → start → created; scheduled, start, and created cascade similarly through the remaining date fields. Each cascade step uses its own natural direction (due/scheduled ascending, start/created descending), so a task with no due date but a created date sorts newest-first rather than inheriting due's ascending order. An explicit sort_direction overrides all cascade steps uniformly. "done" does not cascade — it sorts by done date alone, with a modified-time tiebreaker for undated tasks. Fully dateless tasks tie-break by note modified time (most recent first), then file position. Priority sorts highest→lowest with unprioritized between medium and low. "position" sorts by file path then line number — the natural order for Kanban boards where card position IS priority.
 - limit: max results (default 50). The total field always reports the full match count, so "50 of 338" is distinguishable from "all 50".
 
@@ -761,10 +763,31 @@ Errors:
 Returns: JSON { total, tasks }. Each task carries: path, line (1-based file line number), status, status_char (raw checkbox character, for custom-status vaults), description (inline #tags kept in the text), folder (the note's full parent folder), heading (nearest heading above the task — on a Kanban board this is the lane name, null-omitted above the first heading), plus whichever metadata the task has: created/scheduled/start/due/done/cancelled dates, priority, recurrence (rule text — parsed, never executed), on_completion, task_id, depends_on, tags (bare inline tag names), block_id, is_kanban_task (true when the task's parent note has kanban-plugin frontmatter — present only when true, omitted for regular tasks; when true, heading carries the Kanban lane name and completing the task requires a lane move, not just a checkbox toggle). Null fields, false booleans, and empty arrays are omitted to keep responses lean.`,
       inputSchema: {
         status: z
-          .enum(["not_done", "todo", "in_progress", "done", "cancelled", "all"])
+          .union([
+            z.enum([
+              "not_done",
+              "todo",
+              "in_progress",
+              "done",
+              "cancelled",
+              "all",
+            ]),
+            z
+              .array(
+                z.enum([
+                  "not_done",
+                  "todo",
+                  "in_progress",
+                  "done",
+                  "cancelled",
+                  "all",
+                ]),
+              )
+              .min(1),
+          ])
           .optional()
           .describe(
-            'Status filter (default "not_done" = todo + in_progress, excluding done and cancelled)',
+            'Status filter, OR-combined (default "not_done" = todo + in_progress, excluding done and cancelled). Virtual values expand in arrays: "not_done" adds todo + in_progress, "all" includes every status.',
           ),
         due: taskDateFilterSchema.describe("Due date (📅 / [due:: ]) bounds"),
         scheduled: taskDateFilterSchema.describe(
@@ -803,11 +826,10 @@ Returns: JSON { total, tasks }. Each task carries: path, line (1-based file line
             'Inline task tag, bare name without "#"; parent tags match children',
           ),
         heading: z
-          .string()
-          .min(1)
+          .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
           .optional()
           .describe(
-            'Exact heading text above the task (case-sensitive) — a Kanban lane name (e.g. "Active")',
+            'Exact heading text or array of headings, OR-combined, case-sensitive (e.g. "Active" or ["Active", "Up Next"])',
           ),
         path: z
           .string()

--- a/src/vault-mcp/search/__tests__/task-queries.test.ts
+++ b/src/vault-mcp/search/__tests__/task-queries.test.ts
@@ -1068,3 +1068,155 @@ describe("listTasks sorting and paging", () => {
     ])
   })
 })
+
+describe("listTasks array params", () => {
+  /** A Kanban board with four lanes for testing multi-heading filters. */
+  const MULTI_LANE_BOARD = `---
+kanban-plugin: board
+---
+
+## Active
+
+- [/] Implement feature ➕ 2026-07-01
+
+## Up Next
+
+- [ ] Write docs ➕ 2026-07-02
+
+## Waiting On
+
+- [ ] Blocked on review ➕ 2026-07-03
+
+## Someday
+
+- [ ] Nice to have ➕ 2026-07-04
+`
+
+  const indexWithMultiLaneBoard = () => {
+    const index = createTestIndex()
+    index.upsertNote(
+      {
+        filePath: "Projects/board.md",
+        rawContent: MULTI_LANE_BOARD,
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    return index
+  }
+
+  // ── heading array ──
+
+  it("accepts a single-element heading array, equivalent to a scalar", () => {
+    const index = indexWithMultiLaneBoard()
+    const arrayResult = index.listTasks(
+      { status: "all", heading: ["Active"] },
+      logger,
+    )
+    const scalarResult = index.listTasks(
+      { status: "all", heading: "Active" },
+      logger,
+    )
+    expect(arrayResult).toEqual(scalarResult)
+    expect(arrayResult.tasks).toHaveLength(1)
+    expect(arrayResult.tasks[0]?.description).toBe("Implement feature")
+  })
+
+  it("returns tasks from multiple headings, excluding unselected lanes", () => {
+    const index = indexWithMultiLaneBoard()
+    const result = index.listTasks(
+      { status: "all", heading: ["Active", "Up Next", "Waiting On"] },
+      logger,
+    )
+    // Default sort is due ASC; all dateless, so cascade falls through to
+    // created DESC (newest first): 07-03 → 07-02 → 07-01.
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Blocked on review",
+      "Write docs",
+      "Implement feature",
+    ])
+    expect(result.total).toBe(3)
+  })
+
+  it("excludes tasks under headings not in the array", () => {
+    const index = indexWithMultiLaneBoard()
+    const result = index.listTasks(
+      { status: "all", heading: ["Active", "Up Next"] },
+      logger,
+    )
+    const headings = result.tasks.map((entry) => entry.heading)
+    expect(headings).not.toContain("Someday")
+    expect(headings).not.toContain("Waiting On")
+  })
+
+  // ── status array ──
+
+  it("accepts an array of real statuses, OR-combined", () => {
+    const index = indexWithBoard()
+    const result = index.listTasks({ status: ["done", "cancelled"] }, logger)
+    expect(result.tasks.map((entry) => entry.status)).toEqual(
+      expect.arrayContaining(["done", "cancelled"]),
+    )
+    expect(result.tasks).toHaveLength(2)
+  })
+
+  it("treats a single-element status array as equivalent to the scalar", () => {
+    const index = indexWithBoard()
+    const arrayResult = index.listTasks({ status: ["todo"] }, logger)
+    const scalarResult = index.listTasks({ status: "todo" }, logger)
+    expect(arrayResult).toEqual(scalarResult)
+  })
+
+  it("expands not_done in an array to todo + in_progress", () => {
+    const index = indexWithBoard()
+    const result = index.listTasks({ status: ["not_done", "done"] }, logger)
+    const statuses = result.tasks.map((entry) => entry.status)
+    expect(statuses).toContain("todo")
+    expect(statuses).toContain("in_progress")
+    expect(statuses).toContain("done")
+    expect(statuses).not.toContain("cancelled")
+  })
+
+  it("deduplicates when not_done overlaps with an explicit status", () => {
+    const index = indexWithBoard()
+    const result = index.listTasks({ status: ["not_done", "todo"] }, logger)
+    // not_done expands to todo + in_progress; the explicit "todo" is a duplicate
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Fix login bug",
+      "Write tests",
+    ])
+  })
+
+  it("treats all in an array as a no-filter, returning every status", () => {
+    const index = indexWithBoard()
+    const arrayResult = index.listTasks({ status: ["all"] }, logger)
+    const scalarResult = index.listTasks({ status: "all" }, logger)
+    expect(arrayResult).toEqual(scalarResult)
+    expect(arrayResult.tasks).toHaveLength(4)
+  })
+
+  it("matches explicit real statuses equivalent to not_done", () => {
+    const index = indexWithBoard()
+    const arrayResult = index.listTasks(
+      { status: ["todo", "in_progress"] },
+      logger,
+    )
+    const defaultResult = index.listTasks({}, logger)
+    expect(arrayResult).toEqual(defaultResult)
+  })
+
+  // ── combined array filters ──
+
+  it("AND-combines heading array with status array", () => {
+    const index = indexWithMultiLaneBoard()
+    const result = index.listTasks(
+      { heading: ["Active", "Someday"], status: ["todo"] },
+      logger,
+    )
+    // Only "Nice to have" is todo under Active or Someday;
+    // "Implement feature" is in_progress so excluded by status filter
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Nice to have",
+    ])
+  })
+})

--- a/src/vault-mcp/search/__tests__/task-queries.test.ts
+++ b/src/vault-mcp/search/__tests__/task-queries.test.ts
@@ -1144,9 +1144,12 @@ kanban-plugin: board
       { status: "all", heading: ["Active", "Up Next"] },
       logger,
     )
-    const headings = result.tasks.map((entry) => entry.heading)
-    expect(headings).not.toContain("Someday")
-    expect(headings).not.toContain("Waiting On")
+    // Exact match proves inclusion of Active + Up Next AND exclusion of
+    // Someday + Waiting On — a vacuous empty result cannot satisfy this.
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Write docs",
+      "Implement feature",
+    ])
   })
 
   // ── status array ──
@@ -1154,10 +1157,10 @@ kanban-plugin: board
   it("accepts an array of real statuses, OR-combined", () => {
     const index = indexWithBoard()
     const result = index.listTasks({ status: ["done", "cancelled"] }, logger)
-    expect(result.tasks.map((entry) => entry.status)).toEqual(
-      expect.arrayContaining(["done", "cancelled"]),
-    )
-    expect(result.tasks).toHaveLength(2)
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Old idea",
+      "Ship release",
+    ])
   })
 
   it("treats a single-element status array as equivalent to the scalar", () => {
@@ -1170,11 +1173,13 @@ kanban-plugin: board
   it("expands not_done in an array to todo + in_progress", () => {
     const index = indexWithBoard()
     const result = index.listTasks({ status: ["not_done", "done"] }, logger)
-    const statuses = result.tasks.map((entry) => entry.status)
-    expect(statuses).toContain("todo")
-    expect(statuses).toContain("in_progress")
-    expect(statuses).toContain("done")
-    expect(statuses).not.toContain("cancelled")
+    // Exact ordered match: due ASC puts Fix login bug first (due 2026-07-01),
+    // then dateless tasks cascade through related dates.
+    expect(result.tasks.map((entry) => entry.description)).toEqual([
+      "Fix login bug",
+      "Write tests",
+      "Ship release",
+    ])
   })
 
   it("deduplicates when not_done overlaps with an explicit status", () => {

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -633,12 +633,12 @@ export const listTasks = (
   ] as const
   // Expand virtual values to concrete DB statuses, then deduplicate so
   // ["not_done", "todo"] doesn't double-bind "todo" in the IN clause.
-  const withExpansions = statusValues.flatMap((value) => {
+  const statusValuesWithExpansions = statusValues.flatMap((value) => {
     if (value === "all") return [...CONCRETE_STATUSES]
     if (value === "not_done") return ["todo", "in_progress"] as const
     return [value]
   })
-  const expandedStatuses = [...new Set(withExpansions)]
+  const expandedStatuses = [...new Set(statusValuesWithExpansions)]
   const coversAllStatuses = CONCRETE_STATUSES.every((status) =>
     expandedStatuses.includes(status),
   )

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -631,21 +631,18 @@ export const listTasks = (
     "done",
     "cancelled",
   ] as const
-  // Virtual → concrete: "not_done" becomes ["todo","in_progress"], "all" becomes
-  // every concrete status. Deduplicated so ["not_done","todo"] doesn't double-bind.
-  const expandedStatuses = [
-    ...new Set(
-      statusValues.flatMap((value) => {
-        if (value === "all") return [...CONCRETE_STATUSES]
-        if (value === "not_done") return ["todo", "in_progress"] as const
-        return [value]
-      }),
-    ),
-  ]
-  const isUnfiltered = CONCRETE_STATUSES.every((status) =>
-    expandedStatuses.includes(status),
-  )
-  if (!isUnfiltered && expandedStatuses.length > 0) {
+  // Expand virtual values to concrete DB statuses, then deduplicate so
+  // ["not_done", "todo"] doesn't double-bind "todo" in the IN clause.
+  const withExpansions = statusValues.flatMap((value) => {
+    if (value === "all") return [...CONCRETE_STATUSES]
+    if (value === "not_done") return ["todo", "in_progress"] as const
+    return [value]
+  })
+  const expandedStatuses = [...new Set(withExpansions)]
+  const needsStatusFilter =
+    expandedStatuses.length > 0 &&
+    !CONCRETE_STATUSES.every((status) => expandedStatuses.includes(status))
+  if (needsStatusFilter) {
     conditions.push(
       `t.status IN (${expandedStatuses.map(() => "?").join(", ")})`,
     )

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -621,11 +621,11 @@ export const listTasks = (
   const conditions: string[] = []
   const queryParams: unknown[] = []
 
-  // Normalize status to an array of real DB values (todo/in_progress/done/cancelled),
+  // Normalize status to concrete DB values (todo/in_progress/done/cancelled),
   // expanding virtual values: not_done → todo + in_progress, all → skip the filter.
   const statusInput = params.status ?? "not_done"
   const statusValues = Array.isArray(statusInput) ? statusInput : [statusInput]
-  const ALL_REAL_STATUSES = [
+  const CONCRETE_STATUSES = [
     "todo",
     "in_progress",
     "done",
@@ -634,16 +634,16 @@ export const listTasks = (
   const expandedStatuses = [
     ...new Set(
       statusValues.flatMap((value) => {
-        if (value === "all") return [...ALL_REAL_STATUSES]
+        if (value === "all") return [...CONCRETE_STATUSES]
         if (value === "not_done") return ["todo", "in_progress"] as const
         return [value]
       }),
     ),
   ]
-  const isAllStatuses = ALL_REAL_STATUSES.every((real) =>
-    expandedStatuses.includes(real),
+  const isUnfiltered = CONCRETE_STATUSES.every((status) =>
+    expandedStatuses.includes(status),
   )
-  if (!isAllStatuses && expandedStatuses.length > 0) {
+  if (!isUnfiltered && expandedStatuses.length > 0) {
     conditions.push(
       `t.status IN (${expandedStatuses.map(() => "?").join(", ")})`,
     )

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -631,6 +631,8 @@ export const listTasks = (
     "done",
     "cancelled",
   ] as const
+  // Virtual → concrete: "not_done" becomes ["todo","in_progress"], "all" becomes
+  // every concrete status. Deduplicated so ["not_done","todo"] doesn't double-bind.
   const expandedStatuses = [
     ...new Set(
       statusValues.flatMap((value) => {

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -638,16 +638,17 @@ export const listTasks = (
     if (value === "not_done") return ["todo", "in_progress"] as const
     return [value]
   })
-  const expandedStatuses = [...new Set(statusValuesWithExpansions)]
+  const expandedStatusValues = [...new Set(statusValuesWithExpansions)]
   const coversAllStatuses = CONCRETE_STATUSES.every((status) =>
-    expandedStatuses.includes(status),
+    expandedStatusValues.includes(status),
   )
-  const needsStatusFilter = expandedStatuses.length > 0 && !coversAllStatuses
+  const needsStatusFilter =
+    expandedStatusValues.length > 0 && !coversAllStatuses
   if (needsStatusFilter) {
     conditions.push(
-      `t.status IN (${expandedStatuses.map(() => "?").join(", ")})`,
+      `t.status IN (${expandedStatusValues.map(() => "?").join(", ")})`,
     )
-    queryParams.push(...expandedStatuses)
+    queryParams.push(...expandedStatusValues)
   }
 
   // A date filter only ever matches tasks that HAVE that date — SQL comparison

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -643,7 +643,7 @@ export const listTasks = (
   const isAllStatuses = ALL_REAL_STATUSES.every((real) =>
     expandedStatuses.includes(real),
   )
-  if (!isAllStatuses) {
+  if (!isAllStatuses && expandedStatuses.length > 0) {
     conditions.push(
       `t.status IN (${expandedStatuses.map(() => "?").join(", ")})`,
     )
@@ -719,8 +719,10 @@ export const listTasks = (
     const headings = Array.isArray(params.heading)
       ? params.heading
       : [params.heading]
-    conditions.push(`t.heading IN (${headings.map(() => "?").join(", ")})`)
-    queryParams.push(...headings)
+    if (headings.length > 0) {
+      conditions.push(`t.heading IN (${headings.map(() => "?").join(", ")})`)
+      queryParams.push(...headings)
+    }
   }
 
   if (params.path !== undefined) {

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -600,7 +600,7 @@ const TASK_ORDER_BY: Record<
 export const listTasks = (
   context: SearchQueryContext,
   params: {
-    status?: TaskStatusFilter | undefined
+    status?: TaskStatusFilter | TaskStatusFilter[] | undefined
     due?: TaskDateFilter | undefined
     scheduled?: TaskDateFilter | undefined
     start?: TaskDateFilter | undefined
@@ -610,7 +610,7 @@ export const listTasks = (
     priority?: TaskPriorityFilter[] | undefined
     folder?: string | undefined
     tag?: string | undefined
-    heading?: string | undefined
+    heading?: string | string[] | undefined
     path?: string | undefined
     limit?: number | undefined
     sortBy?: TaskSortKey | undefined
@@ -621,12 +621,33 @@ export const listTasks = (
   const conditions: string[] = []
   const queryParams: unknown[] = []
 
-  const status = params.status ?? "not_done"
-  if (status === "not_done") {
-    conditions.push("t.status IN ('todo', 'in_progress')")
-  } else if (status !== "all") {
-    conditions.push("t.status = ?")
-    queryParams.push(status)
+  // Normalize status to an array of real DB values (todo/in_progress/done/cancelled),
+  // expanding virtual values: not_done → todo + in_progress, all → skip the filter.
+  const statusInput = params.status ?? "not_done"
+  const statusValues = Array.isArray(statusInput) ? statusInput : [statusInput]
+  const ALL_REAL_STATUSES = [
+    "todo",
+    "in_progress",
+    "done",
+    "cancelled",
+  ] as const
+  const expandedStatuses = [
+    ...new Set(
+      statusValues.flatMap((value) => {
+        if (value === "all") return [...ALL_REAL_STATUSES]
+        if (value === "not_done") return ["todo", "in_progress"] as const
+        return [value]
+      }),
+    ),
+  ]
+  const isAllStatuses = ALL_REAL_STATUSES.every((real) =>
+    expandedStatuses.includes(real),
+  )
+  if (!isAllStatuses) {
+    conditions.push(
+      `t.status IN (${expandedStatuses.map(() => "?").join(", ")})`,
+    )
+    queryParams.push(...expandedStatuses)
   }
 
   // A date filter only ever matches tasks that HAVE that date — SQL comparison
@@ -695,8 +716,11 @@ export const listTasks = (
   }
 
   if (params.heading !== undefined) {
-    conditions.push("t.heading = ?")
-    queryParams.push(params.heading)
+    const headings = Array.isArray(params.heading)
+      ? params.heading
+      : [params.heading]
+    conditions.push(`t.heading IN (${headings.map(() => "?").join(", ")})`)
+    queryParams.push(...headings)
   }
 
   if (params.path !== undefined) {
@@ -744,7 +768,7 @@ export const listTasks = (
   const taskEntries = rows.map(rowToTaskEntry)
 
   logger.info("list tasks", {
-    status,
+    status: statusInput,
     sortBy,
     resultCount: taskEntries.length,
     total,

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -639,9 +639,10 @@ export const listTasks = (
     return [value]
   })
   const expandedStatuses = [...new Set(withExpansions)]
-  const needsStatusFilter =
-    expandedStatuses.length > 0 &&
-    !CONCRETE_STATUSES.every((status) => expandedStatuses.includes(status))
+  const coversAllStatuses = CONCRETE_STATUSES.every((status) =>
+    expandedStatuses.includes(status),
+  )
+  const needsStatusFilter = expandedStatuses.length > 0 && !coversAllStatuses
   if (needsStatusFilter) {
     conditions.push(
       `t.status IN (${expandedStatuses.map(() => "?").join(", ")})`,


### PR DESCRIPTION
## Summary

- `heading` and `status` params on `vault_list_tasks` now accept `string | string[]`, backward-compatible with existing scalar callers
- Multi-heading queries collapse 3 Kanban lane calls into one: `heading: ["Active", "Up Next", "Waiting On"]`
- Status arrays OR-combine real values; virtual values (`not_done`, `all`) expand naturally in arrays — `["not_done", "done"]` matches todo + in_progress + done
- Deduplication handles overlap (e.g. `["not_done", "todo"]` doesn't double-count)
- 10 new tests covering heading arrays, status arrays, virtual expansion, dedup, and combined filters; mutation-verified

## Test plan

- [x] All 1522 tests pass (`npm test`)
- [x] `tsc --noEmit` clean
- [x] Mutation-verified: broke heading IN clause → 2 tests fail; broke status array normalization → 3 tests fail
- [ ] Ship-check pipeline (5 phases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)