### PR TITLE
docs(readme): surface memory + file-tools opt-outs in feature sections, add Memory architecture link

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -69,6 +69,8 @@ Your notes embed screenshots, reference architecture diagrams, and link out to c
 - **Text and data files** — SVG, JSON, CSV, logs, and [Bases](https://help.obsidian.md/bases) files return exactly as written
 - **Browse** — list any folder's files with per-extension counts and file sizes; files a note links to report their size in the link graph too
 
+Set `FILE_TOOLS_ENABLED=false` to hide the file tools — useful when your remote vault syncs without attachments.
+
 See [ARCHITECTURE.md → Files](https://github.com/aliasunder/vault-cortex/blob/main/ARCHITECTURE.md#files) for the image pipeline and dispatch model.
 
 ## Tools

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ The layer is a folder of plain Markdown files (default: `About Me/`) holding dat
 
 Files that describe what's current rather than what has been true (routines, active commitments) can declare `entry-policy: living` in frontmatter — their expired entries are prunable rather than preserved, keeping the current-state picture accurate.
 
-See [templates/memory](./templates/memory/) for the file format, entry-policy convention, and starter templates.
+The whole layer is optional — set `MEMORY_ENABLED=false` to hide the memory tools and skip the folder auto-creation entirely.
+
+See [ARCHITECTURE.md → Memory](./ARCHITECTURE.md#memory) for the recall pipeline, indexing model, auto-initialization, and opt-out behavior, and [templates/memory](./templates/memory/) for the file format, entry-policy convention, and starter templates.
 
 ## Tasks
 
@@ -222,6 +224,8 @@ Your notes embed screenshots, reference architecture diagrams, and link out to c
 - **PDFs** — text is extracted with heading hierarchy, code blocks, and hyperlinks preserved; set `raw: true` to render pages as images instead, showing layout, diagrams, and tables that text extraction can't preserve — scanned and image-only PDFs work in this mode
 - **Text and data files** — SVG, JSON, CSV, logs, and [Bases](https://help.obsidian.md/bases) files return exactly as written
 - **Browse** — list any folder's files with per-extension counts and file sizes; files a note links to report their size in the link graph too
+
+Set `FILE_TOOLS_ENABLED=false` to hide the file tools — useful when your remote vault syncs without attachments.
 
 See [ARCHITECTURE.md → Files](./ARCHITECTURE.md#files) for the image pipeline and dispatch model.
 


### PR DESCRIPTION
## Summary

- **Memory section** now closes with the same `See ARCHITECTURE.md → X` pointer every other feature section has (Hybrid Search, Tasks, Files, Data Integrity, Auth) — previously it linked only to `templates/memory`, so readers had no path to the recall pipeline, indexing model, auto-initialization, and opt-out details in [ARCHITECTURE.md → Memory](./ARCHITECTURE.md#memory). Combined with the existing templates link in one sentence, following the Data Integrity section's two-pointer precedent.
- **Inline opt-out sentences** added to the Memory and Files sections. Hybrid Search already surfaces its toggles inline (`EMBEDDING_ENABLED=false`, `RERANK_MODE=none`), but `MEMORY_ENABLED` and `FILE_TOOLS_ENABLED` were only discoverable in the config table. A reader evaluating the Memory section learns the server auto-creates a folder in their vault — the opt-out belongs at the point where that objection arises, not 100+ lines down. Each sentence sits as the last content line before the section's See-also, matching Hybrid Search's structure.
- **DOCKERHUB.md regenerated** (`npm run generate:dockerhub-readme`) — picks up the Files sentence; the Memory prose section isn't part of the Docker Hub cut.

Note: the generated DOCKERHUB.md is now 24,366 bytes against Docker Hub's 25,000-byte truncation limit (~630 bytes headroom, pre-existing tightness — this PR adds ~110 bytes).

## Test plan

- [x] `#memory` anchor verified unambiguous in ARCHITECTURE.md (only other memory heading is `#### Memory layer safety`, a different slug)
- [x] Opt-out sentence claims match the config table's documented behavior for `MEMORY_ENABLED` / `FILE_TOOLS_ENABLED`
- [x] `npm run generate:dockerhub-readme` — output under the 25,000-byte limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)