### PR TITLE
ci: guard server.json description length in publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Guard server.json description length (≤100 chars)
+        run: |
+          length=$(jq -r '.description | length' server.json)
+          if [ "$length" -gt 100 ]; then
+            echo "::error::server.json description is ${length} chars (limit: 100). The MCP Registry rejects descriptions > 100 chars with 422."
+            exit 1
+          fi
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
- Fail fast in CI when `server.json` description exceeds 100 chars — the MCP Registry rejects publish with 422 (hit on v0.19.0; fixed forward in #147).
- Adds a `jq` pre-check step right after the version verification that measures `.description | length` and exits with a clear error message.