### PR TITLE
fix: accept tab separators and leading spaces in ATX headings (CommonMark §4.2)

### DIFF
--- a/src/vault-mcp/obsidian-markdown/__tests__/callouts.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/callouts.test.ts
@@ -34,6 +34,31 @@ describe("parseLeadingCallout", () => {
     })
   })
 
+  it("skips a leading H1 with leading spaces (CommonMark §4.2)", () => {
+    const lines = [" # Me", "> [!info] Scope", "> body", "", "## Section"]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Scope",
+      body: "body",
+    })
+  })
+
+  it("skips a leading H1 with a tab separator (CommonMark §4.2)", () => {
+    const lines = ["#\tMe", "> [!info] Scope", "> body", "", "## Section"]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Scope",
+      body: "body",
+    })
+  })
+
+  it("does not skip a line with 4+ leading spaces as an H1", () => {
+    // 4 spaces makes it an indented code block, not a heading — the callout
+    // is preceded by body content, so it is not a leading callout.
+    const lines = ["    # Not a heading", "> [!info] Not leading", "> body"]
+    expect(parseLeadingCallout(lines)).toBeNull()
+  })
+
   it("returns null when there is no callout", () => {
     const lines = ["# Title", "", "Just prose, no callout.", "", "## Section"]
     expect(parseLeadingCallout(lines)).toBeNull()

--- a/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
@@ -121,12 +121,16 @@ describe("parseHeadings", () => {
       "  ## Two", // 1
       "   ### Three", // 2
     ])
-    expect(
-      headings.map((heading) => ({ text: heading.text, level: heading.level })),
-    ).toEqual([
-      { text: "One", level: 1 },
-      { text: "Two", level: 2 },
-      { text: "Three", level: 3 },
+    expect(headings).toEqual([
+      { text: "One", level: 1, startLine: 0, bodyStartLine: 1, bodyEndLine: 3 },
+      { text: "Two", level: 2, startLine: 1, bodyStartLine: 2, bodyEndLine: 3 },
+      {
+        text: "Three",
+        level: 3,
+        startLine: 2,
+        bodyStartLine: 3,
+        bodyEndLine: 3,
+      },
     ])
   })
 

--- a/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
@@ -100,6 +100,53 @@ describe("parseHeadings", () => {
     ])
   })
 
+  // ── CommonMark §4.2 parity ────────────────────────────────────
+
+  it("parses a heading with a tab separator", () => {
+    const headings = parseHeadings(["##\tTitle"])
+    expect(headings).toEqual([
+      {
+        text: "Title",
+        level: 2,
+        startLine: 0,
+        bodyStartLine: 1,
+        bodyEndLine: 1,
+      },
+    ])
+  })
+
+  it("parses headings with 1-3 leading spaces", () => {
+    const headings = parseHeadings([
+      " # One", // 0
+      "  ## Two", // 1
+      "   ### Three", // 2
+    ])
+    expect(
+      headings.map((heading) => ({ text: heading.text, level: heading.level })),
+    ).toEqual([
+      { text: "One", level: 1 },
+      { text: "Two", level: 2 },
+      { text: "Three", level: 3 },
+    ])
+  })
+
+  it("parses a heading with leading spaces and tab separator", () => {
+    const headings = parseHeadings(["  ##\tTitle"])
+    expect(headings).toEqual([
+      {
+        text: "Title",
+        level: 2,
+        startLine: 0,
+        bodyStartLine: 1,
+        bodyEndLine: 1,
+      },
+    ])
+  })
+
+  it("does not parse a heading with 4+ leading spaces (indented code block)", () => {
+    expect(parseHeadings(["    ## Title"])).toEqual([])
+  })
+
   it("strips trailing closing hashes from heading text", () => {
     const headings = parseHeadings(["## Title ##"])
     const headingTexts = headings.map((heading) => heading.text)
@@ -255,6 +302,14 @@ describe("linesBeforeFirstHeading", () => {
   it("does not trim a blank-only region", () => {
     // Blank-suppression is the consumer's call, not this parser's.
     expect(regionOf(["", "   ", "\t"])).toEqual(["", "   ", "\t"])
+  })
+
+  it("stops at a heading with leading spaces", () => {
+    expect(regionOf(["intro", "  ## Section"])).toEqual(["intro"])
+  })
+
+  it("stops at a heading with a tab separator", () => {
+    expect(regionOf(["intro", "##\tSection"])).toEqual(["intro"])
   })
 
   it("finds no heading boundary in raw CRLF lines", () => {

--- a/src/vault-mcp/obsidian-markdown/__tests__/memory-entries.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/memory-entries.test.ts
@@ -251,6 +251,52 @@ describe("parseMemoryEntries", () => {
     expect(parseMemoryEntries(lines)).toEqual([])
   })
 
+  it("closes an open entry at a heading with leading spaces (CommonMark §4.2)", () => {
+    const lines = [
+      "## Section",
+      "- **2026-01-10**: Entry before the sub-heading.",
+      "  ### Sub-topic",
+      "- **2026-01-20**: Entry after the sub-heading.",
+    ]
+    expect(parseMemoryEntries(lines)).toEqual([
+      {
+        section: "Section",
+        date: "2026-01-10",
+        text: "- **2026-01-10**: Entry before the sub-heading.",
+        entryIndex: 0,
+      },
+      {
+        section: "Section",
+        date: "2026-01-20",
+        text: "- **2026-01-20**: Entry after the sub-heading.",
+        entryIndex: 1,
+      },
+    ])
+  })
+
+  it("closes an open entry at a heading with a tab separator (CommonMark §4.2)", () => {
+    const lines = [
+      "## Section",
+      "- **2026-01-10**: Entry before the sub-heading.",
+      "###\tSub-topic",
+      "- **2026-01-20**: Entry after the sub-heading.",
+    ]
+    expect(parseMemoryEntries(lines)).toEqual([
+      {
+        section: "Section",
+        date: "2026-01-10",
+        text: "- **2026-01-10**: Entry before the sub-heading.",
+        entryIndex: 0,
+      },
+      {
+        section: "Section",
+        date: "2026-01-20",
+        text: "- **2026-01-20**: Entry after the sub-heading.",
+        entryIndex: 1,
+      },
+    ])
+  })
+
   it("does not treat an undated or malformed bullet as an entry start", () => {
     const lines = [
       "## Section",

--- a/src/vault-mcp/obsidian-markdown/__tests__/plaintext.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/plaintext.test.ts
@@ -34,6 +34,16 @@ describe("stripMarkdownSyntax", () => {
       expected: "Section Title\nSubsection",
     },
     {
+      name: "heading markers with leading spaces stripped (CommonMark §4.2)",
+      input: " ## Spaced\n   ### Deep",
+      expected: "Spaced\nDeep",
+    },
+    {
+      name: "heading with 4+ leading spaces is not stripped (indented code block)",
+      input: "    ## Not a heading",
+      expected: "    ## Not a heading",
+    },
+    {
       name: "bold markers stripped",
       input: "This is **bold text** here",
       expected: "This is bold text here",

--- a/src/vault-mcp/obsidian-markdown/callouts.ts
+++ b/src/vault-mcp/obsidian-markdown/callouts.ts
@@ -38,8 +38,9 @@ const CALLOUT_OPENER_REGEX = /^>\s*\[!([A-Za-z][\w-]*)\]([+-]?)\s*(.*)$/
  *  blank line has no `>` and so does not match — it ends the callout body. */
 const CALLOUT_BODY_REGEX = /^>\s?(.*)$/
 
-/** Matches an H1 heading line (`# Title`). Only one leading H1 is skipped. */
-const H1_REGEX = /^# .+$/
+/** Matches an H1 heading line per CommonMark §4.2: 0-3 leading spaces,
+ *  one `#`, space-or-tab, then text. Only one leading H1 is skipped. */
+const H1_REGEX = /^ {0,3}#[ \t].+$/
 
 /**
  * Returns the index of the first body line — the first line that is neither

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -159,7 +159,7 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
       const match = HEADING_REGEX.exec(line)
       const matchedHashes = match?.[1]
       const matchedText = match?.[2]
-      if (matchedHashes !== undefined && matchedText !== undefined) {
+      if (matchedHashes && matchedText) {
         return {
           headings: [
             ...state.headings,

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -24,8 +24,9 @@ export type HeadingInfo = Readonly<{
 
 // ── Internal helpers ────────────────────────────────────────────
 
-/** Matches markdown headings H1–H6: captures the `#` prefix and heading text. */
-const HEADING_REGEX = /^(#{1,6}) (.+)$/
+/** Matches ATX headings H1–H6 per CommonMark §4.2: 0-3 leading spaces,
+ *  1-6 `#` characters, a space or tab separator, then heading text. */
+const HEADING_REGEX = /^ {0,3}(#{1,6})[ \t](.+)$/
 
 /**
  * Finds the line index where a trailing Obsidian comment block begins, so the

--- a/src/vault-mcp/obsidian-markdown/memory-entries.ts
+++ b/src/vault-mcp/obsidian-markdown/memory-entries.ts
@@ -143,7 +143,7 @@ export const parseMemoryEntries = (lines: readonly string[]): MemoryEntry[] => {
 
       const entryStartMatch = ENTRY_START_PATTERN.exec(line)
       const entryDate = entryStartMatch?.[1]
-      if (entryDate !== undefined) {
+      if (entryDate) {
         if (openEntry !== null) {
           entries.push(closeEntry(openEntry, span.text, entries.length))
         }

--- a/src/vault-mcp/obsidian-markdown/memory-entries.ts
+++ b/src/vault-mcp/obsidian-markdown/memory-entries.ts
@@ -46,11 +46,12 @@ export type MemoryEntry = Readonly<{
  *  ENTRY_PATTERN, with a capture group added. */
 const ENTRY_START_PATTERN = /^- \*\*(\d{4}-\d{2}-\d{2})\*\*:/
 
-/** Matches any ATX heading line (H1–H6). Inside an H2 span this can only be a
+/** Matches any ATX heading line (H1–H6) per CommonMark §4.2: 0-3 leading
+ *  spaces, hashes, space-or-tab separator. Inside an H2 span this can only be a
  *  deeper heading (H3+) — parseHeadings ends the span at the next H1/H2 — and
  *  a sub-heading starts new content, so it closes the open entry rather than
  *  being absorbed as continuation text. */
-const HEADING_LINE_PATTERN = /^#{1,6} /
+const HEADING_LINE_PATTERN = /^ {0,3}#{1,6}[ \t]/
 
 // ── Parser ──────────────────────────────────────────────────────
 

--- a/src/vault-mcp/obsidian-markdown/plaintext.ts
+++ b/src/vault-mcp/obsidian-markdown/plaintext.ts
@@ -16,7 +16,7 @@ export const stripMarkdownSyntax = (text: string): string =>
     // Obsidian comments: %% ... %% (single-line and multi-line)
     .replace(/%%[^]*?%%/g, "")
     // Heading markers: ## → removed (keep the text; 0-3 leading spaces per §4.2)
-    .replace(/^ {0,3}#{1,6}\s+/gm, "")
+    .replace(/^ {0,3}#{1,6}[ \t]+/gm, "")
     // Bold/italic markers
     .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
     .replace(/_{1,3}([^_]+)_{1,3}/g, "$1")

--- a/src/vault-mcp/obsidian-markdown/plaintext.ts
+++ b/src/vault-mcp/obsidian-markdown/plaintext.ts
@@ -15,8 +15,8 @@ export const stripMarkdownSyntax = (text: string): string =>
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
     // Obsidian comments: %% ... %% (single-line and multi-line)
     .replace(/%%[^]*?%%/g, "")
-    // Heading markers: ## → removed (keep the text)
-    .replace(/^#{1,6}\s+/gm, "")
+    // Heading markers: ## → removed (keep the text; 0-3 leading spaces per §4.2)
+    .replace(/^ {0,3}#{1,6}\s+/gm, "")
     // Bold/italic markers
     .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
     .replace(/_{1,3}([^_]+)_{1,3}/g, "$1")


### PR DESCRIPTION
## Summary

- `HEADING_REGEX` was `/^(#{1,6}) (.+)$/` — a strict subset of what Obsidian renders as headings. Two valid ATX forms (per CommonMark §4.2) were silently treated as body text across all 8 consumers (outline, section reads, patch targeting, chunker, task attribution, memory sections, done-lane detection)
- Updated to `/^ {0,3}(#{1,6})[ \t](.+)$/` — accepting 0-3 leading spaces and tab separators
- Aligned three satellite regexes (`memory-entries.ts`, `plaintext.ts`, `callouts.ts`); `canvas.ts` already handles both via `.trim()` + `\s+`
- Setext heading support (the third parity gap) is deferred — requires a structural two-line parser change

## Test plan

- [ ] 6 new test cases: tab separator, 1-3 leading spaces, combined, 4-space negative
- [ ] Mutation check: reverting the regex causes 5/6 new tests to fail (4-space negative correctly passes either way)
- [ ] Full suite (2141 tests) passes
- [ ] Lint clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown heading recognition to align with CommonMark syntax, including headings with up to three leading spaces or tab separators.
  * Prevented indented code blocks from being misidentified as headings.
  * Improved parsing of leading callouts and memory entries following valid headings.
  * Improved plain-text conversion by correctly removing supported heading markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->