### PR TITLE
fix(deps): bump hono and fast-uri to resolve transitive CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5129,9 +5129,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -5512,9 +5512,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

- `hono` 4.12.25 → 4.12.31 — fixes 3 moderate advisories (context leak, XSS bypass, header dedup)
- `fast-uri` 3.1.2 → 3.1.4 — fixes 1 high advisory (host confusion via failed IDN canonicalization)
- Both are transitive via `@modelcontextprotocol/sdk@1.29.0`; the SDK's own semver ranges already allow these versions — `npm update` within existing ranges, no overrides needed

## Remaining alert

`@hono/node-server` #22 (moderate, Windows `serve-static` path traversal) requires ≥2.0.5 but the SDK pins `^1.19.9`. Dismissed as `not_used` — vault-cortex runs in Linux Docker, does not use Hono's `serve-static`, and does not serve static files. Tracked upstream: [modelcontextprotocol/typescript-sdk#2036](https://github.com/modelcontextprotocol/typescript-sdk/issues/2036).

## Test plan

- [x] 2033 tests pass
- [ ] `npm audit` shows 0 high, remaining moderate is dismissed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)