### PR TITLE
fix: log error name and stack trace in error middleware, enable source maps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,4 @@ RUN mkdir -p /data && chown -R node:node /data /app
 USER node
 EXPOSE 8000
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["node", "dist/src/vault-mcp/server.js"]
+CMD ["node", "--enable-source-maps", "dist/src/vault-mcp/server.js"]

--- a/src/utils/__tests__/describe-error.test.ts
+++ b/src/utils/__tests__/describe-error.test.ts
@@ -4,14 +4,14 @@ import { describeError } from "../describe-error.js"
 describe("describeError", () => {
   const scenarios = [
     {
-      name: "returns an Error's message",
+      name: "returns an Error's name and message",
       input: new Error("boom"),
-      expected: "boom",
+      expected: "[Error]: boom",
     },
     {
-      name: "returns the message of an Error subclass",
+      name: "returns the name and message of an Error subclass",
       input: new TypeError("bad type"),
-      expected: "bad type",
+      expected: "[TypeError]: bad type",
     },
     {
       name: "stringifies a non-Error string",

--- a/src/utils/describe-error.ts
+++ b/src/utils/describe-error.ts
@@ -1,5 +1,5 @@
 /** Returns a human-readable message from an unknown thrown value, for structured
- *  logs and error wrapping. An Error yields its `message`; anything else is
+ *  logs and error wrapping. An Error yields `[name]: message`; anything else is
  *  stringified. */
 export const describeError = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error)
+  error instanceof Error ? `[${error.name}]: ${error.message}` : String(error)

--- a/src/vault-mcp/__tests__/server.test.ts
+++ b/src/vault-mcp/__tests__/server.test.ts
@@ -85,6 +85,9 @@ describe("createErrorMiddleware", () => {
       path: "/mcp",
     })
     const err = new Error("kaboom")
+    // Replace V8's generated stack with a predictable value so the assertion
+    // below is an exact match — otherwise `stack: err.stack` in the assertion
+    // passes trivially even if the middleware never sets the field.
     Object.defineProperty(err, "stack", {
       value: "Error: kaboom\n    at test",
     })
@@ -113,6 +116,9 @@ describe("createErrorMiddleware", () => {
       path: "/healthz",
     })
     const err = new Error("nope")
+    // Replace V8's generated stack with a predictable value so the assertion
+    // below is an exact match — otherwise `stack: err.stack` in the assertion
+    // passes trivially even if the middleware never sets the field.
     Object.defineProperty(err, "stack", {
       value: "Error: nope\n    at test",
     })

--- a/src/vault-mcp/__tests__/server.test.ts
+++ b/src/vault-mcp/__tests__/server.test.ts
@@ -74,7 +74,7 @@ describe("createErrorMiddleware", () => {
     expect(resJson).not.toHaveBeenCalled()
   })
 
-  it("logs unhandled_error with session, ip, method, path, and error message", () => {
+  it("logs unhandled_error with session, ip, method, path, error, and stack", () => {
     const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {})
     onTestFinished(() => errorSpy.mockRestore())
     const middleware = createErrorMiddleware()
@@ -94,11 +94,12 @@ describe("createErrorMiddleware", () => {
       clientIp: "192.0.2.5",
       method: "POST",
       path: "/mcp",
-      error: "kaboom",
+      error: "[Error]: kaboom",
+      stack: err.stack,
     })
   })
 
-  it("logs sessionId as undefined when mcp-session-id header is absent", () => {
+  it("logs sessionId as undefined, error, and stack when mcp-session-id header is absent", () => {
     const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {})
     onTestFinished(() => errorSpy.mockRestore())
     const middleware = createErrorMiddleware()
@@ -117,7 +118,8 @@ describe("createErrorMiddleware", () => {
       clientIp: "192.0.2.6",
       method: "GET",
       path: "/healthz",
-      error: "nope",
+      error: "[Error]: nope",
+      stack: err.stack,
     })
   })
 

--- a/src/vault-mcp/__tests__/server.test.ts
+++ b/src/vault-mcp/__tests__/server.test.ts
@@ -95,8 +95,13 @@ describe("createErrorMiddleware", () => {
       method: "POST",
       path: "/mcp",
       error: "[Error]: kaboom",
-      stack: err.stack,
+      stack: expect.any(String),
     })
+    // Verify stack has content, not just `undefined` matching `undefined`
+    const [[, data]] = errorSpy.mock.calls as [
+      ["unhandled_error", Record<string, unknown>],
+    ]
+    expect(data.stack).toBeTruthy()
   })
 
   it("logs sessionId as undefined, error, and stack when mcp-session-id header is absent", () => {
@@ -119,7 +124,36 @@ describe("createErrorMiddleware", () => {
       method: "GET",
       path: "/healthz",
       error: "[Error]: nope",
-      stack: err.stack,
+      stack: expect.any(String),
+    })
+    const [[, data]] = errorSpy.mock.calls as [
+      ["unhandled_error", Record<string, unknown>],
+    ]
+    expect(data.stack).toBeTruthy()
+  })
+
+  it("logs stack as undefined when the error has no stack property", () => {
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {})
+    onTestFinished(() => errorSpy.mockRestore())
+    const middleware = createErrorMiddleware()
+    const { req, res, next } = createMockReqRes({
+      headers: { "mcp-session-id": "session-456" },
+      ip: "10.0.0.2",
+      method: "PUT",
+      path: "/api",
+    })
+    const err = { name: "Error", message: "no stack" } as Error
+    delete (err as { stack?: string }).stack
+
+    middleware(err, req, res, next)
+
+    expect(errorSpy).toHaveBeenCalledWith("unhandled_error", {
+      sessionId: "session-456",
+      clientIp: "10.0.0.2",
+      method: "PUT",
+      path: "/api",
+      error: "[Error]: no stack",
+      stack: undefined,
     })
   })
 

--- a/src/vault-mcp/__tests__/server.test.ts
+++ b/src/vault-mcp/__tests__/server.test.ts
@@ -85,6 +85,9 @@ describe("createErrorMiddleware", () => {
       path: "/mcp",
     })
     const err = new Error("kaboom")
+    Object.defineProperty(err, "stack", {
+      value: "Error: kaboom\n    at test",
+    })
 
     middleware(err, req, res, next)
 
@@ -95,13 +98,8 @@ describe("createErrorMiddleware", () => {
       method: "POST",
       path: "/mcp",
       error: "[Error]: kaboom",
-      stack: expect.any(String),
+      stack: "Error: kaboom\n    at test",
     })
-    // Verify stack has content, not just `undefined` matching `undefined`
-    const [[, data]] = errorSpy.mock.calls as [
-      ["unhandled_error", Record<string, unknown>],
-    ]
-    expect(data.stack).toBeTruthy()
   })
 
   it("logs sessionId as undefined, error, and stack when mcp-session-id header is absent", () => {
@@ -115,6 +113,9 @@ describe("createErrorMiddleware", () => {
       path: "/healthz",
     })
     const err = new Error("nope")
+    Object.defineProperty(err, "stack", {
+      value: "Error: nope\n    at test",
+    })
 
     middleware(err, req, res, next)
 
@@ -124,12 +125,8 @@ describe("createErrorMiddleware", () => {
       method: "GET",
       path: "/healthz",
       error: "[Error]: nope",
-      stack: expect.any(String),
+      stack: "Error: nope\n    at test",
     })
-    const [[, data]] = errorSpy.mock.calls as [
-      ["unhandled_error", Record<string, unknown>],
-    ]
-    expect(data.stack).toBeTruthy()
   })
 
   it("logs stack as undefined when the error has no stack property", () => {

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -347,7 +347,9 @@ describe("error handling", () => {
       isError?: boolean
     }
     expect(result.isError).toBe(true)
-    expect(result.content[0]?.text).toBe('note not found: "nonexistent.md"')
+    expect(result.content[0]?.text).toBe(
+      '[Error]: note not found: "nonexistent.md"',
+    )
   })
 
   it("error text does not contain stack traces", async () => {
@@ -383,7 +385,7 @@ describe("error handling", () => {
     }
     expect(result.isError).toBe(true)
     expect(result.content[0]?.text).toBe(
-      'memory file not found: "About Me/Nonexistent.md"',
+      '[Error]: memory file not found: "About Me/Nonexistent.md"',
     )
   })
 
@@ -728,7 +730,7 @@ describe("vault_list_tasks handler", () => {
     }
     expect(result.isError).toBe(true)
     expect(result.content[0]?.text).toBe(
-      'invalid due.before date: "not-a-date". Use YYYY-MM-DD (e.g. 2026-07-03).',
+      '[Error]: invalid due.before date: "not-a-date". Use YYYY-MM-DD (e.g. 2026-07-03).',
     )
   })
 

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -2891,7 +2891,7 @@ It has multiple sentences to verify chunking works correctly.
       // One note failed, warn logged with the specific error
       expect(warnSpy).toHaveBeenCalledWith(
         "failed to embed note",
-        expect.objectContaining({ error: "embedding failed" }),
+        expect.objectContaining({ error: "[Error]: embedding failed" }),
       )
       // Both notes attempted embedding (first failed, second succeeded)
       expect(mockEmbedder.embedText).toHaveBeenCalledTimes(2)
@@ -3012,7 +3012,7 @@ the Lightsail budget estimates for next quarter.
       expect(search_mode).toBe("fts")
       expect(warnSpy).toHaveBeenCalledWith(
         "vector search failed, falling back to FTS-only",
-        expect.objectContaining({ error: "model unavailable" }),
+        expect.objectContaining({ error: "[Error]: model unavailable" }),
       )
     })
   })
@@ -3659,7 +3659,7 @@ This is a note with many words that should be truncated when using a small snipp
       expect(results).toHaveLength(2)
       expect(warnSpy).toHaveBeenCalledWith(
         "reranker failed, using RRF-only ordering",
-        expect.objectContaining({ error: "model failed to load" }),
+        expect.objectContaining({ error: "[Error]: model failed to load" }),
       )
       warnSpy.mockRestore()
     })

--- a/src/vault-mcp/server.ts
+++ b/src/vault-mcp/server.ts
@@ -27,7 +27,8 @@ export const createErrorMiddleware =
       clientIp: req.ip,
       method: req.method,
       path: req.path,
-      error: err.message,
+      error: `[${err.name}]: ${err.message}`,
+      stack: err.stack,
     })
     if (!res.headersSent) {
       res.status(500).json({ error: "internal server error" })

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -156,7 +156,7 @@ export const getDailyNote = async (
     return { path, content, exists: true }
   } catch (err) {
     const errorMessage = describeError(err)
-    if (errorMessage.includes("note not found")) {
+    if (errorMessage.startsWith("[Error]: note not found")) {
       logger.info("daily note not found", { path })
       return { path, content: null, exists: false }
     }

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -156,7 +156,7 @@ export const getDailyNote = async (
     return { path, content, exists: true }
   } catch (err) {
     const errorMessage = describeError(err)
-    if (errorMessage.startsWith("note not found")) {
+    if (errorMessage.includes("note not found")) {
       logger.info("daily note not found", { path })
       return { path, content: null, exists: false }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "declaration": true,
+    "sourceMap": true,
     "noImplicitOverride": true,
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true


### PR DESCRIPTION
### What

Unhandled errors in the Express error middleware only surfaced `err.message` — the error type and full call chain were invisible. This PR:

- Logs errors as `[ErrorName]: message` (e.g. `[TypeError]: bad type`) in both the error middleware and `describeError()` used by every background error site
- Logs `err.stack` for the full call chain
- Enables source maps in production (`tsconfig.json` + `Dockerfile`) so both the logger's `source` field and `err.stack` resolve to `.ts` lines instead of `.js`

### Changes

| File | Change |
|---|---|
| `src/vault-mcp/server.ts` | Error middleware logs `[${err.name}]: ${err.message}` + `err.stack` |
| `src/utils/describe-error.ts` | Now returns `[name]: message` for all `Error` instances — 20+ background error sites inherit this |
| `src/vault-mcp/vault-operations/daily-notes.ts` | `startsWith` guard updated for `[Error]:` prefix |
| `tsconfig.json` | `"sourceMap": true` |
| `Dockerfile` | `--enable-source-maps` in CMD |
| `src/vault-mcp/__tests__/server.test.ts` | 3 stack tests: present (exact assertion), absent session header (exact), undefined (new test) |
| `src/utils/__tests__/describe-error.test.ts` | Updated expectations for `[name]: message` format |
| `src/vault-mcp/search/__tests__/search-index.test.ts` | Updated `describeError` assertions |
| `src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts` | Updated `describeError` assertions |

### Verification

All 1576 tests pass across 50 test files.