### PR TITLE
ci(dependabot): ignore TypeScript majors until typescript-eslint supports them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
       # Node >=22.12. Major bumps are a deliberate cli decision.
       - dependency-name: commander
         update-types: ["version-update:semver-major"]
+      # typescript-eslint's peer range caps TypeScript at <6.1.0, so a TS
+      # major in the dev group breaks npm ci with ERESOLVE (PR #301). TS
+      # majors are a deliberate decision gated on typescript-eslint support.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Problem

PR #301 (Dependabot dev-group bump) fails all CI jobs at `npm ci` with ERESOLVE: the group bumps `typescript` 6.0.3 → 7.0.2 (a major) alongside `typescript-eslint` 8.63.0, whose peer range is `typescript ">=4.8.4 <6.1.0"`. TS 7 is outside every typescript-eslint 8.x peer range, so the dependency set cannot install — the group bump is internally inconsistent.

## Fix

Add `typescript` semver-major to the npm `ignore` list in `dependabot.yml`, mirroring the existing commander-major precedent (same failure shape in PR #109: a group bump pulling in a major that a constraint elsewhere forbids). TypeScript majors become a deliberate upgrade taken once typescript-eslint's peer range admits them.

After this merges, `@dependabot recreate` on #301 regenerates the group with the remaining five updates (@clack/prompts 1.7.0, @types/node 26.1.1, prettier 3.9.5, typescript-eslint 8.63.0, +1) minus the TS major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)