### PR TITLE
fix(deploy): sync test_deploy.yml env template with deploy.yml

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -191,11 +191,18 @@ jobs:
           VAULT_NAME: ${{ secrets.VAULT_NAME }}
           VAULT_PASSWORD: ${{ secrets.VAULT_PASSWORD }}
           GHCR_USER: ${{ vars.GHCR_USER }}
+          EMBEDDING_ENABLED: ${{ vars.EMBEDDING_ENABLED }}
+          RERANK_MODE: ${{ vars.RERANK_MODE }}
+          MEMORY_ENABLED: ${{ vars.MEMORY_ENABLED }}
           MEMORY_DIR: ${{ vars.MEMORY_DIR }}
           PROTECTED_PATHS: ${{ vars.PROTECTED_PATHS }}
           ORPHAN_EXCLUDE_FOLDERS: ${{ vars.ORPHAN_EXCLUDE_FOLDERS }}
           SERVICE_DOCUMENTATION_URL: ${{ vars.SERVICE_DOCUMENTATION_URL }}
           TZ: ${{ vars.TZ }}
+          LOG_LEVEL: ${{ vars.LOG_LEVEL }}
+          LOG_DIR: ${{ vars.LOG_DIR }}
+          LOG_RETENTION_DAYS: ${{ vars.LOG_RETENTION_DAYS }}
+          WINDOWS_MODE: ${{ vars.WINDOWS_MODE }}
         run: |
           umask 077
           cat > "$RUNNER_TEMP/lightsail.env" <<EOF
@@ -205,6 +212,9 @@ jobs:
           VAULT_NAME=$VAULT_NAME
           VAULT_PASSWORD=$VAULT_PASSWORD
           GHCR_USER=$GHCR_USER
+          EMBEDDING_ENABLED=${EMBEDDING_ENABLED:-true}
+          RERANK_MODE=${RERANK_MODE:-blended}
+          MEMORY_ENABLED=${MEMORY_ENABLED:-true}
           MEMORY_DIR=${MEMORY_DIR:-About Me}
           PROTECTED_PATHS=$PROTECTED_PATHS
           ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS
@@ -214,8 +224,10 @@ jobs:
           DEVICE_NAME=vault-cortex-lightsail
           CONFLICT_STRATEGY=merge
           SYNC_MODE=bidirectional
-          LOG_LEVEL=info
-          LOG_RETENTION_DAYS=365
+          LOG_LEVEL=${LOG_LEVEL:-info}
+          LOG_DIR=${LOG_DIR:-/data/logs}
+          LOG_RETENTION_DAYS=${LOG_RETENTION_DAYS:-30}
+          WINDOWS_MODE=${WINDOWS_MODE:-false}
           TZ=${TZ:-UTC}
           VAULT_CORTEX_TAG=test
           EOF


### PR DESCRIPTION
## Summary

- **test_deploy.yml env template synced with deploy.yml** — PR #333 added optional config var passthrough (`EMBEDDING_ENABLED`, `RERANK_MODE`, `MEMORY_ENABLED`, `LOG_LEVEL`, `LOG_DIR`, `LOG_RETENTION_DAYS`, `WINDOWS_MODE`) to `deploy.yml` but missed `test_deploy.yml`. Test deploys still wrote the old hardcoded template (`LOG_LEVEL=info`, `LOG_RETENTION_DAYS=365`), so setting repo Variables had no effect on the test instance.
- Verified via SSH: the current instance `.env` (from a test deploy on this commit) is missing all 5 new vars and has `LOG_RETENTION_DAYS=365` hardcoded

## Test plan

- [x] `npm test` — 1833 tests pass
- [x] SSH'd into instance and confirmed current (stale) env state
- [ ] Re-run Test Deploy from this branch and verify the instance `.env` carries the new vars with correct defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)