### PR TITLE
feat: recognize setext headings per CommonMark §4.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ src/
       lines.ts                         # splitIntoLines (CRLF) + fence state machine + classifyLines
       frontmatter.ts                   # gray-matter parse/stringify + frontmatter merge
       callouts.ts                      # Leading-callout parser (> [!type] blocks)
-      headings.ts                      # Shared H1–H6 section-span parser (read + patch)
+      headings.ts                      # Shared H1–H6 section-span parser — ATX + setext (read + patch)
       links.ts                         # Link grammar: parse, extract, resolve (wikilinks + md; notes + assets)
       tasks.ts                         # Tasks-plugin task-line grammar + mutation (emoji + Dataview fields)
       memory-entries.ts                # Memory-entry grammar (dated bullets in About Me/ files)

--- a/src/vault-mcp/obsidian-markdown/__tests__/callouts.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/callouts.test.ts
@@ -91,6 +91,30 @@ describe("parseLeadingCallout", () => {
     expect(parseLeadingCallout(lines)).toBeNull()
   })
 
+  it("skips a setext H1 before a callout", () => {
+    const lines = ["Title", "===", "> [!info] Scope", "> body"]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Scope",
+      body: "body",
+    })
+  })
+
+  it("does not skip a setext H2 before a callout", () => {
+    // Only H1 is skipped; a setext H2 (---) is body content.
+    const lines = ["Title", "---", "> [!info] Not leading", "> body"]
+    expect(parseLeadingCallout(lines)).toBeNull()
+  })
+
+  it("skips a setext H1 with leading spaces on the underline", () => {
+    const lines = ["Title", "  ===", "> [!info] Scope", "> body"]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Scope",
+      body: "body",
+    })
+  })
+
   it("collects only the first of two stacked callouts", () => {
     const lines = [
       "> [!info] First",

--- a/src/vault-mcp/obsidian-markdown/__tests__/callouts.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/callouts.test.ts
@@ -115,6 +115,20 @@ describe("parseLeadingCallout", () => {
     })
   })
 
+  it("does not swallow a callout opener followed by === as setext H1", () => {
+    const lines = ["> [!info] Scope", "===", "> body"]
+    expect(parseLeadingCallout(lines)).toEqual({
+      type: "info",
+      title: "Scope",
+      body: "",
+    })
+  })
+
+  it("does not swallow a list item followed by === as setext H1", () => {
+    const lines = ["- item", "===", "> [!info] Scope", "> body"]
+    expect(parseLeadingCallout(lines)).toBeNull()
+  })
+
   it("collects only the first of two stacked callouts", () => {
     const lines = [
       "> [!info] First",

--- a/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
@@ -310,14 +310,39 @@ describe("parseHeadings", () => {
 
   it("parses setext underlines with trailing whitespace", () => {
     const headings = parseHeadings(["Title", "=== \t "])
-    expect(headings[0]?.level).toBe(1)
+    expect(headings).toEqual([
+      {
+        text: "Title",
+        level: 1,
+        startLine: 0,
+        bodyStartLine: 2,
+        bodyEndLine: 2,
+      },
+    ])
   })
 
-  it("parses a single-character setext underline", () => {
-    const headingsH1 = parseHeadings(["Title", "="])
-    expect(headingsH1[0]?.level).toBe(1)
-    const headingsH2 = parseHeadings(["Title", "-"])
-    expect(headingsH2[0]?.level).toBe(2)
+  it("parses a single-character = underline as H1", () => {
+    expect(parseHeadings(["Title", "="])).toEqual([
+      {
+        text: "Title",
+        level: 1,
+        startLine: 0,
+        bodyStartLine: 2,
+        bodyEndLine: 2,
+      },
+    ])
+  })
+
+  it("parses a single-character - underline as H2", () => {
+    expect(parseHeadings(["Title", "-"])).toEqual([
+      {
+        text: "Title",
+        level: 2,
+        startLine: 0,
+        bodyStartLine: 2,
+        bodyEndLine: 2,
+      },
+    ])
   })
 
   it("does not parse --- after a blank line as setext (thematic break)", () => {
@@ -408,8 +433,15 @@ describe("parseHeadings", () => {
   })
 
   it("trims whitespace from setext heading text", () => {
-    const headings = parseHeadings(["  Padded Title  ", "==="])
-    expect(headings[0]?.text).toBe("Padded Title")
+    expect(parseHeadings(["  Padded Title  ", "==="])).toEqual([
+      {
+        text: "Padded Title",
+        level: 1,
+        startLine: 0,
+        bodyStartLine: 2,
+        bodyEndLine: 2,
+      },
+    ])
   })
 
   it("spans a setext heading body to the next same-or-higher heading", () => {
@@ -421,21 +453,22 @@ describe("parseHeadings", () => {
       "---", // 4
       "body b", // 5
     ]
-    const headings = parseHeadings(lines)
-    expect(headings[0]).toEqual({
-      text: "Section A",
-      level: 1,
-      startLine: 0,
-      bodyStartLine: 2,
-      bodyEndLine: 6,
-    })
-    expect(headings[1]).toEqual({
-      text: "Section B",
-      level: 2,
-      startLine: 3,
-      bodyStartLine: 5,
-      bodyEndLine: 6,
-    })
+    expect(parseHeadings(lines)).toEqual([
+      {
+        text: "Section A",
+        level: 1,
+        startLine: 0,
+        bodyStartLine: 2,
+        bodyEndLine: 6,
+      },
+      {
+        text: "Section B",
+        level: 2,
+        startLine: 3,
+        bodyStartLine: 5,
+        bodyEndLine: 6,
+      },
+    ])
   })
 })
 
@@ -571,8 +604,12 @@ describe("findHeading", () => {
 
   it("resolves a setext heading by text and level", () => {
     const mixedHeadings = parseHeadings(["# ATX", "Setext Title", "---"])
-    const found = findHeading(mixedHeadings, "Setext Title")
-    expect(found.level).toBe(2)
-    expect(found.startLine).toBe(1)
+    expect(findHeading(mixedHeadings, "Setext Title")).toEqual({
+      text: "Setext Title",
+      level: 2,
+      startLine: 1,
+      bodyStartLine: 3,
+      bodyEndLine: 3,
+    })
   })
 })

--- a/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/headings.test.ts
@@ -269,6 +269,174 @@ describe("parseHeadings", () => {
       "Real",
     ])
   })
+
+  // ── setext heading support (CommonMark §4.3) ─────────────────
+
+  it("parses a setext H1 heading (=== underline)", () => {
+    const headings = parseHeadings(["Title", "==="])
+    expect(headings).toEqual([
+      {
+        text: "Title",
+        level: 1,
+        startLine: 0,
+        bodyStartLine: 2,
+        bodyEndLine: 2,
+      },
+    ])
+  })
+
+  it("parses a setext H2 heading (--- underline)", () => {
+    const headings = parseHeadings(["Title", "---"])
+    expect(headings).toEqual([
+      {
+        text: "Title",
+        level: 2,
+        startLine: 0,
+        bodyStartLine: 2,
+        bodyEndLine: 2,
+      },
+    ])
+  })
+
+  it("parses setext underlines with 0-3 leading spaces", () => {
+    const headings = parseHeadings(["H1", " ===", "H2", "  ---"])
+    expect(
+      headings.map((heading) => ({ text: heading.text, level: heading.level })),
+    ).toEqual([
+      { text: "H1", level: 1 },
+      { text: "H2", level: 2 },
+    ])
+  })
+
+  it("parses setext underlines with trailing whitespace", () => {
+    const headings = parseHeadings(["Title", "=== \t "])
+    expect(headings[0]?.level).toBe(1)
+  })
+
+  it("parses a single-character setext underline", () => {
+    const headingsH1 = parseHeadings(["Title", "="])
+    expect(headingsH1[0]?.level).toBe(1)
+    const headingsH2 = parseHeadings(["Title", "-"])
+    expect(headingsH2[0]?.level).toBe(2)
+  })
+
+  it("does not parse --- after a blank line as setext (thematic break)", () => {
+    expect(parseHeadings(["Text", "", "---"])).toEqual([])
+  })
+
+  it("does not parse --- as the first line as setext", () => {
+    expect(parseHeadings(["---", "body"])).toEqual([])
+  })
+
+  it("does not parse a setext underline with 4+ leading spaces", () => {
+    expect(parseHeadings(["Title", "    ==="])).toEqual([])
+  })
+
+  it("ignores setext underlines inside a fenced code block", () => {
+    const lines = ["```", "Title", "===", "```", "## Real"]
+    expect(parseHeadings(lines).map((heading) => heading.text)).toEqual([
+      "Real",
+    ])
+  })
+
+  it("ignores setext underlines inside a comment block", () => {
+    const lines = ["%%", "Title", "===", "%%", "## Real"]
+    expect(parseHeadings(lines).map((heading) => heading.text)).toEqual([
+      "Real",
+    ])
+  })
+
+  it("parses adjacent setext headings", () => {
+    // H2 is a child of H1, so H1's body spans to EOF (includes the H2).
+    const headings = parseHeadings(["H1 Title", "===", "H2 Title", "---"])
+    expect(headings).toEqual([
+      {
+        text: "H1 Title",
+        level: 1,
+        startLine: 0,
+        bodyStartLine: 2,
+        bodyEndLine: 4,
+      },
+      {
+        text: "H2 Title",
+        level: 2,
+        startLine: 2,
+        bodyStartLine: 4,
+        bodyEndLine: 4,
+      },
+    ])
+  })
+
+  it("parses mixed ATX and setext headings with correct spans", () => {
+    const lines = [
+      "# ATX H1", // 0
+      "body", // 1
+      "Setext H2", // 2
+      "---", // 3
+      "more body", // 4
+    ]
+    const headings = parseHeadings(lines)
+    expect(headings).toEqual([
+      {
+        text: "ATX H1",
+        level: 1,
+        startLine: 0,
+        bodyStartLine: 1,
+        bodyEndLine: 5,
+      },
+      {
+        text: "Setext H2",
+        level: 2,
+        startLine: 2,
+        bodyStartLine: 4,
+        bodyEndLine: 5,
+      },
+    ])
+  })
+
+  it("does not parse ATX heading followed by === as setext", () => {
+    const headings = parseHeadings(["## ATX Title", "==="])
+    expect(headings).toEqual([
+      {
+        text: "ATX Title",
+        level: 2,
+        startLine: 0,
+        bodyStartLine: 1,
+        bodyEndLine: 2,
+      },
+    ])
+  })
+
+  it("trims whitespace from setext heading text", () => {
+    const headings = parseHeadings(["  Padded Title  ", "==="])
+    expect(headings[0]?.text).toBe("Padded Title")
+  })
+
+  it("spans a setext heading body to the next same-or-higher heading", () => {
+    const lines = [
+      "Section A", // 0
+      "===", // 1
+      "body a", // 2
+      "Section B", // 3
+      "---", // 4
+      "body b", // 5
+    ]
+    const headings = parseHeadings(lines)
+    expect(headings[0]).toEqual({
+      text: "Section A",
+      level: 1,
+      startLine: 0,
+      bodyStartLine: 2,
+      bodyEndLine: 6,
+    })
+    expect(headings[1]).toEqual({
+      text: "Section B",
+      level: 2,
+      startLine: 3,
+      bodyStartLine: 5,
+      bodyEndLine: 6,
+    })
+  })
 })
 
 describe("linesBeforeFirstHeading", () => {
@@ -350,6 +518,14 @@ describe("linesBeforeFirstHeading", () => {
     expect(regionOf(["intro", "##"])).toEqual(["intro"])
   })
 
+  it("stops at a setext heading", () => {
+    expect(regionOf(["intro", "Section", "===", "body"])).toEqual(["intro"])
+  })
+
+  it("returns nothing when the first line is a setext heading's text line", () => {
+    expect(regionOf(["Title", "===", "body"])).toEqual([])
+  })
+
   it("finds no heading boundary in raw CRLF lines", () => {
     // Documents the contract: callers normalize with splitIntoLines first.
     // HEADING_REGEX uses `(.*)` where `.` excludes CR, so "## S\r" is not a
@@ -391,5 +567,12 @@ describe("findHeading", () => {
     expect(() => findHeading(headings, "   ")).toThrow(
       "heading cannot be empty",
     )
+  })
+
+  it("resolves a setext heading by text and level", () => {
+    const mixedHeadings = parseHeadings(["# ATX", "Setext Title", "---"])
+    const found = findHeading(mixedHeadings, "Setext Title")
+    expect(found.level).toBe(2)
+    expect(found.startLine).toBe(1)
   })
 })

--- a/src/vault-mcp/obsidian-markdown/__tests__/plaintext.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/plaintext.test.ts
@@ -54,6 +54,26 @@ describe("stripMarkdownSyntax", () => {
       expected: "\nSome content",
     },
     {
+      name: "setext H1 underline stripped (===)",
+      input: "Title\n===\nBody",
+      expected: "Title\n\nBody",
+    },
+    {
+      name: "setext H2 underline stripped (---)",
+      input: "Title\n---\nBody",
+      expected: "Title\n\nBody",
+    },
+    {
+      name: "setext underline with leading spaces stripped",
+      input: "Title\n  ===\nBody",
+      expected: "Title\n\nBody",
+    },
+    {
+      name: "setext underline with 4+ leading spaces not stripped",
+      input: "Title\n    ===\nBody",
+      expected: "Title\n    ===\nBody",
+    },
+    {
       name: "bold markers stripped",
       input: "This is **bold text** here",
       expected: "This is bold text here",

--- a/src/vault-mcp/obsidian-markdown/callouts.ts
+++ b/src/vault-mcp/obsidian-markdown/callouts.ts
@@ -38,10 +38,15 @@ const CALLOUT_OPENER_REGEX = /^>\s*\[!([A-Za-z][\w-]*)\]([+-]?)\s*(.*)$/
  *  blank line has no `>` and so does not match — it ends the callout body. */
 const CALLOUT_BODY_REGEX = /^>\s?(.*)$/
 
-/** Matches an H1 heading line per CommonMark §4.2: 0-3 leading spaces,
+/** Matches an ATX H1 heading line per CommonMark §4.2: 0-3 leading spaces,
  *  one `#`, then optionally a space/tab separator and text. Empty H1
  *  (`#` alone on a line) is valid. Only one leading H1 is skipped. */
 const H1_REGEX = /^ {0,3}#(?:[ \t].*)?$/
+
+/** Matches a setext H1 underline: 0-3 leading spaces, one or more `=`,
+ *  optional trailing whitespace. Only `=` (H1), not `-` (H2) — the
+ *  function skips exactly one H1 title, and only H1 is relevant here. */
+const SETEXT_H1_UNDERLINE_REGEX = /^ {0,3}=+[ \t]*$/
 
 /**
  * Returns the index of the first body line — the first line that is neither
@@ -61,6 +66,12 @@ const firstBodyLineIndex = (
   if (line.trim() === "") return firstBodyLineIndex(lines, index + 1, skippedH1)
   if (!skippedH1 && H1_REGEX.test(line))
     return firstBodyLineIndex(lines, index + 1, true)
+  // Setext H1: current non-blank line is content, next line is a `===` underline.
+  if (!skippedH1) {
+    const nextLine = index + 1 < lines.length ? lines[index + 1] : undefined
+    if (nextLine !== undefined && SETEXT_H1_UNDERLINE_REGEX.test(nextLine))
+      return firstBodyLineIndex(lines, index + 2, true)
+  }
   return index
 }
 

--- a/src/vault-mcp/obsidian-markdown/callouts.ts
+++ b/src/vault-mcp/obsidian-markdown/callouts.ts
@@ -48,6 +48,11 @@ const H1_REGEX = /^ {0,3}#(?:[ \t].*)?$/
  *  function skips exactly one H1 title, and only H1 is relevant here. */
 const SETEXT_H1_UNDERLINE_REGEX = /^ {0,3}=+[ \t]*$/
 
+/** Matches block-level line openers (list items, blockquotes) that can't be
+ *  setext heading content per CommonMark §4.3. Used to prevent a callout
+ *  opener or list item followed by `===` from being swallowed as a heading. */
+const BLOCK_LEVEL_LINE_REGEX = /^[-*+] |^\d+[.)] |^>/
+
 /**
  * Returns the index of the first body line — the first line that is neither
  * blank nor the note's single leading H1 title. Returns lines.length when no
@@ -67,7 +72,8 @@ const firstBodyLineIndex = (
   if (!skippedH1 && H1_REGEX.test(line))
     return firstBodyLineIndex(lines, index + 1, true)
   // Setext H1: current non-blank line is content, next line is a `===` underline.
-  if (!skippedH1) {
+  // Block-level lines are excluded — they can't be heading content.
+  if (!skippedH1 && !BLOCK_LEVEL_LINE_REGEX.test(line.trimStart())) {
     const nextLine = index + 1 < lines.length ? lines[index + 1] : undefined
     if (nextLine !== undefined && SETEXT_H1_UNDERLINE_REGEX.test(nextLine))
       return firstBodyLineIndex(lines, index + 2, true)

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -207,10 +207,13 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
     }
 
     // Track setext candidate: non-blank content → candidate; blank → reset.
+    // Block-level lines (list items, blockquotes) can't be setext heading
+    // content per CommonMark §4.3 — only paragraph text qualifies.
     if (line.trim() === "") {
       setextCandidate = null
     } else {
-      setextCandidate = { text: line, index: i }
+      const isBlockLevelLine = /^[-*+] |^\d+[.)] |^>/.test(line.trimStart())
+      setextCandidate = isBlockLevelLine ? null : { text: line, index: i }
     }
   }
 

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -1,4 +1,5 @@
-/** Markdown heading parser — shared section-span logic for read and write.
+/** Markdown heading parser (ATX + setext) — shared section-span logic for read
+ * and write.
  *
  * Both the read side (`vault_read_note` outline + section reads) and the write
  * side (`vault_patch_note`) target sections by heading, so they share one
@@ -28,6 +29,14 @@ export type HeadingInfo = Readonly<{
  *  1-6 `#` characters, then optionally a space/tab separator and heading text.
  *  Empty headings (`##` alone on a line) are valid — group 2 is undefined. */
 const HEADING_REGEX = /^ {0,3}(#{1,6})(?:[ \t](.*))?$/
+
+/** Matches setext heading underlines per CommonMark §4.3: 0-3 leading spaces,
+ *  one or more `=` (H1) or `-` (H2) characters, optional trailing whitespace.
+ *  A valid setext heading requires a non-blank text line immediately above.
+ *  Multi-line content before the underline is not supported — only the single
+ *  immediately preceding line becomes the heading text. This matches Obsidian,
+ *  which renders multi-line setext inconsistently (Edit mode ≠ Reading mode). */
+const SETEXT_UNDERLINE_REGEX = /^ {0,3}(=+|-+)[ \t]*$/
 
 /**
  * Finds the line index where a trailing Obsidian comment block begins, so the
@@ -119,86 +128,110 @@ export const findTrailingCommentBlockStart = (
 // ── Exported parser ─────────────────────────────────────────────
 
 /**
- * Single-pass heading parser for H1–H6 with code-block and comment awareness.
- * Section body = heading+1 through next heading of same-or-higher level (or EOF).
+ * Heading parser for H1–H6 with code-block and comment awareness. Recognizes
+ * both ATX (`## Title`) and setext (`Title` over `===`/`---`) headings.
+ * Section body = heading line(s)+1 through next same-or-higher heading (or EOF).
  */
 export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
   // Phase 1: collect headings, skipping content inside fenced code blocks and
-  // `%% %%` comment blocks. Fence and comment state are threaded through the
-  // accumulator (no mutable external state).
-  const { headings: collectedHeadings } = lines.reduce<{
-    headings: Array<{ text: string; level: number; startLine: number }>
-    openFence: OpenFence
-    commentOpen: boolean
-  }>(
-    (state, line, i) => {
-      // Fence/comment precedence: fence state advances only outside comments
-      // (inside a comment, fence delimiters are just text); comment toggles
-      // run only outside fences (inside a fence, `%%` is just text).
-      const fenceResult = state.commentOpen
-        ? null
-        : advanceFence(line, state.openFence)
-      // fenceResult is null when inside a comment (fence processing skipped);
-      // fenceResult.openFence is null when a fence just closed — both are valid
-      // states, so `??` can't distinguish them.
-      const openFence =
-        fenceResult !== null ? fenceResult.openFence : state.openFence
+  // `%% %%` comment blocks. Setext detection requires two-line awareness
+  // (text line + underline), so the parser uses a for-loop with mutable state
+  // rather than a reduce — a parser threading line-by-line state with lookahead.
+  const collectedHeadings: Array<{
+    text: string
+    level: number
+    startLine: number
+    bodyStartLine: number
+  }> = []
+  // `let` carries fence, comment, and setext-candidate state across lines —
+  // inherently sequential parser state that cannot be expressed as a fold.
+  let openFence: OpenFence = null
+  let commentOpen = false
+  // The previous non-blank, non-heading, non-fence/comment content line — a
+  // candidate for setext heading text if the current line is an underline.
+  let setextCandidate: { text: string; index: number } | null = null
 
-      if (fenceResult?.lineIsCode) {
-        return { headings: state.headings, openFence, commentOpen: false }
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (line === undefined) continue
+
+    // Fence/comment precedence: fence state advances only outside comments
+    // (inside a comment, fence delimiters are just text); comment toggles
+    // run only outside fences (inside a fence, `%%` is just text).
+    if (!commentOpen) {
+      const fenceResult = advanceFence(line, openFence)
+      openFence = fenceResult.openFence
+      if (fenceResult.lineIsCode) {
+        setextCandidate = null
+        continue
       }
+    }
 
-      const commentResult = advanceComment(line, state.commentOpen)
-      if (commentResult.lineIsComment) {
-        return {
-          headings: state.headings,
-          openFence,
-          commentOpen: commentResult.commentOpen,
-        }
+    const commentResult = advanceComment(line, commentOpen)
+    commentOpen = commentResult.commentOpen
+    if (commentResult.lineIsComment) {
+      setextCandidate = null
+      continue
+    }
+
+    const atxMatch = HEADING_REGEX.exec(line)
+    const matchedHashes = atxMatch?.[1]
+    if (matchedHashes) {
+      const matchedText = atxMatch?.[2] ?? ""
+      collectedHeadings.push({
+        // Strip trailing closing hashes (e.g. "## Title ##" → "Title")
+        text: matchedText.replace(/\s+#+\s*$/, "").trim(),
+        level: matchedHashes.length,
+        startLine: i,
+        bodyStartLine: i + 1,
+      })
+      setextCandidate = null
+      continue
+    }
+
+    // Setext underline check — a setext heading is a non-blank content line
+    // followed by a `===` (H1) or `---` (H2) underline (CommonMark §4.3).
+    if (setextCandidate !== null) {
+      const setextMatch = SETEXT_UNDERLINE_REGEX.exec(line)
+      const underlineChars = setextMatch?.[1]
+      if (underlineChars !== undefined) {
+        collectedHeadings.push({
+          text: setextCandidate.text.trim(),
+          level: underlineChars.startsWith("=") ? 1 : 2,
+          startLine: setextCandidate.index,
+          bodyStartLine: i + 1,
+        })
+        setextCandidate = null
+        continue
       }
+    }
 
-      const match = HEADING_REGEX.exec(line)
-      const matchedHashes = match?.[1]
-      const matchedText = match?.[2] ?? ""
-      if (matchedHashes) {
-        return {
-          headings: [
-            ...state.headings,
-            {
-              // Strip trailing closing hashes (e.g. "## Title ##" → "Title")
-              text: matchedText.replace(/\s+#+\s*$/, "").trim(),
-              level: matchedHashes.length,
-              startLine: i,
-            },
-          ],
-          openFence,
-          commentOpen: false,
-        }
-      }
-
-      return { headings: state.headings, openFence, commentOpen: false }
-    },
-    { headings: [], openFence: null, commentOpen: false },
-  )
+    // Track setext candidate: non-blank content → candidate; blank → reset.
+    if (line.trim() === "") {
+      setextCandidate = null
+    } else {
+      setextCandidate = { text: line, index: i }
+    }
+  }
 
   // Phase 2: compute body ranges — each section's body ends where the next
   // heading of the same or higher level starts. Sections with no such heading
   // run to EOF, but must stop before a trailing `%% %%` comment block (e.g. a
   // Kanban board's `%% kanban:settings %%`) so replace/append don't clobber it.
   const trailingCommentBlockStart = findTrailingCommentBlockStart(lines)
-  return collectedHeadings.map((heading, i) => {
+  return collectedHeadings.map((heading, idx) => {
     const nextSameOrHigher = collectedHeadings
-      .slice(i + 1)
+      .slice(idx + 1)
       .find((next) => next.level <= heading.level)
     return {
       text: heading.text,
       level: heading.level,
       startLine: heading.startLine,
-      bodyStartLine: heading.startLine + 1,
+      bodyStartLine: heading.bodyStartLine,
       // Math.max keeps bodyEndLine >= bodyStartLine for malformed input.
       bodyEndLine:
         nextSameOrHigher?.startLine ??
-        Math.max(heading.startLine + 1, trailingCommentBlockStart),
+        Math.max(heading.bodyStartLine, trailingCommentBlockStart),
     }
   })
 }

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -38,6 +38,10 @@ const HEADING_REGEX = /^ {0,3}(#{1,6})(?:[ \t](.*))?$/
  *  which renders multi-line setext inconsistently (Edit mode ≠ Reading mode). */
 const SETEXT_UNDERLINE_REGEX = /^ {0,3}(=+|-+)[ \t]*$/
 
+/** Matches block-level line openers (list items, blockquotes) that can't be
+ *  setext heading content per CommonMark §4.3 — only paragraph text qualifies. */
+const BLOCK_LEVEL_LINE_REGEX = /^[-*+] |^\d+[.)] |^>/
+
 /**
  * Finds the line index where a trailing Obsidian comment block begins, so the
  * final section's body can stop short of it. Returns `lines.length` when none
@@ -130,21 +134,20 @@ export const findTrailingCommentBlockStart = (
 /**
  * Heading parser for H1–H6 with code-block and comment awareness. Recognizes
  * both ATX (`## Title`) and setext (`Title` over `===`/`---`) headings.
+ * Skips content inside fenced code blocks and `%% %%` comment blocks.
  * Section body = heading line(s)+1 through next same-or-higher heading (or EOF).
  */
 export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
-  // Phase 1: collect headings, skipping content inside fenced code blocks and
-  // `%% %%` comment blocks. Setext detection requires two-line awareness
-  // (text line + underline), so the parser uses a for-loop with mutable state
-  // rather than a reduce — a parser threading line-by-line state with lookahead.
+  // Phase 1: collect headings. Setext detection needs two-line lookahead
+  // (text line + underline), so the parser uses a for-loop with mutable
+  // state rather than a reduce.
   const collectedHeadings: Array<{
     text: string
     level: number
     startLine: number
     bodyStartLine: number
   }> = []
-  // `let` carries fence, comment, and setext-candidate state across lines —
-  // inherently sequential parser state that cannot be expressed as a fold.
+  // `let` carries fence, comment, and setext-candidate state across lines.
   let openFence: OpenFence = null
   let commentOpen = false
   // The previous non-blank, non-heading, non-fence/comment content line — a
@@ -207,13 +210,12 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
     }
 
     // Track setext candidate: non-blank content → candidate; blank → reset.
-    // Block-level lines (list items, blockquotes) can't be setext heading
-    // content per CommonMark §4.3 — only paragraph text qualifies.
     if (line.trim() === "") {
       setextCandidate = null
     } else {
-      const isBlockLevelLine = /^[-*+] |^\d+[.)] |^>/.test(line.trimStart())
-      setextCandidate = isBlockLevelLine ? null : { text: line, index: i }
+      setextCandidate = BLOCK_LEVEL_LINE_REGEX.test(line.trimStart())
+        ? null
+        : { text: line, index: i }
     }
   }
 

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -194,7 +194,7 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
     if (setextCandidate !== null) {
       const setextMatch = SETEXT_UNDERLINE_REGEX.exec(line)
       const underlineChars = setextMatch?.[1]
-      if (underlineChars !== undefined) {
+      if (underlineChars) {
         collectedHeadings.push({
           text: setextCandidate.text.trim(),
           level: underlineChars.startsWith("=") ? 1 : 2,
@@ -219,9 +219,9 @@ export const parseHeadings = (lines: readonly string[]): HeadingInfo[] => {
   // run to EOF, but must stop before a trailing `%% %%` comment block (e.g. a
   // Kanban board's `%% kanban:settings %%`) so replace/append don't clobber it.
   const trailingCommentBlockStart = findTrailingCommentBlockStart(lines)
-  return collectedHeadings.map((heading, idx) => {
+  return collectedHeadings.map((heading, index) => {
     const nextSameOrHigher = collectedHeadings
-      .slice(idx + 1)
+      .slice(index + 1)
       .find((next) => next.level <= heading.level)
     return {
       text: heading.text,

--- a/src/vault-mcp/obsidian-markdown/plaintext.ts
+++ b/src/vault-mcp/obsidian-markdown/plaintext.ts
@@ -18,6 +18,8 @@ export const stripMarkdownSyntax = (text: string): string =>
     // Heading markers: ## → removed (keep the text; 0-3 leading spaces per §4.2,
     // empty headings match via the end-of-line alternative)
     .replace(/^ {0,3}#{1,6}(?:[ \t]+|$)/gm, "")
+    // Setext heading underlines: === or --- lines (0-3 leading spaces per §4.3)
+    .replace(/^ {0,3}(?:=+|-+)[ \t]*$/gm, "")
     // Bold/italic markers
     .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
     .replace(/_{1,3}([^_]+)_{1,3}/g, "$1")


### PR DESCRIPTION
## Summary

- Recognize setext headings (`Title` over `===`/`---`) in `parseHeadings`, closing Gap 2 on `^heading-parity-gaps`
- Convert Phase 1 from `reduce` to `for`-loop for two-line setext detection (text line + underline)
- Satellite: `callouts.ts` skips setext H1 before leading callouts; `plaintext.ts` strips setext underlines for embeddings
- All 8 downstream consumers (outline, section reads, patch, chunker, tasks, memory, search-index) work unchanged — they use `HeadingInfo` span fields

## Background

`HEADING_REGEX` only recognized ATX headings (`## Title`). AGENTS.md treats a strict subset of Obsidian's heading behavior as a bug. Setext headings are the structural parser change — unlike the prior ATX fixes (PRs #378, #379), setext requires two-line awareness because the heading occupies a text line plus an underline.

Obsidian rendering verified empirically: `Title\n===` = H1, `Title\n---` = H2, `---` after blank = thematic break. Multi-line setext content is inconsistent in Obsidian (renders in Edit mode, not Reading mode) — deferred.

## Design decisions

- **`startLine` = text line**, `bodyStartLine` = underline + 1. All consumers slice/compare via these fields
- **Phase 1 intermediate gains `bodyStartLine`** so Phase 2 doesn't hardcode `+1` (ATX: `startLine + 1`, setext: `startLine + 2`)
- **Reduce → for-loop** justified by AGENTS.md's parser-state guidance and the circular type inference the `let openFence` + null ternary pattern would cause
- **`---` disambiguation**: setext H2 only when the immediately preceding line is non-blank, non-heading, non-fence/comment content. Blank line before `---` = thematic break
- **`memory-entries.ts` HEADING_LINE_PATTERN** unchanged — it detects H3+ within H2 spans; setext produces only H1/H2

## Test plan

- [ ] 18 new `parseHeadings` setext tests (basic H1/H2, leading spaces, trailing whitespace, single-char underlines, thematic-break disambiguation, fence/comment awareness, adjacent/mixed headings, body spans, ATX precedence, text trimming)
- [ ] 2 new `linesBeforeFirstHeading` setext tests
- [ ] 1 new `findHeading` setext test
- [ ] 3 new callout tests (setext H1 skipped, setext H2 not skipped, leading spaces)
- [ ] 4 new plaintext tests (=== stripped, --- stripped, leading spaces, 4+ spaces not stripped)
- [ ] Full suite: 2181 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Setext-style Markdown headings using `===` and `---` underlines.
  * Heading detection now recognizes mixed ATX and Setext formats with accurate section boundaries.
  * Leading callouts are correctly detected after Setext H1 headings.
  * Plain-text output excludes Setext heading underline lines.

* **Bug Fixes**
  * Improved handling of headings in fenced code blocks, comments, and indented content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->