### PR TITLE
fix(deps): bump js-yaml override to 4.3.0 (CVE-2026-59869)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5444,9 +5444,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "overrides": {
     "adm-zip": "0.6.0",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "@huggingface/transformers": {
       "onnxruntime-web": "npm:empty-npm-package@1.0.0",
       "sharp": "npm:empty-npm-package@1.0.0"


### PR DESCRIPTION
## Summary

- Bumps the `js-yaml` npm override from `4.2.0` to `4.3.0` to fix [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (quadratic CPU via YAML merge-key chains)
- Dependabot failed with `security_update_not_possible` because it can't resolve npm overrides — it sees `gray-matter@4.0.3` pinning `js-yaml` and thinks bumping would require downgrading gray-matter

## Test plan

- [ ] CI passes (lint, typecheck, tests)
- [ ] `npm ls js-yaml --all` resolves to `4.3.0`
- [ ] `npm audit` shows 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)