### PR TITLE
docs(security): fix stale directional self-reference in Runtime Hardening intro

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,8 @@ The attack surface includes:
 
 ## Runtime Hardening
 
-Beyond the authentication and scanning protections described above, the
+Beyond the authentication layers listed under [Scope](#scope) and the
+scanners covered in [Automated Scanning](#automated-scanning) below, the
 following runtime patterns address specific attack classes. See
 [ARCHITECTURE.md → Data Integrity](./ARCHITECTURE.md#data-integrity) for
 mechanism-level detail.


### PR DESCRIPTION
## Summary

The Runtime Hardening intro in SECURITY.md claimed the authentication and scanning protections were "described above" — but nothing above describes scanning protections. The Scope section above is an attack-surface list (authentication appears there only as a surface, not a protection), and the scanning content lives in the **Automated Scanning** section *below* the reference.

Replaced the directional claim with anchored references that resolve against the current document structure:

- authentication → `[Scope](#scope)`
- scanning → `[Automated Scanning](#automated-scanning)` (correctly noted as below)

Both anchors verified against the file's own headings. A repo-wide sweep for other directional self-references (`described above/below`, `section above/below`, `shown above/below`) found one other instance, ARCHITECTURE.md:416, which was verified accurate (the embedding pipeline and file watcher are described above it) and left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)