### PR TITLE
fix: bust apt-get upgrade cache in deploy and test-deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,15 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         if: ${{ !inputs.skip_build }}
 
+      # The base stage's apt-get upgrade layer is content-addressed — it
+      # caches indefinitely until the Dockerfile or base image changes.
+      # Passing today's date as APT_UPGRADE_DATE busts that layer so
+      # Debian security patches are always current in the released image.
+      - name: Cache-bust date for apt-get upgrade
+        if: ${{ !inputs.skip_build }}
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GHCR (build push)
         if: ${{ !inputs.skip_build }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -160,6 +169,7 @@ jobs:
             ${{ env.IMAGE }}:remote
             ${{ env.IMAGE_HUB != '' && format('{0}:v{1}-remote', env.IMAGE_HUB, inputs.version) || '' }}
             ${{ env.IMAGE_HUB != '' && format('{0}:remote', env.IMAGE_HUB) || '' }}
+          build-args: APT_UPGRADE_DATE=${{ steps.date.outputs.date }}
           # Mirror the remote-stage Dockerfile LABEL description.
           annotations: |
             index:org.opencontainers.image.title=vault-cortex
@@ -184,6 +194,7 @@ jobs:
             ${{ env.IMAGE_HUB != '' && format('{0}:v{1}', env.IMAGE_HUB, inputs.version) || '' }}
             ${{ env.IMAGE_HUB != '' && format('{0}:{1}', env.IMAGE_HUB, inputs.version) || '' }}
             ${{ env.IMAGE_HUB != '' && format('{0}:latest', env.IMAGE_HUB) || '' }}
+          build-args: APT_UPGRADE_DATE=${{ steps.date.outputs.date }}
           # GHCR shows a multi-arch package's description from the image *index*
           # annotation (a Dockerfile LABEL alone doesn't surface on the package
           # page). Mirror the server.json / Dockerfile description here.

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -120,6 +120,11 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         if: ${{ !inputs.skip_build }}
 
+      - name: Cache-bust date for apt-get upgrade
+        if: ${{ !inputs.skip_build }}
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GHCR (build push)
         if: ${{ !inputs.skip_build }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -141,6 +146,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.IMAGE }}:test
+          build-args: APT_UPGRADE_DATE=${{ steps.date.outputs.date }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=https://github.com/aliasunder/vault-cortex

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -120,6 +120,8 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         if: ${{ !inputs.skip_build }}
 
+      # Bust the apt-get upgrade layer so test images ship current Debian
+      # security patches — same pattern as deploy.yml and trivy.yml.
       - name: Cache-bust date for apt-get upgrade
         if: ${{ !inputs.skip_build }}
         id: date


### PR DESCRIPTION
## Summary
- Add `APT_UPGRADE_DATE` build-arg to `deploy.yml` and `test_deploy.yml`, matching the existing pattern in `trivy.yml`
- Without this, the GHA-cached `apt-get upgrade` layer could persist across releases, shipping stale Debian packages (e.g. CVE-2026-34743 in `liblzma5`)

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Next release build includes the `APT_UPGRADE_DATE` arg and pulls current Debian security patches
- [ ] Trivy scan on next release shows CVE-2026-34743 resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)