### PR TITLE
fix(deps): bump brace-expansion to 5.0.8 for CVE-2026-14257

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4103,16 +4103,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bytes": {


### PR DESCRIPTION
## What

Bumps the transitive `brace-expansion` from 5.0.7 to 5.0.8.

## Why

[GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / CVE-2026-14257 (high) — unbounded expansion length can exhaust memory and crash the process. Published 2026-07-24; it is the single vulnerability behind the open Scorecard code-scanning alert (#105), which currently reports `score is 9: 1 existing vulnerabilities detected`.

## Exposure

Dev-only. The path is `eslint -> minimatch -> brace-expansion`, and the lockfile marks it `"dev": true`, so it never reaches the Docker image or the published npm package. Scorecard evaluates the repository's dependency graph regardless of that distinction, so the alert stays open until the lockfile moves.

## Why no override

`minimatch` declares `brace-expansion: ^5.0.5`, so 5.0.8 satisfies the existing range and `npm update brace-expansion` resolves it. That differs from the `js-yaml` and `adm-zip` entries in `overrides`, which exist because their parents pin exact versions and Dependabot could not resolve them.

The diff is confined to `package-lock.json` — one package's `version`, `resolved`, `integrity`, and its declared `engines` range (the patched release drops Node 18). No vulnerable copy remains in the tree.

## Verification

- `npm test` — 2076 passed (62 files)
- `npm run lint` — 0 errors (brace-expansion is on eslint's own code path, so a clean lint run exercises the bump)
- `npm run build:server` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)