### PR TITLE
feat(cli): add beta publish option to Release CLI workflow

### DIFF
--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -3,7 +3,9 @@ name: Release CLI
 # Publishes the cli/ package to npm. CLI releases are explicit and
 # independent of server releases — run this workflow when a merged cli/
 # change should ship. "none" publishes the current cli/package.json
-# version without bumping (used for the first publish).
+# version without bumping (used for the first publish). "beta" publishes
+# a prerelease under the `beta` dist-tag for testing from any branch —
+# no commit, no tag, no GitHub release. Test with: npx vault-cortex@beta
 #
 # Safe to re-run after a failed publish: a version that is tagged but
 # absent from npm is detected as a failed earlier release. Bump "none"
@@ -22,6 +24,7 @@ on:
           - patch
           - minor
           - major
+          - beta
           - none
 
 concurrency:
@@ -40,6 +43,7 @@ jobs:
       id-token: write # npm provenance
     steps:
       - name: Generate App token
+        if: inputs.bump != 'beta'
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -72,7 +76,9 @@ jobs:
             echo "::error::cli/package.json has no version field"
             exit 1
           fi
-          if [ "$BUMP" = "none" ]; then
+          if [ "$BUMP" = "beta" ]; then
+            NEXT="${CURRENT}-beta.${{ github.run_number }}"
+          elif [ "$BUMP" = "none" ]; then
             NEXT="$CURRENT"
           # The checked-out version being tagged yet absent from npm is the
           # signature of a release that failed at npm publish. Don't bump
@@ -117,6 +123,7 @@ jobs:
           npx prettier --write cli/package.json
 
       - name: Commit, tag, and push
+        if: inputs.bump != 'beta'
         env:
           NEXT: ${{ steps.next.outputs.version }}
           # The App token enters git only here, after npm ci has run.
@@ -135,7 +142,23 @@ jobs:
           git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD --tags
 
       - name: Publish to npm (Trusted Publishing / OIDC)
-        run: npm publish ./cli --provenance --access public
+        env:
+          TAG_FLAG: ${{ inputs.bump == 'beta' && '--tag beta' || '' }}
+        run: npm publish ./cli $TAG_FLAG --provenance --access public
+
+      - name: Beta summary
+        if: inputs.bump == 'beta'
+        env:
+          BETA_VERSION: ${{ steps.next.outputs.version }}
+        run: |
+          echo "### CLI Beta Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** \`vault-cortex@${BETA_VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Test with:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
+          echo "npx vault-cortex@beta" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
 
       # --latest=false keeps the "Latest" badge on server releases. Notes
       # list only cli/ commits — server commits interleave on main, so
@@ -143,6 +166,7 @@ jobs:
       # fails after a successful publish, create the release manually
       # (re-running the workflow would refuse to republish the version).
       - name: Create GitHub release
+        if: inputs.bump != 'beta'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXT: ${{ steps.next.outputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,13 @@ that change `cli/` should **not** bump the version — the release workflow owns
 it. The npm package is deliberately absent from `server.json` — it's a
 scaffolder, not a way to run the server.
 
+**Beta testing:** The same **"Release CLI"** workflow supports a `beta` bump
+option that publishes a prerelease under the `beta` dist-tag for testing CLI
+changes before a real release. Dispatch from any branch — the version is set
+to `{current}-beta.{run_number}` ephemerally (no commits, no tags, no GitHub
+release). Test with `npx vault-cortex@beta`. The `latest` dist-tag is never
+touched.
+
 ## Code Conventions
 
 All code conventions — style, naming, logging, test patterns, MCP tool naming —


### PR DESCRIPTION
## Summary

- Add `beta` choice to the `bump` input in `cli_release.yml` — publishes a prerelease under the `beta` dist-tag for testing CLI changes from any branch without a real release
- Version is set to `{current}-beta.{run_number}` ephemerally — no commit, no tag, no GitHub release
- Uses the same Trusted Publishing (OIDC) auth as production releases — no new secrets or npm config needed
- Document the beta option in CONTRIBUTING.md

## Test plan

- [ ] Dispatch "Release CLI" with `bump: beta` from a feature branch
- [ ] Verify `npm view vault-cortex@beta` shows the beta version
- [ ] Verify `npx vault-cortex@beta --version` prints the beta version
- [ ] Verify `npm view vault-cortex@latest` still shows the production version
- [ ] Dispatch again — version increments via `run_number`
- [ ] Dispatch a real release (`patch`) — confirm it still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing CLI beta prereleases under the `beta` npm tag.
  * Beta releases use versioned prerelease builds and do not alter the stable `latest` release.
  * Added guidance for testing beta versions with `npx vault-cortex@beta`.

* **Documentation**
  * Documented the beta release workflow, version format, and publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->