### PR TITLE
feat: env var consolidation — sync script, drift tests, AGENTS.md checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ deploy/                                # End-user quickstart (no clone needed)
     .env.example                       #     + OBSIDIAN_AUTH_TOKEN, VAULT_NAME, PUBLIC_URL
 scripts/                               # Dev/ops helpers (not shipped in Docker)
   dev.ts                               # Deployment helper (subcommands for SSH, sync, etc.)
-  sync-cli-templates.ts                # Copies deploy/ compose files into cli/templates/
+  sync-cli-templates.ts                # Syncs deploy/ compose files + .env.example optional blocks into cli/
 cli/                                   # npx vault-cortex CLI (published as vault-cortex npm package)
   src/
     bin.ts                             # Entry point (version injection + run)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,11 +626,38 @@ changed:
 | `deploy/local/` + `deploy/remote/`            | New env var, changed default, new deployment step, or Docker Compose service change — update `.env.example` and `README.md` in the affected directory    |
 | `.env.example` (root)                         | New env var or changed default for the Lightsail reference deployment                                                                                    |
 | `cli/README.md`                               | Feature description, tool/prompt count, or search capability changes — this is the npmjs.com landing page                                                |
-| `cli/src/env.ts`                              | New env var or changed default — the CLI generates `.env` files with optional blocks that must mirror `deploy/*/.env.example`                            |
+| `cli/src/env.ts`                              | Auto-synced optional blocks from `deploy/*/.env.example` via `npm run sync:cli-templates` — run the script after editing deploy/ env files               |
 | `cli/templates/`                              | Docker Compose service change, new env var passthrough — templates must mirror `deploy/*/docker-compose.yml`                                             |
 | `CONTRIBUTING.md`                             | CI pipeline, repo settings, or release conventions change                                                                                                |
 | `DEPLOY.md`                                   | Infrastructure, env vars, or deployment procedure changes                                                                                                |
 | `.github/workflows/dockerhub-description.yml` | Tool/prompt count changes (the `short-description` field hardcodes the count). Docker Hub limits short descriptions to 100 characters.                   |
+
+**Env var update checklist** — when adding, removing, or changing an
+env var that the server reads (defined in `config.ts`, `server.ts`, or
+`logger.ts`), update every downstream surface. Not every var goes in
+every file — container-internal vars (HOST, INDEX_DB_PATH) are hardcoded
+in compose and skip .env.example; remote-only vars (OBSIDIAN_AUTH_TOKEN,
+PUID, etc.) only go in the remote surfaces. Use existing entries as a
+pattern:
+
+1. **Server source** (`config.ts`, `server.ts`, or `logger.ts`) —
+   authoritative definition via `env-var` package
+2. **Deploy compose** (`deploy/local/docker-compose.yml` and/or
+   `deploy/remote/docker-compose.yml`) — add `${VAR:-default}` passthrough
+   in `environment:`
+3. **Deploy .env.example** (`deploy/local/.env.example` and/or
+   `deploy/remote/.env.example`) — document for users with comment + default.
+   These are the source of truth for optional var documentation.
+4. **Run `npm run sync:cli-templates`** — syncs the optional sections from
+   step 3 into `cli/src/env.ts` (`LOCAL_OPTIONAL_BLOCK` /
+   `REMOTE_OPTIONAL_BLOCK`), and copies the deploy compose files into
+   `cli/templates/`. Always run after editing deploy/ files.
+5. **Root .env.example** — Lightsail reference deployment (if applicable)
+6. **Root compose files** (`docker-compose.yml`, `docker-compose.local.yml`)
+   — maintainer/contributor surfaces (if applicable)
+
+CI drift tests in `templates.test.ts` catch omissions across steps 2–4,
+but the checklist prevents them.
 
 **Regenerating `social-preview.png`:** The SVG uses `font-family="DejaVu Sans"`
 for the subtitle and feature line (`<text>` elements — the wordmark is already

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,10 +72,10 @@ development. A test fails if the versions drift.
 - Try it: `node cli/dist/bin.js init --help`
 
 **Template sync rule:** `cli/templates/` holds verbatim copies of
-`deploy/local/docker-compose.yml` and `deploy/remote/docker-compose.yml` so the
-npm tarball can ship them. If you change either deploy compose file, run
-`npm run sync:cli-templates` in the same PR — a byte-equality test fails CI
-otherwise.
+`deploy/local/docker-compose.yml` and `deploy/remote/docker-compose.yml`, and the
+optional env blocks in `cli/src/env.ts` are derived from `deploy/*/.env.example`.
+If you change any deploy compose file or `.env.example`, run
+`npm run sync:cli-templates` in the same PR — drift tests fail CI otherwise.
 
 **Publishing:** CLI releases are explicit and independent of server releases —
 nothing publishes to npm as a side effect of a server release. The maintainer

--- a/cli/src/__tests__/templates.test.ts
+++ b/cli/src/__tests__/templates.test.ts
@@ -72,6 +72,123 @@ describe("bundled compose templates", () => {
   })
 })
 
+// --- Env var consistency helpers ---
+
+/** Matches compose variable interpolations: `${VAR:-...}` and `${VAR:?...}`. */
+const COMPOSE_INTERPOLATION = /\$\{([A-Z_]+):[-?]/g
+
+/** Matches commented env var assignments: `# VAR_NAME=value`. */
+const COMMENTED_VAR_LINE = /^# ([A-Z_]+)=/gm
+
+/** Matches active (uncommented) env var assignments: `VAR_NAME=value`. */
+const UNCOMMENTED_VAR_LINE = /^([A-Z_]+)=/gm
+
+/** Extracts deduplicated var names from all `${VAR}` interpolations in compose content. */
+const interpolatedVars = (composeContent: string): string[] => [
+  ...new Set(
+    [...composeContent.matchAll(COMPOSE_INTERPOLATION)].map(
+      (match) => match[1],
+    ),
+  ),
+]
+
+/** Returns the content after the `# Optional` header (empty string if absent). */
+const optionalSection = (content: string): string => {
+  const parts = content.split(/^# Optional\b/m)
+  return parts.length > 1 ? parts[1] : ""
+}
+
+/** Extracts commented var names from the optional section only. */
+const optionalVarNames = (content: string): string[] => [
+  ...new Set(
+    [...optionalSection(content).matchAll(COMMENTED_VAR_LINE)].map(
+      (match) => match[1],
+    ),
+  ),
+]
+
+/** Extracts all var names from a .env.example file (required + optional). */
+const allEnvExampleVarNames = (envExampleContent: string): string[] => {
+  const required = [...envExampleContent.matchAll(UNCOMMENTED_VAR_LINE)].map(
+    (match) => match[1],
+  )
+  const optional = [...envExampleContent.matchAll(COMMENTED_VAR_LINE)].map(
+    (match) => match[1],
+  )
+  return [...new Set([...required, ...optional])]
+}
+
+describe("env var consistency across deploy surfaces", () => {
+  const modes = [
+    {
+      mode: "local" as const,
+      buildEnv: () => buildLocalEnv({ mcpAuthToken: "t", vaultPath: "/v" }),
+      conditionalVars: [] as string[],
+    },
+    {
+      mode: "remote" as const,
+      buildEnv: () =>
+        buildRemoteEnv({
+          mcpAuthToken: "t",
+          publicUrl: "https://v.example.com",
+          obsidianAuthToken: "tok",
+          vaultName: "V",
+        }),
+      conditionalVars: ["VAULT_PASSWORD"],
+    },
+  ]
+
+  it.each(modes)(
+    "$mode: every compose interpolation is documented in .env.example",
+    ({ mode }) => {
+      const composeVars = new Set(
+        interpolatedVars(readRepoFile(`deploy/${mode}/docker-compose.yml`)),
+      )
+      const exampleVars = new Set(
+        allEnvExampleVarNames(readRepoFile(`deploy/${mode}/.env.example`)),
+      )
+
+      const undocumented = [...composeVars]
+        .filter((varName) => !exampleVars.has(varName))
+        .sort()
+      expect(undocumented).toEqual([])
+    },
+  )
+
+  it.each(modes)(
+    "$mode: every .env.example var appears as a compose interpolation",
+    ({ mode }) => {
+      const composeVars = new Set(
+        interpolatedVars(readRepoFile(`deploy/${mode}/docker-compose.yml`)),
+      )
+      const exampleVars = new Set(
+        allEnvExampleVarNames(readRepoFile(`deploy/${mode}/.env.example`)),
+      )
+
+      const unconsumed = [...exampleVars]
+        .filter((varName) => !composeVars.has(varName))
+        .sort()
+      expect(unconsumed).toEqual([])
+    },
+  )
+
+  it.each(modes)(
+    "$mode: CLI optional block vars match .env.example optional vars (fix: npm run sync:cli-templates)",
+    ({ mode, buildEnv, conditionalVars }) => {
+      const conditionalSet = new Set(conditionalVars)
+
+      const cliOptional = optionalVarNames(buildEnv()).sort()
+      const exampleOptional = optionalVarNames(
+        readRepoFile(`deploy/${mode}/.env.example`),
+      )
+        .filter((varName) => !conditionalSet.has(varName))
+        .sort()
+
+      expect(cliOptional).toEqual(exampleOptional)
+    },
+  )
+})
+
 describe("cli dependency pinning", () => {
   it("cli dependencies match the root devDependencies versions (single install for dev, real deps for npx)", () => {
     const cliManifest = JSON.parse(readRepoFile("cli/package.json")) as {

--- a/cli/src/env.ts
+++ b/cli/src/env.ts
@@ -15,14 +15,20 @@ export type RemoteEnvAnswers = {
   vaultPassword?: string
 }
 
-// The optional blocks mirror the canonical deploy/<mode>/.env.example files.
+// Optional env blocks are synced from deploy/<mode>/.env.example by
+// npm run sync:cli-templates. Edit the deploy/ files, then re-run the script.
 // cli/src/templates.test.ts asserts every required `${VAR:?}` in the compose
 // templates has a matching line here, so a new required var breaks CI until
 // these builders learn it.
 
+// sync:local-optional:begin
 const LOCAL_OPTIONAL_BLOCK = `# Optional ──────────────────────────────────────────────────
 # To override a setting: uncomment it, set a value, then apply with
 # "docker compose up -d" (restart alone does not re-read this file).
+
+# Public URL for OAuth issuer URL in discovery metadata (default: http://localhost:8000).
+# Override if you expose the server on a different URL (e.g. via a reverse proxy).
+# PUBLIC_URL=http://localhost:8000
 
 # Your IANA timezone — affects daily note resolution and memory timestamps.
 # TZ=America/New_York
@@ -81,6 +87,9 @@ const LOCAL_OPTIONAL_BLOCK = `# Optional ─────────────
 # WINDOWS_MODE=true
 `
 
+// sync:local-optional:end
+
+// sync:remote-optional:begin
 const REMOTE_OPTIONAL_BLOCK = `# Optional ──────────────────────────────────────────────────
 # To override a setting: uncomment it, set a value, then apply with
 # "docker compose up -d" (restart alone does not re-read this file).
@@ -148,11 +157,14 @@ const REMOTE_OPTIONAL_BLOCK = `# Optional ────────────�
 # DEVICE_NAME=vault-cortex
 
 # Obsidian Sync conflict resolution: merge | conflict (default: merge).
+# 'merge' integrates changes automatically; 'conflict' writes a separate conflict file.
 # CONFLICT_STRATEGY=merge
 
 # Sync direction: bidirectional | pull-only | push-only (default: bidirectional).
 # SYNC_MODE=bidirectional
 `
+
+// sync:remote-optional:end
 
 export const buildLocalEnv = (
   answers: LocalEnvAnswers,

--- a/cli/src/env.ts
+++ b/cli/src/env.ts
@@ -21,6 +21,11 @@ export type RemoteEnvAnswers = {
 // templates has a matching line here, so a new required var breaks CI until
 // these builders learn it.
 
+// ┌─────────────────────────────────────────────────────────────────────────┐
+// │ GENERATED — do not edit between sync markers.                          │
+// │ Source: deploy/local/.env.example → npm run sync:cli-templates         │
+// │ The script replaces everything between :begin and :end on each run.    │
+// └─────────────────────────────────────────────────────────────────────────┘
 // sync:local-optional:begin
 const LOCAL_OPTIONAL_BLOCK = `# Optional ──────────────────────────────────────────────────
 # To override a setting: uncomment it, set a value, then apply with
@@ -89,6 +94,11 @@ const LOCAL_OPTIONAL_BLOCK = `# Optional ─────────────
 
 // sync:local-optional:end
 
+// ┌─────────────────────────────────────────────────────────────────────────┐
+// │ GENERATED — do not edit between sync markers.                          │
+// │ Source: deploy/remote/.env.example → npm run sync:cli-templates        │
+// │ VAULT_PASSWORD is excluded (handled conditionally in buildRemoteEnv).  │
+// └─────────────────────────────────────────────────────────────────────────┘
 // sync:remote-optional:begin
 const REMOTE_OPTIONAL_BLOCK = `# Optional ──────────────────────────────────────────────────
 # To override a setting: uncomment it, set a value, then apply with

--- a/deploy/local/.env.example
+++ b/deploy/local/.env.example
@@ -13,6 +13,10 @@ VAULT_PATH=
 
 # Optional ──────────────────────────────────────────────────
 
+# Public URL for OAuth issuer URL in discovery metadata (default: http://localhost:8000).
+# Override if you expose the server on a different URL (e.g. via a reverse proxy).
+# PUBLIC_URL=http://localhost:8000
+
 # Your IANA timezone — affects daily note resolution and memory timestamps.
 # TZ=America/New_York
 

--- a/scripts/sync-cli-templates.ts
+++ b/scripts/sync-cli-templates.ts
@@ -1,15 +1,25 @@
-// Copies the canonical deploy/ compose files into cli/templates/ so the
-// published npm package ships them. cli/src/templates.test.ts fails CI when
-// the copies drift; this script is the one-command fix.
+// Syncs canonical deploy/ files into cli/ so the published npm package ships
+// current content. Two sync targets:
+//
+//   1. Compose files:    deploy/<mode>/docker-compose.yml → cli/templates/<mode>/
+//   2. Optional env blocks: deploy/<mode>/.env.example → cli/src/env.ts constants
+//
+// cli/src/templates.test.ts fails CI when any of these drift; this script is
+// the one-command fix.
 //
 // Usage: npm run sync:cli-templates
 
-import { copyFileSync } from "node:fs"
+import { copyFileSync, readFileSync, writeFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 
 const repoRoot = new URL("..", import.meta.url)
 
-const templateSources = [
+const resolvePath = (repoRelative: string): string =>
+  fileURLToPath(new URL(repoRelative, repoRoot))
+
+// --- 1. Compose file sync (byte-exact copy) --------------------------------
+
+const composeSources = [
   {
     from: "deploy/local/docker-compose.yml",
     to: "cli/templates/local/docker-compose.yml",
@@ -20,10 +30,98 @@ const templateSources = [
   },
 ]
 
-for (const { from, to } of templateSources) {
-  copyFileSync(
-    fileURLToPath(new URL(from, repoRoot)),
-    fileURLToPath(new URL(to, repoRoot)),
-  )
+for (const { from, to } of composeSources) {
+  copyFileSync(resolvePath(from), resolvePath(to))
   console.log(`synced ${from} -> ${to}`)
 }
+
+// --- 2. Optional env block sync (extract + embed) ---------------------------
+
+/** Header prepended to each optional block in the CLI-generated .env. */
+const CLI_OPTIONAL_HEADER = `# Optional ──────────────────────────────────────────────────
+# To override a setting: uncomment it, set a value, then apply with
+# "docker compose up -d" (restart alone does not re-read this file).
+
+`
+
+/**
+ * Extracts the optional section from a .env.example file — everything after
+ * the `# Optional ──────` header line. Returns the content without the header
+ * itself (the CLI prepends its own instruction-enriched header).
+ */
+const extractOptionalSection = (envExampleContent: string): string => {
+  const headerPattern = /^# Optional\b[^\n]*/m
+  const match = headerPattern.exec(envExampleContent)
+  if (!match) {
+    throw new Error("could not find '# Optional' header in .env.example")
+  }
+  const rawSection = envExampleContent.slice(match.index + match[0].length)
+  return rawSection.replace(/^\n+/, "")
+}
+
+/**
+ * Removes the VAULT_PASSWORD entry block from the remote optional section.
+ * VAULT_PASSWORD is handled conditionally in buildRemoteEnv's required section,
+ * not in the optional block.
+ */
+const removeVaultPasswordBlock = (optionalContent: string): string => {
+  const blocks = optionalContent.split("\n\n")
+  const filtered = blocks.filter((block) => !block.includes("VAULT_PASSWORD"))
+  return filtered.join("\n\n")
+}
+
+/**
+ * Replaces content between sync markers in env.ts. Markers are line comments
+ * like `// sync:local-optional:begin` and `// sync:local-optional:end`.
+ */
+const replaceSyncBlock = (
+  fileContent: string,
+  blockName: string,
+  newContent: string,
+): string => {
+  const beginMarker = `// sync:${blockName}:begin`
+  const endMarker = `// sync:${blockName}:end`
+
+  const beginIndex = fileContent.indexOf(beginMarker)
+  const endIndex = fileContent.indexOf(endMarker)
+  if (beginIndex === -1 || endIndex === -1) {
+    throw new Error(`sync markers for '${blockName}' not found in env.ts`)
+  }
+
+  const beforeBlock = fileContent.slice(0, beginIndex + beginMarker.length)
+  const afterBlock = fileContent.slice(endIndex)
+
+  return `${beforeBlock}\n${newContent}\n${afterBlock}`
+}
+
+const envSources = [
+  {
+    envExample: "deploy/local/.env.example",
+    blockName: "local-optional",
+    constName: "LOCAL_OPTIONAL_BLOCK",
+    transform: (section: string): string => section,
+  },
+  {
+    envExample: "deploy/remote/.env.example",
+    blockName: "remote-optional",
+    constName: "REMOTE_OPTIONAL_BLOCK",
+    transform: removeVaultPasswordBlock,
+  },
+]
+
+const envTsPath = resolvePath("cli/src/env.ts")
+let envTsContent = readFileSync(envTsPath, "utf8")
+
+for (const { envExample, blockName, constName, transform } of envSources) {
+  const exampleContent = readFileSync(resolvePath(envExample), "utf8")
+  const rawSection = extractOptionalSection(exampleContent)
+  const processedSection = transform(rawSection)
+
+  const blockContent = `const ${constName} = \`${CLI_OPTIONAL_HEADER}${processedSection}\`
+`
+
+  envTsContent = replaceSyncBlock(envTsContent, blockName, blockContent)
+  console.log(`synced ${envExample} optional section -> env.ts ${constName}`)
+}
+
+writeFileSync(envTsPath, envTsContent)

--- a/scripts/sync-cli-templates.ts
+++ b/scripts/sync-cli-templates.ts
@@ -118,7 +118,9 @@ for (const { envExample, blockName, constName, transform } of envSources) {
   const optionalSection = extractOptionalSection(exampleContent)
   const transformedSection = transform(optionalSection)
 
-  const blockContent = `const ${constName} = \`${CLI_OPTIONAL_HEADER}${transformedSection}\`
+  const escapedSection = transformedSection.replaceAll("`", "\\`")
+
+  const blockContent = `const ${constName} = \`${CLI_OPTIONAL_HEADER}${escapedSection}\`
 `
 
   envTsContent = replaceSyncBlock(envTsContent, blockName, blockContent)

--- a/scripts/sync-cli-templates.ts
+++ b/scripts/sync-cli-templates.ts
@@ -55,8 +55,8 @@ const extractOptionalSection = (envExampleContent: string): string => {
   if (!match) {
     throw new Error("could not find '# Optional' header in .env.example")
   }
-  const rawSection = envExampleContent.slice(match.index + match[0].length)
-  return rawSection.replace(/^\n+/, "")
+  const afterHeader = envExampleContent.slice(match.index + match[0].length)
+  return afterHeader.replace(/^\n+/, "")
 }
 
 /**
@@ -110,14 +110,15 @@ const envSources = [
 ]
 
 const envTsPath = resolvePath("cli/src/env.ts")
+// Mutable — each loop iteration replaces a different sync block in the file content
 let envTsContent = readFileSync(envTsPath, "utf8")
 
 for (const { envExample, blockName, constName, transform } of envSources) {
   const exampleContent = readFileSync(resolvePath(envExample), "utf8")
-  const rawSection = extractOptionalSection(exampleContent)
-  const processedSection = transform(rawSection)
+  const optionalSection = extractOptionalSection(exampleContent)
+  const transformedSection = transform(optionalSection)
 
-  const blockContent = `const ${constName} = \`${CLI_OPTIONAL_HEADER}${processedSection}\`
+  const blockContent = `const ${constName} = \`${CLI_OPTIONAL_HEADER}${transformedSection}\`
 `
 
   envTsContent = replaceSyncBlock(envTsContent, blockName, blockContent)


### PR DESCRIPTION
## Summary

- **Three-layer defense** against env var duplication drift across the ~9-file surface (deploy compose files, .env.example files, CLI env builder):
  1. **Prevention**: AGENTS.md env var update checklist — ties the full update chain together with an explicit 6-step numbered sequence, including when to run the sync script
  2. **Automation**: sync script (`npm run sync:cli-templates`) now derives CLI optional blocks from `deploy/*.env.example`, making .env.example the single source of truth for optional var documentation
  3. **Detection**: 6 new drift tests (3 invariants × 2 modes) catch remaining mismatches at CI — compose↔.env.example bidirectional coverage, and CLI optional block↔.env.example parity
- **Fixes pre-existing gap**: PUBLIC_URL was passed through in `deploy/local/docker-compose.yml` but not documented in `deploy/local/.env.example`
- 1692 → 1713 tests (6 new drift tests + 15 from recent other work on main)

## Test plan

- [x] All 12 template tests pass (6 existing + 6 new)
- [x] Mutation checks: Invariant A catches undocumented compose var, Invariant B catches unconsumed .env.example var, Invariant C catches CLI/example optional mismatch
- [x] Sync script round-trips correctly (`npm run sync:cli-templates` produces clean env.ts)
- [x] Full test suite passes (1713 tests, 0 failures)
- [x] TypeScript build passes (server + CLI + CLI tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)