### PR TITLE
fix(parser): make task and heading parsers comment-aware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -416,7 +416,10 @@ undefined) return`) or schema validation to narrow types instead.
   explaining the overall strategy before the query.
 - Early returns over nested `if/else` — reduces indentation depth
   and cognitive load. Prefer `if (done) return` over wrapping 15
-  lines in `if (!done) { ... }`.
+  lines in `if (!done) { ... }`. In loops, prefer `if (cond) { …;
+continue }` over `if/else if` chains — each branch is
+  self-contained and the reader doesn't have to track mutual
+  exclusivity across the chain.
 - Extract multi-clause conditionals into a named boolean when the `if`
   condition spans more than one line or combines unrelated checks. A
   reader should understand the guard's intent from the variable name

--- a/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
@@ -151,6 +151,26 @@ describe("parseHeadings", () => {
     ])
   })
 
+  it("ignores a heading inside a single-line inline comment", () => {
+    const lines = ["# Real", "%% ## Hidden %%", "## Also real"]
+    expect(parseHeadings(lines).map((heading) => heading.text)).toEqual([
+      "Real",
+      "Also real",
+    ])
+  })
+
+  it("ignores headings inside an unclosed comment running to EOF", () => {
+    const lines = [
+      "# Real",
+      "%%",
+      "## Hidden by unclosed comment",
+      "## Also hidden",
+    ]
+    expect(parseHeadings(lines).map((heading) => heading.text)).toEqual([
+      "Real",
+    ])
+  })
+
   it("does not toggle comment state inside a fenced code block", () => {
     const lines = [
       "```",

--- a/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
@@ -119,6 +119,51 @@ describe("parseHeadings", () => {
   it("returns an empty array when there are no headings", () => {
     expect(parseHeadings(["just", "prose"])).toEqual([])
   })
+
+  // ── comment-block awareness ───────────────────────────────────
+
+  it("ignores headings inside a %% %% comment block", () => {
+    const lines = ["# Real", "%%", "## Hidden", "%%", "## Also real"]
+    expect(parseHeadings(lines).map((heading) => heading.text)).toEqual([
+      "Real",
+      "Also real",
+    ])
+  })
+
+  it("recognizes a heading after a comment block closes", () => {
+    const lines = ["%%", "## Hidden", "%%", "## Visible"]
+    expect(parseHeadings(lines).map((heading) => heading.text)).toEqual([
+      "Visible",
+    ])
+  })
+
+  it("does not open a fence inside a comment block", () => {
+    const lines = [
+      "%%",
+      "```",
+      "## Hidden inside comment",
+      "```",
+      "%%",
+      "## Visible",
+    ]
+    expect(parseHeadings(lines).map((heading) => heading.text)).toEqual([
+      "Visible",
+    ])
+  })
+
+  it("does not toggle comment state inside a fenced code block", () => {
+    const lines = [
+      "```",
+      "%%",
+      "## Hidden inside fence",
+      "%%",
+      "```",
+      "## Real",
+    ]
+    expect(parseHeadings(lines).map((heading) => heading.text)).toEqual([
+      "Real",
+    ])
+  })
 })
 
 describe("findHeading", () => {

--- a/src/vault-mcp/obsidian-markdown/__tests__/lines.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/lines.test.ts
@@ -106,6 +106,13 @@ describe("advanceComment", () => {
       lineIsComment: true,
     })
   })
+
+  it("counts only the boundary %% when a non-boundary %% sits mid-line", () => {
+    expect(advanceComment("%% note %% more text", false)).toEqual({
+      commentOpen: true,
+      lineIsComment: true,
+    })
+  })
 })
 
 // ── advanceFence ─────────────────────────────────────────────────

--- a/src/vault-mcp/obsidian-markdown/__tests__/lines.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/lines.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import {
   splitIntoLines,
   advanceFence,
+  advanceComment,
   classifyLines,
   type OpenFence,
 } from "../lines.js"
@@ -23,6 +24,87 @@ describe("splitIntoLines", () => {
 
   it("returns a single empty line for empty content", () => {
     expect(splitIntoLines("")).toEqual([""])
+  })
+})
+
+// ── advanceComment ──────────────────────────────────────────────
+
+describe("advanceComment", () => {
+  it("reports a plain line outside a comment as not comment", () => {
+    expect(advanceComment("some text", false)).toEqual({
+      commentOpen: false,
+      lineIsComment: false,
+    })
+  })
+
+  it("reports a plain line inside an open comment as comment", () => {
+    expect(advanceComment("some text", true)).toEqual({
+      commentOpen: true,
+      lineIsComment: true,
+    })
+  })
+
+  it("opens a comment on a standalone %% delimiter", () => {
+    expect(advanceComment("%%", false)).toEqual({
+      commentOpen: true,
+      lineIsComment: true,
+    })
+  })
+
+  it("closes a comment on a standalone %% delimiter", () => {
+    expect(advanceComment("%%", true)).toEqual({
+      commentOpen: false,
+      lineIsComment: true,
+    })
+  })
+
+  it("opens a comment when line starts with %%", () => {
+    expect(advanceComment("%% hidden text", false)).toEqual({
+      commentOpen: true,
+      lineIsComment: true,
+    })
+  })
+
+  it("closes a comment when line ends with %%", () => {
+    expect(advanceComment("end of comment %%", true)).toEqual({
+      commentOpen: false,
+      lineIsComment: true,
+    })
+  })
+
+  it("handles inline comment (2 toggles) from closed state — net unchanged", () => {
+    expect(advanceComment("%% inline comment %%", false)).toEqual({
+      commentOpen: false,
+      lineIsComment: true,
+    })
+  })
+
+  it("handles inline comment (2 toggles) from open state — net unchanged", () => {
+    expect(advanceComment("%% inline comment %%", true)).toEqual({
+      commentOpen: true,
+      lineIsComment: true,
+    })
+  })
+
+  it("does not toggle on mid-line %% surrounded by other text", () => {
+    expect(advanceComment("Card with 100%% off", false)).toEqual({
+      commentOpen: false,
+      lineIsComment: false,
+    })
+  })
+
+  it("does not toggle on mid-line %% inside an open comment", () => {
+    expect(advanceComment("100%% done items", true)).toEqual({
+      commentOpen: true,
+      lineIsComment: true,
+    })
+  })
+
+  it("treats a whitespace-padded %% as a delimiter", () => {
+    expect(advanceComment("  %%  ", false)).toEqual({
+      commentOpen: true,
+      lineIsComment: true,
+    })
   })
 })
 

--- a/src/vault-mcp/obsidian-markdown/__tests__/tasks.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/tasks.test.ts
@@ -598,6 +598,105 @@ describe("tasks.extractTasks", () => {
     })
   })
 
+  describe("comment blocks", () => {
+    it("excludes task lines inside a %% %% comment block", () => {
+      const content = [
+        "- [ ] Visible task",
+        "%%",
+        "- [ ] Hidden task",
+        "%%",
+        "- [ ] Another visible task",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 1, description: "Visible task" }),
+        task({ line: 5, description: "Another visible task" }),
+      ])
+    })
+
+    it("excludes a single-line inline comment containing a task", () => {
+      const content = [
+        "- [ ] Visible task",
+        "%% - [ ] Hidden inline task %%",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 1, description: "Visible task" }),
+      ])
+    })
+
+    it("skips all tasks after an unclosed comment running to EOF", () => {
+      const content = [
+        "- [ ] Visible task",
+        "%%",
+        "- [ ] Hidden by unclosed comment",
+        "- [ ] Also hidden",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 1, description: "Visible task" }),
+      ])
+    })
+
+    it("does not open a fence inside a comment block", () => {
+      const content = [
+        "%%",
+        "```",
+        "- [ ] Hidden inside comment, fence is just text",
+        "```",
+        "%%",
+        "- [ ] Visible after comment closes",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 6, description: "Visible after comment closes" }),
+      ])
+    })
+
+    it("does not toggle comment state inside a fenced code block", () => {
+      const content = [
+        "```",
+        "%%",
+        "- [ ] Inside fence, %% is just text",
+        "%%",
+        "```",
+        "- [ ] Visible after fence closes",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 6, description: "Visible after fence closes" }),
+      ])
+    })
+
+    it("does not toggle on mid-line %% in card text", () => {
+      const content = ["- [ ] Card with 100%% off", "- [ ] Another card"].join(
+        "\n",
+      )
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 1, description: "Card with 100%% off" }),
+        task({ line: 2, description: "Another card" }),
+      ])
+    })
+
+    it("attributes tasks after a comment block to the heading before it", () => {
+      const content = [
+        "## Active",
+        "- [ ] Active task",
+        "%%",
+        "## Hidden Heading",
+        "- [ ] Hidden task",
+        "%%",
+        "- [ ] Still under Active",
+      ].join("\n")
+      const extracted = tasks.extractTasks(content)
+      expect(extracted).toEqual([
+        task({ line: 2, description: "Active task", heading: "Active" }),
+        task({ line: 7, description: "Still under Active", heading: "Active" }),
+      ])
+    })
+  })
+
   describe("heading attribution", () => {
     it("attributes each task to the nearest heading above it", () => {
       const content = [

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -62,6 +62,8 @@ export const findTrailingCommentBlockStart = (
     commentOpen = commentResult.commentOpen
 
     // Derive block-tracking transitions from before/after state.
+    const isInlineComment =
+      !wasOpen && !commentOpen && commentResult.lineIsComment
     if (!wasOpen && commentOpen) {
       // Comment just opened on this line.
       commentOpenLine = i
@@ -72,7 +74,7 @@ export const findTrailingCommentBlockStart = (
       lastClosedBlock = validCloser
         ? { startLine: commentOpenLine, endLine: i }
         : null
-    } else if (!wasOpen && !commentOpen && commentResult.lineIsComment) {
+    } else if (isInlineComment) {
       // Inline comment (`%% text %%`) — opened and closed on the same line.
       const validCloser = line.trimEnd().endsWith(COMMENT_DELIMITER)
       lastClosedBlock = validCloser ? { startLine: i, endLine: i } : null

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -5,7 +5,12 @@
  * parser: "read section X" and "edit section X" resolve to the exact same span.
  */
 
-import { advanceFence, type OpenFence } from "./lines.js"
+import {
+  advanceComment,
+  advanceFence,
+  COMMENT_DELIMITER,
+  type OpenFence,
+} from "./lines.js"
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -22,83 +27,62 @@ export type HeadingInfo = Readonly<{
 /** Matches markdown headings H1–H6: captures the `#` prefix and heading text. */
 const HEADING_REGEX = /^(#{1,6}) (.+)$/
 
-/** Obsidian comment delimiter — toggles comment state when it occurs at a
- * line boundary (start or end of trimmed line). Mid-line `%%` (e.g. `100%%`
- * embedded in card text) is not a delimiter. */
-const COMMENT_DELIMITER = "%%"
-
-/**
- * Counts how many comment-state toggles a single line produces. Obsidian
- * treats `%%` as a comment delimiter only at line boundaries — mid-line
- * occurrences like `100%%` or `text %% mid` do not toggle state.
- *
- * Returns 0, 1, or 2:
- * - 0 — trimmed line has no `%%` at start or end
- * - 1 — trimmed line is exactly `%%`, OR starts XOR ends with `%%`
- * - 2 — trimmed line both starts and ends with `%%` (inline `%% comment %%`)
- */
-const countCommentToggles = (line: string): number => {
-  const trimmed = line.trim()
-  if (trimmed === COMMENT_DELIMITER) return 1
-  const startsWithDelimiter = trimmed.startsWith(COMMENT_DELIMITER)
-  const endsWithDelimiter = trimmed.endsWith(COMMENT_DELIMITER)
-  return (startsWithDelimiter ? 1 : 0) + (endsWithDelimiter ? 1 : 0)
-}
-
 /**
  * Finds the line index where a trailing Obsidian comment block begins, so the
  * final section's body can stop short of it. Returns `lines.length` when none
  * exists. A block is "trailing" when only blank lines follow its closing `%%`
  * (or when an unclosed comment runs to EOF).
- *
- * Known limitation: heading detection in `parseHeadings` is NOT comment-aware,
- * so a `## heading` inside a `%% %%` block is still treated as a real heading.
  */
 export const findTrailingCommentBlockStart = (
   lines: readonly string[],
 ): number => {
-  // `let` carries fence + comment parser state across lines — a per-line
-  // reduce can't express the per-`%%` toggle cleanly.
+  // `let` carries fence + comment parser state and block-tracking across
+  // lines — the block-tracking logic (where a comment opened/closed) is
+  // domain-specific to trailing-block detection, layered on top of the
+  // shared advanceComment state machine.
   let openFence: OpenFence = null
-  let comment: { openLine: number } | null = null
+  let commentOpen = false
+  let commentOpenLine = -1
   let lastClosedBlock: { startLine: number; endLine: number } | null = null
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
     if (line === undefined) continue
 
-    // Fence state advances only outside comments: inside a `%%` comment, `%%`
-    // takes precedence and fence delimiters are just comment text (matching
-    // Obsidian's parser). A fence-delimiter line never toggles comment state.
-    if (!comment) {
+    // Fence/comment precedence: fence state advances only outside comments;
+    // comment toggles run only outside fences.
+    if (!commentOpen) {
       const fenceResult = advanceFence(line, openFence)
       openFence = fenceResult.openFence
       if (fenceResult.lineIsCode) continue
     }
 
-    // Outside fences (or inside a comment): `%%` at the start or end of the
-    // trimmed line toggles comment state. Mid-line `%%` (e.g. `100%%` in card
-    // text) is not a delimiter and is ignored.
-    const toggleCount = countCommentToggles(line)
-    for (let occurrence = 0; occurrence < toggleCount; occurrence++) {
-      if (comment) {
-        // Validate that the closer ends its own line — otherwise the block
-        // isn't cleanly separable from body text and can't be preserved.
-        const validCloser = line.trimEnd().endsWith(COMMENT_DELIMITER)
-        lastClosedBlock = validCloser
-          ? { startLine: comment.openLine, endLine: i }
-          : null
-        comment = null
-      } else {
-        comment = { openLine: i }
-      }
+    const wasOpen = commentOpen
+    const commentResult = advanceComment(line, commentOpen)
+    commentOpen = commentResult.commentOpen
+
+    // Derive block-tracking transitions from before/after state.
+    if (!wasOpen && commentOpen) {
+      // Comment just opened on this line.
+      commentOpenLine = i
+    } else if (wasOpen && !commentOpen) {
+      // Comment just closed on this line. Validate that the closer ends its
+      // own line — otherwise the block isn't cleanly separable from body text.
+      const validCloser = line.trimEnd().endsWith(COMMENT_DELIMITER)
+      lastClosedBlock = validCloser
+        ? { startLine: commentOpenLine, endLine: i }
+        : null
+    } else if (!wasOpen && !commentOpen && commentResult.lineIsComment) {
+      // Inline comment (`%% text %%`) — opened and closed on the same line.
+      const validCloser = line.trimEnd().endsWith(COMMENT_DELIMITER)
+      lastClosedBlock = validCloser ? { startLine: i, endLine: i } : null
     }
   }
 
   // An unclosed comment runs to EOF and is trailing by definition. A closed
   // block is trailing only when nothing but blank lines follow it.
-  const trailingBlock = comment
-    ? { startLine: comment.openLine }
+  const trailingBlock = commentOpen
+    ? { startLine: commentOpenLine }
     : lastClosedBlock &&
         lines
           .slice(lastClosedBlock.endLine + 1)
@@ -129,22 +113,42 @@ export const findTrailingCommentBlockStart = (
 // ── Exported parser ─────────────────────────────────────────────
 
 /**
- * Single-pass heading parser for H1–H6 with code-block awareness.
+ * Single-pass heading parser for H1–H6 with code-block and comment awareness.
  * Section body = heading+1 through next heading of same-or-higher level (or EOF).
  */
 export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
-  // Phase 1: collect headings, skipping content inside fenced code blocks. Fence
-  // state is threaded through advanceFence in the accumulator (no mutable
-  // external state).
+  // Phase 1: collect headings, skipping content inside fenced code blocks and
+  // `%% %%` comment blocks. Fence and comment state are threaded through the
+  // accumulator (no mutable external state).
   const { headings: collectedHeadings } = lines.reduce<{
     headings: Array<{ text: string; level: number; startLine: number }>
     openFence: OpenFence
+    commentOpen: boolean
   }>(
     (state, line, i) => {
-      const fenceResult = advanceFence(line, state.openFence)
+      // Fence/comment precedence: fence state advances only outside comments
+      // (inside a comment, fence delimiters are just text); comment toggles
+      // run only outside fences (inside a fence, `%%` is just text).
+      const fenceResult = state.commentOpen
+        ? null
+        : advanceFence(line, state.openFence)
+      // fenceResult is null when inside a comment (fence processing skipped);
+      // fenceResult.openFence is null when a fence just closed — both are valid
+      // states, so `??` can't distinguish them.
+      const openFence =
+        fenceResult !== null ? fenceResult.openFence : state.openFence
 
-      if (fenceResult.lineIsCode) {
-        return { headings: state.headings, openFence: fenceResult.openFence }
+      if (fenceResult?.lineIsCode) {
+        return { headings: state.headings, openFence, commentOpen: false }
+      }
+
+      const commentResult = advanceComment(line, state.commentOpen)
+      if (commentResult.lineIsComment) {
+        return {
+          headings: state.headings,
+          openFence,
+          commentOpen: commentResult.commentOpen,
+        }
       }
 
       const match = HEADING_REGEX.exec(line)
@@ -161,13 +165,14 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
               startLine: i,
             },
           ],
-          openFence: fenceResult.openFence,
+          openFence,
+          commentOpen: false,
         }
       }
 
-      return { headings: state.headings, openFence: fenceResult.openFence }
+      return { headings: state.headings, openFence, commentOpen: false }
     },
-    { headings: [], openFence: null },
+    { headings: [], openFence: null, commentOpen: false },
   )
 
   // Phase 2: compute body ranges — each section's body ends where the next

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -62,20 +62,22 @@ export const findTrailingCommentBlockStart = (
     commentOpen = commentResult.commentOpen
 
     // Derive block-tracking transitions from before/after state.
-    const isInlineComment =
-      !wasOpen && !commentOpen && commentResult.lineIsComment
     if (!wasOpen && commentOpen) {
-      // Comment just opened on this line.
       commentOpenLine = i
-    } else if (wasOpen && !commentOpen) {
-      // Comment just closed on this line. Validate that the closer ends its
-      // own line — otherwise the block isn't cleanly separable from body text.
+      continue
+    }
+
+    if (wasOpen && !commentOpen) {
       const validCloser = line.trimEnd().endsWith(COMMENT_DELIMITER)
       lastClosedBlock = validCloser
         ? { startLine: commentOpenLine, endLine: i }
         : null
-    } else if (isInlineComment) {
-      // Inline comment (`%% text %%`) — opened and closed on the same line.
+      continue
+    }
+
+    const isInlineComment =
+      !wasOpen && !commentOpen && commentResult.lineIsComment
+    if (isInlineComment) {
       const validCloser = line.trimEnd().endsWith(COMMENT_DELIMITER)
       lastClosedBlock = validCloser ? { startLine: i, endLine: i } : null
     }

--- a/src/vault-mcp/obsidian-markdown/lines.ts
+++ b/src/vault-mcp/obsidian-markdown/lines.ts
@@ -200,17 +200,11 @@ export const advanceComment = (
   commentOpen: boolean,
 ): CommentResult => {
   const toggleCount = countCommentToggles(line)
-  const wasOpen = commentOpen
-  // Apply toggles sequentially: each occurrence flips the state.
-  // For 2 toggles (inline `%% text %%`), the state flips twice — net
-  // unchanged when starting closed, net unchanged when starting open.
-  let currentlyOpen = commentOpen
-  for (let toggle = 0; toggle < toggleCount; toggle++) {
-    currentlyOpen = !currentlyOpen
-  }
+  // Each toggle flips the state; an even count nets no change.
+  const currentlyOpen = toggleCount % 2 === 0 ? commentOpen : !commentOpen
   return {
     commentOpen: currentlyOpen,
-    lineIsComment: wasOpen || toggleCount > 0,
+    lineIsComment: commentOpen || toggleCount > 0,
   }
 }
 

--- a/src/vault-mcp/obsidian-markdown/lines.ts
+++ b/src/vault-mcp/obsidian-markdown/lines.ts
@@ -1,12 +1,10 @@
-/** Low-level Markdown line and fenced-code primitives, shared across the parsing
- *  domain: the link grammar (links.ts), the heading/section parser (headings.ts),
- *  and — via splitIntoLines — the note-editing layer that turns raw note content
- *  into lines.
+/** Low-level Markdown line primitives shared across the parsing domain: the link
+ *  grammar (links.ts), the heading/section parser (headings.ts), and — via
+ *  splitIntoLines — the note-editing layer that turns raw note content into lines.
  *
- *  This is the single home of the CommonMark §4.5 fenced-code state machine
- *  (advanceFence). classifyLines (a content -> {text, inCode} generator) and the
- *  heading parser both thread their fence state through advanceFence, so they can
- *  never disagree about where a code fence opens or closes. */
+ *  Two per-line state machines live here — advanceFence (CommonMark §4.5 fenced-code)
+ *  and advanceComment (Obsidian `%% %%` comments) — so every consumer threads the
+ *  same logic and they can never disagree about where code or comments begin. */
 
 // ── Line splitting ──────────────────────────────────────────────
 
@@ -152,6 +150,67 @@ export const advanceFence = (
     openFence: closesFence ? null : openFence,
     isFenceDelimiter: true,
     lineIsCode: true,
+  }
+}
+
+// ── Obsidian comment state machine ─────────────────────────────
+
+/** Obsidian comment delimiter — toggles comment state when it occurs at a
+ *  line boundary (start or end of trimmed line). Mid-line `%%` (e.g. `100%%`
+ *  embedded in card text) is not a delimiter. */
+export const COMMENT_DELIMITER = "%%"
+
+/**
+ * Counts how many comment-state toggles a single line produces. Obsidian
+ * treats `%%` as a comment delimiter only at line boundaries — mid-line
+ * occurrences like `100%%` or `text %% mid` do not toggle state.
+ *
+ * Returns 0, 1, or 2:
+ * - 0 — trimmed line has no `%%` at start or end
+ * - 1 — trimmed line is exactly `%%`, OR starts XOR ends with `%%`
+ * - 2 — trimmed line both starts and ends with `%%` (inline `%% comment %%`)
+ */
+const countCommentToggles = (line: string): number => {
+  const trimmed = line.trim()
+  if (trimmed === COMMENT_DELIMITER) return 1
+  const startsWithDelimiter = trimmed.startsWith(COMMENT_DELIMITER)
+  const endsWithDelimiter = trimmed.endsWith(COMMENT_DELIMITER)
+  return (startsWithDelimiter ? 1 : 0) + (endsWithDelimiter ? 1 : 0)
+}
+
+export type CommentResult = {
+  commentOpen: boolean
+  lineIsComment: boolean
+}
+
+/** Advances the Obsidian `%% %%` comment state machine by one line — the
+ *  single comment transition shared by every comment-aware walk.
+ *
+ *  `lineIsComment` is true when the line is inside a comment block (the entry
+ *  state was open) OR the line contains a `%%` delimiter (opener, closer, or
+ *  inline `%% text %%`). Delimiter lines themselves are comment content because
+ *  Obsidian does not render them.
+ *
+ *  Callers orchestrate fence/comment precedence: advance fences only outside
+ *  comments, and call advanceComment only outside fences. This matches
+ *  Obsidian's parser — inside a comment, fence delimiters are just text;
+ *  inside a fence, `%%` is just text. */
+export const advanceComment = (
+  line: string,
+  commentOpen: boolean,
+): CommentResult => {
+  const toggleCount = countCommentToggles(line)
+  const wasOpen = commentOpen
+  // Apply toggles sequentially: each occurrence flips the state.
+  // For 2 toggles (inline `%% text %%`), the state flips twice — net
+  // unchanged when starting closed, net unchanged when starting open.
+  let currentlyOpen = commentOpen
+  for (let toggle = 0; toggle < toggleCount; toggle++) {
+    currentlyOpen = !currentlyOpen
+  }
+  return {
+    commentOpen: currentlyOpen,
+    lineIsComment: wasOpen || toggleCount > 0,
   }
 }
 

--- a/src/vault-mcp/obsidian-markdown/tasks.ts
+++ b/src/vault-mcp/obsidian-markdown/tasks.ts
@@ -18,7 +18,12 @@
  *  `$`-anchored field regexes are only meaningful inside the stripping loop. */
 
 import { DateTime } from "luxon"
-import { advanceFence, type OpenFence, splitIntoLines } from "./lines.js"
+import {
+  advanceComment,
+  advanceFence,
+  type OpenFence,
+  splitIntoLines,
+} from "./lines.js"
 import { parseHeadings } from "./headings.js"
 
 // ── Types ───────────────────────────────────────────────────────
@@ -426,9 +431,10 @@ const findBodyStartLine = (lines: readonly string[]): number => {
 
 /** Extracts every task line from raw note content (frontmatter included — it
  *  is skipped here so reported line numbers stay file-relative). Lines inside
- *  fenced code blocks are excluded via the shared fence state machine. Each
- *  task carries the text of the nearest heading above it (its Kanban lane on
- *  a board), or null before the first heading. */
+ *  fenced code blocks and `%% %%` comment blocks are excluded via the shared
+ *  fence and comment state machines. Each task carries the text of the nearest
+ *  heading above it (its Kanban lane on a board), or null before the first
+ *  heading. */
 const extractTasks = (rawContent: string): ParsedTask[] => {
   const allLines = splitIntoLines(rawContent)
   const bodyStartLine = findBodyStartLine(allLines)
@@ -436,15 +442,26 @@ const extractTasks = (rawContent: string): ParsedTask[] => {
   const headings = parseHeadings(bodyLines)
 
   const extractedTasks: ParsedTask[] = []
-  // A fenced-code scan is inherently sequential, so the open fence threads
-  // through the loop mutably (same pattern as classifyLines).
+  // Fence and comment scans are inherently sequential — both thread mutable
+  // state across the loop (same pattern as classifyLines).
   let openFence: OpenFence = null
+  let commentOpen = false
   for (let lineIndex = 0; lineIndex < bodyLines.length; lineIndex++) {
     const lineText = bodyLines[lineIndex]
     if (lineText === undefined) continue
-    const fenceResult = advanceFence(lineText, openFence)
-    openFence = fenceResult.openFence
-    if (fenceResult.lineIsCode) continue
+
+    // Fence/comment precedence: fence state advances only outside comments
+    // (inside a comment, fence delimiters are just text). Comment toggles
+    // run only outside fences (inside a fence, `%%` is just text).
+    if (!commentOpen) {
+      const fenceResult = advanceFence(lineText, openFence)
+      openFence = fenceResult.openFence
+      if (fenceResult.lineIsCode) continue
+    }
+
+    const commentResult = advanceComment(lineText, commentOpen)
+    commentOpen = commentResult.commentOpen
+    if (commentResult.lineIsComment) continue
 
     const taskLineMatch = TASK_LINE_RE.exec(lineText)
     if (taskLineMatch === null) continue

--- a/src/vault-mcp/search/__tests__/task-queries.test.ts
+++ b/src/vault-mcp/search/__tests__/task-queries.test.ts
@@ -1225,3 +1225,37 @@ kanban-plugin: board
     ])
   })
 })
+
+describe("comment block exclusion", () => {
+  it("does not index tasks inside %% %% comment blocks", () => {
+    const index = createTestIndex()
+    index.upsertNote(
+      {
+        filePath: "board.md",
+        rawContent: [
+          "## Active",
+          "",
+          "- [ ] Visible task ➕ 2026-07-01",
+          "",
+          "%%",
+          "- [ ] Hidden by comment ➕ 2026-07-02",
+          "%%",
+          "",
+          "- [ ] Also visible ➕ 2026-07-03",
+        ].join("\n"),
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+
+    const result = index.listTasks(
+      { status: "all", sortBy: "created", sortDirection: "asc" },
+      logger,
+    )
+    expect(result.total).toBe(2)
+    expect(result.tasks.map((task) => task.description)).toEqual([
+      "Visible task",
+      "Also visible",
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- Extracts `advanceComment` to `lines.ts` as the shared Obsidian `%% %%` comment state machine, alongside `advanceFence` — same "single home" rationale
- Threads `advanceComment` through `extractTasks` (tasks.ts) and `parseHeadings` (headings.ts) so task lines and headings inside comment blocks are skipped
- Refactors `findTrailingCommentBlockStart` to use the shared primitive
- Removes the documented limitation at headings.ts:54 ("parseHeadings is NOT comment-aware")

Fence/comment precedence matches Obsidian's parser: fence state advances only outside comments (inside a comment, ``` is just text); comment toggles run only outside fences (inside a fence, `%%` is just text).

Fixes a confirmed divergence from the Tasks plugin: "Tasks does not read any tasks inside comments, because Obsidian does not read them" — vault-cortex was surfacing tasks the plugin and Obsidian would never show.

## Test plan

- [x] 11 `advanceComment` unit tests (state transitions, mid-line `%%`, inline comments)
- [x] 7 task comment-block tests (full block, inline, unclosed, fence/comment precedence, mid-line `%%`, heading attribution)
- [x] 4 heading comment-block tests (hidden headings, fence inside comment, comment inside fence)
- [x] 1 integration test (task-queries: commented tasks not indexed)
- [x] All 124 existing `findTrailingCommentBlockStart` tests pass (behavior-preserving refactor)
- [x] Mutation-verified: removing the comment guard in `extractTasks` fails 4 tests; removing it in `parseHeadings` fails 2 tests
- [x] Full suite: 1535 tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment blocks (`%% ... %%`) are now respected when parsing headings and tasks, so hidden note content no longer shows up in results.
  * Task search/indexing now ignores tasks inside comment blocks while still capturing visible tasks around them.

* **Bug Fixes**
  * Improved handling of headings immediately after comment blocks.
  * Better line parsing for inline and unclosed comment markers, matching expected note behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->