### PR TITLE
chore(deps): ignore @hono/node-server GHSA-frvp in OSV scanner

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "GHSA-frvp-7c67-39w9"
+reason = "@hono/node-server Windows serve-static path traversal — vault-cortex runs in Linux Docker, does not use serve-static. Transitive via @modelcontextprotocol/sdk which pins ^1.19.9; fix requires SDK release (modelcontextprotocol/typescript-sdk#2036)."


### PR DESCRIPTION
## Summary

Adds `osv-scanner.toml` to ignore GHSA-frvp-7c67-39w9 (`@hono/node-server` Windows `serve-static` path traversal) in the Scorecard vulnerability check.

## Why this doesn't apply

1. **Windows-only** — `%5C` decodes to `\` which acts as a path separator only on Windows. vault-cortex runs in Linux Docker, always.
2. **`serve-static` only** — requires Hono's static file serving middleware. vault-cortex doesn't serve static files.
3. **Not used directly** — `@hono/node-server` is transitive via `@modelcontextprotocol/sdk`. vault-cortex uses Express, not the Hono adapter.

The fix requires `>=2.0.5` but the SDK pins `^1.19.9`. Tracked upstream: [modelcontextprotocol/typescript-sdk#2036](https://github.com/modelcontextprotocol/typescript-sdk/issues/2036). Remove the ignore entry when the SDK bumps its range.

Also dismissed on Dependabot alert \#22 with the same rationale.

## Test plan

- [ ] Scorecard workflow re-runs and alert \#105 clears
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)