### PR TITLE
docs: R9 task queries → task management, reorder roadmap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,17 +31,17 @@ The server provides three capability layers, each additive:
 
 ## User Requirements
 
-| ID  | Requirement                     | Phase | Summary                                                                                     |
-| --- | ------------------------------- | ----- | ------------------------------------------------------------------------------------------- |
-| R1  | Bidirectional sync              | 1     | Obsidian Sync + obsidian-headless. One vault, always current.                               |
-| R2  | Remote vault read access        | 1     | Any MCP client can read any note by path, list notes in any folder.                         |
-| R3  | Remote vault write access       | 1     | Writes sync back to all Obsidian apps automatically via R1.                                 |
-| R4  | Full-text and structured search | 1     | SQLite FTS5 — ranked results, filter by tags/type/folder/dates.                             |
-| R5  | Memory tools                    | 1     | Read/append to configurable memory folder (default: `About Me/`).                           |
-| R6  | Secure remote access            | 1     | HTTPS via API Gateway. OAuth 2.1 + static bearer token.                                     |
-| R7  | Low operational overhead        | 1     | Always-on, no manual intervention. Free local, low-cost VPS remote. IaC via SST.            |
-| R8  | Extensible for semantic search  | 2     | Hybrid search (sqlite-vec + local embeddings) plugs into existing watcher. Not a rewrite.   |
-| R9  | Vault-wide task queries         | 3     | Task index parsing Tasks plugin emoji + Dataview formats. Kanban-aware, structured filters. |
+| ID  | Requirement                     | Phase | Summary                                                                                   |
+| --- | ------------------------------- | ----- | ----------------------------------------------------------------------------------------- |
+| R1  | Bidirectional sync              | 1     | Obsidian Sync + obsidian-headless. One vault, always current.                             |
+| R2  | Remote vault read access        | 1     | Any MCP client can read any note by path, list notes in any folder.                       |
+| R3  | Remote vault write access       | 1     | Writes sync back to all Obsidian apps automatically via R1.                               |
+| R4  | Full-text and structured search | 1     | SQLite FTS5 — ranked results, filter by tags/type/folder/dates.                           |
+| R5  | Memory tools                    | 1     | Read/append to configurable memory folder (default: `About Me/`).                         |
+| R6  | Secure remote access            | 1     | HTTPS via API Gateway. OAuth 2.1 + static bearer token.                                   |
+| R7  | Low operational overhead        | 1     | Always-on, no manual intervention. Free local, low-cost VPS remote. IaC via SST.          |
+| R8  | Extensible for semantic search  | 2     | Hybrid search (sqlite-vec + local embeddings) plugs into existing watcher. Not a rewrite. |
+| R9  | Vault-wide task management      | 3     | Task index + one-call mutations. Tasks plugin emoji + Dataview formats. Kanban-aware.     |
 
 ## Component Diagram
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ The server provides three capability layers, each additive:
 | R6  | Secure remote access            | 1     | HTTPS via API Gateway. OAuth 2.1 + static bearer token.                                   |
 | R7  | Low operational overhead        | 1     | Always-on, no manual intervention. Free local, low-cost VPS remote. IaC via SST.          |
 | R8  | Extensible for semantic search  | 2     | Hybrid search (sqlite-vec + local embeddings) plugs into existing watcher. Not a rewrite. |
-| R9  | Vault-wide task management      | 3     | Task index + one-call mutations. Tasks plugin emoji + Dataview formats. Kanban-aware.     |
+| R9  | Vault-wide task management      | 3     | Filter by status, dates, priority. Manage across Kanban lanes. Both task formats.         |
 
 ## Component Diagram
 

--- a/README.md
+++ b/README.md
@@ -380,8 +380,8 @@ npx skills add aliasunder/agent-skills --skill obsidian-vault
 | **2a** | Hybrid search — FTS5 + vector + RRF fusion, heading-aware chunking                                                        | Complete  |
 | **2b** | Reranker — cross-encoder reranking, position-aware score blending                                                         | Complete  |
 | **3a** | Task layer — vault-wide task index, structured queries, and one-call task updates (Tasks plugin emoji + Dataview formats) | Complete  |
-| **3b** | Graph queries — multi-hop traversal over the vault's existing wikilink graph (paths, neighborhoods)                       | Exploring |
 | **3c** | Memory recall — entry-granular retrieval across the memory layer's dated history                                          | Complete  |
+| **3b** | Graph queries — multi-hop traversal over the vault's existing wikilink graph (paths, neighborhoods)                       | Exploring |
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

- ARCHITECTURE.md R9: "Vault-wide task queries" → "Vault-wide task management" — `vault_update_task` added mutations (status, priority, lane moves), not just queries
- README roadmap: move 3b (Exploring) below 3c (Complete) so completed phases sort before in-progress ones

## Test plan

- [ ] ARCHITECTURE.md requirement table renders correctly on GitHub
- [ ] README roadmap table renders correctly on GitHub


🤖 Generated with [Claude Code](https://claude.com/claude-code)