### PR TITLE
docs: name Docker-compatible runtimes in Quick Start and CLI requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 ### Local (2 minutes — Docker + your vault folder)
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/), Node.js >= 20.12 (only for the CLI — the server itself runs in Docker), and an Obsidian vault (or any folder of `.md` files).
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) (or a Docker-compatible runtime — OrbStack, Colima, Podman), Node.js >= 20.12 (only for the CLI — the server itself runs in Docker), and an Obsidian vault (or any folder of `.md` files).
 
 ```bash
 npx vault-cortex@latest init
@@ -83,7 +83,7 @@ docker compose up
 
 ### Remote (access from anywhere — Docker + Obsidian Sync)
 
-**Prerequisites:** a VPS with [Docker](https://docs.docker.com/engine/install/), an [Obsidian Sync](https://obsidian.md/sync) subscription, and Node.js >= 20.12 (only for the CLI — the server itself runs in Docker).
+**Prerequisites:** a VPS with [Docker](https://docs.docker.com/engine/install/) (or a Docker-compatible runtime), an [Obsidian Sync](https://obsidian.md/sync) subscription, and Node.js >= 20.12 (only for the CLI — the server itself runs in Docker).
 
 ```bash
 # On your VPS:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 ### Local (2 minutes — Docker + your vault folder)
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) (or a Docker-compatible runtime — OrbStack, Colima, Podman), Node.js >= 20.12 (only for the CLI — the server itself runs in Docker), and an Obsidian vault (or any folder of `.md` files).
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) (or a Docker-compatible runtime, e.g. OrbStack, Colima, Podman), Node.js >= 20.12 (only for the CLI — the server itself runs in Docker), and an Obsidian vault (or any folder of `.md` files).
 
 ```bash
 npx vault-cortex@latest init

--- a/cli/README.md
+++ b/cli/README.md
@@ -111,8 +111,9 @@ is available.
 ## Requirements
 
 - Node.js >= 20.12 (only for this CLI — the server itself runs in Docker)
-- [Docker](https://docs.docker.com/get-docker/) (or any OCI-compatible
-  runtime, e.g. Podman) to run the server
+- [Docker](https://docs.docker.com/get-docker/) or a Docker-compatible
+  runtime (OrbStack, Colima, Podman) to run the server — the CLI manages
+  the container through the `docker` command
 
 ## Docs
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -112,8 +112,8 @@ is available.
 
 - Node.js >= 20.12 (only for this CLI — the server itself runs in Docker)
 - [Docker](https://docs.docker.com/get-docker/) or a Docker-compatible
-  runtime (OrbStack, Colima, Podman) to run the server — the CLI manages
-  the container through the `docker` command
+  runtime (e.g. OrbStack, Colima, Podman) to run the server — the CLI
+  manages the container through the `docker` command
 
 ## Docs
 


### PR DESCRIPTION
## What does this PR do?

Surfaces the CLI's Docker-compatible-runtime support where users first look for it. The Deployment section already says any OCI runtime runs the container, but both Quick Start prerequisite lines said flat "Docker" — the first thing a Colima/OrbStack/Podman user checks before running `npx vault-cortex init`. The CLI's runtime-agnostic support is deliberate (its daemon check and error messages name these runtimes), just never stated on the front door.

- **README.md** — local Quick Start prerequisites: "(or a Docker-compatible runtime — OrbStack, Colima, Podman)"; remote Quick Start prerequisites: "(or a Docker-compatible runtime)"
- **cli/README.md** — Requirements tightened from "any OCI-compatible runtime" to "a Docker-compatible runtime (OrbStack, Colima, Podman)" with the reason: the CLI manages the container through the `docker` command, so a docker-compatible CLI/socket is the actual requirement. "OCI-compatible" is the broader claim — true for the container image, but not for the CLI wrapper.

DOCKERHUB.md needs no regeneration — verified by running the generator (Quick Start is excluded; no diff).

## Type of change

- [x] Documentation

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run prettier:check` passes
- [x] `npm run build` succeeds
- [ ] New MCP tools follow the naming and description conventions in AGENTS.md <!-- N/A — no tool changes -->
- [x] README or ARCHITECTURE.md updated (if user-facing behavior changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ltn7iJhHaieYENpi9u3Hpy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ltn7iJhHaieYENpi9u3Hpy)_