### PR TITLE
feat: recognize empty ATX headings (##, ## )

### DIFF
--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -73,7 +73,7 @@ Errors:
 
 Returns: Raw markdown string (default); JSON object of properties (properties_only); JSON outline object (outline); raw markdown of the section, heading line included (heading).
 
-Outline shape: { leading_callout?, leading_content?, headings } — headings is [{ level, text, bytes }]; leading_callout ({ type, title, body }) is the note's top-of-file callout; leading_content is the rest of the body text above the first heading, with the callout's own lines excluded so the two never repeat the same text. Either key is omitted when the note has none.`,
+Outline shape: { leading_callout?, leading_content?, headings } — headings is [{ level, text, bytes }]; leading_callout ({ type, title, body }) is the note's top-of-file callout; leading_content is the rest of the body text above the first heading, with the callout's own lines excluded so the two never repeat the same text. Either key is omitted when the note has none. Empty headings ("##" with no text) appear with text: "" — they act as section boundaries but cannot be targeted by the heading parameter; read the parent section (which includes child headings) or the full note, and edit via vault_replace_in_note.`,
       inputSchema: {
         path: z
           .string()
@@ -321,7 +321,7 @@ Heading-targeted ops keep the matched heading and write content verbatim — don
 
 Limitation: A no-heading prepend inserts at body line 0. If the note has content above its first heading and your content starts with a heading, that content becomes the new section's body. The write still succeeds and the confirmation says so — use insert_before on the first heading to place a section above it instead.
 
-Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section.
+Section boundaries: a section spans from its heading to the next heading of the same or higher level (or EOF). Child headings are included in the parent section. Empty headings ("##" with no text) act as boundaries but cannot be targeted — edit their content via vault_replace_in_note instead.
 
 Editing a leading callout: read it via vault_read_note(outline: true), then vault_replace_in_note the old block for the new one (a no-heading prepend would stack a second callout above it).
 

--- a/src/vault-mcp/obsidian-markdown/__tests__/callouts.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/callouts.test.ts
@@ -59,6 +59,15 @@ describe("parseLeadingCallout", () => {
     expect(parseLeadingCallout(lines)).toBeNull()
   })
 
+  it("skips an empty H1 (no separator or text)", () => {
+    const lines = ["#", "> [!info] Scope", "> body", "", "## Section"]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Scope",
+      body: "body",
+    })
+  })
+
   it("returns null when there is no callout", () => {
     const lines = ["# Title", "", "Just prose, no callout.", "", "## Section"]
     expect(parseLeadingCallout(lines)).toBeNull()

--- a/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
@@ -151,6 +151,36 @@ describe("parseHeadings", () => {
     expect(parseHeadings(["    ## Title"])).toEqual([])
   })
 
+  it("parses an empty heading (hashes only, no separator or text)", () => {
+    const headings = parseHeadings(["##"])
+    expect(headings).toEqual([
+      {
+        text: "",
+        level: 2,
+        startLine: 0,
+        bodyStartLine: 1,
+        bodyEndLine: 1,
+      },
+    ])
+  })
+
+  it("parses an empty heading with trailing space (separator but no text)", () => {
+    const headings = parseHeadings(["## "])
+    expect(headings).toEqual([
+      {
+        text: "",
+        level: 2,
+        startLine: 0,
+        bodyStartLine: 1,
+        bodyEndLine: 1,
+      },
+    ])
+  })
+
+  it("does not parse hashes followed by text without a separator", () => {
+    expect(parseHeadings(["##NoSpace"])).toEqual([])
+  })
+
   it("strips trailing closing hashes from heading text", () => {
     const headings = parseHeadings(["## Title ##"])
     const headingTexts = headings.map((heading) => heading.text)
@@ -316,9 +346,13 @@ describe("linesBeforeFirstHeading", () => {
     expect(regionOf(["intro", "##\tSection"])).toEqual(["intro"])
   })
 
+  it("stops at an empty heading (no separator or text)", () => {
+    expect(regionOf(["intro", "##"])).toEqual(["intro"])
+  })
+
   it("finds no heading boundary in raw CRLF lines", () => {
     // Documents the contract: callers normalize with splitIntoLines first.
-    // HEADING_REGEX ends in `(.+)$` and `.` excludes CR, so "## S\r" is not a
+    // HEADING_REGEX uses `(.*)` where `.` excludes CR, so "## S\r" is not a
     // heading and the whole body reads as leading content.
     const lines = "intro\r\n## S\r\n".split("\n")
     expect(regionOf(lines)).toEqual(["intro\r", "## S\r", ""])

--- a/src/vault-mcp/obsidian-markdown/__tests__/memory-entries.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/memory-entries.test.ts
@@ -297,6 +297,29 @@ describe("parseMemoryEntries", () => {
     ])
   })
 
+  it("closes an open entry at an empty heading (no separator or text)", () => {
+    const lines = [
+      "## Section",
+      "- **2026-01-10**: Entry before the empty heading.",
+      "###",
+      "- **2026-01-20**: Entry after the empty heading.",
+    ]
+    expect(parseMemoryEntries(lines)).toEqual([
+      {
+        section: "Section",
+        date: "2026-01-10",
+        text: "- **2026-01-10**: Entry before the empty heading.",
+        entryIndex: 0,
+      },
+      {
+        section: "Section",
+        date: "2026-01-20",
+        text: "- **2026-01-20**: Entry after the empty heading.",
+        entryIndex: 1,
+      },
+    ])
+  })
+
   it("does not treat an undated or malformed bullet as an entry start", () => {
     const lines = [
       "## Section",

--- a/src/vault-mcp/obsidian-markdown/__tests__/plaintext.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/plaintext.test.ts
@@ -44,6 +44,11 @@ describe("stripMarkdownSyntax", () => {
       expected: "    ## Not a heading",
     },
     {
+      name: "heading with tab separator stripped (CommonMark §4.2)",
+      input: "##\tSection Title",
+      expected: "Section Title",
+    },
+    {
       name: "empty heading markers stripped (hashes only, no text)",
       input: "##\nSome content",
       expected: "\nSome content",

--- a/src/vault-mcp/obsidian-markdown/__tests__/plaintext.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/plaintext.test.ts
@@ -44,6 +44,11 @@ describe("stripMarkdownSyntax", () => {
       expected: "    ## Not a heading",
     },
     {
+      name: "empty heading markers stripped (hashes only, no text)",
+      input: "##\nSome content",
+      expected: "\nSome content",
+    },
+    {
       name: "bold markers stripped",
       input: "This is **bold text** here",
       expected: "This is bold text here",

--- a/src/vault-mcp/obsidian-markdown/callouts.ts
+++ b/src/vault-mcp/obsidian-markdown/callouts.ts
@@ -39,8 +39,9 @@ const CALLOUT_OPENER_REGEX = /^>\s*\[!([A-Za-z][\w-]*)\]([+-]?)\s*(.*)$/
 const CALLOUT_BODY_REGEX = /^>\s?(.*)$/
 
 /** Matches an H1 heading line per CommonMark §4.2: 0-3 leading spaces,
- *  one `#`, space-or-tab, then text. Only one leading H1 is skipped. */
-const H1_REGEX = /^ {0,3}#[ \t].+$/
+ *  one `#`, then optionally a space/tab separator and text. Empty H1
+ *  (`#` alone on a line) is valid. Only one leading H1 is skipped. */
+const H1_REGEX = /^ {0,3}#(?:[ \t].*)?$/
 
 /**
  * Returns the index of the first body line — the first line that is neither

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -25,8 +25,9 @@ export type HeadingInfo = Readonly<{
 // ── Internal helpers ────────────────────────────────────────────
 
 /** Matches ATX headings H1–H6 per CommonMark §4.2: 0-3 leading spaces,
- *  1-6 `#` characters, a space or tab separator, then heading text. */
-const HEADING_REGEX = /^ {0,3}(#{1,6})[ \t](.+)$/
+ *  1-6 `#` characters, then optionally a space/tab separator and heading text.
+ *  Empty headings (`##` alone on a line) are valid — group 2 is undefined. */
+const HEADING_REGEX = /^ {0,3}(#{1,6})(?:[ \t](.*))?$/
 
 /**
  * Finds the line index where a trailing Obsidian comment block begins, so the
@@ -158,8 +159,8 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
 
       const match = HEADING_REGEX.exec(line)
       const matchedHashes = match?.[1]
-      const matchedText = match?.[2]
-      if (matchedHashes && matchedText) {
+      const matchedText = match?.[2] ?? ""
+      if (matchedHashes) {
         return {
           headings: [
             ...state.headings,

--- a/src/vault-mcp/obsidian-markdown/memory-entries.ts
+++ b/src/vault-mcp/obsidian-markdown/memory-entries.ts
@@ -47,11 +47,12 @@ export type MemoryEntry = Readonly<{
 const ENTRY_START_PATTERN = /^- \*\*(\d{4}-\d{2}-\d{2})\*\*:/
 
 /** Matches any ATX heading line (H1–H6) per CommonMark §4.2: 0-3 leading
- *  spaces, hashes, space-or-tab separator. Inside an H2 span this can only be a
- *  deeper heading (H3+) — parseHeadings ends the span at the next H1/H2 — and
- *  a sub-heading starts new content, so it closes the open entry rather than
- *  being absorbed as continuation text. */
-const HEADING_LINE_PATTERN = /^ {0,3}#{1,6}[ \t]/
+ *  spaces, hashes, then a space/tab separator or end of line (empty headings
+ *  are valid). Inside an H2 span this can only be a deeper heading (H3+) —
+ *  parseHeadings ends the span at the next H1/H2 — and a sub-heading starts
+ *  new content, so it closes the open entry rather than being absorbed as
+ *  continuation text. */
+const HEADING_LINE_PATTERN = /^ {0,3}#{1,6}(?:[ \t]|$)/
 
 // ── Parser ──────────────────────────────────────────────────────
 

--- a/src/vault-mcp/obsidian-markdown/plaintext.ts
+++ b/src/vault-mcp/obsidian-markdown/plaintext.ts
@@ -15,8 +15,9 @@ export const stripMarkdownSyntax = (text: string): string =>
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
     // Obsidian comments: %% ... %% (single-line and multi-line)
     .replace(/%%[^]*?%%/g, "")
-    // Heading markers: ## → removed (keep the text; 0-3 leading spaces per §4.2)
-    .replace(/^ {0,3}#{1,6}[ \t]+/gm, "")
+    // Heading markers: ## → removed (keep the text; 0-3 leading spaces per §4.2,
+    // empty headings match via the end-of-line alternative)
+    .replace(/^ {0,3}#{1,6}(?:[ \t]+|$)/gm, "")
     // Bold/italic markers
     .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
     .replace(/_{1,3}([^_]+)_{1,3}/g, "$1")

--- a/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
@@ -998,8 +998,8 @@ describe("patchNote — leading-content advisory", () => {
   })
 
   it("detects a CRLF-authored heading in the prepended content", async () => {
-    // HEADING_REGEX's `(.+)$` excludes CR, so without normalization a
-    // CRLF-authored heading would read as ordinary text and report nothing.
+    // HEADING_REGEX uses `(.*)` where `.` excludes CR, so without
+    // normalization a CRLF-authored heading would read as ordinary text.
     await writeTestNote("intro.md", NOTE_WITH_INTRO)
 
     const result = await patchNote(
@@ -1018,11 +1018,29 @@ describe("patchNote — leading-content advisory", () => {
     })
   })
 
+  it("reports displacement when an empty heading is prepended above leading content", async () => {
+    await writeTestNote("intro.md", NOTE_WITH_INTRO)
+
+    const result = await patchNote(
+      {
+        vaultPath: vault,
+        path: "intro.md",
+        operation: "prepend",
+        content: "#####",
+      },
+      logger,
+    )
+
+    expect(result.displacedLeadingContent).toEqual({
+      bytes: Buffer.byteLength("Intro prose.", "utf8"),
+      firstHeading: { text: "Section", level: 2 },
+    })
+  })
+
   it.each([
     ["a tag line", "#project note"],
     ["a bare tag", "#project"],
     ["seven hashes", "####### Seven"],
-    ["hashes with no text", "#####"],
     ["a fenced heading", "```md\n## Example\n```"],
     ["a callout", "> [!note] Hi"],
     ["plain prose", "Just a line."],

--- a/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
@@ -1035,6 +1035,9 @@ describe("patchNote — leading-content advisory", () => {
       bytes: Buffer.byteLength("Intro prose.", "utf8"),
       firstHeading: { text: "Section", level: 2 },
     })
+    expect(await readTestNote("intro.md")).toBe(
+      "#####\nIntro prose.\n\n## Section\n\nbody\n",
+    )
   })
 
   it.each([

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -54,10 +54,10 @@ export type PatchNoteResult = Readonly<{
  *  line — or null when it starts with anything else. parseHeadings makes this
  *  fence-aware, so a `## foo` inside an opening code fence is not a heading.
  *
- *  Strips a trailing CR before parsing: HEADING_REGEX ends in `(.+)$` and `.`
- *  excludes CR, so a CRLF-authored `## New\r` would otherwise match nothing and
- *  silently read as ordinary text. Detection only — callers insert the caller's
- *  own lines verbatim, line endings untouched. */
+ *  Strips a trailing CR before parsing: HEADING_REGEX uses `(.*)` where `.`
+ *  excludes CR, so a CRLF-authored `## New\r` would otherwise read as ordinary
+ *  text and report nothing. Detection only — callers insert the caller's own
+ *  lines verbatim, line endings untouched. */
 const leadingHeadingOfContent = (
   contentLines: readonly string[],
 ): HeadingInfo | null => {


### PR DESCRIPTION
## Summary

- Accept empty ATX headings (`##` alone on a line, `## ` with trailing space) — valid CommonMark §4.2 and rendered by Obsidian
- `HEADING_REGEX` separator+text group made optional (`.+` → `(.*)?`); `H1_REGEX`, `HEADING_LINE_PATTERN`, and plaintext stripper aligned
- `parseHeadings` guard changed from `if (matchedHashes && matchedText)` to `if (matchedHashes)`, defaulting text to `""`
- Empty headings appear in outlines with `text: ""` — act as section boundaries but cannot be targeted by the `heading` parameter. Tool descriptions document this with remediation (read parent section or full note, edit via `vault_replace_in_note`)
- Patcher test corrected: `#####` is now a valid empty H5, moved from the no-advisory list to a positive displacement test with write-content assertion

Builds on #378 (tab separators + leading spaces), which is merged.

## Test plan

- [x] Empty heading parsed (`##` → text: "", level: 2)
- [x] Empty heading with trailing space (`## ` → text: "")
- [x] Hashes without separator rejected (`##NoSpace` → not a heading)
- [x] `linesBeforeFirstHeading` stops at empty heading
- [x] Leading callout parser skips empty H1
- [x] Memory entry parser closes at empty heading boundary
- [x] Plaintext stripper removes empty heading markers
- [x] Patcher displacement advisory fires for empty heading prepend (+ write assertion)
- [x] CRLF behavior preserved (`.` excludes CR)
- [x] Live verification on deployed instance — outline, section reads, boundary behavior
- [x] Full suite: 2156 tests pass, 0 lint errors, clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)