### PR TITLE
fix: reject control characters in write tool content params

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# @hono/node-server Windows serve-static path traversal — vault-cortex runs in
+# Linux Docker, does not use serve-static. Transitive via @modelcontextprotocol/sdk
+# which pins ^1.19.9; fix requires SDK release (modelcontextprotocol/typescript-sdk#2036).
+# Also suppressed in osv-scanner.toml.
+GHSA-frvp-7c67-39w9

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ src/
     map-with-concurrency.ts            # Bounded-concurrency async map (batch-based)
     describe-error.ts                  # describeError — message from an unknown throw
     fs.ts                              # readFileOrNull / readdirOrNull / fileExists / statOrNull (ENOENT-safe)
+    assert-no-control-characters.ts    # Rejects C0 controls (except tab/LF/CR), DEL, and C1 controls in write params
     assert-path-has-extension.ts       # Generic path extension assertion (used by note-path validation)
     filter-valid-symlinks.ts           # Filters out broken symlinks from directory listings
     fit-image-to-byte-budget.ts        # Downscale/recompress an image buffer to fit a byte budget (sharp)

--- a/src/utils/__tests__/assert-no-control-characters.test.ts
+++ b/src/utils/__tests__/assert-no-control-characters.test.ts
@@ -7,7 +7,10 @@ const getError = (fn: () => void): Error => {
     fn()
     throw new Error("expected function to throw")
   } catch (thrown) {
-    if (thrown instanceof Error && thrown.message !== "expected function to throw")
+    if (
+      thrown instanceof Error &&
+      thrown.message !== "expected function to throw"
+    )
       return thrown
     throw thrown
   }
@@ -57,9 +60,7 @@ describe("assertNoControlCharacters", () => {
   })
 
   it("allows tab (U+0009)", () => {
-    expect(() =>
-      assertNoControlCharacters("col1\tcol2", "body"),
-    ).not.toThrow()
+    expect(() => assertNoControlCharacters("col1\tcol2", "body")).not.toThrow()
   })
 
   it("allows LF (U+000A)", () => {

--- a/src/utils/__tests__/assert-no-control-characters.test.ts
+++ b/src/utils/__tests__/assert-no-control-characters.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest"
+import { assertNoControlCharacters } from "../assert-no-control-characters.js"
+
+describe("assertNoControlCharacters", () => {
+  it("rejects NUL (U+0000)", () => {
+    expect(() => assertNoControlCharacters("hello\x00world", "body")).toThrow(
+      "body contains a control character (U+0000 at position 5)",
+    )
+  })
+
+  it("rejects BEL (U+0007)", () => {
+    expect(() => assertNoControlCharacters("\x07beep", "body")).toThrow(
+      "body contains a control character (U+0007 at position 0)",
+    )
+  })
+
+  it("rejects VT (U+000B)", () => {
+    expect(() => assertNoControlCharacters("line\x0Bbreak", "body")).toThrow(
+      "body contains a control character (U+000B at position 4)",
+    )
+  })
+
+  it("rejects FF (U+000C)", () => {
+    expect(() => assertNoControlCharacters("page\x0Cfeed", "body")).toThrow(
+      "body contains a control character (U+000C at position 4)",
+    )
+  })
+
+  it("rejects DEL (U+007F)", () => {
+    expect(() => assertNoControlCharacters("del\x7F", "body")).toThrow(
+      "body contains a control character (U+007F at position 3)",
+    )
+  })
+
+  it("rejects C1 NEL (U+0085)", () => {
+    expect(() => assertNoControlCharacters("next\x85line", "body")).toThrow(
+      "body contains a control character (U+0085 at position 4)",
+    )
+  })
+
+  it("rejects C1 upper bound (U+009F)", () => {
+    expect(() => assertNoControlCharacters("end\x9F", "body")).toThrow(
+      "body contains a control character (U+009F at position 3)",
+    )
+  })
+
+  it("allows tab (U+0009)", () => {
+    expect(() =>
+      assertNoControlCharacters("col1\tcol2", "body"),
+    ).not.toThrow()
+  })
+
+  it("allows LF (U+000A)", () => {
+    expect(() =>
+      assertNoControlCharacters("line1\nline2", "body"),
+    ).not.toThrow()
+  })
+
+  it("allows CRLF", () => {
+    expect(() =>
+      assertNoControlCharacters("line1\r\nline2", "body"),
+    ).not.toThrow()
+  })
+
+  it("allows empty string", () => {
+    expect(() => assertNoControlCharacters("", "body")).not.toThrow()
+  })
+
+  it("allows normal markdown content", () => {
+    expect(() =>
+      assertNoControlCharacters(
+        "## Heading\n\nBody with [[links]] and #tags",
+        "body",
+      ),
+    ).not.toThrow()
+  })
+
+  it("includes the param name in the error message", () => {
+    expect(() => assertNoControlCharacters("bad\x00", "entry")).toThrow(
+      "entry contains a control character",
+    )
+  })
+
+  it("reports first occurrence only", () => {
+    expect(() => assertNoControlCharacters("\x01\x02", "body")).toThrow(
+      "U+0001 at position 0",
+    )
+  })
+})

--- a/src/utils/__tests__/assert-no-control-characters.test.ts
+++ b/src/utils/__tests__/assert-no-control-characters.test.ts
@@ -1,46 +1,58 @@
 import { describe, it, expect } from "vitest"
 import { assertNoControlCharacters } from "../assert-no-control-characters.js"
 
+/** Captures the thrown error so both message and absence checks are possible. */
+const getError = (fn: () => void): Error => {
+  try {
+    fn()
+    throw new Error("expected function to throw")
+  } catch (thrown) {
+    if (thrown instanceof Error && thrown.message !== "expected function to throw")
+      return thrown
+    throw thrown
+  }
+}
+
 describe("assertNoControlCharacters", () => {
   it("rejects NUL (U+0000)", () => {
     expect(() => assertNoControlCharacters("hello\x00world", "body")).toThrow(
-      "body contains a control character (U+0000 at position 5)",
+      "body contains a control character (U+0000 at position 5) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 
   it("rejects BEL (U+0007)", () => {
     expect(() => assertNoControlCharacters("\x07beep", "body")).toThrow(
-      "body contains a control character (U+0007 at position 0)",
+      "body contains a control character (U+0007 at position 0) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 
   it("rejects VT (U+000B)", () => {
     expect(() => assertNoControlCharacters("line\x0Bbreak", "body")).toThrow(
-      "body contains a control character (U+000B at position 4)",
+      "body contains a control character (U+000B at position 4) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 
   it("rejects FF (U+000C)", () => {
     expect(() => assertNoControlCharacters("page\x0Cfeed", "body")).toThrow(
-      "body contains a control character (U+000C at position 4)",
+      "body contains a control character (U+000C at position 4) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 
   it("rejects DEL (U+007F)", () => {
     expect(() => assertNoControlCharacters("del\x7F", "body")).toThrow(
-      "body contains a control character (U+007F at position 3)",
+      "body contains a control character (U+007F at position 3) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 
   it("rejects C1 NEL (U+0085)", () => {
     expect(() => assertNoControlCharacters("next\x85line", "body")).toThrow(
-      "body contains a control character (U+0085 at position 4)",
+      "body contains a control character (U+0085 at position 4) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 
   it("rejects C1 upper bound (U+009F)", () => {
     expect(() => assertNoControlCharacters("end\x9F", "body")).toThrow(
-      "body contains a control character (U+009F at position 3)",
+      "body contains a control character (U+009F at position 3) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 
@@ -75,15 +87,23 @@ describe("assertNoControlCharacters", () => {
     ).not.toThrow()
   })
 
+  it("allows bare CR (U+000D)", () => {
+    expect(() =>
+      assertNoControlCharacters("line1\rline2", "body"),
+    ).not.toThrow()
+  })
+
   it("includes the param name in the error message", () => {
     expect(() => assertNoControlCharacters("bad\x00", "entry")).toThrow(
-      "entry contains a control character",
+      "entry contains a control character (U+0000 at position 3) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 
   it("reports first occurrence only", () => {
-    expect(() => assertNoControlCharacters("\x01\x02", "body")).toThrow(
-      "U+0001 at position 0",
+    const error = getError(() => assertNoControlCharacters("\x01\x02", "body"))
+    expect(error.message).toBe(
+      "body contains a control character (U+0001 at position 0) — control characters other than tab, LF, and CR are not allowed",
     )
+    expect(error.message).not.toContain("U+0002")
   })
 })

--- a/src/utils/__tests__/assert-no-control-characters.test.ts
+++ b/src/utils/__tests__/assert-no-control-characters.test.ts
@@ -1,21 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { assertNoControlCharacters } from "../assert-no-control-characters.js"
 
-/** Captures the thrown error so both message and absence checks are possible. */
-const getError = (fn: () => void): Error => {
-  try {
-    fn()
-    throw new Error("expected function to throw")
-  } catch (thrown) {
-    if (
-      thrown instanceof Error &&
-      thrown.message !== "expected function to throw"
-    )
-      return thrown
-    throw thrown
-  }
-}
-
 describe("assertNoControlCharacters", () => {
   it("rejects NUL (U+0000)", () => {
     expect(() => assertNoControlCharacters("hello\x00world", "body")).toThrow(
@@ -101,10 +86,8 @@ describe("assertNoControlCharacters", () => {
   })
 
   it("reports first occurrence only", () => {
-    const error = getError(() => assertNoControlCharacters("\x01\x02", "body"))
-    expect(error.message).toBe(
+    expect(() => assertNoControlCharacters("\x01\x02", "body")).toThrow(
       "body contains a control character (U+0001 at position 0) — control characters other than tab, LF, and CR are not allowed",
     )
-    expect(error.message).not.toContain("U+0002")
   })
 })

--- a/src/utils/assert-no-control-characters.ts
+++ b/src/utils/assert-no-control-characters.ts
@@ -17,11 +17,18 @@ export const assertNoControlCharacters = (
   const match = CONTROL_CHARACTER_PATTERN.exec(value)
   if (!match) return
 
-  const charCode = match[0].codePointAt(0)
-  if (charCode === undefined) return
-  const codePoint = charCode.toString(16).toUpperCase().padStart(4, "0")
+  const codePointValue = match[0].codePointAt(0)
+  if (codePointValue === undefined) {
+    throw new Error(
+      `${paramName} contains a control character at position ${match.index} — control characters other than tab, LF, and CR are not allowed`,
+    )
+  }
+  const codePointHex = codePointValue
+    .toString(16)
+    .toUpperCase()
+    .padStart(4, "0")
 
   throw new Error(
-    `${paramName} contains a control character (U+${codePoint} at position ${match.index}) — control characters other than tab, LF, and CR are not allowed in note content`,
+    `${paramName} contains a control character (U+${codePointHex} at position ${match.index}) — control characters other than tab, LF, and CR are not allowed`,
   )
 }

--- a/src/utils/assert-no-control-characters.ts
+++ b/src/utils/assert-no-control-characters.ts
@@ -1,0 +1,27 @@
+/** C0 controls (except tab/LF/CR), DEL, and C1 controls. */
+// eslint-disable-next-line no-control-regex -- matching control characters is the purpose of this guard
+const CONTROL_CHARACTER_PATTERN = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/
+
+/**
+ * Rejects content containing non-printable control characters. A control byte
+ * in a markdown note is invisible in read output but physically present on
+ * disk — exact-match edits (old_text) can never target it because the byte
+ * doesn't survive a round-trip through the MCP transport, leaving the file
+ * stuck with an unmatchable character. Rejecting at the write boundary
+ * prevents the stuck-byte scenario entirely.
+ */
+export const assertNoControlCharacters = (
+  value: string,
+  paramName: string,
+): void => {
+  const match = CONTROL_CHARACTER_PATTERN.exec(value)
+  if (!match) return
+
+  const charCode = match[0].codePointAt(0)
+  if (charCode === undefined) return
+  const codePoint = charCode.toString(16).toUpperCase().padStart(4, "0")
+
+  throw new Error(
+    `${paramName} contains a control character (U+${codePoint} at position ${match.index}) — control characters other than tab, LF, and CR are not allowed in note content`,
+  )
+}

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -114,6 +114,7 @@ Errors:
 - "entry must be a single line" — memory entries are single dated bullets; collapse newlines or append multiple entries.
 - "section must be a single line" — section names become H2 headings; remove line breaks.
 - "date must be a real ISO calendar date" — options.date only accepts an existing calendar date in bare YYYY-MM-DD form (e.g. "2026-07-02"), not a timestamp.
+- "entry/section contains a control character" — entry or section includes a non-printable control byte; remove it before writing.
 
 Returns: Confirmation message (notes when an identical entry already existed and nothing was written).`,
       inputSchema: {

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -215,7 +215,7 @@ Limitation: Writes the entire body. Do not use for surgical edits to large files
 Errors:
 - "note already exists" — a note already lives at this path; set overwrite: true to replace it, or use vault_patch_note / vault_replace_in_note for partial edits
 - "concurrent write in progress" — another write to this note is in flight; re-read the note and retry
-- "body contains a control character" — body includes a non-printable control byte (U+0000–001F except tab/LF/CR, or U+007F–009F); remove it before writing
+- "body contains a control character" — body includes a non-printable control byte; remove it before writing
 
 Obsidian syntax: Body is Obsidian Flavored Markdown (no escaping applied). Watch for: #word = tag (escape with \\#), [[ = wikilink, %% = comment block. In properties: quote wikilink values ("[[Note]]"), use YAML lists for tags, keep property types consistent (string/number/list mismatches cause silent query failures).
 

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -215,6 +215,7 @@ Limitation: Writes the entire body. Do not use for surgical edits to large files
 Errors:
 - "note already exists" — a note already lives at this path; set overwrite: true to replace it, or use vault_patch_note / vault_replace_in_note for partial edits
 - "concurrent write in progress" — another write to this note is in flight; re-read the note and retry
+- "body contains a control character" — body includes a non-printable control byte (U+0000–001F except tab/LF/CR, or U+007F–009F); remove it before writing
 
 Obsidian syntax: Body is Obsidian Flavored Markdown (no escaping applied). Watch for: #word = tag (escape with \\#), [[ = wikilink, %% = comment block. In properties: quote wikilink values ("[[Note]]"), use YAML lists for tags, keep property types consistent (string/number/list mismatches cause silent query failures).
 
@@ -312,6 +313,7 @@ Errors:
 - "operation … requires a heading target" — replace and insert_before need a heading
 - "content begins with the heading … which would duplicate it" — content's first line repeats the target heading; omit it (the matched heading is kept automatically)
 - "concurrent write in progress" — another write to this note is in flight; re-read the note and retry
+- "content contains a control character" — content includes a non-printable control byte; remove it before writing
 
 Obsidian syntax: Content is Obsidian Flavored Markdown (no escaping applied). Watch for: #word = tag, [[ = wikilink, %% = comment block. Inserting heading-level content (## New Section) changes the note's structure — future heading-targeted ops may resolve differently.
 Table rows: send only the data row ("| cell1 | cell2 |"), not the header or separator — duplicating them splits the table.
@@ -408,6 +410,7 @@ Errors:
 - "text not found" — old_text does not appear in the note body; verify exact text with vault_read_note
 - "old_text cannot be empty" — old_text must be at least one character
 - "concurrent write in progress" — another write to this note is in flight; re-read the note and retry
+- "new_text contains a control character" — new_text includes a non-printable control byte; remove it before writing
 
 Obsidian syntax: new_text is Obsidian Flavored Markdown (no escaping applied). Watch for: #word = tag, [[ = wikilink, %% = comment block in replacement text.
 

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -584,7 +584,7 @@ describe("updateMemory idempotency", () => {
         logger,
       ),
     ).rejects.toThrow(
-      "entry contains a control character (U+0000 at position 5)",
+      "entry contains a control character (U+0000 at position 5) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 
@@ -601,7 +601,7 @@ describe("updateMemory idempotency", () => {
         logger,
       ),
     ).rejects.toThrow(
-      "section contains a control character (U+0007 at position 3)",
+      "section contains a control character (U+0007 at position 3) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -571,6 +571,40 @@ describe("updateMemory idempotency", () => {
     expect(fileContent).toBe(PRINCIPLES_MD)
   })
 
+  it("rejects an entry containing a control character", async () => {
+    await expect(
+      updateMemory(
+        {
+          vaultPath: vault,
+          file: "Principles",
+          section: "Decision heuristics (newest first)",
+          entry: "likes\x00nulls",
+          date: "2026-07-02",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      "entry contains a control character (U+0000 at position 5)",
+    )
+  })
+
+  it("rejects a section name containing a control character", async () => {
+    await expect(
+      updateMemory(
+        {
+          vaultPath: vault,
+          file: "Principles",
+          section: "Bad\x07Section",
+          entry: "valid entry",
+          date: "2026-07-02",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      "section contains a control character (U+0007 at position 3)",
+    )
+  })
+
   // A memory file is a bare name, never a path — a separator would let
   // "../.." escape the memory directory (and the vault) entirely.
   it.each([

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -441,7 +441,7 @@ describe("writeNote", () => {
         logger,
       ),
     ).rejects.toThrow(
-      "body contains a control character (U+0000 at position 5)",
+      "body contains a control character (U+0000 at position 5) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 })

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -433,6 +433,17 @@ describe("writeNote", () => {
     const content = await readFile(join(vault, "fresh-overwrite.md"), "utf8")
     expect(content).toBe("created\n")
   })
+
+  it("rejects body containing a control character", async () => {
+    await expect(
+      writeNote(
+        { vaultPath: vault, path: "bad.md", body: "hello\x00world" },
+        logger,
+      ),
+    ).rejects.toThrow(
+      "body contains a control character (U+0000 at position 5)",
+    )
+  })
 })
 
 const DEFAULT_PROTECTED = ["About Me", "Daily Notes"]

--- a/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
@@ -1644,7 +1644,7 @@ describe("patchNote errors", () => {
         logger,
       ),
     ).rejects.toThrow(
-      "content contains a control character (U+0000 at position 3)",
+      "content contains a control character (U+0000 at position 3) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 })
@@ -1951,7 +1951,7 @@ apple and apple and apple.
         logger,
       ),
     ).rejects.toThrow(
-      "new_text contains a control character (U+0000 at position 4)",
+      "new_text contains a control character (U+0000 at position 4) — control characters other than tab, LF, and CR are not allowed",
     )
   })
 

--- a/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
@@ -1630,6 +1630,23 @@ describe("patchNote errors", () => {
       ),
     ).rejects.toThrow("path traversal blocked")
   })
+
+  it("rejects content containing a control character", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          operation: "append",
+          content: "new\x00content",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      "content contains a control character (U+0000 at position 3)",
+    )
+  })
 })
 
 describe("patchNote — duplicate-heading guard", () => {
@@ -1919,6 +1936,23 @@ apple and apple and apple.
         logger,
       ),
     ).rejects.toThrow("old_text cannot be empty")
+  })
+
+  it("rejects new_text containing a control character", async () => {
+    await writeTestNote("note.md", NOTE_WITH_SECTIONS)
+    await expect(
+      replaceInNote(
+        {
+          vaultPath: vault,
+          path: "note.md",
+          oldText: "Task A",
+          newText: "Task\x00A",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      "new_text contains a control character (U+0000 at position 4)",
+    )
   })
 
   it("errors when old_text not found", async () => {

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -7,6 +7,7 @@ import { parseNote, stringifyNote } from "../obsidian-markdown/frontmatter.js"
 import { atomicWriteFile } from "./vault-filesystem.js"
 import { readFileOrNull } from "../../utils/fs.js"
 import { isErrnoException } from "../../utils/is-errno-exception.js"
+import { assertNoControlCharacters } from "../../utils/assert-no-control-characters.js"
 import { withFileLock } from "../../utils/file-write-lock.js"
 import { parseLeadingCallout } from "../obsidian-markdown/callouts.js"
 import type { LeadingCallout } from "../obsidian-markdown/callouts.js"
@@ -504,6 +505,8 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         "section must be a single line: section names become H2 headings — remove line breaks",
       )
     }
+    assertNoControlCharacters(params.entry, "entry")
+    assertNoControlCharacters(params.section, "section")
     // Serialize the read-modify-write so concurrent appends to the same file
     // don't clobber each other's entries (lost update).
     return withFileLock(

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -33,6 +33,7 @@ import { parseHeadings, findHeading } from "../obsidian-markdown/headings.js"
 import { parseLeadingCallout } from "../obsidian-markdown/callouts.js"
 import type { LeadingCallout } from "../obsidian-markdown/callouts.js"
 import { splitIntoLines } from "../obsidian-markdown/lines.js"
+import { assertNoControlCharacters } from "../../utils/assert-no-control-characters.js"
 import { assertPathHasExtension } from "../../utils/assert-path-has-extension.js"
 import type { Logger } from "../../logger.js"
 
@@ -332,6 +333,7 @@ const writeNote = async (
   logger: Logger,
 ): Promise<void> => {
   assertPathHasExtension(params.path, ".md")
+  assertNoControlCharacters(params.body, "body")
   const fullPath = resolveSafePath(params.vaultPath, params.path)
   return withExclusiveFileLock(fullPath, async () => {
     await mkdir(dirname(fullPath), { recursive: true })

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -3,6 +3,7 @@
 import { readFile } from "node:fs/promises"
 import { parseNote, stringifyNote } from "../obsidian-markdown/frontmatter.js"
 import { resolveSafePath, atomicWriteFile } from "./vault-filesystem.js"
+import { assertNoControlCharacters } from "../../utils/assert-no-control-characters.js"
 import { assertPathHasExtension } from "../../utils/assert-path-has-extension.js"
 import { isErrnoException } from "../../utils/is-errno-exception.js"
 import { withExclusiveFileLock } from "../../utils/file-write-lock.js"
@@ -163,6 +164,7 @@ const patchNote = async (
   logger: Logger,
 ): Promise<string> => {
   const { path, operation, content, heading, headingLevel } = params
+  assertNoControlCharacters(content, "content")
   const lockPath = resolveSafePath(params.vaultPath, path)
   return withExclusiveFileLock(lockPath, async () => {
     const { fullPath, data, lines, beforeBytes } = await readNoteForPatch(
@@ -251,6 +253,7 @@ const replaceInNote = async (
   if (oldText.length === 0) {
     throw new Error("old_text cannot be empty")
   }
+  assertNoControlCharacters(newText, "new_text")
 
   const lockPath = resolveSafePath(params.vaultPath, path)
   return withExclusiveFileLock(lockPath, async () => {


### PR DESCRIPTION
## Summary

- Adds a `assertNoControlCharacters` guard utility that rejects C0 controls (except tab/LF/CR), DEL, and C1 controls in content written to vault notes
- Wires the guard into all 4 data-layer write functions: `writeNote` (body), `patchNote` (content), `replaceInNote` (newText), `updateMemory` (entry + section)
- Updates MCP tool descriptions with the new error in their `Errors:` section
- 14 unit tests for the guard + 7 integration tests across the 3 affected test suites

**Motivation:** A NUL byte written via JSON `\uXXXX` escape decoding was faithfully persisted to disk, where it silently broke exact-match `old_text` edits — invisible in `vault_read_note` output, unmatchable in tool params. Defense-in-depth: a control byte in a markdown note is never intended, and rejecting it with a clear error beats a stuck unmatchable byte on disk.

## Test plan

- [ ] `npm test -- --run src/utils/__tests__/assert-no-control-characters.test.ts` — 14 unit tests
- [ ] `npm test -- --run src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts` — writeNote rejection
- [ ] `npm test -- --run src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts` — patchNote + replaceInNote rejection
- [ ] `npm test -- --run src/vault-mcp/vault-operations/__tests__/memory-store.test.ts` — updateMemory entry + section rejection
- [ ] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Vault memory updates and note editing operations now reject non-printable control characters in writable text.
  - Validation identifies the invalid character, its location, and the affected field.
  - Tabs, line feeds, carriage returns, empty content, and normal Markdown remain supported.

- **Documentation**
  - Tool descriptions now explain the control-character validation and related write failures.

- **Tests**
  - Added coverage for invalid control characters across memory and note-writing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->