### PR TITLE
docs(docker): correct stale tool count in image descriptions (25 → 26)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,7 +176,7 @@ jobs:
           # page). Mirror the server.json / Dockerfile description here.
           annotations: |
             index:org.opencontainers.image.title=vault-cortex
-            index:org.opencontainers.image.description=Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools + 3 prompts, OAuth 2.1.
+            index:org.opencontainers.image.description=Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 26 tools + 3 prompts, OAuth 2.1.
             index:org.opencontainers.image.source=https://github.com/aliasunder/vault-cortex
             index:org.opencontainers.image.licenses=MIT
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ ENV NODE_ENV=production PORT=8000 HOST=0.0.0.0 VAULT_PATH=/vault INDEX_DB_PATH=/
 # set in deploy.yml — keep that description and the one here in sync.
 LABEL io.modelcontextprotocol.server.name="io.github.aliasunder/vault-cortex" \
       org.opencontainers.image.title="vault-cortex" \
-      org.opencontainers.image.description="Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 25 tools + 3 prompts, OAuth 2.1." \
+      org.opencontainers.image.description="Standalone MCP server for Obsidian vaults — hybrid search, structured memory, 26 tools + 3 prompts, OAuth 2.1." \
       org.opencontainers.image.source="https://github.com/aliasunder/vault-cortex" \
       org.opencontainers.image.licenses="MIT"
 COPY --from=deps  /app/node_modules ./node_modules


### PR DESCRIPTION
The GHCR package page (which renders the multi-arch *index* annotation from deploy.yml) still says "25 tools + 3 prompts" — the count lagged the Phase 3a task-query tool. The base Dockerfile LABEL had the same stale string; `server.json`, README, and the social preview were already correct at 26.

Two-line fix. The visible package-page description updates on the next release push (annotations are stamped at push time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)