### PR TITLE
fix: strip MCP tool name from protected-path delete error

### DIFF
--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -330,6 +330,20 @@ describe("config interpolation in descriptions", () => {
     expect(config.description).not.toContain("About Me/")
   })
 
+  it("vault_delete_note description scopes memory hint to configured memory dir (default)", () => {
+    const [, config] = requireCall(TOOL_NAMES.VAULT_DELETE_NOTE)
+    expect(config.description).toContain(
+      "use vault_delete_memory for individual entries under About Me/",
+    )
+  })
+
+  it("vault_delete_note description scopes memory hint to configured memory dir (custom)", () => {
+    const [, config] = requireCustomCall(TOOL_NAMES.VAULT_DELETE_NOTE)
+    expect(config.description).toContain(
+      "use vault_delete_memory for individual entries under Profile/",
+    )
+  })
+
   it("vault_find_orphans description references configured exclusion folders", () => {
     const [, config] = requireCustomCall(TOOL_NAMES.VAULT_FIND_ORPHANS)
     expect(config.description).toContain(CUSTOM_MEMORY_DIR)

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -330,17 +330,10 @@ describe("config interpolation in descriptions", () => {
     expect(config.description).not.toContain("About Me/")
   })
 
-  it("vault_delete_note description scopes memory hint to configured memory dir (default)", () => {
+  it("vault_delete_note description includes memory hint when memory is enabled", () => {
     const [, config] = requireCall(TOOL_NAMES.VAULT_DELETE_NOTE)
     expect(config.description).toContain(
-      "use vault_delete_memory for individual entries under About Me/",
-    )
-  })
-
-  it("vault_delete_note description scopes memory hint to configured memory dir (custom)", () => {
-    const [, config] = requireCustomCall(TOOL_NAMES.VAULT_DELETE_NOTE)
-    expect(config.description).toContain(
-      "use vault_delete_memory for individual entries under Profile/",
+      "use vault_delete_memory for memory entries",
     )
   })
 

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -625,7 +625,7 @@ When to use: Removing a note you no longer need.${config.memoryEnabled ? `\nPref
 Behavior: With prune_empty_folders, pruning is best-effort and runs after the delete — it never fails the call, so the note is always removed even if a folder can't be removed.
 
 Errors:
-- "cannot delete protected path" — the path sits under a protected folder${config.memoryEnabled ? `; use vault_delete_memory for individual entries under ${config.memoryDir}/` : ""}
+- "cannot delete protected path" — the path sits under a protected folder${config.memoryEnabled ? "; use vault_delete_memory for memory entries" : ""}
 - "path traversal blocked" — path escapes the vault root; use a vault-relative path
 - "concurrent write in progress" — another write to this note is in flight; retry
 - "note not found: …" — the note does not exist; verify the path with vault_list_notes before deleting

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -625,7 +625,7 @@ When to use: Removing a note you no longer need.${config.memoryEnabled ? `\nPref
 Behavior: With prune_empty_folders, pruning is best-effort and runs after the delete — it never fails the call, so the note is always removed even if a folder can't be removed.
 
 Errors:
-- "cannot delete protected path …" — the path sits under a protected folder${config.memoryEnabled ? `; use vault_delete_memory for individual entries under ${config.memoryDir}/` : ""}
+- "cannot delete protected path" — the path sits under a protected folder${config.memoryEnabled ? `; use vault_delete_memory for individual entries under ${config.memoryDir}/` : ""}
 - "path traversal blocked" — path escapes the vault root; use a vault-relative path
 - "concurrent write in progress" — another write to this note is in flight; retry
 - "note not found: …" — the note does not exist; verify the path with vault_list_notes before deleting

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -625,7 +625,7 @@ When to use: Removing a note you no longer need.${config.memoryEnabled ? `\nPref
 Behavior: With prune_empty_folders, pruning is best-effort and runs after the delete — it never fails the call, so the note is always removed even if a folder can't be removed.
 
 Errors:
-- "cannot delete protected path …" — the path sits under a protected folder${config.memoryEnabled ? "; use vault_delete_memory for memory entries" : ""}
+- "cannot delete protected path …" — the path sits under a protected folder${config.memoryEnabled ? `; use vault_delete_memory for individual entries under ${config.memoryDir}/` : ""}
 - "path traversal blocked" — path escapes the vault root; use a vault-relative path
 - "concurrent write in progress" — another write to this note is in flight; retry
 - "note not found: …" — the note does not exist; verify the path with vault_list_notes before deleting

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -397,6 +397,25 @@ describe("deleteNote", () => {
     },
   )
 
+  it.each(["About Me/Principles.md", "Daily Notes/2025-01-01.md"])(
+    "protected-path rejection for %s is structural — no MCP tool name",
+    async (path) => {
+      await expect(
+        deleteNote(
+          {
+            vaultPath: vault,
+            path,
+            protectedPaths: DEFAULT_PROTECTED,
+            pruneEmptyFolders: false,
+          },
+          logger,
+        ),
+      ).rejects.toMatchObject({
+        message: `cannot delete protected path "${path}"`,
+      })
+    },
+  )
+
   it("rejects custom protected paths", async () => {
     await expect(
       deleteNote(

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -392,9 +392,7 @@ const deleteNote = async (
     folder.endsWith("/") ? folder : `${folder}/`,
   )
   if (protectedPrefixes.some((prefix) => path.startsWith(prefix))) {
-    throw new Error(
-      `cannot delete protected path "${path}" (use vault_delete_memory for individual entries)`,
-    )
+    throw new Error(`cannot delete protected path "${path}"`)
   }
 
   const fullPath = resolveSafePath(params.vaultPath, path)


### PR DESCRIPTION
## Problem

`deleteNote`'s protected-path rejection unconditionally included `"(use vault_delete_memory for individual entries)"` in the runtime error — wrong in three cases:

1. **Daily Notes / custom protected paths** — the hint names a tool that doesn't apply to those folders
2. **`MEMORY_ENABLED=false`** — `vault_delete_memory` isn't registered, so the hint references a tool the client can't call
3. **Layering smell** — the data layer (`vault-filesystem.ts`) named an MCP tool in its error message; `note-mover.ts` is the clean precedent (throws structural messages with no tool names)

## Fix

**Data layer** (`vault-filesystem.ts`) — stripped the parenthetical. The throw is now the clean structural message `cannot delete protected path "${path}"`, matching `note-mover` style. No MCP tool name leaks into the data layer.

**Tool description** (`vault-crud-tools.ts`) — removed the `…` ellipsis from the error pattern so it reads `"cannot delete protected path"`, consistent with other fixed-prefix entries (`"path traversal blocked"`, `"concurrent write in progress"`). The existing `config.memoryEnabled` ternary already gates the hint — absent when memory tools are unregistered.

The runtime error now carries no remediation hint — agents cross-reference the tool description's documented Errors section, the same pattern the move tool already uses.

## Tests

- **Data-layer guardrail** (`vault-filesystem.test.ts`): exact message assertion via `rejects.toMatchObject` for both memory-dir and Daily Notes paths — fails if someone re-adds the tool name to the throw.
- **Description hint** (`tool-definitions.test.ts`): asserts the hint `"use vault_delete_memory for memory entries"` is present when memory is enabled.
- Existing tests unchanged (substring match on `"cannot delete protected path"` still passes).
- **1579 tests pass** (1576 baseline + 3 new).

## Verification

- `grep -r "vault_delete_memory" src/vault-mcp/vault-operations/` → no matches (tool name eliminated from the data layer).

## Follow-up

Added a Someday card (`^error-mcp-coupling`) for the broader architectural pattern: custom error classes in the data layer, tool-handler catch + format, and description-based remediation across all tools — not just this one instance.