### PR TITLE
chore(lint): enforce AGENTS.md code-style rules via eslint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,11 @@ throughout the codebase.
 
 ## Code style
 
+Several rules below are lint-enforced in `eslint.config.ts` (arrow functions,
+`type` over `interface`, no `else` after return, single-char identifier ban,
+Luxon over `Date` and no `console` in `src/`, env access only via `config.ts`)
+— the rest remain review-enforced.
+
 - Functional over OOP. Arrow functions over `function` declarations.
 - Factory/closure pattern for stateful modules (see search-index.ts).
 - `type` over `interface` unless `interface` is specifically required.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -47,7 +47,7 @@ export default defineConfig(
     // Tests are exempt — they build Date fixtures for fs interop (utimes)
     // and fake timers.
     files: ["src/**/*.ts"],
-    ignores: ["**/__tests__/**"],
+    ignores: ["**/__tests__/**", "**/*.test.ts"],
     rules: {
       "no-restricted-syntax": [
         "error",
@@ -68,7 +68,7 @@ export default defineConfig(
     // Env access goes through the env-var package at the sanctioned read
     // site (config.ts) — never raw process.env scattered through the code.
     files: ["src/**/*.ts"],
-    ignores: ["**/__tests__/**", "src/vault-mcp/config.ts"],
+    ignores: ["**/__tests__/**", "**/*.test.ts", "src/vault-mcp/config.ts"],
     rules: {
       "no-restricted-properties": [
         "error",
@@ -105,7 +105,7 @@ export default defineConfig(
     // obsidian-markdown/ is a leaf layer of pure parsers: no I/O, no SDKs, no
     // runtime imports of other internal modules.
     files: ["src/vault-mcp/obsidian-markdown/**/*.ts"],
-    ignores: ["**/__tests__/**"],
+    ignores: ["**/__tests__/**", "**/*.test.ts"],
     rules: {
       "@typescript-eslint/no-restricted-imports": [
         "error",
@@ -145,7 +145,7 @@ export default defineConfig(
     // utils/ is generic with zero domain knowledge; type-only imports from
     // infrastructure modules (Logger, config types) are fine.
     files: ["src/utils/**/*.ts"],
-    ignores: ["**/__tests__/**"],
+    ignores: ["**/__tests__/**", "**/*.test.ts"],
     rules: {
       "@typescript-eslint/no-restricted-imports": [
         "error",
@@ -165,7 +165,7 @@ export default defineConfig(
   {
     // vault-operations/ builds on the parsers and utils only.
     files: ["src/vault-mcp/vault-operations/**/*.ts"],
-    ignores: ["**/__tests__/**"],
+    ignores: ["**/__tests__/**", "**/*.test.ts"],
     rules: {
       "@typescript-eslint/no-restricted-imports": [
         "error",
@@ -186,7 +186,7 @@ export default defineConfig(
     // search/ uses the shared parsers — it never reaches sideways into
     // vault-operations/ or up into the protocol layer.
     files: ["src/vault-mcp/search/**/*.ts"],
-    ignores: ["**/__tests__/**"],
+    ignores: ["**/__tests__/**", "**/*.test.ts"],
     rules: {
       "@typescript-eslint/no-restricted-imports": [
         "error",

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -17,6 +17,68 @@ export default defineConfig(
         "error",
         { assertionStyle: "never" },
       ],
+      // AGENTS.md → Code style: arrow functions over `function` declarations.
+      "func-style": ["error", "expression"],
+      // AGENTS.md → Code style: `type` over `interface`.
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+      // AGENTS.md → Code style: early returns over nested if/else.
+      "no-else-return": "error",
+      // AGENTS.md → Code style: explicit names over abbreviations — no
+      // single-char identifiers. Exceptions: `i` (loop index), `a`/`b`
+      // (sort comparators), `k` (the RRF constant's literature name),
+      // `_` (unused-param convention).
+      "id-length": [
+        "error",
+        { min: 2, properties: "never", exceptions: ["i", "a", "b", "k", "_"] },
+      ],
+    },
+  },
+  {
+    // Logging standard: console never ships in server code — the structured
+    // logger is the only output channel. cli/ and scripts/ are exempt:
+    // console IS their user interface.
+    files: ["src/**/*.ts"],
+    rules: {
+      "no-console": "error",
+    },
+  },
+  {
+    // AGENTS.md → Code style: Luxon DateTime over the native Date API.
+    // Tests are exempt — they build Date fixtures for fs interop (utimes)
+    // and fake timers.
+    files: ["src/**/*.ts"],
+    ignores: ["**/__tests__/**"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: 'NewExpression[callee.name="Date"]',
+          message:
+            "Use Luxon DateTime over the native Date API (AGENTS.md → Code style)",
+        },
+        {
+          selector: 'CallExpression[callee.object.name="Date"]',
+          message:
+            "Use Luxon (DateTime.now(), .toUnixInteger()) over Date static methods (AGENTS.md → Code style)",
+        },
+      ],
+    },
+  },
+  {
+    // Env access goes through the env-var package at the sanctioned read
+    // site (config.ts) — never raw process.env scattered through the code.
+    files: ["src/**/*.ts"],
+    ignores: ["**/__tests__/**", "src/vault-mcp/config.ts"],
+    rules: {
+      "no-restricted-properties": [
+        "error",
+        {
+          object: "process",
+          property: "env",
+          message:
+            "Read env via the env-var package in config.ts — never raw process.env",
+        },
+      ],
     },
   },
   {

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -37,8 +37,8 @@ const loadDotEnv = (): Record<string, string> => {
   return out
 }
 
-const expandHome = (p: string): string =>
-  p.startsWith("~/") ? `${homedir()}${p.slice(1)}` : p
+const expandHome = (path: string): string =>
+  path.startsWith("~/") ? `${homedir()}${path.slice(1)}` : path
 
 const env: NodeJS.ProcessEnv = { ...loadDotEnv(), ...process.env }
 

--- a/scripts/generate-dockerhub-readme.ts
+++ b/scripts/generate-dockerhub-readme.ts
@@ -186,9 +186,11 @@ const generate = (): void => {
       } else if (compactTableDone) {
         continue
       } else if (line.trim() !== "") {
-        const lastTableIdx = output.findLastIndex((l) => l.startsWith("|"))
+        const lastTableIdx = output.findLastIndex((outputLine) =>
+          outputLine.startsWith("|"),
+        )
         const lastHeadingIdx = output.findLastIndex(
-          (l) => parseHeading(l) !== undefined,
+          (outputLine) => parseHeading(outputLine) !== undefined,
         )
         if (lastTableIdx > lastHeadingIdx) {
           compactTableDone = true

--- a/src/functions/authorizer.ts
+++ b/src/functions/authorizer.ts
@@ -42,7 +42,9 @@ const OPEN_PATH_PREFIXES = [
 ]
 
 const isOpenPath = (path: string): boolean =>
-  OPEN_PATH_PREFIXES.some((p) => path === p || path.startsWith(p))
+  OPEN_PATH_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(prefix),
+  )
 
 export const handler = async (
   event: APIGatewayRequestAuthorizerEventV2,

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -66,7 +66,10 @@ export const verifyJwt = (token: string, secret: string): JwtPayload | null => {
       Buffer.from(payload, "base64url").toString(),
     )
     if (!isJwtPayload(decoded)) return null
-    // Reject expired tokens (exp is Unix seconds)
+    // Reject expired tokens (exp is Unix seconds). Native Date here, not
+    // Luxon: this module is bundled into the Lambda authorizer and stays
+    // dependency-free — a single epoch read doesn't justify the bundle weight.
+    // eslint-disable-next-line no-restricted-syntax
     if (decoded.exp < Date.now() / 1000) return null
     return decoded
   } catch {

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -628,7 +628,7 @@ Returns: JSON array of vault-relative path strings (e.g. ["Projects/plan.md", "N
     TOOL_NAMES.VAULT_DELETE_NOTE,
     {
       title: "Delete Note",
-      description: `Permanently delete a markdown note — removed from disk directly (no trash, no undo). After deletion, links to it from other notes become broken (detectable via vault_get_backlinks). Protected paths (${config.protectedPaths.map((p) => p + "/").join(", ")}) are refused.
+      description: `Permanently delete a markdown note — removed from disk directly (no trash, no undo). After deletion, links to it from other notes become broken (detectable via vault_get_backlinks). Protected paths (${config.protectedPaths.map((protectedPath) => protectedPath + "/").join(", ")}) are refused.
 
 Example: vault_delete_note({ path: "Scratch/temp.md" })
 Example: vault_delete_note({ path: "Archive/2024/old.md", prune_empty_folders: true }) — also remove "Archive/2024" (and "Archive") if deleting the note empties them.
@@ -708,7 +708,7 @@ Example: vault_move_note({ old_path: "Inbox/Spec.md", new_path: "Projects/Spec.m
 Example: vault_move_note({ old_path: "Inbox/Spec.md", new_path: "Projects/Spec.md", prune_empty_folders: true }) — also remove "Inbox" if the move empties it.
 
 When to use: Renaming a note or relocating it to a different folder while keeping the link graph intact.
-Prefer this over vault_write_note + vault_delete_note, which would orphan every backlink. To only change a note's body or properties, use vault_patch_note or vault_update_properties. Protected paths (${config.protectedPaths.map((p) => p + "/").join(", ")}) cannot be moved.
+Prefer this over vault_write_note + vault_delete_note, which would orphan every backlink. To only change a note's body or properties, use vault_patch_note or vault_update_properties. Protected paths (${config.protectedPaths.map((protectedPath) => protectedPath + "/").join(", ")}) cannot be moved.
 
 Errors:
 - "destination exists: …" — a note already lives at new_path; this tool never overwrites. Pick a free path or delete the existing note first.

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -184,19 +184,19 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
   // run to EOF, but must stop before a trailing `%% %%` comment block (e.g. a
   // Kanban board's `%% kanban:settings %%`) so replace/append don't clobber it.
   const trailingCommentBlockStart = findTrailingCommentBlockStart(lines)
-  return collectedHeadings.map((h, i) => {
+  return collectedHeadings.map((heading, i) => {
     const nextSameOrHigher = collectedHeadings
       .slice(i + 1)
-      .find((next) => next.level <= h.level)
+      .find((next) => next.level <= heading.level)
     return {
-      text: h.text,
-      level: h.level,
-      startLine: h.startLine,
-      bodyStartLine: h.startLine + 1,
+      text: heading.text,
+      level: heading.level,
+      startLine: heading.startLine,
+      bodyStartLine: heading.startLine + 1,
       // Math.max keeps bodyEndLine >= bodyStartLine for malformed input.
       bodyEndLine:
         nextSameOrHigher?.startLine ??
-        Math.max(h.startLine + 1, trailingCommentBlockStart),
+        Math.max(heading.startLine + 1, trailingCommentBlockStart),
     }
   })
 }
@@ -213,12 +213,14 @@ export const findHeading = (
 
   const searchText = text.trim()
   const matches = headings.filter(
-    (h) => h.text === searchText && (level === undefined || h.level === level),
+    (heading) =>
+      heading.text === searchText &&
+      (level === undefined || heading.level === level),
   )
 
   if (matches.length === 0) {
     const availableHeadings = headings
-      .map((h) => `${"#".repeat(h.level)} ${h.text}`)
+      .map((heading) => `${"#".repeat(heading.level)} ${heading.text}`)
       .join(", ")
     throw new Error(
       `heading not found: "${searchText}". Available headings: ${availableHeadings || "(none)"}`,
@@ -227,12 +229,15 @@ export const findHeading = (
 
   if (matches.length > 1) {
     const matchedHeadings = matches
-      .map((h) => `${"#".repeat(h.level)} ${h.text} (line ${h.startLine + 1})`)
+      .map(
+        (heading) =>
+          `${"#".repeat(heading.level)} ${heading.text} (line ${heading.startLine + 1})`,
+      )
       .join(", ")
     const firstMatch = matches[0]
     const allSameLevel =
       firstMatch !== undefined &&
-      matches.every((h) => h.level === firstMatch.level)
+      matches.every((heading) => heading.level === firstMatch.level)
     const hint = allSameLevel
       ? "Rename one heading to make it unique, or use vault_replace_in_note to target by text."
       : "Use heading_level to disambiguate."

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -58,8 +58,8 @@ export default $config({
       )
     }
 
-    const expandHome = (p: string): string =>
-      p.startsWith("~/") ? `${homedir()}${p.slice(1)}` : p
+    const expandHome = (path: string): string =>
+      path.startsWith("~/") ? `${homedir()}${path.slice(1)}` : path
 
     /**
      * Resolve the SSH public key to upload to Lightsail.


### PR DESCRIPTION
## What

Follow-up to #348 (module layering boundaries): adds lint enforcement for the remaining mechanically-checkable AGENTS.md code-style conventions. No new dependencies — all core/typescript-eslint rules.

| Rule | Convention enforced | Scope |
|---|---|---|
| `func-style` (expression) | Arrow functions over `function` declarations | global |
| `consistent-type-definitions` (type) | `type` over `interface` | global |
| `no-else-return` | Early returns over nested `if/else` | global |
| `id-length` (min 2) | Explicit names — no single-char identifiers | global, exceptions: `i` (loop index), `a`/`b` (sort comparators), `k` (RRF literature constant), `_` (unused-param convention) |
| `no-console` | Logging standard: the structured logger is the only output channel | `src/` only — `cli/` and `scripts/` exempt (console is their UI) |
| `no-restricted-syntax` on `new Date()` / `Date.*` | Luxon over the native Date API | `src/` prod — tests exempt (Date fixtures for fs interop / fake timers) |
| `no-restricted-properties` on `process.env` | Env access via the `env-var` package at the sanctioned read site | `src/` prod, `config.ts` exempt |

## Remediation in this PR

- Renamed single-char callbacks that genuinely violated the naming standard: `h` → `heading` (headings.ts ×6), `p` → `prefix`/`protectedPath`/`path` (authorizer.ts, vault-crud-tools.ts ×2, dev.ts, sst.config.ts), `l` → `outputLine` (generate-dockerhub-readme.ts ×2). Behavior unchanged — vault-crud-tools renames are inside template-literal interpolation, so tool description output is byte-identical.
- `jwt.ts` keeps `Date.now() / 1000` behind a justified `eslint-disable-next-line`: the module is bundled into the Lambda authorizer and stays dependency-free — one epoch read doesn't warrant Luxon in the bundle.

Also adds a short note to AGENTS.md → Code style listing which of its rules are now lint-enforced.

## Verification

- Full `npm run lint` green (0 errors; the 317 pre-existing warn-level assertion-style hits in test files unchanged)
- Mutation-checked all seven rules: a violation of each raises the expected error with its message; the sanctioned exemptions (config.ts env read, test-file Date fixtures, jwt.ts disable) pass in the same run
- `npm run build` green, 1922 tests green, prettier clean on all touched files

Not adopted, deliberately: `explicit-module-boundary-types` (its only 4 hits are the factory-closure `ReturnType<typeof create*>` idiom — the rule fights an established pattern) and plugin-dependent rules (`node:` prefix guardrail, `prefer-await-to-then`) which would add dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hU4zYJBfjr2aNqPfSyx6V