### PR TITLE
ci: make PR-Agent suggestion count configurable

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -56,6 +56,8 @@ jobs:
           github_action_config.auto_describe: "false"
           # Run /improve — posts inline code suggestions on the diff.
           github_action_config.auto_improve: "true"
+          # Max suggestions per /improve run (default 4 in PR-Agent).
+          pr_code_suggestions.num_code_suggestions: ${{ vars.PR_AGENT_MAX_SUGGESTIONS || '10' }}
           pr_code_suggestions.extra_instructions: >-
             FOCUS: Correctness and security only. Ignore style, naming, and test quality.
 
@@ -86,6 +88,7 @@ jobs:
           github_action_config.auto_review: "false"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
+          pr_code_suggestions.num_code_suggestions: ${{ vars.PR_AGENT_MAX_SUGGESTIONS || '10' }}
           pr_code_suggestions.extra_instructions: >-
             FOCUS: Code quality and convention compliance only. Skip correctness bugs and
             test files — other passes handle those.
@@ -114,6 +117,7 @@ jobs:
           github_action_config.auto_review: "false"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
+          pr_code_suggestions.num_code_suggestions: ${{ vars.PR_AGENT_MAX_SUGGESTIONS || '10' }}
           pr_code_suggestions.extra_instructions: >-
             FOCUS: Test quality and coverage gaps only. Skip production code style and
             correctness — other passes handle those.
@@ -142,6 +146,7 @@ jobs:
           github_action_config.auto_review: "false"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
+          pr_code_suggestions.num_code_suggestions: ${{ vars.PR_AGENT_MAX_SUGGESTIONS || '10' }}
           pr_code_suggestions.extra_instructions: >-
             FOCUS: Subtle bug patterns that survive normal code review. Skip style, naming,
             and test quality — other passes handle those.
@@ -194,6 +199,7 @@ jobs:
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
+          pr_code_suggestions.num_code_suggestions: ${{ vars.PR_AGENT_MAX_SUGGESTIONS || '10' }}
           pr_reviewer.extra_instructions: >-
             Read AGENTS.md in the repo root for this project's coding conventions,
             code style rules, naming conventions, test conventions, and module layering.


### PR DESCRIPTION
## Summary
- Adds `pr_code_suggestions.num_code_suggestions` to all 5 PR-Agent steps
- Configurable via `PR_AGENT_MAX_SUGGESTIONS` repo variable (default 10, up from PR-Agent's built-in default of 4)

## Test plan
- [ ] Open a code PR and verify more than 4 suggestions appear per phase
- [ ] Set `PR_AGENT_MAX_SUGGESTIONS` to a lower value and confirm it takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)