### PR TITLE
feat(vault-crud)!: default vault_write_note to create-only with opt-in overwrite

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,7 +182,7 @@ The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from
 | Tool                      | Input                                                        | Annotation      |
 | ------------------------- | ------------------------------------------------------------ | --------------- |
 | `vault_read_note`         | `path, properties_only?, outline?, heading?, heading_level?` | readOnlyHint    |
-| `vault_write_note`        | `path, body, properties?`                                    | destructiveHint |
+| `vault_write_note`        | `path, body, properties?, overwrite?`                        | destructiveHint |
 | `vault_patch_note`        | `path, operation, content, heading?, heading_level?`         | destructiveHint |
 | `vault_replace_in_note`   | `path, old_text, new_text, replace_all_occurrences?`         | destructiveHint |
 | `vault_delete_span`       | `path, start_anchor, end_anchor?, first_match?`              | destructiveHint |

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ See [templates/memory](./templates/memory/) for the file format, entry-policy co
 | Category        | Tool                         | Description                                                                         |
 | --------------- | ---------------------------- | ----------------------------------------------------------------------------------- |
 | **Vault CRUD**  | `vault_read_note`            | Read a note — full body, properties, outline, or a section                          |
-|                 | `vault_write_note`           | Create a note (errors if exists; set `overwrite` to replace)                        |
+|                 | `vault_write_note`           | Create a note (fails if it already exists; set `overwrite` to replace)              |
 |                 | `vault_patch_note`           | Heading-targeted edit (append, prepend, replace, insert)                            |
 |                 | `vault_replace_in_note`      | Find-and-replace text in a note                                                     |
 |                 | `vault_delete_span`          | Delete a block of lines by short anchors, no full re-quote                          |

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ See [templates/memory](./templates/memory/) for the file format, entry-policy co
 | Category        | Tool                         | Description                                                                         |
 | --------------- | ---------------------------- | ----------------------------------------------------------------------------------- |
 | **Vault CRUD**  | `vault_read_note`            | Read a note — full body, properties, outline, or a section                          |
-|                 | `vault_write_note`           | Create or overwrite a note with properties                                          |
+|                 | `vault_write_note`           | Create a note (errors if exists; set `overwrite` to replace)                        |
 |                 | `vault_patch_note`           | Heading-targeted edit (append, prepend, replace, insert)                            |
 |                 | `vault_replace_in_note`      | Find-and-replace text in a note                                                     |
 |                 | `vault_delete_span`          | Delete a block of lines by short anchors, no full re-quote                          |

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -206,6 +206,14 @@ describe("registerTools", () => {
     expect(config.description).toContain("note already exists")
   })
 
+  it("vault_write_note exposes an optional overwrite boolean in its schema", () => {
+    const [, config] = requireCall(TOOL_NAMES.VAULT_WRITE_NOTE)
+    const overwriteSchema = config.inputSchema?.overwrite
+    expect(overwriteSchema).toBeDefined()
+    expect(overwriteSchema?.safeParse(true).success).toBe(true)
+    expect(overwriteSchema?.safeParse(undefined).success).toBe(true)
+  })
+
   it("vault_recent_notes description documents sorting behavior", () => {
     const [, config] = requireCall(TOOL_NAMES.VAULT_RECENT_NOTES)
     expect(config.description).toContain("filesystem mtime")

--- a/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/tool-definitions.test.ts
@@ -201,6 +201,11 @@ describe("registerTools", () => {
     expect(config.description).toContain("keys set to null removed")
   })
 
+  it("vault_write_note description documents the already-exists error", () => {
+    const [, config] = requireCall(TOOL_NAMES.VAULT_WRITE_NOTE)
+    expect(config.description).toContain("note already exists")
+  })
+
   it("vault_recent_notes description documents sorting behavior", () => {
     const [, config] = requireCall(TOOL_NAMES.VAULT_RECENT_NOTES)
     expect(config.description).toContain("filesystem mtime")
@@ -284,6 +289,11 @@ describe("annotations", () => {
   it("vault_update_memory has idempotentHint: true (exact duplicates are no-ops)", () => {
     const [, config] = requireCall(TOOL_NAMES.VAULT_UPDATE_MEMORY)
     expect(config.annotations?.idempotentHint).toBe(true)
+  })
+
+  it("vault_write_note has idempotentHint: false (create-only default errors on retry)", () => {
+    const [, config] = requireCall(TOOL_NAMES.VAULT_WRITE_NOTE)
+    expect(config.annotations?.idempotentHint).toBe(false)
   })
 
   it("all tools have openWorldHint: false", () => {

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -201,16 +201,18 @@ Outline shape: { leading_callout?, headings } — headings is [{ level, text, by
     TOOL_NAMES.VAULT_WRITE_NOTE,
     {
       title: "Write Note",
-      description: `Create or update a markdown note. Body replaces the entire note content — this is a full overwrite, not a partial edit. Properties are passed separately and merged with any existing properties (new keys added, matching keys overwritten, keys set to null removed, unmentioned keys preserved).
+      description: `Create a markdown note. Errors if a note already exists at the path unless overwrite is set. Body replaces the entire note content — this is a full write, not a partial edit. Properties are passed separately and merged with any existing properties when overwriting (new keys added, matching keys overwritten, keys set to null removed, unmentioned keys preserved).
 
 Example: vault_write_note({ path: "Projects/notes.md", body: "# Notes\\n\\nProject notes here.", properties: { tags: ["project"], type: "project" } })
+Example: vault_write_note({ path: "Projects/notes.md", body: "Updated content.", overwrite: true })
 
-When to use: Creating a new note or fully replacing an existing note's body.
+When to use: Creating a new note. Set overwrite: true only when you intend to replace an existing note's body.
 Prefer vault_update_properties for property-only edits (no body round-trip).${config.memoryEnabled ? `\nPrefer vault_update_memory for appending dated entries to ${config.memoryDir}/ memory files.` : ""}
 
-Limitation: Overwrites the entire body. Do not use for surgical edits to large files — existing content will be lost unless you include it in the body parameter.
+Limitation: Writes the entire body. Do not use for surgical edits to large files — existing content will be lost unless you include it in the body parameter.
 
 Errors:
+- "note already exists" — a note already lives at this path; set overwrite: true to replace it, or use vault_patch_note / vault_replace_in_note for partial edits
 - "concurrent write in progress" — another write to this note is in flight; re-read the note and retry
 
 Obsidian syntax: Body is Obsidian Flavored Markdown (no escaping applied). Watch for: #word = tag (escape with \\#), [[ = wikilink, %% = comment block. In properties: quote wikilink values ("[[Note]]"), use YAML lists for tags, keep property types consistent (string/number/list mismatches cause silent query failures).
@@ -234,15 +236,21 @@ Returns: Confirmation message.`,
           .describe(
             "Optional properties to merge. New keys are added; existing keys with matching names are overwritten; a null value deletes that key; unmentioned keys are preserved from the existing file.",
           ),
+        overwrite: z
+          .boolean()
+          .optional()
+          .describe(
+            "Allow overwriting an existing note (default: false — errors if file exists).",
+          ),
       },
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,
-        idempotentHint: true,
+        idempotentHint: false,
         openWorldHint: false,
       },
     },
-    async ({ path, body, properties }, extra) => {
+    async ({ path, body, properties, overwrite }, extra) => {
       const reqLogger = sessionLogger.child({
         requestId: extra.requestId,
         tool: TOOL_NAMES.VAULT_WRITE_NOTE,
@@ -250,11 +258,15 @@ Returns: Confirmation message.`,
       reqLogger.info("tool_call", {
         path,
         hasProperties: Boolean(properties),
+        overwrite: Boolean(overwrite),
       })
       return safeHandler(
         reqLogger,
         () =>
-          vaultFs.writeNote({ vaultPath, path, body, properties }, reqLogger),
+          vaultFs.writeNote(
+            { vaultPath, path, body, properties, overwrite },
+            reqLogger,
+          ),
         () => {
           reqLogger.info("tool_result", { outcome: "written" })
           return `Wrote ${path}`
@@ -278,7 +290,7 @@ Cross-section move (e.g. completing a task on a board):
 Add at the target before deleting from the source — the two writes are not atomic, so this order can briefly duplicate the moved block on a failure but never lose it.
 
 When to use: Modifying part of an existing note without overwriting the entire body.
-Prefer vault_write_note for creating new notes or full rewrites. Prefer vault_replace_in_note for in-place text changes (typos, renaming) that stay in the same location.
+Prefer vault_write_note for creating new notes, or full rewrites (with overwrite: true). Prefer vault_replace_in_note for in-place text changes (typos, renaming) that stay in the same location.
 
 Operations:
 - append: add content at end of section (or end of file if no heading)
@@ -799,7 +811,7 @@ Returns: JSON with moved_to (the new path), links_updated (count of link occurre
 Example: vault_update_properties({ path: "Projects/todo.md", properties: { status: "active", draft: null } })
 
 When to use: Changing tags, status, type, or any property without reading/rewriting the full note body.
-Prefer vault_write_note when creating a new note or replacing the body. Read current properties first with vault_read_note({ properties_only: true }) — arrays are replaced entirely, not appended to.
+Prefer vault_write_note when creating a new note, or replacing the body (with overwrite: true). Read current properties first with vault_read_note({ properties_only: true }) — arrays are replaced entirely, not appended to.
 
 Errors:
 - "note not found" — path does not exist; create the note first with vault_write_note

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -258,7 +258,7 @@ Returns: Confirmation message.`,
       reqLogger.info("tool_call", {
         path,
         hasProperties: Boolean(properties),
-        overwrite: Boolean(overwrite),
+        overwrite,
       })
       return safeHandler(
         reqLogger,

--- a/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
@@ -1019,11 +1019,21 @@ describe("moveNote — concurrent write locking", () => {
       logger,
     )
     await vaultFs.writeNote(
-      { vaultPath: vault, path: "Hub.md", body: "rewritten after move" },
+      {
+        vaultPath: vault,
+        path: "Hub.md",
+        body: "rewritten after move",
+        overwrite: true,
+      },
       logger,
     )
     await vaultFs.writeNote(
-      { vaultPath: vault, path: "Bar.md", body: "updated after move" },
+      {
+        vaultPath: vault,
+        path: "Bar.md",
+        body: "updated after move",
+        overwrite: true,
+      },
       logger,
     )
     expect(await readNote("Foo.md")).toBe("recreated after move\n")
@@ -1046,15 +1056,30 @@ describe("moveNote — concurrent write locking", () => {
     // Every path the failed move locked (old path, destination, backlink
     // source) accepts writes again.
     await vaultFs.writeNote(
-      { vaultPath: vault, path: "Foo.md", body: "written after failed move" },
+      {
+        vaultPath: vault,
+        path: "Foo.md",
+        body: "written after failed move",
+        overwrite: true,
+      },
       logger,
     )
     await vaultFs.writeNote(
-      { vaultPath: vault, path: "Bar.md", body: "destination writable" },
+      {
+        vaultPath: vault,
+        path: "Bar.md",
+        body: "destination writable",
+        overwrite: true,
+      },
       logger,
     )
     await vaultFs.writeNote(
-      { vaultPath: vault, path: "Hub.md", body: "also writable" },
+      {
+        vaultPath: vault,
+        path: "Hub.md",
+        body: "also writable",
+        overwrite: true,
+      },
       logger,
     )
     expect(await readNote("Foo.md")).toBe("written after failed move\n")

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -380,7 +380,7 @@ describe("writeNote", () => {
       ),
     ).rejects.toThrow('note already exists: "guarded.md"')
     const content = await readFile(join(vault, "guarded.md"), "utf8")
-    expect(content).toContain("old body")
+    expect(content).toBe("---\ntitle: Keep\n---\nold body\n")
   })
 
   it("rejects when overwrite is explicitly false", async () => {

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -298,7 +298,12 @@ describe("writeNote", () => {
       "utf8",
     )
     await writeNote(
-      { vaultPath: vault, path: "existing.md", body: "new body\n" },
+      {
+        vaultPath: vault,
+        path: "existing.md",
+        body: "new body\n",
+        overwrite: true,
+      },
       logger,
     )
     const content = await readFile(join(vault, "existing.md"), "utf8")
@@ -319,6 +324,7 @@ describe("writeNote", () => {
         path: "merge.md",
         body: "body\n",
         properties: { status: "active" },
+        overwrite: true,
       },
       logger,
     )
@@ -339,6 +345,7 @@ describe("writeNote", () => {
         path: "merge.md",
         body: "new body\n",
         properties: { draft: null },
+        overwrite: true,
       },
       logger,
     )
@@ -358,6 +365,70 @@ describe("writeNote", () => {
     )
     const content = await readFile(join(vault, "fresh.md"), "utf8")
     expect(content).toBe("---\ntitle: Fresh\n---\nbody\n")
+  })
+
+  it("rejects when the file already exists and overwrite is not set", async () => {
+    await writeFile(
+      join(vault, "guarded.md"),
+      "---\ntitle: Keep\n---\nold body\n",
+      "utf8",
+    )
+    await expect(
+      writeNote(
+        { vaultPath: vault, path: "guarded.md", body: "clobber attempt\n" },
+        logger,
+      ),
+    ).rejects.toThrow('note already exists: "guarded.md"')
+    const content = await readFile(join(vault, "guarded.md"), "utf8")
+    expect(content).toContain("old body")
+  })
+
+  it("rejects when overwrite is explicitly false", async () => {
+    await writeFile(join(vault, "explicit.md"), "original\n", "utf8")
+    await expect(
+      writeNote(
+        {
+          vaultPath: vault,
+          path: "explicit.md",
+          body: "clobber\n",
+          overwrite: false,
+        },
+        logger,
+      ),
+    ).rejects.toThrow('note already exists: "explicit.md"')
+  })
+
+  it("succeeds when overwrite is set and the file exists", async () => {
+    await writeFile(
+      join(vault, "replace.md"),
+      "---\ntitle: Old\n---\nold body\n",
+      "utf8",
+    )
+    await writeNote(
+      {
+        vaultPath: vault,
+        path: "replace.md",
+        body: "new body\n",
+        overwrite: true,
+      },
+      logger,
+    )
+    const content = await readFile(join(vault, "replace.md"), "utf8")
+    expect(content).toBe("---\ntitle: Old\n---\nnew body\n")
+  })
+
+  it("creates a new file when overwrite is set but the file does not exist", async () => {
+    await writeNote(
+      {
+        vaultPath: vault,
+        path: "fresh-overwrite.md",
+        body: "created\n",
+        overwrite: true,
+      },
+      logger,
+    )
+    const content = await readFile(join(vault, "fresh-overwrite.md"), "utf8")
+    expect(content).toBe("created\n")
   })
 })
 
@@ -1028,7 +1099,10 @@ describe("write size logging", () => {
     const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {})
     onTestFinished(() => infoSpy.mockRestore())
 
-    await writeNote({ vaultPath: vault, path: "e.md", body: "new\n" }, logger)
+    await writeNote(
+      { vaultPath: vault, path: "e.md", body: "new\n", overwrite: true },
+      logger,
+    )
     const written = await readFile(join(vault, "e.md"), "utf8")
 
     expect(infoSpy).toHaveBeenCalledWith("wrote note", {
@@ -1259,6 +1333,7 @@ describe("concurrent writes (exclusive lock)", () => {
           path: "race.md",
           body: "Body.",
           properties: { alpha: "a" },
+          overwrite: true,
         },
         logger,
       ),
@@ -1268,6 +1343,7 @@ describe("concurrent writes (exclusive lock)", () => {
           path: "race.md",
           body: "Body.",
           properties: { beta: "b" },
+          overwrite: true,
         },
         logger,
       ),
@@ -1372,7 +1448,12 @@ describe("concurrent writes (exclusive lock)", () => {
     // atomic-rename recreates it. The delete must fail fast instead.
     const [write, del] = await Promise.allSettled([
       writeNote(
-        { vaultPath: vault, path: "contested.md", body: "updated" },
+        {
+          vaultPath: vault,
+          path: "contested.md",
+          body: "updated",
+          overwrite: true,
+        },
         logger,
       ),
       deleteNote(
@@ -1415,7 +1496,12 @@ describe("concurrent writes (exclusive lock)", () => {
         logger,
       ),
       writeNote(
-        { vaultPath: vault, path: "vanishing.md", body: "resurrected?" },
+        {
+          vaultPath: vault,
+          path: "vanishing.md",
+          body: "resurrected?",
+          overwrite: true,
+        },
         logger,
       ),
     ])

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -311,13 +311,14 @@ const readNoteProperties = async (
   return parseNote(content).data
 }
 
-/** Creates or updates a note. Merges frontmatter losslessly if the file exists. */
+/** Creates a note. Rejects if the file already exists unless overwrite is set. */
 const writeNote = async (
   params: {
     vaultPath: string
     path: string
     body: string
     properties?: Record<string, unknown> | undefined
+    overwrite?: boolean | undefined
   },
   logger: Logger,
 ): Promise<void> => {
@@ -327,6 +328,9 @@ const writeNote = async (
     await mkdir(dirname(fullPath), { recursive: true })
 
     const existing = await readFileOrNull(fullPath)
+    if (existing !== null && !params.overwrite) {
+      throw new Error(`note already exists: "${params.path}"`)
+    }
     const serialized = serializeNote(existing, params.body, params.properties)
     await atomicWriteFile(fullPath, serialized)
     logger.info("wrote note", {


### PR DESCRIPTION
## Summary

- `vault_write_note` now errors with `"note already exists"` when the target file already exists, unless the new `overwrite: true` input is passed
- The existence check runs inside the exclusive write lock (TOCTOU-safe) using the existing `readFileOrNull` call — no new filesystem primitives needed
- The overwrite path preserves the existing frontmatter-merge behavior identically
- Cross-reference descriptions in `vault_patch_note` and `vault_update_properties` updated to mention `overwrite: true` for full rewrites
- `idempotentHint` changed from `true` to `false` (create-only default is not idempotent)

## Motivation

Two parallel session-end agents picked the same session-log filename (`session-log-c`) within ~30s on 2026-07-11. The second write silently clobbered the first — the write lock serialized them but couldn't reject an unintended overwrite. With create-only as default, the second agent gets a clear error and can increment the filename.

## Test plan

- [x] 1713 tests pass (4 new + 9 existing updated)
- [x] Mutation check: temporarily removed the guard, confirmed new tests fail
- [x] Lint clean (0 errors)
- [x] Build clean
- [ ] Live-verify via deployed MCP: call without `overwrite` on existing note → error; with `overwrite: true` → success; on new path → success

BREAKING CHANGE: `vault_write_note` now rejects with `"note already exists"` when writing to an existing path. Callers that intend to replace an existing note must pass `overwrite: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)