### PR TITLE
fix(deps): override adm-zip to 0.6.0 for CVE-2026-39244

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3183,12 +3183,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "zod": "4.4.3"
   },
   "overrides": {
+    "adm-zip": "0.6.0",
     "js-yaml": "4.2.0",
     "@huggingface/transformers": {
       "onnxruntime-web": "npm:empty-npm-package@1.0.0",


### PR DESCRIPTION
## What

Adds `"adm-zip": "0.6.0"` to the existing `overrides` block, forcing the transitive dependency (`@huggingface/transformers` → `onnxruntime-node` → `adm-zip ^0.5.16`) onto the patched release.

## Why

adm-zip 0.5.17 is vulnerable to **CVE-2026-39244** (crafted ZIP triggers a 4GB memory allocation, high severity — Dependabot alert #19). The fix landed in 0.6.0, which is outside onnxruntime-node's declared `^0.5.16` range, so it can't arrive via a normal lockfile bump. Since the trivy vulnerability DB picked up the CVE today, `trivy-pr` fails the image scan on **every** branch build (first observed on #349, whose changes are unrelated) — this unblocks CI repo-wide and clears the CVE from the shipped image.

## Verification

- onnxruntime-node uses adm-zip only in its CUDA-binaries install path via three APIs — `new AdmZip(path)`, `getEntry`, `extractEntryTo(entry, dir, false, true)` (`script/install-utils.js`). All three exercised against adm-zip 0.6.0 with a real nested-path zip: open, lookup, extract, content round-trip all correct.
- Fresh `npm ci` from wiped node_modules (onnxruntime-node postinstall included) succeeds; `npm ls adm-zip` shows `0.6.0 overridden`.
- `npm run build` green, full 1922-test suite green.
- `npm audit`: 0 vulnerabilities (was 3 high).
- The `trivy-pr` check on this PR is the end-to-end proof — it scans the freshly built image.

When onnxruntime-node bumps its own range past 0.6.0, the override can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hU4zYJBfjr2aNqPfSyx6V