### PR TITLE
chore(lint): enforce module layering boundaries via no-restricted-imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,10 @@ Two rules keep this honest:
 - **Top level is wiring only.** Folders are domains; the only loose files at
   `vault-mcp/` are the entry point (`server.ts`) and its `config.ts`.
 
+The dependency-direction rule is lint-enforced: `eslint.config.ts` bans runtime
+cross-layer imports per folder via `@typescript-eslint/no-restricted-imports`
+(type-only imports allowed — erased at compile time; tests exempt).
+
 **`utils/` admission:** a helper belongs here only if it is **generic with zero
 domain knowledge** (no vault, Markdown, or MCP concepts) **and** clears one of two
 bars. `import type` from infrastructure modules (`Logger`, config types) is fine —

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -35,6 +35,116 @@ export default defineConfig(
       "@typescript-eslint/triple-slash-reference": "off",
     },
   },
+  // Layering boundaries (see AGENTS.md → Module layering): lower layers never
+  // import upward or sideways at runtime. Type-only imports are allowed — they
+  // are erased at compile time. Tests are exempt (they may compose layers to
+  // build fixtures).
+  {
+    // obsidian-markdown/ is a leaf layer of pure parsers: no I/O, no SDKs, no
+    // runtime imports of other internal modules.
+    files: ["src/vault-mcp/obsidian-markdown/**/*.ts"],
+    ignores: ["**/__tests__/**"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/vault-operations/**",
+                "**/search/**",
+                "**/mcp-core/**",
+                "**/oauth/**",
+                "**/utils/**",
+                "**/logger.js",
+              ],
+              allowTypeImports: true,
+              message:
+                "obsidian-markdown/ is a leaf layer — no runtime imports of other internal modules (AGENTS.md → Module layering)",
+            },
+            {
+              group: [
+                "node:fs",
+                "node:fs/**",
+                "better-sqlite3",
+                "sqlite-vec",
+                "@modelcontextprotocol/**",
+              ],
+              allowTypeImports: true,
+              message:
+                "pure parsers do no I/O — no fs, SQLite, or MCP SDK in obsidian-markdown/ (AGENTS.md → Module layering)",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // utils/ is generic with zero domain knowledge; type-only imports from
+    // infrastructure modules (Logger, config types) are fine.
+    files: ["src/utils/**/*.ts"],
+    ignores: ["**/__tests__/**"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/vault-mcp/**", "**/logger.js"],
+              allowTypeImports: true,
+              message:
+                "utils/ has zero domain knowledge — no runtime imports of domain or infrastructure modules (AGENTS.md → utils/ admission)",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // vault-operations/ builds on the parsers and utils only.
+    files: ["src/vault-mcp/vault-operations/**/*.ts"],
+    ignores: ["**/__tests__/**"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/search/**", "**/mcp-core/**", "**/oauth/**"],
+              allowTypeImports: true,
+              message:
+                "vault-operations/ builds on parsers and utils only — no runtime imports of search/, mcp-core/, or oauth/ (AGENTS.md → Module layering)",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // search/ uses the shared parsers — it never reaches sideways into
+    // vault-operations/ or up into the protocol layer.
+    files: ["src/vault-mcp/search/**/*.ts"],
+    ignores: ["**/__tests__/**"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/vault-operations/**",
+                "**/mcp-core/**",
+                "**/oauth/**",
+              ],
+              allowTypeImports: true,
+              message:
+                "search/ builds on parsers and utils only — never reaches sideways into vault-operations/ or up into mcp-core/ (AGENTS.md → Module layering)",
+            },
+          ],
+        },
+      ],
+    },
+  },
   {
     ignores: ["dist/", "cli/dist/", ".sst/", "sst-env.d.ts"],
   },


### PR DESCRIPTION
## What

Adds per-layer `@typescript-eslint/no-restricted-imports` blocks to `eslint.config.ts`, encoding the AGENTS.md → Module layering contract as lint errors (same approach as umm-actually's layering enforcement):

- **`obsidian-markdown/`** — pure leaf layer: no runtime imports of any other internal module (`vault-operations/`, `search/`, `mcp-core/`, `oauth/`, `utils/`, the logger), and no `node:fs`, `better-sqlite3`, `sqlite-vec`, or MCP SDK.
- **`src/utils/`** — zero domain knowledge: no runtime imports from `vault-mcp/` or the logger.
- **`vault-operations/`** — builds on parsers + utils only: no runtime imports of `search/`, `mcp-core/`, `oauth/`.
- **`search/`** — same, plus never reaches sideways into `vault-operations/`.

All groups set `allowTypeImports: true` — type-only imports are erased at compile time and stay allowed (e.g. `tasks.ts` → `TaskFormatConfig`, `utils/filter-valid-symlinks.ts` → `Logger`). Test files are exempt. AGENTS.md gets a one-paragraph note that the dependency-direction rule is now lint-enforced.

## Why

The layering contract lived only in AGENTS.md prose; a sideways import would pass CI silently. No new dependencies — the existing typescript-eslint rule covers it since all internal imports are relative and alias-free.

## Verification

- `npm run lint` green on the unchanged codebase (0 errors; the 317 pre-existing warn-level assertion-style hits in test files are untouched)
- Mutation-checked every block: a violating runtime import in each guarded layer raises the expected error with its message; a type-only import across a banned boundary passes
- `npm run build` + 1922 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hU4zYJBfjr2aNqPfSyx6V