### PR TITLE
ci: enrich umm-actually review instructions from ship-check

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -61,7 +61,12 @@ jobs:
             Look for: logic errors, incorrect conditions, off-by-one errors, null/undefined
             access, race conditions, unhandled error paths, missing edge cases, security
             vulnerabilities (injection, path traversal, auth bypass), and performance issues
-            (unbounded queries, missing indices, O(n^2) in hot paths).
+            (unbounded queries, missing indices, O(n^2) in hot paths). Symlink safety: verify
+            targets are within expected bounds and of expected type. Silent catches: .catch(() =>
+            {}) and catch (e) {} swallow errors — every catch must log or re-throw. If the PR
+            modifies user-facing docs, verify factual claims (capabilities, architecture, data
+            flow) match the actual implementation — a doc claiming "no external communication"
+            when the system has outbound sync is a correctness bug.
 
 
             DIMENSION 2 — CODE QUALITY & CONVENTIONS.
@@ -70,38 +75,58 @@ jobs:
             if/else, immutable by default, no disguised mutation in reduce), module layering
             (dependency direction, export style), comment conventions (comments above complex
             logic, regex doc comments), and simplicity (simple code over clever code, no
-            premature abstractions). Only flag violations of AGENTS.md rules.
+            premature abstractions). Functions with >2 args or adjacent same-typed args (swap
+            hazard) should use named-params objects. When a .map()/.flatMap() callback spans many
+            lines or contains nested pipelines, extract to a named function. For convention
+            issues, ground them in AGENTS.md rules rather than inventing conventions the project
+            doesn't have.
 
 
             DIMENSION 3 — TEST QUALITY & COVERAGE.
             For test files: check that each it() tests what its name claims, assertions are
             exact (toHaveLength(2) not toBeGreaterThanOrEqual(1)), tests include both positive
             and negative cases, tests would fail if the behavior broke (not pass by coincidence),
-            and const-per-test is preferred over let+beforeEach. For production files: check if
-            new functions, branches, or error paths have corresponding tests. Flag missing
-            coverage with the specific untested scenario.
+            and const-per-test is preferred over let+beforeEach. Watch for tests that pass for
+            the wrong reason: silent no-op (asserts state preserved but never proves operation
+            ran), wrong-error pass (rejects.toThrow() with no argument matches ANY error),
+            early-return pass (result could come from a guard instead of the intended path).
+            Flag coverage regressions: removed it() blocks, weakened assertions (toBe changed
+            to toBeDefined), or .skip'd tests. For production files: check if new functions,
+            branches, or error paths have corresponding tests. Flag missing coverage with the
+            specific untested scenario.
 
 
             DIMENSION 4 — SUBTLE BUG PATTERNS.
             Apply these checks systematically:
-            (a) Description-vs-implementation mismatch — do comments, tool descriptions, error
-            messages accurately describe what the code actually does?
+            (a) Description-vs-implementation mismatch — quote each sentence of a description
+            before checking it against the code. Verify cross-references name the right sibling
+            and describe what it actually does. If a feature is gated behind a flag or env var,
+            the description must qualify the claim or describe degraded behavior.
             (b) SQL correctness — missing quotes around LIKE patterns, wrong JOIN type, missing
             WHERE clauses, injection via string interpolation.
             (c) Type safety — JSON.parse without runtime validation, type assertions (as/!)
             that bypass the compiler.
             (d) Boundary and off-by-one — fencepost errors in slicing, pagination, or loop
-            bounds; empty-input handling.
+            bounds; empty-input handling. Truncation indicators: if showing "N+" for overflow,
+            must fetch limit + 1 to detect truncation.
             (e) Behavioral asymmetry — create/update/delete paths that handle the same field
             differently.
             (f) Input validation gaps — user inputs that reach data layer unchecked; path
             traversal (../) in file paths.
             (g) Platform/encoding — path separator assumptions, Unicode normalization,
             locale-dependent string operations, timezone-naive date handling.
+            (h) Config default divergence — defaults must agree across docker-compose,
+            .env.example, CLI templates, and config parser. A var added to compose but missing
+            from CLI templates means npx init users never see it.
+            (i) Shared helpers not used — before accepting a stdlib call, check src/utils/ for
+            an existing helper (e.g. mapWithConcurrency exists but new code uses bare
+            Promise.all for bounded concurrency).
 
 
-            For CI/workflow files (.yml), also check action pinning (full commit SHA, not
-            mutable tags), permissions least privilege, and multi-trigger event guards.
+            For CI/workflow files (.yml), also check: action pinning (full commit SHA, not
+            mutable tags), permissions least privilege, multi-trigger event guards, secrets
+            scoped to step-level not job-level env, persist-credentials: false on
+            actions/checkout, and concurrency blocks on deploy workflows.
 
 
             For each suggestion, explain the concrete failure scenario — what input or state


### PR DESCRIPTION
## Summary
- Pull concrete review criteria from the ship-check agent pipeline (pr-review, code-quality, test-audit, bug-check) into the PR-Agent `extra_instructions`
- Soften "Only flag violations of AGENTS.md rules" to "ground convention issues in AGENTS.md" so real bugs aren't self-censored

## Changes by dimension
- **D1 (Correctness):** symlink safety, silent catch detection, doc-vs-implementation accuracy
- **D2 (Code Quality):** named-params trigger (>2 args / swap hazard), callback decomposition for long `.map()`/`.flatMap()` callbacks
- **D3 (Tests):** wrong-reason passes (silent no-op, wrong-error, early-return), coverage regressions (removed tests, weakened assertions, `.skip`)
- **D4 (Bug Patterns):** verbatim description quoting, cross-reference directionality, conditional capabilities, truncation indicators, config default divergence, shared helper detection
- **CI:** step-scoped secrets, `persist-credentials: false`, deploy concurrency blocks

## Test plan
- [ ] Verify on the next PR that suggestions are higher quality and cover more dimensions
- [ ] Confirm no duplicate comments (single `/improve` run preserved from PR #284)

🤖 Generated with [Claude Code](https://claude.com/claude-code)