### PR TITLE
feat: switch obsidian-sync image to maintained fork

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ PUBLIC_URL=
 # Obsidian Sync credentials
 # Generate OBSIDIAN_AUTH_TOKEN once with:
 #   docker run --rm -it --entrypoint get-token \
-#     ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+#     ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
 OBSIDIAN_AUTH_TOKEN=
 VAULT_NAME=
 VAULT_PASSWORD=              # only if vault has E2E encryption

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -62,7 +62,7 @@ Then open `~/.config/vault-cortex/.env` and fill in the remaining values:
 The [`.env.example`](./.env.example) file also includes optional configuration for the embedding pipeline (`EMBEDDING_ENABLED`), the reranker (`RERANK_MODE`), the memory system (`MEMORY_ENABLED`, `MEMORY_DIR`, `PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`), timezone (`TZ`), and OAuth metadata (`SERVICE_DOCUMENTATION_URL`). All have sensible defaults — see the [Configuration](./README.md#configuration) section in the README.
 
 ```bash
-docker run --rm -it --entrypoint get-token ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+docker run --rm -it --entrypoint get-token ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
 ```
 
 **4. Authenticate to GHCR** (once per machine):
@@ -233,7 +233,7 @@ To find your stage: `cat .sst/stage` (after your first deploy).
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GHCR_TOKEN`             | Personal access token (classic) with `write:packages` + `read:packages`. Used by `docker login` both at build-push and on-instance pull. Persists across runs; rotate when stale. |
 | `MCP_AUTH_TOKEN`         | Same value as the SST secret of the same name. Written into the instance `.env` for the Express auth layer.                                                                       |
-| `OBSIDIAN_AUTH_TOKEN`    | Output of `docker run --rm -it --entrypoint get-token ghcr.io/belphemur/obsidian-headless-sync-docker:latest`.                                                                    |
+| `OBSIDIAN_AUTH_TOKEN`    | Output of `docker run --rm -it --entrypoint get-token ghcr.io/aliasunder/obsidian-headless-sync-docker:latest`.                                                                   |
 | `VAULT_PASSWORD`         | Optional — only set if your vault uses end-to-end encryption. Empty value is fine and ships through to `.env` as `VAULT_PASSWORD=`.                                               |
 | `SSH_PUBKEY`             | Public key contents of your `~/.ssh/vault-cortex.pub` (literal, single line). Same key local dev and CI use — see [Prerequisites](#prerequisites).                                |
 | `SSH_PRIVATE_KEY`        | Private half (`~/.ssh/vault-cortex`, full multi-line block including BEGIN/END markers). Loaded by `webfactory/ssh-agent` for SCP/SSH to the instance.                            |

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ npx skills add aliasunder/agent-skills --skill obsidian-vault
 
 ## Acknowledgments
 
-This project uses a maintained fork of [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker) — thank you to Belphemur for the original work. The fork ([aliasunder/obsidian-headless-sync-docker](https://github.com/aliasunder/obsidian-headless-sync-docker)) is maintained in lockstep with vault-cortex's release cycle.
+Obsidian sync is powered by [obsidian-headless](https://obsidian.md/help/headless) — containerization approach inspired by [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker). The [maintained fork](https://github.com/aliasunder/obsidian-headless-sync-docker) is released in lockstep with vault-cortex.
 
 The hybrid search pipeline draws on patterns from [@tobi](https://github.com/tobi)'s [qmd](https://github.com/tobi/qmd) — RRF fusion with rank bonuses, position-aware score blending for cross-encoder reranking, content-hash gating, and heading-aware chunking.
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ npx skills add aliasunder/agent-skills --skill obsidian-vault
 
 ## Acknowledgments
 
-Obsidian sync is powered by [obsidian-headless](https://github.com/nicolo-ribaudo/obsidian-headless) — containerization approach inspired by [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker). The [maintained fork](https://github.com/aliasunder/obsidian-headless-sync-docker) is released in lockstep with vault-cortex.
+This project uses a maintained fork of [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker) — thank you to Belphemur for the original work. The fork ([aliasunder/obsidian-headless-sync-docker](https://github.com/aliasunder/obsidian-headless-sync-docker)) is maintained in lockstep with vault-cortex's release cycle.
 
 The hybrid search pipeline draws on patterns from [@tobi](https://github.com/tobi)'s [qmd](https://github.com/tobi/qmd) — RRF fusion with rank bonuses, position-aware score blending for cross-encoder reranking, content-hash gating, and heading-aware chunking.
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ npx skills add aliasunder/agent-skills --skill obsidian-vault
 
 ## Acknowledgments
 
-Obsidian sync powered by [obsidian-headless](https://github.com/nicolo-ribaudo/obsidian-headless) — containerization approach inspired by [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker). The [maintained fork](https://github.com/aliasunder/obsidian-headless-sync-docker) is released in lockstep with vault-cortex.
+Obsidian sync is powered by [obsidian-headless](https://github.com/nicolo-ribaudo/obsidian-headless) — containerization approach inspired by [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker). The [maintained fork](https://github.com/aliasunder/obsidian-headless-sync-docker) is released in lockstep with vault-cortex.
 
 The hybrid search pipeline draws on patterns from [@tobi](https://github.com/tobi)'s [qmd](https://github.com/tobi/qmd) — RRF fusion with rank bonuses, position-aware score blending for cross-encoder reranking, content-hash gating, and heading-aware chunking.
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ npx skills add aliasunder/agent-skills --skill obsidian-vault
 
 ## Acknowledgments
 
-Vault Cortex's remote capability exists because of [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker) — a [headless Obsidian Sync](https://obsidian.md/help/sync/headless) client that runs in Docker without a display server. It's the piece that makes "access your vault from anywhere" possible.
+Obsidian sync powered by [obsidian-headless](https://github.com/nicolo-ribaudo/obsidian-headless) — containerization approach inspired by [@Belphemur](https://github.com/Belphemur)'s [obsidian-headless-sync-docker](https://github.com/Belphemur/obsidian-headless-sync-docker). The [maintained fork](https://github.com/aliasunder/obsidian-headless-sync-docker) is released in lockstep with vault-cortex.
 
 The hybrid search pipeline draws on patterns from [@tobi](https://github.com/tobi)'s [qmd](https://github.com/tobi/qmd) — RRF fusion with rank bonuses, position-aware score blending for cross-encoder reranking, content-hash gating, and heading-aware chunking.
 

--- a/cli/src/__tests__/scaffold.test.ts
+++ b/cli/src/__tests__/scaffold.test.ts
@@ -38,7 +38,7 @@ describe("buildFilesToWrite", () => {
 
     expect(composeContent).toContain("obsidian-sync")
     expect(composeContent).toContain(
-      "ghcr.io/belphemur/obsidian-headless-sync-docker:latest",
+      "ghcr.io/aliasunder/obsidian-headless-sync-docker:latest",
     )
     expect(composeContent).not.toContain("init-config-perms")
   })

--- a/cli/src/docker.ts
+++ b/cli/src/docker.ts
@@ -12,7 +12,7 @@ export type DockerRunner = {
 
 /** The image whose `get-token` entrypoint issues Obsidian Sync auth tokens. */
 export const OBSIDIAN_SYNC_IMAGE =
-  "ghcr.io/belphemur/obsidian-headless-sync-docker:latest"
+  "ghcr.io/aliasunder/obsidian-headless-sync-docker:latest"
 
 export const createDockerRunner = (): DockerRunner => ({
   isComposeAvailable: () =>

--- a/cli/src/env.ts
+++ b/cli/src/env.ts
@@ -151,7 +151,7 @@ VAULT_PASSWORD=${answers.vaultPassword}`
       ? `# Obsidian Sync auth token — FILL THIS IN before docker compose up.
 # Generate once with:
 #   docker run --rm -it --entrypoint get-token \\
-#     ghcr.io/belphemur/obsidian-headless-sync-docker:latest`
+#     ghcr.io/aliasunder/obsidian-headless-sync-docker:latest`
       : `# Obsidian Sync auth token.`
 
   return `# vault-cortex — remote quickstart (Obsidian Sync)

--- a/cli/templates/remote/docker-compose.yml
+++ b/cli/templates/remote/docker-compose.yml
@@ -13,7 +13,7 @@ name: vault-cortex
 
 services:
   obsidian-sync:
-    image: ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+    image: ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
     container_name: obsidian-sync
     hostname: ${DEVICE_NAME:-vault-cortex}
     restart: unless-stopped

--- a/deploy/remote/.env.example
+++ b/deploy/remote/.env.example
@@ -14,7 +14,7 @@ PUBLIC_URL=
 
 # Obsidian Sync auth token. Generate once with:
 #   docker run --rm -it --entrypoint get-token \
-#     ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+#     ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
 OBSIDIAN_AUTH_TOKEN=
 
 # Exact name of your Obsidian vault (case-sensitive).

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -36,7 +36,7 @@ Or clone the repo and `cd deploy/remote`.
 
 ```bash
 docker run --rm -it --entrypoint get-token \
-  ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+  ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
 ```
 
 **4. Create your `.env` file:**

--- a/deploy/remote/docker-compose.yml
+++ b/deploy/remote/docker-compose.yml
@@ -13,7 +13,7 @@ name: vault-cortex
 
 services:
   obsidian-sync:
-    image: ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+    image: ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
     container_name: obsidian-sync
     hostname: ${DEVICE_NAME:-vault-cortex}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ name: vault-cortex
 
 services:
   obsidian-sync:
-    image: ghcr.io/belphemur/obsidian-headless-sync-docker:latest
+    image: ghcr.io/aliasunder/obsidian-headless-sync-docker:latest
     container_name: obsidian-sync
     hostname: ${DEVICE_NAME:-vault-cortex}
     restart: unless-stopped


### PR DESCRIPTION
## What does this PR do?

Replace all `ghcr.io/belphemur/obsidian-headless-sync-docker` image references with `ghcr.io/aliasunder/obsidian-headless-sync-docker` across compose files, deploy docs, CLI templates, env examples, and tests. Update README acknowledgment to credit the original project while pointing to the maintained fork.

## Type of change

- [ ] New MCP tool
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / workflow change
- [x] Infrastructure (SST, Docker)
- [ ] Other:

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run prettier:check` passes
- [x] `npm run build` succeeds
- [ ] New MCP tools follow the naming and description conventions in AGENTS.md
- [ ] README or ARCHITECTURE.md updated (if user-facing behavior changed)

---
_Generated by [Claude Code](https://claude.ai/code/session_019WrWMS2CeVKXBHaqxKthsT)_