### PR TITLE
fix(ci): generate WAF-safe DOCKERHUB.md for Docker Hub description sync

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -24,3 +24,4 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ vars.DOCKERHUB_USERNAME }}/vault-cortex
           short-description: "Standalone MCP server for Obsidian vaults — hybrid search, memory, 27 tools + 3 prompts, OAuth 2.1."
+          readme-filepath: DOCKERHUB.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ node_modules/
 *.db
 *.sqlite
 CHANGELOG.md
+DOCKERHUB.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ deploy/                                # End-user quickstart (no clone needed)
 scripts/                               # Dev/ops helpers (not shipped in Docker)
   dev.ts                               # Deployment helper (subcommands for SSH, sync, etc.)
   sync-cli-templates.ts                # Syncs deploy/ compose files + .env.example optional blocks into cli/
+  generate-dockerhub-readme.ts         # Generates DOCKERHUB.md (WAF-safe Docker Hub README) from README.md
 cli/                                   # npx vault-cortex CLI (published as vault-cortex npm package)
   src/
     bin.ts                             # Entry point (version injection + run)
@@ -619,21 +620,22 @@ Several files outside `src/` reflect the project's feature surface and
 need updating alongside code changes. What to check depends on what
 changed:
 
-| File                                          | Update when…                                                                                                                                             |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `README.md`                                   | Tool/prompt count changes, new deployment mode, new feature worth mentioning in the value prop                                                           |
-| `ARCHITECTURE.md`                             | New component, requirement, or design decision; component diagram changes                                                                                |
-| `server.json`                                 | Tool/prompt count changes (the `tools` and `prompts` fields), description changes. `description` has a 100-character limit per the MCP registry schema.  |
-| `assets/social-preview.svg` + `.png`          | Tool count changes (rendered in the image); regenerate PNG after SVG edits (see recipe below table)                                                      |
-| `.devin/wiki.json`                            | New architectural area (new page), module renamed/moved (update `repo_notes` or `purpose` references), significant tool count jump (update `repo_notes`) |
-| `deploy/local/` + `deploy/remote/`            | New env var, changed default, new deployment step, or Docker Compose service change — update `.env.example` and `README.md` in the affected directory    |
-| `.env.example` (root)                         | New env var or changed default for the Lightsail reference deployment                                                                                    |
-| `cli/README.md`                               | Feature description, tool/prompt count, or search capability changes — this is the npmjs.com landing page                                                |
-| `cli/src/env.ts`                              | Auto-synced optional blocks from `deploy/*/.env.example` via `npm run sync:cli-templates` — run the script after editing deploy/ env files               |
-| `cli/templates/`                              | Docker Compose service change, new env var passthrough — templates must mirror `deploy/*/docker-compose.yml`                                             |
-| `CONTRIBUTING.md`                             | CI pipeline, repo settings, or release conventions change                                                                                                |
-| `DEPLOY.md`                                   | Infrastructure, env vars, or deployment procedure changes                                                                                                |
-| `.github/workflows/dockerhub-description.yml` | Tool/prompt count changes (the `short-description` field hardcodes the count). Docker Hub limits short descriptions to 100 characters.                   |
+| File                                          | Update when…                                                                                                                                                      |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `README.md`                                   | Tool/prompt count changes, new deployment mode, new feature worth mentioning in the value prop                                                                    |
+| `ARCHITECTURE.md`                             | New component, requirement, or design decision; component diagram changes                                                                                         |
+| `server.json`                                 | Tool/prompt count changes (the `tools` and `prompts` fields), description changes. `description` has a 100-character limit per the MCP registry schema.           |
+| `assets/social-preview.svg` + `.png`          | Tool count changes (rendered in the image); regenerate PNG after SVG edits (see recipe below table)                                                               |
+| `.devin/wiki.json`                            | New architectural area (new page), module renamed/moved (update `repo_notes` or `purpose` references), significant tool count jump (update `repo_notes`)          |
+| `deploy/local/` + `deploy/remote/`            | New env var, changed default, new deployment step, or Docker Compose service change — update `.env.example` and `README.md` in the affected directory             |
+| `.env.example` (root)                         | New env var or changed default for the Lightsail reference deployment                                                                                             |
+| `cli/README.md`                               | Feature description, tool/prompt count, or search capability changes — this is the npmjs.com landing page                                                         |
+| `cli/src/env.ts`                              | Auto-synced optional blocks from `deploy/*/.env.example` via `npm run sync:cli-templates` — run the script after editing deploy/ env files                        |
+| `cli/templates/`                              | Docker Compose service change, new env var passthrough — templates must mirror `deploy/*/docker-compose.yml`                                                      |
+| `CONTRIBUTING.md`                             | CI pipeline, repo settings, or release conventions change                                                                                                         |
+| `DEPLOY.md`                                   | Infrastructure, env vars, or deployment procedure changes                                                                                                         |
+| `DOCKERHUB.md`                                | Auto-generated — regenerate via `npm run generate:dockerhub-readme` after README changes. Do not edit manually.                                                   |
+| `.github/workflows/dockerhub-description.yml` | Tool/prompt count changes (the `short-description` field hardcodes the count). Reads from `DOCKERHUB.md`. Docker Hub limits short descriptions to 100 characters. |
 
 **Env var update checklist** — when adding, removing, or changing an
 env var that the server reads (defined in `config.ts`, `server.ts`, or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -620,22 +620,22 @@ Several files outside `src/` reflect the project's feature surface and
 need updating alongside code changes. What to check depends on what
 changed:
 
-| File                                          | Update when…                                                                                                                                                      |
-| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `README.md`                                   | Tool/prompt count changes, new deployment mode, new feature worth mentioning in the value prop                                                                    |
-| `ARCHITECTURE.md`                             | New component, requirement, or design decision; component diagram changes                                                                                         |
-| `server.json`                                 | Tool/prompt count changes (the `tools` and `prompts` fields), description changes. `description` has a 100-character limit per the MCP registry schema.           |
-| `assets/social-preview.svg` + `.png`          | Tool count changes (rendered in the image); regenerate PNG after SVG edits (see recipe below table)                                                               |
-| `.devin/wiki.json`                            | New architectural area (new page), module renamed/moved (update `repo_notes` or `purpose` references), significant tool count jump (update `repo_notes`)          |
-| `deploy/local/` + `deploy/remote/`            | New env var, changed default, new deployment step, or Docker Compose service change — update `.env.example` and `README.md` in the affected directory             |
-| `.env.example` (root)                         | New env var or changed default for the Lightsail reference deployment                                                                                             |
-| `cli/README.md`                               | Feature description, tool/prompt count, or search capability changes — this is the npmjs.com landing page                                                         |
-| `cli/src/env.ts`                              | Auto-synced optional blocks from `deploy/*/.env.example` via `npm run sync:cli-templates` — run the script after editing deploy/ env files                        |
-| `cli/templates/`                              | Docker Compose service change, new env var passthrough — templates must mirror `deploy/*/docker-compose.yml`                                                      |
-| `CONTRIBUTING.md`                             | CI pipeline, repo settings, or release conventions change                                                                                                         |
-| `DEPLOY.md`                                   | Infrastructure, env vars, or deployment procedure changes                                                                                                         |
-| `DOCKERHUB.md`                                | Auto-generated — regenerate via `npm run generate:dockerhub-readme` after README changes. Do not edit manually.                                                   |
-| `.github/workflows/dockerhub-description.yml` | Tool/prompt count changes (the `short-description` field hardcodes the count). Reads from `DOCKERHUB.md`. Docker Hub limits short descriptions to 100 characters. |
+| File                                          | Update when…                                                                                                                                                                                     |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `README.md`                                   | Tool/prompt count changes, new deployment mode, new feature worth mentioning in the value prop                                                                                                   |
+| `ARCHITECTURE.md`                             | New component, requirement, or design decision; component diagram changes                                                                                                                        |
+| `server.json`                                 | Tool/prompt count changes (the `tools` and `prompts` fields), description changes. `description` has a 100-character limit per the MCP registry schema.                                          |
+| `assets/social-preview.svg` + `.png`          | Tool count changes (rendered in the image); regenerate PNG after SVG edits (see recipe below table)                                                                                              |
+| `.devin/wiki.json`                            | New architectural area (new page), module renamed/moved (update `repo_notes` or `purpose` references), significant tool count jump (update `repo_notes`)                                         |
+| `deploy/local/` + `deploy/remote/`            | New env var, changed default, new deployment step, or Docker Compose service change — update `.env.example` and `README.md` in the affected directory                                            |
+| `.env.example` (root)                         | New env var or changed default for the Lightsail reference deployment                                                                                                                            |
+| `cli/README.md`                               | Feature description, tool/prompt count, or search capability changes — this is the npmjs.com landing page                                                                                        |
+| `cli/src/env.ts`                              | Auto-synced optional blocks from `deploy/*/.env.example` via `npm run sync:cli-templates` — run the script after editing deploy/ env files                                                       |
+| `cli/templates/`                              | Docker Compose service change, new env var passthrough — templates must mirror `deploy/*/docker-compose.yml`                                                                                     |
+| `CONTRIBUTING.md`                             | CI pipeline, repo settings, or release conventions change                                                                                                                                        |
+| `DEPLOY.md`                                   | Infrastructure, env vars, or deployment procedure changes                                                                                                                                        |
+| `DOCKERHUB.md`                                | Auto-generated — regenerate via `npm run generate:dockerhub-readme` when README.md changes tool/prompt tables, feature descriptions, env var table, or deployment options. Do not edit manually. |
+| `.github/workflows/dockerhub-description.yml` | Tool/prompt count changes (the `short-description` field hardcodes the count). Reads from `DOCKERHUB.md`. Docker Hub limits short descriptions to 100 characters.                                |
 
 **Env var update checklist** — when adding, removing, or changing an
 env var that the server reads (defined in `config.ts`, `server.ts`, or

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,0 +1,186 @@
+<!-- AUTO-GENERATED from README.md — do not edit manually. Run: npm run generate:dockerhub-readme -->
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/aliasunder/vault-cortex/main/assets/banner.svg" width="720" alt="Vault Cortex">
+</p>
+
+<div align="center">
+
+[![CI](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/ci.yml?branch=main&logo=github&label=CI&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/ci.yml)
+[![Gitleaks](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/gitleaks.yml?branch=main&logo=github&label=Gitleaks&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/actions/workflows/gitleaks.yml)
+[![Trivy](https://img.shields.io/github/actions/workflow/status/aliasunder/vault-cortex/trivy.yml?branch=main&logo=github&label=Trivy&cacheSeconds=43200&v=1)](https://github.com/aliasunder/vault-cortex/actions/workflows/trivy.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/aliasunder/vault-cortex?cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/releases)
+[![License: MIT](https://img.shields.io/github/license/aliasunder/vault-cortex?v=1&cacheSeconds=43200)](https://github.com/aliasunder/vault-cortex/blob/main/LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/aliasunder/vault-cortex)
+[![vault-cortex MCP server](https://glama.ai/mcp/servers/aliasunder/vault-cortex/badges/score.svg)](https://glama.ai/mcp/servers/aliasunder/vault-cortex)
+
+</div>
+
+> **Full documentation:** [github.com/aliasunder/vault-cortex](https://github.com/aliasunder/vault-cortex)
+>
+> This is an abbreviated version for Docker Hub. See the full README for quick-start guides, authentication details, and development instructions.
+
+
+**Vault Cortex** is a standalone MCP server that gives any AI agent **hybrid search, task queries, structured memory, and read/write access** to your [Obsidian](https://obsidian.md) vault. No plugins, no running Obsidian, no separate bridge. One Docker container, your vault folder, 27 tools + 3 guided prompts. Deploy on a VPS with Obsidian Sync and the same vault is accessible from your phone, claude.ai, or any remote MCP client, secured with OAuth 2.1.
+
+
+## What you get
+
+<table align="center">
+  <tr>
+    <td align="center"><strong>Search the vault</strong></td>
+    <td align="center"><strong>Reason over notes</strong></td>
+    <td align="center"><strong>Write back to Obsidian</strong></td>
+  </tr>
+  <tr>
+    <td><img src="https://raw.githubusercontent.com/aliasunder/vault-cortex/main/assets/demo-remember.gif" width="240" alt="Ask Claude about a past trip — it searches the vault and recalls the route, cities, and highlights"></td>
+    <td><img src="https://raw.githubusercontent.com/aliasunder/vault-cortex/main/assets/demo-reason.gif" width="240" alt="Ask what went wrong — Claude synthesizes lessons from session logs and itinerary notes"></td>
+    <td><img src="https://raw.githubusercontent.com/aliasunder/vault-cortex/main/assets/demo-writeback.gif" width="240" alt="Save lessons learned to the vault, update travel preferences, then see both in Obsidian"></td>
+  </tr>
+</table>
+
+<p align="center"><em>All three demos run on Claude mobile. The vault is on a remote server, not the phone.</em></p>
+
+- **[Remote access](https://github.com/aliasunder/vault-cortex#deployment-options)** — works from your phone, a remote server, or any MCP client via OAuth 2.1. Deploy on a VPS with Obsidian Sync for access from anywhere.
+- **[Plugin-free](https://github.com/aliasunder/vault-cortex#how-it-works)** — Obsidian doesn't need to be running. The server works directly with `.md` files on disk. Headless sync keeps the vault current.
+- **[Hybrid search](https://github.com/aliasunder/vault-cortex#hybrid-search)** — FTS5 keyword matching + vector semantic similarity via RRF fusion, refined by cross-encoder reranking for intent-heavy queries. Keywords stay precise on exact terms and jargon; vectors find notes even when your words differ from the vault's.
+- **[Structured memory](https://github.com/aliasunder/vault-cortex#memory)** — dated, append-only entries accumulate into a personal knowledge layer, auto-initialized for AI personalization. Topic recall answers "what do I think about X?" with the current take and the dated history behind it — evolution included.
+- **[Task queries](https://github.com/aliasunder/vault-cortex#tools-27)** — Kanban-aware, vault-wide task index parsing both [Tasks plugin](https://publish.obsidian.md/tasks/) emoji and [Dataview](https://blacksmithgu.github.io/obsidian-dataview/) inline-field formats. Filter by status, six date fields, priority, folder, or heading — or pull board lanes in position order.
+- **[Link graph](https://github.com/aliasunder/vault-cortex#tools-27)** — backlinks, outgoing links, and orphan detection across the vault
+- **[Obsidian-native](https://github.com/aliasunder/vault-cortex#properties)** — understands frontmatter, wikilinks, tags, headings, and daily notes
+- **[Guided workflows](https://github.com/aliasunder/vault-cortex#prompts-3)** — three built-in prompts for vault health, memory review, and daily reconciliation — assembled from live vault data each time
+
+**Tested across a 15-day trip through Europe.** 30+ sessions from a phone, 216 tool calls, zero laptop access needed. Writes in one session were immediately available in the next, across cities and days.
+
+
+## Quick Start
+
+See the [full Quick Start guide](https://github.com/aliasunder/vault-cortex#quick-start) for local setup (2 minutes with Docker), remote deployment with Obsidian Sync, and MCP client configuration.
+
+## How It Works
+
+
+The search index is rebuildable derived state — FTS5 keyword tables rebuild on startup, vector embeddings persist across restarts with content-hash gating (only changed notes re-embed). A file watcher keeps both current, and queries fuse both signals via Reciprocal Rank Fusion. The sync service keeps the vault in sync with your Obsidian apps — it ships inside the same container in the `:remote` image variant (remote deployments only; the default `:latest` image is the MCP server alone).
+
+See [ARCHITECTURE.md](https://github.com/aliasunder/vault-cortex/blob/main/ARCHITECTURE.md) for the full design, auth flow diagrams, and component breakdown.
+
+## Hybrid Search
+
+Keyword search alone fails when your vocabulary doesn't match the vault's — "aspirations" won't find a note about "targets", "coworkers" won't surface your "references" file. In testing against a real vault, 30% of natural-language queries returned zero or tangential results with keywords alone. Hybrid search eliminated those misses — vectors bridge the vocabulary gap, and the reranker rescues intent-heavy queries where neither signal is strong on its own.
+
+Hybrid search combines three ranking signals via [Reciprocal Rank Fusion](https://github.com/aliasunder/vault-cortex/blob/main/ARCHITECTURE.md#hybrid-search-r8):
+
+- **Keywords** (FTS5) stay precise on exact terms, jargon, and property values
+- **Vectors** (sqlite-vec) bridge the vocabulary gap by matching on meaning
+- **Reranker** (cross-encoder) refines ordering by scoring each query-document pair jointly — rescues intent-heavy queries where keywords and vectors both miss
+
+All models run locally (~45MB total, no external API). Set `EMBEDDING_ENABLED=false` for keyword-only search, or `RERANK_MODE=none` to skip reranking for lower latency.
+
+See [ARCHITECTURE.md → Hybrid Search](https://github.com/aliasunder/vault-cortex/blob/main/ARCHITECTURE.md#hybrid-search-r8) for model details, blend weights, and the full pipeline breakdown.
+
+## Memory
+
+A memory layer that only grows is only useful if agents can retrieve the right entries without dumping everything into context. Once you have hundreds of dated entries across multiple files — preferences, principles, communication style, ongoing commitments — reading whole files wastes context on irrelevant material and buries the signal. The memory system is designed for targeted retrieval: agents accumulate knowledge over time and recall exactly what's relevant to the task at hand.
+
+The layer is a folder of plain Markdown files (default: `About Me/`) holding dated entries under topic headings — auto-created with starter templates on first run, grown by agents through `vault_update_memory`. Three properties make it work:
+
+- **Append-only** — entries are never overwritten; corrections arrive as new dated entries. The layer becomes a personal knowledge base that captures your current state _and_ the evolution behind it
+- **Topic recall** — `vault_memory_recall` retrieves every relevant entry across all memory files at once, keyword- and semantically-matched, oldest first. Ask "what do I think about X?" and get the current take plus the dated history of how it developed — no need to read entire files or guess which file holds what
+- **Grows without degrading** — capping results (`max_results`) drops the least-relevant entries, never a slice of the timeline. A memory layer with 500 entries serves a targeted query as well as one with 50
+
+Files that describe what's current rather than what has been true (routines, active commitments) can declare `entry-policy: living` in frontmatter — their expired entries are prunable rather than preserved, keeping the current-state picture accurate.
+
+See [templates/memory](https://github.com/aliasunder/vault-cortex/tree/main/templates/memory/) for the file format, entry-policy convention, and starter templates.
+
+## Tools (27)
+
+| Category        | Tool                         | Description                                                                         |
+| --------------- | ---------------------------- | ----------------------------------------------------------------------------------- |
+| **Vault CRUD**  | `vault_read_note`            | Read a note — full body, properties, outline, or a section                          |
+|                 | `vault_write_note`           | Create a note (fails if it already exists; set `overwrite` to replace)              |
+|                 | `vault_patch_note`           | Heading-targeted edit (append, prepend, replace, insert)                            |
+|                 | `vault_replace_in_note`      | Find-and-replace text in a note                                                     |
+|                 | `vault_delete_span`          | Delete a block of lines by short anchors, no full re-quote                          |
+|                 | `vault_list_notes`           | List notes with optional glob/folder filter                                         |
+|                 | `vault_delete_note`          | Delete a note (protected paths enforced)                                            |
+|                 | `vault_move_note`            | Move or rename a note, rewriting links across the vault                             |
+| **Search**      | `vault_search`               | Hybrid search with tag/folder/property/date filters                                 |
+|                 | `vault_search_by_tag`        | Find notes by tag (exact or prefix match)                                           |
+|                 | `vault_search_by_folder`     | Browse notes in a folder with metadata                                              |
+|                 | `vault_recent_notes`         | Recently modified or created notes                                                  |
+|                 | `vault_list_tags`            | All tags with usage counts                                                          |
+|                 | `vault_list_tasks`           | Vault-wide task index — Kanban-aware, 6 date fields, priority, folder/heading scope |
+| **Memory**      | `vault_get_memory`           | Read structured memory (file, section, or all)                                      |
+|                 | `vault_update_memory`        | Append a dated entry to a memory section                                            |
+|                 | `vault_delete_memory`        | Remove a specific memory entry by date                                              |
+|                 | `vault_list_memory_files`    | Discover memory files, their sections, and each file's entry policy                 |
+|                 | `vault_memory_recall`        | Entry-granular hybrid recall of a topic across memory files, oldest-first           |
+| **Properties**  | `vault_list_property_keys`   | All property keys with sample values                                                |
+|                 | `vault_list_property_values` | Distinct values for a property key                                                  |
+|                 | `vault_search_by_property`   | Find notes by property key-value                                                    |
+|                 | `vault_update_properties`    | Add or update properties without touching the body                                  |
+| **Links**       | `vault_get_backlinks`        | Notes linking to a given path                                                       |
+|                 | `vault_get_outgoing_links`   | Links from a given note                                                             |
+|                 | `vault_find_orphans`         | Notes with no incoming links                                                        |
+| **Daily Notes** | `vault_get_daily_note`       | Today's (or any date's) daily note                                                  |
+
+## Prompts (3)
+
+Tools are model-driven — the assistant calls them. **Prompts** are workflows _you_ trigger. Each one queries the search index, link graph, and memory layer at invocation time, then assembles the results with guided instructions — so the session starts grounded in your vault's actual state, not assumptions.
+
+| Prompt              | Arguments             | What it does                                                                                                                                                                                                                                                                                            |
+| ------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `vault-orientation` | —                     | Surveys vault stats, folder distribution, property adoption rates (flags low adoption), orphans, broken link count, tags, recent notes, and the memory layer — with contextual tool suggestions                                                                                                         |
+| `memory-review`     | `file?`, `max_chars?` | Structural overview (scope callouts, section entry counts) + dated content as a timeline. Guided reflection: evolution narrative, scope-fit, backfill gaps, and coverage analysis — append-only by default, pruning proposed only for `entry-policy: living` files. Hidden when `MEMORY_ENABLED=false`. |
+| `daily-review`      | `date?`, `max_chars?` | Reconciles a day — daily note, vault-wide task status (due/overdue, scheduled), modified notes, outgoing links (broken-link detection), and backlinks — surfaces what happened, what's open, and what needs follow-up                                                                                   |
+
+Prompts adapt to your configuration (`MEMORY_DIR`, daily-notes settings) and work for any vault out of the box. Pass `max_chars` to cap embedded content if your client has payload limits.
+
+> **Client support:** Prompts work in Claude Desktop (Chat and Cowork — via the **+** menu under your connector), Claude Code (slash commands), and OpenCode. Support in other clients (Cursor, Windsurf) varies — see the [MCP clients matrix](https://modelcontextprotocol.io/clients) for the latest.
+
+## Properties
+
+Vault Cortex indexes every [property](https://help.obsidian.md/Editing+and+formatting/Properties) in your notes, but five get **promoted** treatment — dedicated columns for fast filtering, and top-level fields in every search and discovery result:
+
+| Property  | What you can do                                                                                              |
+| --------- | ------------------------------------------------------------------------------------------------------------ |
+| `title`   | Display name in search results; falls back to the filename when missing                                      |
+| `tags`    | Search and filter by tag, including parent-child hierarchies (`project` matches `project/vault-cortex`)      |
+| `type`    | Filter by note type — `meeting`, `person`, `session-log`, or any value your vault uses                       |
+| `created` | Sort by creation date and see when each note was created alongside every search result                       |
+| `related` | Filter for notes that cross-reference a specific link — surfaces connections invisible without a graph query |
+
+## Configuration
+
+All settings are environment variables with sensible defaults.
+
+| Variable                    | Required?   | Default                              | Description                                                                                                                                                                                                                       |
+| --------------------------- | ----------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MCP_AUTH_TOKEN`            | Yes         | —                                    | Bearer token for authentication (also the JWT signing key)                                                                                                                                                                        |
+| `VAULT_PATH`                | Local only  | —                                    | Host path to your vault (bind mount source; remote uses a named volume)                                                                                                                                                           |
+| `PUBLIC_URL`                | Remote only | —                                    | Public URL for OAuth discovery metadata                                                                                                                                                                                           |
+| `EMBEDDING_ENABLED`         | —           | `true`                               | Set `false` to disable the embedding pipeline — skips model download, vector tables, embedding passes, and hybrid search. Search falls back to FTS5 keyword matching.                                                             |
+| `RERANK_MODE`               | —           | `blended`                            | Cross-encoder reranking mode: `blended` applies position-aware score blending after RRF fusion (~200ms added latency), `none` skips reranking. Only takes effect when `EMBEDDING_ENABLED` is true.                                |
+| `MEMORY_ENABLED`            | —           | `true`                               | Set `false` to fully disable the memory layer — hides memory tools, skips bootstrap, omits memory from server metadata. `MEMORY_DIR` is ignored when `false`.                                                                     |
+| `MEMORY_DIR`                | —           | `About Me`                           | Vault folder for structured memory files                                                                                                                                                                                          |
+| `PROTECTED_PATHS`           | —           | `MEMORY_DIR, Daily Notes`            | Folders that `vault_delete_note` refuses to touch                                                                                                                                                                                 |
+| `ORPHAN_EXCLUDE_FOLDERS`    | —           | `Daily Notes, Templates, MEMORY_DIR` | Folders excluded from orphan detection                                                                                                                                                                                            |
+| `TZ`                        | —           | `UTC`                                | IANA timezone for timestamps and daily note resolution                                                                                                                                                                            |
+| `SERVICE_DOCUMENTATION_URL` | —           | GitHub repo URL                      | URL returned in OAuth discovery metadata                                                                                                                                                                                          |
+| `LOG_LEVEL`                 | —           | `info`                               | Logging verbosity: `debug`, `info`, `warn`, `error`                                                                                                                                                                               |
+| `LOG_DIR`                   | —           | `/data/logs` (Docker)                | Directory for persistent log files. Logs survive container restarts.                                                                                                                                                              |
+| `LOG_RETENTION_DAYS`        | —           | `30`                                 | Days to keep log files before automatic cleanup on startup                                                                                                                                                                        |
+| `WINDOWS_MODE`              | —           | `false`                              | On Windows? Set `true`. Switches the file watcher to polling and note moves to rename-based writes so a vault on a `C:` drive works through Docker Desktop. Safe to leave on for any Windows setup; unneeded on macOS/Linux/WSL2. |
+
+## Deployment Options
+
+| Path          | What                                               | Guide                                |
+| ------------- | -------------------------------------------------- | ------------------------------------ |
+| **Local**     | Docker on your machine, vault bind-mounted         | [`deploy/local/`](https://github.com/aliasunder/vault-cortex/tree/main/deploy/local/)   |
+| **Remote**    | VPS + Obsidian Sync, access from anywhere          | [`deploy/remote/`](https://github.com/aliasunder/vault-cortex/tree/main/deploy/remote/) |
+| **AWS (SST)** | Full IaC: Lightsail + API Gateway + Lambda + CI/CD | [`DEPLOY.md`](https://github.com/aliasunder/vault-cortex/blob/main/DEPLOY.md)           |
+
+
+## License
+
+[MIT](https://github.com/aliasunder/vault-cortex/blob/main/LICENSE) — see the full [License section](https://github.com/aliasunder/vault-cortex#license) for details on bundled components.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build:server": "tsc",
     "build:cli": "tsc -p cli/tsconfig.json && tsc -p cli/tsconfig.test.json",
     "sync:cli-templates": "tsx scripts/sync-cli-templates.ts",
+    "generate:dockerhub-readme": "tsx scripts/generate-dockerhub-readme.ts",
     "dev:mcp": "tsx watch src/vault-mcp/server.ts",
     "dev:docker": "docker compose -f docker-compose.local.yml up --build",
     "start": "node dist/src/vault-mcp/server.js",

--- a/scripts/generate-dockerhub-readme.ts
+++ b/scripts/generate-dockerhub-readme.ts
@@ -1,0 +1,238 @@
+// Generates DOCKERHUB.md from README.md with WAF-triggering content stripped.
+//
+// Cloudflare's WAF sits in front of Docker Hub and blocks PATCH requests whose
+// body contains patterns resembling shell injection, auth headers, or security
+// terminology. This script produces a "brochure" version safe for the Hub API.
+//
+// Usage: npm run generate:dockerhub-readme
+
+import { readFileSync, writeFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = new URL("..", import.meta.url)
+
+const resolvePath = (repoRelative: string): string =>
+  fileURLToPath(new URL(repoRelative, repoRoot))
+
+const GITHUB_REPO = "https://github.com/aliasunder/vault-cortex"
+const GITHUB_RAW =
+  "https://raw.githubusercontent.com/aliasunder/vault-cortex/main"
+
+const HEADER = `<!-- AUTO-GENERATED from README.md — do not edit manually. Run: npm run generate:dockerhub-readme -->\n`
+
+const NOTICE = [
+  "",
+  `> **Full documentation:** [github.com/aliasunder/vault-cortex](${GITHUB_REPO})`,
+  ">",
+  "> This is an abbreviated version for Docker Hub. See the full README for quick-start guides, authentication details, and development instructions.",
+  "",
+]
+
+const QUICKSTART_REDIRECT = [
+  "",
+  "## Quick Start",
+  "",
+  `See the [full Quick Start guide](${GITHUB_REPO}#quick-start) for local setup (2 minutes with Docker), remote deployment with Obsidian Sync, and MCP client configuration.`,
+  "",
+]
+
+const LICENSE_REPLACEMENT = [
+  "",
+  "## License",
+  "",
+  `[MIT](${GITHUB_REPO}/blob/main/LICENSE) — see the full [License section](${GITHUB_REPO}#license) for details on bundled components.`,
+  "",
+]
+
+const EXCLUDED_H2 = new Set([
+  "Quick Start",
+  "Data Integrity",
+  "Authentication",
+  "Development",
+  "Companion: obsidian-vault skill",
+  "Contributing",
+  "Security",
+  "Roadmap",
+  "Acknowledgments",
+])
+
+const REPLACED_H2 = new Set(["License"])
+
+// Sections where we keep only the heading, intro sentence, and tables — strip
+// verbose paragraphs that add bulk without adding Docker Hub value
+const COMPACT_H2 = new Set([
+  "Properties",
+  "Configuration",
+  "Deployment Options",
+])
+
+// Directories that need /tree/ instead of /blob/ in GitHub links
+const DIRECTORY_PATHS = ["deploy/local/", "deploy/remote/", "templates/memory/"]
+
+const rewriteUrls = (line: string): string => {
+  let result = line
+
+  result = result.replace(/src="\.\/assets\//g, `src="${GITHUB_RAW}/assets/`)
+
+  result = result.replace(/\]\(\.\/assets\//g, `](${GITHUB_RAW}/assets/`)
+
+  for (const dir of DIRECTORY_PATHS) {
+    result = result.replace(
+      new RegExp(`\\]\\(\\./${dir.replace("/", "\\/")}`, "g"),
+      `](${GITHUB_REPO}/tree/main/${dir}`,
+    )
+  }
+
+  result = result.replace(/\]\(\.\//g, `](${GITHUB_REPO}/blob/main/`)
+
+  result = result.replace(/\]\(#/g, `](${GITHUB_REPO}#`)
+
+  return result
+}
+
+const isContentsLine = (line: string): boolean =>
+  line.startsWith("**Contents**") || line.startsWith("**Contents** —")
+
+const parseHeading = (
+  line: string,
+): { level: number; text: string } | undefined => {
+  const match = line.match(/^(#{2,3})\s+(.+)$/)
+  if (!match?.[1] || !match[2]) return undefined
+  return { level: match[1].length, text: match[2] }
+}
+
+const generate = (): void => {
+  const readme = readFileSync(resolvePath("README.md"), "utf-8")
+  const lines = readme.split("\n")
+  const output: string[] = [HEADER]
+
+  let insideFence = false
+  let insideDetails = false
+  let skipSection = false
+  let skipLevel = 0
+  let insertedNotice = false
+  let compactSection = false
+  let compactTableDone = false
+
+  for (const line of lines) {
+    if (line.startsWith("```")) {
+      if (!insideFence) {
+        insideFence = true
+        continue
+      }
+      insideFence = false
+      continue
+    }
+    if (insideFence) continue
+
+    if (line.trim() === "<details>") {
+      insideDetails = true
+      continue
+    }
+    if (line.trim() === "</details>") {
+      insideDetails = false
+      continue
+    }
+    if (insideDetails) continue
+
+    if (isContentsLine(line)) continue
+
+    const heading = parseHeading(line)
+    if (heading) {
+      if (heading.level === 2) {
+        if (EXCLUDED_H2.has(heading.text)) {
+          skipSection = true
+          skipLevel = 2
+          if (heading.text === "Quick Start") {
+            output.push(...QUICKSTART_REDIRECT)
+          }
+          continue
+        }
+
+        if (REPLACED_H2.has(heading.text)) {
+          skipSection = true
+          skipLevel = 2
+          output.push(...LICENSE_REPLACEMENT)
+          continue
+        }
+
+        skipSection = false
+        skipLevel = 0
+        compactSection = COMPACT_H2.has(heading.text)
+        compactTableDone = false
+      } else if (heading.level === 3) {
+        if (skipSection && skipLevel === 2) continue
+      }
+    }
+
+    if (skipSection) {
+      if (heading && heading.level <= skipLevel) {
+        skipSection = false
+        skipLevel = 0
+      } else {
+        continue
+      }
+    }
+
+    // In compact sections, keep heading + intro + tables, drop post-table prose
+    if (compactSection && !heading) {
+      const isTableRow = line.startsWith("|")
+      if (isTableRow) {
+        compactTableDone = false
+      } else if (compactTableDone) {
+        continue
+      } else if (line.trim() !== "") {
+        const lastTableIdx = output.findLastIndex((l) => l.startsWith("|"))
+        const lastHeadingIdx = output.findLastIndex(
+          (l) => parseHeading(l) !== undefined,
+        )
+        if (lastTableIdx > lastHeadingIdx) {
+          compactTableDone = true
+          continue
+        }
+      }
+    }
+
+    if (!insertedNotice && line.trim() === "</div>") {
+      output.push(rewriteUrls(line))
+      output.push(...NOTICE)
+      insertedNotice = true
+      continue
+    }
+
+    output.push(rewriteUrls(line))
+  }
+
+  // Collapse runs of 3+ blank lines to 2
+  const collapsed: string[] = []
+  let blankRun = 0
+  for (const line of output) {
+    if (line.trim() === "") {
+      blankRun++
+      if (blankRun > 2) continue
+    } else {
+      blankRun = 0
+    }
+    collapsed.push(line)
+  }
+
+  // Trim trailing blanks, ensure single newline at end
+  while (collapsed.length > 0 && collapsed.at(-1)?.trim() === "") {
+    collapsed.pop()
+  }
+  collapsed.push("")
+
+  const content = collapsed.join("\n")
+  const byteCount = Buffer.byteLength(content, "utf-8")
+
+  writeFileSync(resolvePath("DOCKERHUB.md"), content, "utf-8")
+
+  console.log(`generated DOCKERHUB.md (${byteCount} bytes)`)
+  if (byteCount > 24_000) {
+    console.warn(
+      `warning: output is ${byteCount} bytes — Docker Hub truncates at 25000`,
+    )
+  }
+}
+
+generate()


### PR DESCRIPTION
## Summary

- The `sync-dockerhub-description` CI job was failing with `403 Forbidden` because Cloudflare's WAF (in front of Docker Hub) blocks PATCH requests whose body contains shell commands, auth headers, or security-related strings ([upstream issue](https://github.com/peter-evans/dockerhub-description/issues/331))
- Adds `scripts/generate-dockerhub-readme.ts` that generates a WAF-safe `DOCKERHUB.md` from `README.md` — strips all code blocks, excludes security/auth/dev sections, rewrites relative URLs to absolute GitHub links, trims compact sections to heading + table only
- Output is 23.7KB (under Docker Hub's 25KB limit), zero code blocks, zero WAF-trigger patterns
- Workflow updated to read from `DOCKERHUB.md` instead of `README.md`

## Files changed

| File | Change |
|---|---|
| `scripts/generate-dockerhub-readme.ts` | New generation script |
| `DOCKERHUB.md` | Generated output (committed) |
| `.github/workflows/dockerhub-description.yml` | Added `readme-filepath: DOCKERHUB.md` |
| `AGENTS.md` | Structure tree + feature surface table entries |
| `package.json` | Added `generate:dockerhub-readme` npm script |
| `.prettierignore` | Added `DOCKERHUB.md` |

## Test plan

- [x] `npm run generate:dockerhub-readme` produces 23.7KB output
- [x] Zero fenced code blocks in output
- [x] No WAF-trigger patterns (`Authorization: Bearer`, `curl`, `openssl`, `path traversal`, `injection`)
- [x] All relative links converted to absolute GitHub URLs
- [x] Excluded sections absent (Quick Start, Auth, Data Integrity, Development, Security, etc.)
- [x] All tests pass (1720)
- [x] Prettier + lint clean
- [ ] Next release triggers the workflow and Docker Hub description updates without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)