### PR TITLE
fix(cli): add bookend rules and section dividers to connect output

### DIFF
--- a/cli/src/__tests__/messages.test.ts
+++ b/cli/src/__tests__/messages.test.ts
@@ -5,6 +5,19 @@ import {
   buildRemoteConnectMessage,
 } from "../messages.js"
 
+// ── Expected rules (mirrors the module-private helpers at RULE_WIDTH = 56) ────
+// Tests run in non-TTY, so paint() is a no-op — these are the raw strings.
+
+const RULE_WIDTH = 56
+
+const expectedTopRule = (label: string): string =>
+  `╭── ${label} ${"─".repeat(Math.max(0, RULE_WIDTH - label.length - 6))}╮`
+
+const expectedBottomRule = (): string => `╰${"─".repeat(RULE_WIDTH - 2)}╯`
+
+const expectedSectionRule = (label: string): string =>
+  `── ${label} ${"─".repeat(Math.max(0, RULE_WIDTH - label.length - 4))}`
+
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
 const localDefaults = {
@@ -31,19 +44,16 @@ describe("buildLocalConnectMessage", () => {
     const message = buildLocalConnectMessage(localDefaults)
 
     const lines = message.split("\n")
-    expect(lines[0]).toContain("╭──")
-    expect(lines[0]).toContain("Connect")
-    expect(lines[0]).toContain("╮")
-    expect(lines[lines.length - 1]).toContain("╰")
-    expect(lines[lines.length - 1]).toContain("╯")
+    expect(lines[0]).toBe(expectedTopRule("Connect"))
+    expect(lines[lines.length - 1]).toBe(expectedBottomRule())
   })
 
   it("includes MCP client, Non-OAuth, and Settings section dividers", () => {
-    const message = buildLocalConnectMessage(localDefaults)
+    const lines = buildLocalConnectMessage(localDefaults).split("\n")
 
-    expect(message).toContain("── MCP client ")
-    expect(message).toContain("── Non-OAuth ")
-    expect(message).toContain("── Settings ")
+    expect(lines).toContain(expectedSectionRule("MCP client"))
+    expect(lines).toContain(expectedSectionRule("Non-OAuth"))
+    expect(lines).toContain(expectedSectionRule("Settings"))
   })
 
   it("builds URLs from the given port", () => {
@@ -137,19 +147,16 @@ describe("buildRemoteConnectMessage", () => {
     const message = buildRemoteConnectMessage(remoteDefaults)
 
     const lines = message.split("\n")
-    expect(lines[0]).toContain("╭──")
-    expect(lines[0]).toContain("Connect")
-    expect(lines[0]).toContain("╮")
-    expect(lines[lines.length - 1]).toContain("╰")
-    expect(lines[lines.length - 1]).toContain("╯")
+    expect(lines[0]).toBe(expectedTopRule("Connect"))
+    expect(lines[lines.length - 1]).toBe(expectedBottomRule())
   })
 
   it("includes MCP client, Non-OAuth, and Settings section dividers", () => {
-    const message = buildRemoteConnectMessage(remoteDefaults)
+    const lines = buildRemoteConnectMessage(remoteDefaults).split("\n")
 
-    expect(message).toContain("── MCP client ")
-    expect(message).toContain("── Non-OAuth ")
-    expect(message).toContain("── Settings ")
+    expect(lines).toContain(expectedSectionRule("MCP client"))
+    expect(lines).toContain(expectedSectionRule("Non-OAuth"))
+    expect(lines).toContain(expectedSectionRule("Settings"))
   })
 
   it("builds URLs from the given publicUrl", () => {

--- a/cli/src/__tests__/messages.test.ts
+++ b/cli/src/__tests__/messages.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildLocalConnectMessage,
+  buildRemoteConnectMessage,
+} from "../messages.js"
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const localDefaults = {
+  targetDir: "/home/user/vault-cortex",
+  token: "abc123deadbeef",
+  started: false,
+  port: 8000,
+  tokenWritten: true,
+}
+
+const remoteDefaults = {
+  targetDir: "/home/user/vault-cortex",
+  token: "abc123deadbeef",
+  publicUrl: "https://vault.example.com",
+  started: false,
+  obsidianTokenMissing: false,
+  tokenWritten: true,
+}
+
+// ── buildLocalConnectMessage ───────────────────────────────────────────────────
+
+describe("buildLocalConnectMessage", () => {
+  it("wraps the output in top and bottom box-drawing rules", () => {
+    const message = buildLocalConnectMessage(localDefaults)
+
+    const lines = message.split("\n")
+    expect(lines[0]).toContain("╭──")
+    expect(lines[0]).toContain("Connect")
+    expect(lines[0]).toContain("╮")
+    expect(lines[lines.length - 1]).toContain("╰")
+    expect(lines[lines.length - 1]).toContain("╯")
+  })
+
+  it("includes MCP client, Non-OAuth, and Settings section dividers", () => {
+    const message = buildLocalConnectMessage(localDefaults)
+
+    expect(message).toContain("── MCP client ")
+    expect(message).toContain("── Non-OAuth ")
+    expect(message).toContain("── Settings ")
+  })
+
+  it("builds URLs from the given port", () => {
+    const message = buildLocalConnectMessage({ ...localDefaults, port: 9999 })
+
+    expect(message).toContain("http://localhost:9999/mcp")
+    expect(message).toContain("http://localhost:9999/healthz")
+  })
+
+  it("shows 'The server is running.' when started is true", () => {
+    const message = buildLocalConnectMessage({
+      ...localDefaults,
+      started: true,
+    })
+
+    expect(message).toContain("The server is running.")
+    expect(message).not.toContain("Start the server:")
+  })
+
+  it("shows the start command when started is false", () => {
+    const message = buildLocalConnectMessage({
+      ...localDefaults,
+      started: false,
+    })
+
+    expect(message).toContain("Start the server:")
+    expect(message).toContain(
+      `cd ${localDefaults.targetDir} && docker compose up -d`,
+    )
+  })
+
+  it("displays the token on its own line when tokenWritten is true", () => {
+    const message = buildLocalConnectMessage({
+      ...localDefaults,
+      tokenWritten: true,
+    })
+
+    expect(message).toContain("Auth token:")
+    expect(message).toContain(localDefaults.token)
+    expect(message).not.toContain("use the existing MCP_AUTH_TOKEN")
+  })
+
+  it("points at the existing .env token when tokenWritten is false", () => {
+    const message = buildLocalConnectMessage({
+      ...localDefaults,
+      tokenWritten: false,
+    })
+
+    expect(message).toContain(
+      `use the existing MCP_AUTH_TOKEN in ${localDefaults.targetDir}/.env`,
+    )
+  })
+
+  it("includes the targetDir in the settings paragraph", () => {
+    const message = buildLocalConnectMessage(localDefaults)
+
+    expect(message).toContain(`${localDefaults.targetDir}/.env`)
+  })
+
+  it("includes the local docs link", () => {
+    const message = buildLocalConnectMessage(localDefaults)
+
+    expect(message).toContain("deploy/local/README.md")
+  })
+
+  it("includes the OAuth connect walkthrough", () => {
+    const message = buildLocalConnectMessage(localDefaults)
+
+    expect(message).toContain("claude mcp add")
+    expect(message).toContain("approve the browser consent page")
+  })
+
+  it("includes the curl guidance for non-OAuth clients", () => {
+    const message = buildLocalConnectMessage(localDefaults)
+
+    expect(message).toContain('curl -H "Authorization: Bearer <token>"')
+  })
+
+  it("includes the smoke test command", () => {
+    const message = buildLocalConnectMessage(localDefaults)
+
+    expect(message).toContain("Smoke test:")
+    expect(message).toContain("curl http://localhost:8000/healthz")
+  })
+})
+
+// ── buildRemoteConnectMessage ──────────────────────────────────────────────────
+
+describe("buildRemoteConnectMessage", () => {
+  it("wraps the output in top and bottom box-drawing rules", () => {
+    const message = buildRemoteConnectMessage(remoteDefaults)
+
+    const lines = message.split("\n")
+    expect(lines[0]).toContain("╭──")
+    expect(lines[0]).toContain("Connect")
+    expect(lines[0]).toContain("╮")
+    expect(lines[lines.length - 1]).toContain("╰")
+    expect(lines[lines.length - 1]).toContain("╯")
+  })
+
+  it("includes MCP client, Non-OAuth, and Settings section dividers", () => {
+    const message = buildRemoteConnectMessage(remoteDefaults)
+
+    expect(message).toContain("── MCP client ")
+    expect(message).toContain("── Non-OAuth ")
+    expect(message).toContain("── Settings ")
+  })
+
+  it("builds URLs from the given publicUrl", () => {
+    const message = buildRemoteConnectMessage({
+      ...remoteDefaults,
+      publicUrl: "https://my-vault.example.com",
+    })
+
+    expect(message).toContain("https://my-vault.example.com/mcp")
+    expect(message).toContain("https://my-vault.example.com/healthz")
+  })
+
+  it("shows 'The server is running.' when started is true", () => {
+    const message = buildRemoteConnectMessage({
+      ...remoteDefaults,
+      started: true,
+    })
+
+    expect(message).toContain("The server is running.")
+    expect(message).not.toContain("Start the server:")
+    expect(message).not.toContain("Fill in OBSIDIAN_AUTH_TOKEN")
+  })
+
+  it("shows 'Fill in OBSIDIAN_AUTH_TOKEN' when obsidianTokenMissing and not started", () => {
+    const message = buildRemoteConnectMessage({
+      ...remoteDefaults,
+      started: false,
+      obsidianTokenMissing: true,
+    })
+
+    expect(message).toContain("Fill in OBSIDIAN_AUTH_TOKEN")
+    expect(message).toContain(`${remoteDefaults.targetDir}/.env`)
+    expect(message).toContain("docker compose up -d")
+  })
+
+  it("shows the start command when not started and obsidian token present", () => {
+    const message = buildRemoteConnectMessage({
+      ...remoteDefaults,
+      started: false,
+      obsidianTokenMissing: false,
+    })
+
+    expect(message).toContain("Start the server:")
+    expect(message).toContain(
+      `cd ${remoteDefaults.targetDir} && docker compose up -d`,
+    )
+  })
+
+  it("shows https guidance when publicUrl is https", () => {
+    const message = buildRemoteConnectMessage({
+      ...remoteDefaults,
+      publicUrl: "https://vault.example.com",
+    })
+
+    expect(message).toContain("Reachable over https from any MCP client")
+    expect(message).not.toContain("only accept https URLs")
+  })
+
+  it("shows http guidance when publicUrl is http", () => {
+    const message = buildRemoteConnectMessage({
+      ...remoteDefaults,
+      publicUrl: "http://vault.example.com",
+    })
+
+    expect(message).toContain("only accept https URLs")
+    expect(message).not.toContain("Reachable over https from any MCP client")
+  })
+
+  it("handles case-insensitive HTTPS scheme", () => {
+    const message = buildRemoteConnectMessage({
+      ...remoteDefaults,
+      publicUrl: "HTTPS://vault.example.com",
+    })
+
+    expect(message).toContain("Reachable over https from any MCP client")
+  })
+
+  it("displays the token on its own line when tokenWritten is true", () => {
+    const message = buildRemoteConnectMessage({
+      ...remoteDefaults,
+      tokenWritten: true,
+    })
+
+    expect(message).toContain("Auth token:")
+    expect(message).toContain(remoteDefaults.token)
+    expect(message).not.toContain("use the existing MCP_AUTH_TOKEN")
+  })
+
+  it("points at the existing .env token when tokenWritten is false", () => {
+    const message = buildRemoteConnectMessage({
+      ...remoteDefaults,
+      tokenWritten: false,
+    })
+
+    expect(message).toContain(
+      `use the existing MCP_AUTH_TOKEN in ${remoteDefaults.targetDir}/.env`,
+    )
+  })
+
+  it("includes the remote docs link", () => {
+    const message = buildRemoteConnectMessage(remoteDefaults)
+
+    expect(message).toContain("deploy/remote/README.md#https-access")
+  })
+
+  it("includes the OAuth connect walkthrough", () => {
+    const message = buildRemoteConnectMessage(remoteDefaults)
+
+    expect(message).toContain("claude mcp add")
+    expect(message).toContain("approve the browser consent page")
+  })
+
+  it("includes the curl guidance for non-OAuth clients", () => {
+    const message = buildRemoteConnectMessage(remoteDefaults)
+
+    expect(message).toContain('curl -H "Authorization: Bearer <token>"')
+  })
+
+  it("includes the smoke test command", () => {
+    const message = buildRemoteConnectMessage(remoteDefaults)
+
+    expect(message).toContain("Smoke test:")
+    expect(message).toContain("curl https://vault.example.com/healthz")
+  })
+})

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -8,11 +8,14 @@ import { styleText } from "node:util"
 // so a colored URL or token still copies clean.
 type TextStyle = Parameters<typeof styleText>[0]
 
-// Strip styling when stdout isn't a color TTY (piped output, NO_COLOR, CI) so
+// Strip styling when stdout isn't a color TTY (piped output, CI) or NO_COLOR
+// is set (any value, including empty — per the NO_COLOR spec) so
 // captured/redirected output stays plain — no stray escape codes in copied
 // commands or logs.
 const paint = (style: TextStyle, text: string): string =>
-  process.stdout.isTTY && !process.env.NO_COLOR ? styleText(style, text) : text
+  process.stdout.isTTY && !("NO_COLOR" in process.env)
+    ? styleText(style, text)
+    : text
 
 const RULE_WIDTH = 56
 

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -14,11 +14,21 @@ type TextStyle = Parameters<typeof styleText>[0]
 const paint = (style: TextStyle, text: string): string =>
   process.stdout.isTTY && !process.env.NO_COLOR ? styleText(style, text) : text
 
-// Section header that replaces the old clack note box: a bold title over a
-// dim rule. The rule is its own line (not a per-line prefix), so it never
-// touches a copyable command.
-const connectHeader = (): string =>
-  `${paint("bold", "Connect")}\n${paint("dim", "─".repeat(56))}`
+const RULE_WIDTH = 56
+
+const topRule = (label: string): string =>
+  paint(
+    "dim",
+    `╭── ${label} ${"─".repeat(Math.max(0, RULE_WIDTH - label.length - 6))}╮`,
+  )
+
+const bottomRule = (): string => paint("dim", `╰${"─".repeat(RULE_WIDTH - 2)}╯`)
+
+const sectionRule = (label: string): string =>
+  paint(
+    "dim",
+    `── ${label} ${"─".repeat(Math.max(0, RULE_WIDTH - label.length - 4))}`,
+  )
 
 const composeUpCommand = (targetDir: string): string =>
   `cd ${targetDir} && docker compose up -d`
@@ -120,9 +130,11 @@ export const buildLocalConnectMessage = (params: {
   // that claude.ai can't reach localhost at all and Claude Desktop needs the
   // mcp-remote bridge (the dialog rejects http, but mcp-remote exempts
   // localhost, so no --allow-http).
-  const connectMessage = `${connectHeader()}
+  const connectMessage = `${topRule("Connect")}
 
 ${startLine}
+
+${sectionRule("MCP client")}
 
 ${connectUrlBlock(`${baseUrl}/mcp`, tokenLine)}
 
@@ -138,15 +150,21 @@ it with mcp-remote:
       "--header", "Authorization: Bearer <token above>"]
   }
 
+${sectionRule("Non-OAuth")}
+
 ${curlGuidance(`${baseUrl}/mcp`)}
 
 ${smokeTest(`${baseUrl}/healthz`)}
+
+${sectionRule("Settings")}
 
 Optional settings (timezone, memory folder, port, logging) are commented
 out in ${targetDir}/.env — uncomment, set a value, then apply with
 "docker compose up -d" (restart alone does not re-read .env).
 
-Full docs: https://github.com/aliasunder/vault-cortex/blob/main/deploy/local/README.md`
+Full docs: https://github.com/aliasunder/vault-cortex/blob/main/deploy/local/README.md
+
+${bottomRule()}`
 
   return connectMessage
 }
@@ -200,17 +218,23 @@ Claude Desktop only accept https URLs — set up HTTPS for those clients
 
   // Flush-left on purpose: this is printed as plain text (see paint), so
   // leading whitespace would render as literal indentation.
-  const connectMessage = `${connectHeader()}
+  const connectMessage = `${topRule("Connect")}
 
 ${startLine}
+
+${sectionRule("MCP client")}
 
 ${connectUrlBlock(`${publicUrl}/mcp`, tokenLine)}
 
 ${clientGuidance}
 
+${sectionRule("Non-OAuth")}
+
 ${curlGuidance(`${publicUrl}/mcp`)}
 
 ${smokeTest(`${publicUrl}/healthz`)}
+
+${sectionRule("Settings")}
 
 Optional settings (timezone, memory folder, port, logging, sync
 behavior) are commented out in ${targetDir}/.env — uncomment, set a
@@ -218,7 +242,9 @@ value, then apply with "docker compose up -d" (restart alone does not
 re-read .env).
 
 For HTTPS options (API Gateway, Caddy, Cloudflare Tunnel), see:
-https://github.com/aliasunder/vault-cortex/blob/main/deploy/remote/README.md#https-access`
+https://github.com/aliasunder/vault-cortex/blob/main/deploy/remote/README.md#https-access
+
+${bottomRule()}`
 
   return connectMessage
 }


### PR DESCRIPTION
## Summary

- Replace the flat bold-title-over-rule header with clack-style corner bookends (`╭──╮` / `╰──╯`) and labeled section dividers (`── Label ──`)
- Creates visual containment and hierarchy without side borders, preserving clean copy-paste of commands, URLs, and tokens
- Both local and remote connect messages get the same treatment (MCP client, Non-OAuth, Settings sections)

Closes the "bottom-rule bookend" direction from the connect-message-styling task card.

**Before** (bold title + single dim rule, no containment):
```
Connect
────────────────────────────────────────────────────────

Start the server:
  cd ./vault-cortex && docker compose up -d

Connect your MCP client:
  ...
```

**After** (corner bookends + section dividers):
```
╭── Connect ───────────────────────────────────────────╮

Start the server:
  cd ./vault-cortex && docker compose up -d

── MCP client ──────────────────────────────────────────

Connect your MCP client:
  ...

── Non-OAuth ───────────────────────────────────────────

  ...

── Settings ────────────────────────────────────────────

  ...

╰──────────────────────────────────────────────────────╯
```

## Test plan

- [x] `npm run build` passes (no type errors)
- [x] All 27 CLI init tests pass — connect message content assertions unaffected (structural elements only)
- [x] Verified both `buildLocalConnectMessage` and `buildRemoteConnectMessage` render correctly via `node -e`
- [ ] Visual check: run `npx vault-cortex init` in a terminal and confirm the output looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved local and remote connection messages with clearer framed sections and cleaner terminal formatting.
  * Added more helpful guidance for setup, including docs links, OAuth walkthrough text, curl examples, and smoke test commands.

* **Bug Fixes**
  * Better handling of color output in terminals, including respecting `NO_COLOR` and non-color TTYs.
  * Refined message behavior for running vs. not-running states, token display, HTTPS guidance, and remote URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->