### PR TITLE
fix: make upsertNote and removeNote atomic; state busy_timeout explicitly

### DIFF
--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -528,7 +528,7 @@ describe("upsertNote", () => {
 
 describe("upsertNote atomicity", () => {
   it("rolls back to the prior version when a statement fails mid-upsert", () => {
-    const poison = installStatementPoison("INSERT INTO tasks")
+    const taskInsertPoison = installStatementPoison("INSERT INTO tasks")
     const atomicIndex = createSearchIndex(":memory:")
     atomicIndex.upsertNote(
       {
@@ -543,7 +543,7 @@ describe("upsertNote atomicity", () => {
     // notes upsert, FTS insert, and tasks delete have already run inside the
     // transaction — intact version-A state below proves genuine rollback,
     // not a no-op.
-    poison.arm()
+    taskInsertPoison.arm()
     expect(() =>
       atomicIndex.upsertNote(
         {
@@ -553,8 +553,8 @@ describe("upsertNote atomicity", () => {
         },
         logger,
       ),
-    ).toThrow(poison.message)
-    poison.disarm()
+    ).toThrow(taskInsertPoison.message)
+    taskInsertPoison.disarm()
 
     expect(atomicIndex.recentNotes({}, logger)).toEqual([versionAMetadata()])
     const versionAHits = atomicIndex.fullTextSearch(
@@ -577,7 +577,9 @@ describe("upsertNote atomicity", () => {
   })
 
   it("rolls back the link phase when a link statement fails mid-upsert", () => {
-    const poison = installStatementPoison("INSERT OR IGNORE INTO links")
+    const linkInsertPoison = installStatementPoison(
+      "INSERT OR IGNORE INTO links",
+    )
     const atomicIndex = createSearchIndex(":memory:")
     atomicIndex.upsertNote(
       {
@@ -593,7 +595,7 @@ describe("upsertNote atomicity", () => {
     // version-A link below proves link-phase rollback specifically, which
     // the tasks-phase poison above never exercises (it throws before the
     // links table is touched).
-    poison.arm()
+    linkInsertPoison.arm()
     expect(() =>
       atomicIndex.upsertNote(
         {
@@ -603,8 +605,8 @@ describe("upsertNote atomicity", () => {
         },
         logger,
       ),
-    ).toThrow(poison.message)
-    poison.disarm()
+    ).toThrow(linkInsertPoison.message)
+    linkInsertPoison.disarm()
 
     expect(atomicIndex.recentNotes({}, logger)).toEqual([versionAMetadata()])
     const versionAHits = atomicIndex.fullTextSearch(
@@ -627,7 +629,7 @@ describe("upsertNote atomicity", () => {
   })
 
   it("leaves no trace when a statement fails on a first-ever upsert", () => {
-    const poison = installStatementPoison("INSERT INTO tasks")
+    const taskInsertPoison = installStatementPoison("INSERT INTO tasks")
     const atomicIndex = createSearchIndex(":memory:")
     // Control note: its positive assertions below prove the query path works,
     // so the target note's empty results can't pass vacuously (fullTextSearch
@@ -641,7 +643,7 @@ describe("upsertNote atomicity", () => {
       logger,
     )
 
-    poison.arm()
+    taskInsertPoison.arm()
     expect(() =>
       atomicIndex.upsertNote(
         {
@@ -651,8 +653,8 @@ describe("upsertNote atomicity", () => {
         },
         logger,
       ),
-    ).toThrow(poison.message)
-    poison.disarm()
+    ).toThrow(taskInsertPoison.message)
+    taskInsertPoison.disarm()
 
     const controlMetadata: NoteMetadata = {
       path: "atomic/control.md",
@@ -714,7 +716,7 @@ describe("removeNote atomicity", () => {
     // embedder or memoryDir here), so the FTS, notes, and links deletes have
     // all run inside the transaction when the poison fires — full presence
     // below proves they rolled back.
-    const poison = installStatementPoison("DELETE FROM tasks")
+    const taskDeletePoison = installStatementPoison("DELETE FROM tasks")
     const atomicIndex = createSearchIndex(":memory:")
     atomicIndex.upsertNote(
       {
@@ -725,11 +727,11 @@ describe("removeNote atomicity", () => {
       logger,
     )
 
-    poison.arm()
+    taskDeletePoison.arm()
     expect(() => atomicIndex.removeNote("atomic/target.md")).toThrow(
-      poison.message,
+      taskDeletePoison.message,
     )
-    poison.disarm()
+    taskDeletePoison.disarm()
 
     expect(atomicIndex.recentNotes({}, logger)).toEqual([versionAMetadata()])
     const versionAHits = atomicIndex.fullTextSearch(

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -15,7 +15,12 @@ import { DateTime } from "luxon"
 import * as sqliteVec from "sqlite-vec"
 vi.mock("sqlite-vec", { spy: true })
 import { createSearchIndex } from "../search-index.js"
-import type { SearchIndex } from "../search-index.js"
+import type {
+  NoteMetadata,
+  OutgoingLinkEntry,
+  SearchIndex,
+  TaskEntry,
+} from "../search-index.js"
 import { logger } from "../../../logger.js"
 
 let index: SearchIndex
@@ -67,6 +72,134 @@ const testStat = (
 ): { mtimeMs: number; size: number } => ({
   mtimeMs,
   size,
+})
+
+/** Expected NoteMetadata.modified for a testStat mtime — same epoch-ms → ISO
+ *  conversion the index performs, computed independently in the test's zone. */
+const isoFromMillis = (mtimeMs: number): string => {
+  const iso = DateTime.fromMillis(mtimeMs).toISO()
+  if (iso === null) throw new Error(`invalid test mtime: ${mtimeMs}`)
+  return iso
+}
+
+/** Poisons one factory-prepared statement, identified by an SQL fragment: a
+ *  prototype-level prepare spy patches the matching statement's .run to throw
+ *  while armed. Must be installed BEFORE createSearchIndex — every write
+ *  statement is prepared at factory scope — and stays disarmed so factory
+ *  setup and seeding writes succeed until a test arms it. */
+const installStatementPoison = (sqlFragment: string) => {
+  const message = `injected failure on: ${sqlFragment}`
+  // Concrete function type: prepare's generic conditional return type doesn't
+  // resolve through .call, so pin the default instantiation explicitly.
+  const realPrepare: (
+    this: Database.Database,
+    source: string,
+  ) => Database.Statement = Database.prototype.prepare
+  // Mutable arming flag: the patched .run closes over this object so tests
+  // can trigger the failure long after the statement was prepared.
+  const poisonState = { armed: false }
+  const prepareSpy = vi
+    .spyOn(Database.prototype, "prepare")
+    .mockImplementation(function (this: Database.Database, source: string) {
+      const statement = realPrepare.call(this, source)
+      if (source.includes(sqlFragment)) {
+        const realRun = statement.run.bind(statement)
+        statement.run = (...runParams: unknown[]) => {
+          if (poisonState.armed) throw new Error(message)
+          return realRun(...runParams)
+        }
+      }
+      return statement
+    })
+  onTestFinished(() => prepareSpy.mockRestore())
+  return {
+    message,
+    arm: () => {
+      poisonState.armed = true
+    },
+    disarm: () => {
+      poisonState.armed = false
+    },
+  }
+}
+
+/** Version A of the atomicity-test note: distinct title, tag, body term,
+ *  one task (so the poisoned tasks statement provably fires), one link. */
+const ATOMIC_NOTE_VERSION_A = `---
+title: Version A
+tags: [atomic-a]
+---
+
+Alpha body about penguins.
+
+- [ ] alpha task
+
+[[Alpha Target]]
+`
+
+/** Version B — differs from A in every asserted dimension. */
+const ATOMIC_NOTE_VERSION_B = `---
+title: Version B
+tags: [atomic-b]
+---
+
+Beta body about walruses.
+
+- [ ] beta task
+
+[[Beta Target]]
+`
+
+/** The full NoteMetadata row version A produces with testStat(1000). */
+const versionAMetadata = (): NoteMetadata => ({
+  path: "atomic/target.md",
+  title: "Version A",
+  tags: ["atomic-a"],
+  related: [],
+  folder: "atomic",
+  type: null,
+  created: null,
+  modified: isoFromMillis(1000),
+  bytes: 100,
+  properties: { title: "Version A", tags: ["atomic-a"] },
+  leading_callout: null,
+})
+
+/** The full TaskEntry version A's `- [ ] alpha task` (line 8) produces. */
+const versionATask = (): TaskEntry => ({
+  path: "atomic/target.md",
+  line: 8,
+  status: "todo",
+  status_char: " ",
+  description: "alpha task",
+  heading: null,
+  folder: "atomic",
+  created: null,
+  scheduled: null,
+  start: null,
+  due: null,
+  done: null,
+  cancelled: null,
+  priority: null,
+  recurrence: null,
+  on_completion: null,
+  task_id: null,
+  depends_on: [],
+  tags: [],
+  block_id: null,
+  is_kanban_task: false,
+  lane: null,
+  done_lanes: null,
+})
+
+/** The full OutgoingLinkEntry for version A's unresolved [[Alpha Target]]. */
+const versionALink = (): OutgoingLinkEntry => ({
+  path: "Alpha Target",
+  title: null,
+  exists: false,
+  kind: "note",
+  bytes: null,
+  daily_note_forward_ref: false,
 })
 
 describe("schema creation", () => {
@@ -393,6 +526,118 @@ describe("upsertNote", () => {
   })
 })
 
+describe("upsertNote atomicity", () => {
+  it("rolls back to the prior version when a statement fails mid-upsert", () => {
+    const poison = installStatementPoison("INSERT INTO tasks")
+    const atomicIndex = createSearchIndex(":memory:")
+    atomicIndex.upsertNote(
+      {
+        filePath: "atomic/target.md",
+        rawContent: ATOMIC_NOTE_VERSION_A,
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+
+    // By the time the poisoned task INSERT fires, version B's FTS delete,
+    // notes upsert, FTS insert, and tasks delete have already run inside the
+    // transaction — intact version-A state below proves genuine rollback,
+    // not a no-op.
+    poison.arm()
+    expect(() =>
+      atomicIndex.upsertNote(
+        {
+          filePath: "atomic/target.md",
+          rawContent: ATOMIC_NOTE_VERSION_B,
+          fileStat: testStat(2000),
+        },
+        logger,
+      ),
+    ).toThrow(poison.message)
+    poison.disarm()
+
+    expect(atomicIndex.recentNotes({}, logger)).toEqual([versionAMetadata()])
+    const versionAHits = atomicIndex.fullTextSearch(
+      { query: "penguins" },
+      logger,
+    )
+    expect(versionAHits.map((result) => result.path)).toEqual([
+      "atomic/target.md",
+    ])
+    expect(atomicIndex.fullTextSearch({ query: "walruses" }, logger)).toEqual(
+      [],
+    )
+    expect(atomicIndex.listTasks({ status: "all" }, logger)).toEqual({
+      total: 1,
+      tasks: [versionATask()],
+    })
+    expect(
+      atomicIndex.getOutgoingLinks({ path: "atomic/target.md" }, logger),
+    ).toEqual([versionALink()])
+  })
+
+  it("leaves no trace when a statement fails on a first-ever upsert", () => {
+    const poison = installStatementPoison("INSERT INTO tasks")
+    const atomicIndex = createSearchIndex(":memory:")
+    // Control note: its positive assertions below prove the query path works,
+    // so the target note's empty results can't pass vacuously (fullTextSearch
+    // catches SQL errors and returns []).
+    atomicIndex.upsertNote(
+      {
+        filePath: "atomic/control.md",
+        rawContent: "Control body about flamingos.\n",
+        fileStat: testStat(500),
+      },
+      logger,
+    )
+
+    poison.arm()
+    expect(() =>
+      atomicIndex.upsertNote(
+        {
+          filePath: "atomic/target.md",
+          rawContent: ATOMIC_NOTE_VERSION_A,
+          fileStat: testStat(1000),
+        },
+        logger,
+      ),
+    ).toThrow(poison.message)
+    poison.disarm()
+
+    const controlMetadata: NoteMetadata = {
+      path: "atomic/control.md",
+      title: "control",
+      tags: [],
+      related: [],
+      folder: "atomic",
+      type: null,
+      created: null,
+      modified: isoFromMillis(500),
+      bytes: 100,
+      properties: {},
+      leading_callout: null,
+    }
+    expect(atomicIndex.recentNotes({}, logger)).toEqual([controlMetadata])
+    expect(atomicIndex.fullTextSearch({ query: "penguins" }, logger)).toEqual(
+      [],
+    )
+    const controlHits = atomicIndex.fullTextSearch(
+      { query: "flamingos" },
+      logger,
+    )
+    expect(controlHits.map((result) => result.path)).toEqual([
+      "atomic/control.md",
+    ])
+    expect(atomicIndex.listTasks({ status: "all" }, logger)).toEqual({
+      total: 0,
+      tasks: [],
+    })
+    expect(
+      atomicIndex.getOutgoingLinks({ path: "atomic/target.md" }, logger),
+    ).toEqual([])
+  })
+})
+
 describe("removeNote", () => {
   it("removes an indexed note", () => {
     index.upsertNote(
@@ -410,6 +655,47 @@ describe("removeNote", () => {
 
   it("does not throw for non-existent path", () => {
     expect(() => index.removeNote("ghost.md")).not.toThrow()
+  })
+})
+
+describe("removeNote atomicity", () => {
+  it("keeps the note fully present when a delete fails mid-removal", () => {
+    // The tasks delete is the last unconditional statement in removeNote (no
+    // embedder or memoryDir here), so the FTS, notes, and links deletes have
+    // all run inside the transaction when the poison fires — full presence
+    // below proves they rolled back.
+    const poison = installStatementPoison("DELETE FROM tasks")
+    const atomicIndex = createSearchIndex(":memory:")
+    atomicIndex.upsertNote(
+      {
+        filePath: "atomic/target.md",
+        rawContent: ATOMIC_NOTE_VERSION_A,
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+
+    poison.arm()
+    expect(() => atomicIndex.removeNote("atomic/target.md")).toThrow(
+      poison.message,
+    )
+    poison.disarm()
+
+    expect(atomicIndex.recentNotes({}, logger)).toEqual([versionAMetadata()])
+    const versionAHits = atomicIndex.fullTextSearch(
+      { query: "penguins" },
+      logger,
+    )
+    expect(versionAHits.map((result) => result.path)).toEqual([
+      "atomic/target.md",
+    ])
+    expect(atomicIndex.listTasks({ status: "all" }, logger)).toEqual({
+      total: 1,
+      tasks: [versionATask()],
+    })
+    expect(
+      atomicIndex.getOutgoingLinks({ path: "atomic/target.md" }, logger),
+    ).toEqual([versionALink()])
   })
 })
 

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -576,6 +576,56 @@ describe("upsertNote atomicity", () => {
     ).toEqual([versionALink()])
   })
 
+  it("rolls back the link phase when a link statement fails mid-upsert", () => {
+    const poison = installStatementPoison("INSERT OR IGNORE INTO links")
+    const atomicIndex = createSearchIndex(":memory:")
+    atomicIndex.upsertNote(
+      {
+        filePath: "atomic/target.md",
+        rawContent: ATOMIC_NOTE_VERSION_A,
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+
+    // By the time the poisoned link INSERT fires, `deleteLinksStmt` has
+    // already cleared version A's links inside the transaction — the intact
+    // version-A link below proves link-phase rollback specifically, which
+    // the tasks-phase poison above never exercises (it throws before the
+    // links table is touched).
+    poison.arm()
+    expect(() =>
+      atomicIndex.upsertNote(
+        {
+          filePath: "atomic/target.md",
+          rawContent: ATOMIC_NOTE_VERSION_B,
+          fileStat: testStat(2000),
+        },
+        logger,
+      ),
+    ).toThrow(poison.message)
+    poison.disarm()
+
+    expect(atomicIndex.recentNotes({}, logger)).toEqual([versionAMetadata()])
+    const versionAHits = atomicIndex.fullTextSearch(
+      { query: "penguins" },
+      logger,
+    )
+    expect(versionAHits.map((result) => result.path)).toEqual([
+      "atomic/target.md",
+    ])
+    expect(atomicIndex.fullTextSearch({ query: "walruses" }, logger)).toEqual(
+      [],
+    )
+    expect(atomicIndex.listTasks({ status: "all" }, logger)).toEqual({
+      total: 1,
+      tasks: [versionATask()],
+    })
+    expect(
+      atomicIndex.getOutgoingLinks({ path: "atomic/target.md" }, logger),
+    ).toEqual([versionALink()])
+  })
+
   it("leaves no trace when a statement fails on a first-ever upsert", () => {
     const poison = installStatementPoison("INSERT INTO tasks")
     const atomicIndex = createSearchIndex(":memory:")

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -1055,8 +1055,8 @@ export const createSearchIndex = (
     // All index writes commit or roll back together — a mid-sequence throw
     // must not leave notes/FTS/tasks/links mutually inconsistent. The
     // `skipLinks` return exits the transaction callback (return commits,
-    // throw rolls back), so nothing may run between the wrap's `)()` and
-    // the function's end.
+    // throw rolls back), so code after the wrap's `)()` runs on both paths
+    // — no link-phase work may live there.
     db.transaction(() => {
       deleteFtsStmt.run(note.path)
       upsertNotesStmt.run(
@@ -1108,12 +1108,6 @@ export const createSearchIndex = (
         upsertMemoryEntries(memoryFile, parsed.content, logger)
       }
 
-      logger.debug("indexed note", {
-        path: note.path,
-        bytes: note.bytes,
-        tasksIndexed: extractedTasks.length,
-      })
-
       if (skipLinks) return
 
       const allPaths = selectAllNotePathsStmt.all()
@@ -1146,6 +1140,14 @@ export const createSearchIndex = (
         }
       }
     })()
+
+    // Emitted after the transaction commits so a rolled-back write can't
+    // leave a success line behind.
+    logger.debug("indexed note", {
+      path: note.path,
+      bytes: note.bytes,
+      tasksIndexed: extractedTasks.length,
+    })
   }
 
   // ── Embedding pipeline ─────────────────────────────────────────
@@ -1493,9 +1495,7 @@ export const createSearchIndex = (
       // Pass 2: re-extract links now that all paths are in the notes table,
       // resolving targets that the per-note upsertNote pass may have missed
       // (e.g. Note A links to Note B, but Note B was indexed after Note A).
-      const allPaths = db
-        .prepare<[], { path: string }>("SELECT path FROM notes")
-        .all()
+      const allPaths = selectAllNotePathsStmt.all()
       const pathList = allPaths.map((row) => row.path)
 
       db.exec("DELETE FROM links")

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -300,14 +300,11 @@ export const createSearchIndex = (
   // better-sqlite3 already defaults sqlite3_busy_timeout to 5000 ms at open;
   // stated explicitly so the retry contract survives refactors (e.g. a future
   // `timeout: 0` open option) and isn't re-flagged by audits as missing.
-  // Caveat: the busy handler does not retry a deferred transaction that reads
-  // before its first write — the read pins a WAL snapshot, a concurrent commit
-  // from another connection makes it stale, and the later write-lock upgrade
-  // fails immediately with SQLITE_BUSY_SNAPSHOT (retrying can't refresh a
-  // mid-transaction snapshot). Write-first wraps (upsertNote, removeNote) are
-  // immune — their lock is contested at statement 1, where the busy handler
-  // does apply. A wrap that must read before its first write only gets the
-  // timeout's protection via the .immediate() variant.
+  // Caveat: the timeout doesn't protect a deferred transaction that reads
+  // before its first write — its pinned WAL snapshot goes stale on a
+  // concurrent commit and the write-lock upgrade fails instantly with
+  // SQLITE_BUSY_SNAPSHOT. Write-first wraps (upsertNote, removeNote) are
+  // covered; a read-first wrap needs the .immediate() variant.
   db.pragma("busy_timeout = 5000")
   sqliteVec.load(db)
 

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -297,6 +297,10 @@ export const createSearchIndex = (
   const db = new Database(dbPath)
   db.pragma("journal_mode = WAL")
   db.pragma("synchronous = NORMAL")
+  // better-sqlite3 already defaults sqlite3_busy_timeout to 5000 ms at open;
+  // stated explicitly so the retry contract survives refactors (e.g. a future
+  // `timeout: 0` open option) and isn't re-flagged by audits as missing.
+  db.pragma("busy_timeout = 5000")
   sqliteVec.load(db)
 
   // FTS5 doesn't support ALTER TABLE ADD COLUMN. When opening a warm database
@@ -1035,103 +1039,112 @@ export const createSearchIndex = (
       kanban_done_lanes: kanbanDoneLanes,
     }
 
-    deleteFtsStmt.run(note.path)
-    upsertNotesStmt.run(
-      note.path,
-      note.title,
-      note.content,
-      note.tags,
-      note.related,
-      note.folder,
-      note.type,
-      note.created,
-      note.mtime,
-      note.properties,
-      note.leading_callout,
-      note.bytes,
-      note.kanban_done_lanes,
-    )
     const metadataText = buildFtsMetadataText(frontmatter)
-    insertFtsStmt.run(note.path, note.title, note.content, metadataText)
 
     // Task rows carry the full immediate-parent folder (posix dirname), unlike
     // notes.folder which stores only the first path segment — task triage
     // needs project-level attribution ("Code Projects/vault-cortex", not
     // "Code Projects").
     const taskFolder = filePath.includes("/") ? posix.dirname(filePath) : ""
-    deleteTasksStmt.run(note.path)
     const extractedTasks = tasks.extractTasks(rawContent)
-    for (const extractedTask of extractedTasks) {
-      insertTaskStmt.run({
-        notePath: note.path,
-        line: extractedTask.line,
-        statusChar: extractedTask.statusChar,
-        status: extractedTask.status,
-        description: extractedTask.description,
-        created: extractedTask.createdDate,
-        scheduled: extractedTask.scheduledDate,
-        start: extractedTask.startDate,
-        due: extractedTask.dueDate,
-        done: extractedTask.doneDate,
-        cancelled: extractedTask.cancelledDate,
-        priority: extractedTask.priority,
-        recurrence: extractedTask.recurrence,
-        onCompletion: extractedTask.onCompletion,
-        taskId: extractedTask.taskId,
-        dependsOn: JSON.stringify(extractedTask.dependsOn),
-        tags: JSON.stringify(extractedTask.tags),
-        blockId: extractedTask.blockId,
-        heading: extractedTask.heading,
-        folder: taskFolder,
-      })
-    }
-
-    // Memory files additionally maintain their entry-granular index. Placed
-    // before the skipLinks return so rebuild Pass 1 covers it.
     const memoryFile = memoryFileNameFromPath(filePath)
-    if (memoryFile !== null) {
-      upsertMemoryEntries(memoryFile, parsed.content, logger)
-    }
 
-    logger.debug("indexed note", {
-      path: note.path,
-      bytes: note.bytes,
-      tasksIndexed: extractedTasks.length,
-    })
+    // All index writes commit or roll back together — a mid-sequence throw
+    // must not leave notes/FTS/tasks/links mutually inconsistent. The
+    // `skipLinks` return exits the transaction callback (return commits,
+    // throw rolls back), so nothing may run between the wrap's `)()` and
+    // the function's end.
+    db.transaction(() => {
+      deleteFtsStmt.run(note.path)
+      upsertNotesStmt.run(
+        note.path,
+        note.title,
+        note.content,
+        note.tags,
+        note.related,
+        note.folder,
+        note.type,
+        note.created,
+        note.mtime,
+        note.properties,
+        note.leading_callout,
+        note.bytes,
+        note.kanban_done_lanes,
+      )
+      insertFtsStmt.run(note.path, note.title, note.content, metadataText)
 
-    if (skipLinks) return
-
-    const allPaths = db
-      .prepare<unknown[], { path: string }>("SELECT path FROM notes")
-      .all()
-    const pathList = allPaths.map((row) => row.path)
-
-    deleteLinksStmt.run(note.path)
-    for (const rawTarget of links.extractAll(parsed.content, frontmatter)) {
-      const resolved = links.resolve(rawTarget, pathList, note.path)
-      if (resolved !== null) {
-        insertLinkStmt.run(note.path, resolved)
-      } else {
-        const resolvedNonMdPath = resolveNonMarkdownFile(rawTarget, note.path)
-        insertLinkStmt.run(note.path, resolvedNonMdPath ?? rawTarget)
-      }
-    }
-
-    // Re-resolve links still stored as raw text now that this note exists.
-    // Re-run resolveLink with each link's own source so every form upgrades
-    // uniformly — basename, full path, and source-relative ("../") — covering
-    // Obsidian's "link first, create the note later" workflow.
-    const unresolvedLinks = selectUnresolvedLinksStmt.all()
-    for (const link of unresolvedLinks) {
-      const resolved = links.resolve(link.target, pathList, link.source)
-      if (resolved !== null) {
-        updateLinkTargetStmt.run({
-          resolved,
-          source: link.source,
-          rawTarget: link.target,
+      deleteTasksStmt.run(note.path)
+      for (const extractedTask of extractedTasks) {
+        insertTaskStmt.run({
+          notePath: note.path,
+          line: extractedTask.line,
+          statusChar: extractedTask.statusChar,
+          status: extractedTask.status,
+          description: extractedTask.description,
+          created: extractedTask.createdDate,
+          scheduled: extractedTask.scheduledDate,
+          start: extractedTask.startDate,
+          due: extractedTask.dueDate,
+          done: extractedTask.doneDate,
+          cancelled: extractedTask.cancelledDate,
+          priority: extractedTask.priority,
+          recurrence: extractedTask.recurrence,
+          onCompletion: extractedTask.onCompletion,
+          taskId: extractedTask.taskId,
+          dependsOn: JSON.stringify(extractedTask.dependsOn),
+          tags: JSON.stringify(extractedTask.tags),
+          blockId: extractedTask.blockId,
+          heading: extractedTask.heading,
+          folder: taskFolder,
         })
       }
-    }
+
+      // Memory files additionally maintain their entry-granular index. Placed
+      // before the skipLinks return so rebuild Pass 1 covers it.
+      if (memoryFile !== null) {
+        upsertMemoryEntries(memoryFile, parsed.content, logger)
+      }
+
+      logger.debug("indexed note", {
+        path: note.path,
+        bytes: note.bytes,
+        tasksIndexed: extractedTasks.length,
+      })
+
+      if (skipLinks) return
+
+      const allPaths = db
+        .prepare<unknown[], { path: string }>("SELECT path FROM notes")
+        .all()
+      const pathList = allPaths.map((row) => row.path)
+
+      deleteLinksStmt.run(note.path)
+      for (const rawTarget of links.extractAll(parsed.content, frontmatter)) {
+        const resolved = links.resolve(rawTarget, pathList, note.path)
+        if (resolved !== null) {
+          insertLinkStmt.run(note.path, resolved)
+        } else {
+          const resolvedNonMdPath = resolveNonMarkdownFile(rawTarget, note.path)
+          insertLinkStmt.run(note.path, resolvedNonMdPath ?? rawTarget)
+        }
+      }
+
+      // Re-resolve links still stored as raw text now that this note exists.
+      // Re-run resolveLink with each link's own source so every form upgrades
+      // uniformly — basename, full path, and source-relative ("../") — covering
+      // Obsidian's "link first, create the note later" workflow.
+      const unresolvedLinks = selectUnresolvedLinksStmt.all()
+      for (const link of unresolvedLinks) {
+        const resolved = links.resolve(link.target, pathList, link.source)
+        if (resolved !== null) {
+          updateLinkTargetStmt.run({
+            resolved,
+            source: link.source,
+            rawTarget: link.target,
+          })
+        }
+      }
+    })()
   }
 
   // ── Embedding pipeline ─────────────────────────────────────────
@@ -1319,18 +1332,23 @@ export const createSearchIndex = (
    *  arrives as unlink+add, so a renamed memory file behaves as delete+create:
    *  its entries re-enter as new rows and re-embed once in the background. */
   const removeNote = (filePath: string): void => {
-    deleteFtsStmt.run(filePath)
-    removeNotesStmt.run(filePath)
-    deleteLinksStmt.run(filePath)
-    deleteTasksStmt.run(filePath)
-    if (deleteVectorsForNoteStmt && deleteChunksForNoteStmt) {
-      deleteVectorsForNoteStmt.run(filePath)
-      deleteChunksForNoteStmt.run(filePath)
-    }
     const memoryFile = memoryFileNameFromPath(filePath)
-    if (memoryFile !== null) {
-      removeMemoryEntriesForFile(memoryFile)
-    }
+
+    // All deletes commit or roll back together — a mid-sequence throw must
+    // not leave the note half-removed across notes/FTS/tasks/links.
+    db.transaction(() => {
+      deleteFtsStmt.run(filePath)
+      removeNotesStmt.run(filePath)
+      deleteLinksStmt.run(filePath)
+      deleteTasksStmt.run(filePath)
+      if (deleteVectorsForNoteStmt && deleteChunksForNoteStmt) {
+        deleteVectorsForNoteStmt.run(filePath)
+        deleteChunksForNoteStmt.run(filePath)
+      }
+      if (memoryFile !== null) {
+        removeMemoryEntriesForFile(memoryFile)
+      }
+    })()
   }
 
   /** Drops the entire index and re-indexes every .md file in the vault.

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -517,6 +517,9 @@ export const createSearchIndex = (
   const updateLinkTargetStmt = db.prepare(
     `UPDATE OR REPLACE links SET target = @resolved WHERE source = @source AND target = @rawTarget`,
   )
+  const selectAllNotePathsStmt = db.prepare<unknown[], { path: string }>(
+    `SELECT path FROM notes`,
+  )
 
   // ── Non-markdown file awareness ────────────────────────────────
   //
@@ -1101,7 +1104,7 @@ export const createSearchIndex = (
 
       // Memory files additionally maintain their entry-granular index. Placed
       // before the skipLinks return so rebuild Pass 1 covers it.
-      if (memoryFile !== null) {
+      if (memoryFile) {
         upsertMemoryEntries(memoryFile, parsed.content, logger)
       }
 
@@ -1113,9 +1116,7 @@ export const createSearchIndex = (
 
       if (skipLinks) return
 
-      const allPaths = db
-        .prepare<unknown[], { path: string }>("SELECT path FROM notes")
-        .all()
+      const allPaths = selectAllNotePathsStmt.all()
       const pathList = allPaths.map((row) => row.path)
 
       deleteLinksStmt.run(note.path)
@@ -1322,7 +1323,7 @@ export const createSearchIndex = (
     if (!embedder) return
     await embedAndStoreChunks(params, logger)
     const memoryFile = memoryFileNameFromPath(params.notePath)
-    if (memoryFile !== null) {
+    if (memoryFile) {
       await embedMemoryEntriesForFile(memoryFile, logger)
     }
   }
@@ -1345,7 +1346,7 @@ export const createSearchIndex = (
         deleteVectorsForNoteStmt.run(filePath)
         deleteChunksForNoteStmt.run(filePath)
       }
-      if (memoryFile !== null) {
+      if (memoryFile) {
         removeMemoryEntriesForFile(memoryFile)
       }
     })()
@@ -1592,7 +1593,7 @@ export const createSearchIndex = (
                 logger,
               )
               const memoryFile = memoryFileNameFromPath(note.relativePath)
-              if (memoryFile !== null) {
+              if (memoryFile) {
                 entriesEmbedded += await embedMemoryEntriesForFile(
                   memoryFile,
                   logger,

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -300,6 +300,14 @@ export const createSearchIndex = (
   // better-sqlite3 already defaults sqlite3_busy_timeout to 5000 ms at open;
   // stated explicitly so the retry contract survives refactors (e.g. a future
   // `timeout: 0` open option) and isn't re-flagged by audits as missing.
+  // Caveat: the busy handler does not retry a deferred transaction that reads
+  // before its first write — the read pins a WAL snapshot, a concurrent commit
+  // from another connection makes it stale, and the later write-lock upgrade
+  // fails immediately with SQLITE_BUSY_SNAPSHOT (retrying can't refresh a
+  // mid-transaction snapshot). Write-first wraps (upsertNote, removeNote) are
+  // immune — their lock is contested at statement 1, where the busy handler
+  // does apply. A wrap that must read before its first write only gets the
+  // timeout's protection via the .immediate() variant.
   db.pragma("busy_timeout = 5000")
   sqliteVec.load(db)
 


### PR DESCRIPTION
## What

Two hardening changes to `search-index.ts` (task: SQLite index robustness), plus one same-class fix found during planning:

1. **`upsertNote` is now transactional.** Its full statement sequence (FTS delete → notes upsert → FTS insert → tasks delete/insert → memory entries → links delete/insert/re-resolve) runs inside `db.transaction(() => { ... })()`. A mid-sequence throw previously left notes/FTS/tasks/links mutually inconsistent until the next full reindex; it now rolls back cleanly. Pure computation (`metadataText`, `taskFolder`, `extractedTasks`, `memoryFile`) is hoisted above the wrap so the write lock isn't held during parsing. `links.extractAll` deliberately stays inside: it only runs when `!skipLinks`, and rebuild Pass 1 calls every note with `skipLinks: true` — hoisting would add wasted per-note extraction to every rebuild.
2. **`removeNote` gets the same wrap** — it ran 4–6 bare deletes, so a mid-sequence failure left a note half-removed. Its `removeMemoryEntriesForFile` call (itself non-transactional) now also participates in the atomic scope.
3. **`busy_timeout` stated explicitly.** Planning verified the original premise was wrong: better-sqlite3 already applies `sqlite3_busy_timeout(handle, 5000)` at open by default (`lib/database.js:34`, native `database.cpp:172`), so no behavior changes. The explicit pragma + comment exist so the retry contract survives refactors (e.g. a future `timeout: 0` open option) and isn't re-flagged by audits. Per that finding, no dedicated test — a worker-thread contention harness to verify a library default was judged disproportionate.

## Design notes

- **Default (deferred) transaction variant**, consistent with the four existing `db.transaction()` uses. Background: `busy_timeout`'s retry handler only protects plain write-lock acquisition — it deliberately does not retry a deferred transaction that *reads before its first write*. There, the read pins a WAL snapshot; if another connection commits meanwhile, the snapshot is stale and the later write-lock upgrade fails instantly with `SQLITE_BUSY_SNAPSHOT`, ignoring the timeout (retrying can't refresh a mid-transaction snapshot — only rollback-and-restart can). Both new wraps open with a DELETE — a write — so the write lock is contested at statement 1, where the busy handler does apply and waits the full 5000 ms. The write-first shape makes the stale-snapshot window structurally impossible, giving the deferred default the same safety as `.immediate()` here. The caveat is recorded in a comment on the `busy_timeout` pragma for future wraps (a wrap that must read before its first write should use `.immediate()`).
- **Nesting is safe**: `rebuildFromVault` (own tx) → `upsertNote` → `upsertMemoryEntries` (own tx) becomes savepoint nesting, which better-sqlite3 handles natively; no manual `BEGIN`/`COMMIT` exists anywhere in `src/`.
- The `if (skipLinks) return` now exits the transaction callback (return = commit, throw = rollback); a comment on the wrap notes that nothing may run between the wrap's `)()` and the function's end.
- The OAuth DB relies on the same 5000 ms driver default — same non-gap, consciously left untouched.

## Tests

Three atomicity tests via a statement-poisoning seam: a prototype-level `prepare` spy (installed before `createSearchIndex`, since all write statements are prepared at factory scope) patches one statement's `.run` to throw while armed, so seeding runs clean and the failure fires mid-sequence on demand.

- **Update-over-existing rolls back**: version B's upsert throws after its notes/FTS writes already ran in-transaction; version A asserted fully intact (exact whole-value assertions: `recentNotes`, `fullTextSearch`, `listTasks`, `getOutgoingLinks`).
- **Fresh insert leaves no trace**, with a control note guarding against `fullTextSearch`'s catch-and-return-`[]` making absence assertions vacuous.
- **removeNote keeps the note fully present**: poisons the last unconditional delete, so the FTS/notes/links deletes had all run when it fired — full presence proves rollback.

**Mutation-tested**: each wrap was temporarily replaced with a bare IIFE; the matching tests failed on partial-state assertions (version B persisted / note vanished despite the throw), not on the throw assertion, then the wraps were restored.

## Verification

- `npm test`: 2159 passed, 3 consecutive full-suite runs (one unidentified single-test failure on the very first run did not reproduce across three reruns — suspected pre-existing flake; watching CI)
- `npm run lint`: 0 errors, 336 warnings (identical count to main — none introduced)
- `npm run build`: clean

No user-facing surface changes: no env vars, no tool descriptions, no docs impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search index reliability by making note updates and removals atomic.
  * Prevented partially completed changes from leaving behind inconsistent search results, tasks, links, vectors, or memory entries.
  * Failed operations now roll back cleanly, preserving the previously saved state or leaving no residual data for new notes.
  * Improved database handling during temporary contention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
