### PR TITLE
fix(ci): trim Docker Hub short-description to fit 100-byte limit

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -23,5 +23,5 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ vars.DOCKERHUB_USERNAME }}/vault-cortex
-          short-description: "Standalone MCP server for Obsidian vaults — hybrid search, memory, 27 tools + 3 prompts, OAuth 2.1."
+          short-description: "Standalone MCP server for Obsidian vaults — hybrid search, memory, tasks, 27 tools, OAuth 2.1."
           readme-filepath: DOCKERHUB.md


### PR DESCRIPTION
## Summary
- Docker Hub limits `short-description` to 100 bytes; the em-dash (3 UTF-8 bytes) pushed ours to 101, causing a truncation warning on every sync
- Replaces `+ 3 prompts` with `tasks` to match `server.json`'s feature set — stays at 96 bytes with room for future edits

## Test plan
- [ ] Verify the next `sync-dockerhub-description` run completes without the truncation warning
- [ ] Confirm Docker Hub page shows the full description without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)