### PR TITLE
docs: fix roadmap phase lettering (3a, 3b, 3c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,8 +380,8 @@ npx skills add aliasunder/agent-skills --skill obsidian-vault
 | **2a** | Hybrid search — FTS5 + vector + RRF fusion, heading-aware chunking                                                        | Complete  |
 | **2b** | Reranker — cross-encoder reranking, position-aware score blending                                                         | Complete  |
 | **3a** | Task layer — vault-wide task index, structured queries, and one-call task updates (Tasks plugin emoji + Dataview formats) | Complete  |
-| **3c** | Memory recall — entry-granular retrieval across the memory layer's dated history                                          | Complete  |
-| **3b** | Graph queries — multi-hop traversal over the vault's existing wikilink graph (paths, neighborhoods)                       | Exploring |
+| **3b** | Memory recall — entry-granular retrieval across the memory layer's dated history                                          | Complete  |
+| **3c** | Graph queries — multi-hop traversal over the vault's existing wikilink graph (paths, neighborhoods)                       | Exploring |
 
 ## Acknowledgments
 


### PR DESCRIPTION
Renumber memory recall from 3c → 3b and graph queries from 3b → 3c to restore alphabetical order after the reorder in #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)