### PR TITLE
fix(deploy): omit user-specific overrides from .env when unset

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -271,9 +271,6 @@ jobs:
           RERANK_MODE=${RERANK_MODE:-blended}
           MEMORY_ENABLED=${MEMORY_ENABLED:-true}
           MEMORY_DIR=${MEMORY_DIR:-About Me}
-          PROTECTED_PATHS=$PROTECTED_PATHS
-          ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS
-          SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL
           PUID=1000
           PGID=1000
           DEVICE_NAME=vault-cortex-lightsail
@@ -285,6 +282,11 @@ jobs:
           WINDOWS_MODE=${WINDOWS_MODE:-false}
           TZ=${TZ:-UTC}
           EOF
+          # Only write user-specific overrides when the repo Variable is set —
+          # the server falls back to sensible defaults when these are absent.
+          [ -n "$PROTECTED_PATHS" ] && echo "PROTECTED_PATHS=$PROTECTED_PATHS" >> "$RUNNER_TEMP/lightsail.env"
+          [ -n "$ORPHAN_EXCLUDE_FOLDERS" ] && echo "ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS" >> "$RUNNER_TEMP/lightsail.env"
+          [ -n "$SERVICE_DOCUMENTATION_URL" ] && echo "SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL" >> "$RUNNER_TEMP/lightsail.env"
 
       - name: Ship compose + .env to instance
         if: ${{ !inputs.skip_instance }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -284,9 +284,9 @@ jobs:
           EOF
           # Only write user-specific overrides when the repo Variable is set —
           # the server falls back to sensible defaults when these are absent.
-          [ -n "$PROTECTED_PATHS" ] && echo "PROTECTED_PATHS=$PROTECTED_PATHS" >> "$RUNNER_TEMP/lightsail.env"
-          [ -n "$ORPHAN_EXCLUDE_FOLDERS" ] && echo "ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS" >> "$RUNNER_TEMP/lightsail.env"
-          [ -n "$SERVICE_DOCUMENTATION_URL" ] && echo "SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL" >> "$RUNNER_TEMP/lightsail.env"
+          if [ -n "$PROTECTED_PATHS" ]; then echo "PROTECTED_PATHS=$PROTECTED_PATHS" >> "$RUNNER_TEMP/lightsail.env"; fi
+          if [ -n "$ORPHAN_EXCLUDE_FOLDERS" ]; then echo "ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS" >> "$RUNNER_TEMP/lightsail.env"; fi
+          if [ -n "$SERVICE_DOCUMENTATION_URL" ]; then echo "SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL" >> "$RUNNER_TEMP/lightsail.env"; fi
 
       - name: Ship compose + .env to instance
         if: ${{ !inputs.skip_instance }}

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -230,9 +230,9 @@ jobs:
           EOF
           # Only write user-specific overrides when the repo Variable is set —
           # the server falls back to sensible defaults when these are absent.
-          [ -n "$PROTECTED_PATHS" ] && echo "PROTECTED_PATHS=$PROTECTED_PATHS" >> "$RUNNER_TEMP/lightsail.env"
-          [ -n "$ORPHAN_EXCLUDE_FOLDERS" ] && echo "ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS" >> "$RUNNER_TEMP/lightsail.env"
-          [ -n "$SERVICE_DOCUMENTATION_URL" ] && echo "SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL" >> "$RUNNER_TEMP/lightsail.env"
+          if [ -n "$PROTECTED_PATHS" ]; then echo "PROTECTED_PATHS=$PROTECTED_PATHS" >> "$RUNNER_TEMP/lightsail.env"; fi
+          if [ -n "$ORPHAN_EXCLUDE_FOLDERS" ]; then echo "ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS" >> "$RUNNER_TEMP/lightsail.env"; fi
+          if [ -n "$SERVICE_DOCUMENTATION_URL" ]; then echo "SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL" >> "$RUNNER_TEMP/lightsail.env"; fi
 
       - name: Ship compose + .env to instance
         env:

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -216,9 +216,6 @@ jobs:
           RERANK_MODE=${RERANK_MODE:-blended}
           MEMORY_ENABLED=${MEMORY_ENABLED:-true}
           MEMORY_DIR=${MEMORY_DIR:-About Me}
-          PROTECTED_PATHS=$PROTECTED_PATHS
-          ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS
-          SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL
           PUID=1000
           PGID=1000
           DEVICE_NAME=vault-cortex-lightsail
@@ -231,6 +228,11 @@ jobs:
           TZ=${TZ:-UTC}
           VAULT_CORTEX_TAG=test
           EOF
+          # Only write user-specific overrides when the repo Variable is set —
+          # the server falls back to sensible defaults when these are absent.
+          [ -n "$PROTECTED_PATHS" ] && echo "PROTECTED_PATHS=$PROTECTED_PATHS" >> "$RUNNER_TEMP/lightsail.env"
+          [ -n "$ORPHAN_EXCLUDE_FOLDERS" ] && echo "ORPHAN_EXCLUDE_FOLDERS=$ORPHAN_EXCLUDE_FOLDERS" >> "$RUNNER_TEMP/lightsail.env"
+          [ -n "$SERVICE_DOCUMENTATION_URL" ] && echo "SERVICE_DOCUMENTATION_URL=$SERVICE_DOCUMENTATION_URL" >> "$RUNNER_TEMP/lightsail.env"
 
       - name: Ship compose + .env to instance
         env:


### PR DESCRIPTION
## Summary

- **`PROTECTED_PATHS`, `ORPHAN_EXCLUDE_FOLDERS`, and `SERVICE_DOCUMENTATION_URL` no longer written as empty lines** when no repo Variable is set — both `deploy.yml` and `test_deploy.yml`. The server falls back to sensible defaults (`[memoryDir, "Daily Notes"]`, `["Daily Notes", "Templates", memoryDir]`, `https://github.com/aliasunder/vault-cortex`), but `PROTECTED_PATHS=` in the .env looked like protection was disabled.
- Conditional appends after the heredoc: `[ -n "$VAR" ] && echo "VAR=$VAR" >> ...`

Spotted during live verification of PR #335 — SSH'd into the instance and saw the empty lines.

## Test plan

- [x] `npm test` — 1833 tests pass
- [x] SSH verified current instance .env shows the empty lines (before state)
- [ ] Re-run Test Deploy and confirm the three lines are absent from instance .env

🤖 Generated with [Claude Code](https://claude.com/claude-code)