### PR TITLE
ci: per-arch image build + boot smoke on every PR

### DIFF
--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -64,11 +64,12 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
-      # Per-arch cache scope: the two legs here plus trivy-pr (which
-      # writes the default scope) would otherwise all write mode=max into
-      # one scope on one ref — last write wins and evicts the rest. The
-      # bare type=gha cache-from lets the amd64 leg still read trivy-pr's
-      # layers; it is a no-op on arm64 (no matching blobs).
+      # Per-arch, per-target cache scope: a GHA cache scope keeps only its
+      # last mode=max export, so every build sharing one scope — the two
+      # legs here, trivy-pr (default scope), or the arm64 leg's local and
+      # remote builds — would evict each other's layers. The bare type=gha
+      # cache-from lets the amd64 leg still read trivy-pr's layers; it is
+      # a no-op on arm64 (no matching blobs).
       - name: Build image from branch (local target)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -80,14 +81,15 @@ jobs:
           tags: vault-cortex:smoke
           build-args: APT_UPGRADE_DATE=${{ steps.date.outputs.date }}
           cache-from: |
-            type=gha,scope=arch-smoke-${{ matrix.arch }}
+            type=gha,scope=arch-smoke-${{ matrix.arch }}-local
             type=gha
-          cache-to: type=gha,mode=max,scope=arch-smoke-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=arch-smoke-${{ matrix.arch }}-local
 
       # Compile check only: nothing had ever built the remote target for
       # arm64 before merge. No load/tags — the image is never run, and
       # amd64 remote coverage is trivy-pr's job (building it here too
-      # would be pure redundancy in the same PR run).
+      # would be pure redundancy in the same PR run). Reads the local
+      # scope too — both targets share the base/deps/build stages.
       - name: Build image from branch (remote target, arm64 compile check)
         if: matrix.arch == 'arm64'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -96,8 +98,9 @@ jobs:
           target: remote
           build-args: APT_UPGRADE_DATE=${{ steps.date.outputs.date }}
           cache-from: |
-            type=gha,scope=arch-smoke-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=arch-smoke-${{ matrix.arch }}
+            type=gha,scope=arch-smoke-${{ matrix.arch }}-remote
+            type=gha,scope=arch-smoke-${{ matrix.arch }}-local
+          cache-to: type=gha,mode=max,scope=arch-smoke-${{ matrix.arch }}-remote
 
       # Two notes across two folders exercise the boot-time index build
       # for real: frontmatter properties, tags, a wikilink pair (link

--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           MCP_AUTH_TOKEN="$(openssl rand -hex 24)"
 
-          docker run -d --name smoke -p 8000:8000 \
+          docker run -d --name smoke --pull=never -p 8000:8000 \
             -v "$RUNNER_TEMP/smoke-vault:/vault:ro" \
             -e MCP_AUTH_TOKEN="$MCP_AUTH_TOKEN" \
             -e PUBLIC_URL=http://localhost:8000 \

--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -148,7 +148,7 @@ jobs:
               echo "::error::container exited during startup (poll attempt $i)"
               exit 1
             fi
-            if curl -fsS http://localhost:8001/healthz > /dev/null 2>&1; then
+            if curl -fsS http://localhost:8000/healthz > /dev/null 2>&1; then
               echo "healthz ok (attempt $i)"
               break
             fi
@@ -160,7 +160,7 @@ jobs:
           done
 
           curl -fsS --max-time 30 -D "$RUNNER_TEMP/mcp-headers.txt" -o "$RUNNER_TEMP/mcp-body.txt" \
-            http://localhost:8001/mcp \
+            http://localhost:8000/mcp \
             -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json, text/event-stream" \

--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -148,7 +148,7 @@ jobs:
               echo "::error::container exited during startup (poll attempt $i)"
               exit 1
             fi
-            if curl -fsS http://localhost:8000/healthz > /dev/null 2>&1; then
+            if curl -fsS http://localhost:8001/healthz > /dev/null 2>&1; then
               echo "healthz ok (attempt $i)"
               break
             fi
@@ -160,7 +160,7 @@ jobs:
           done
 
           curl -fsS --max-time 30 -D "$RUNNER_TEMP/mcp-headers.txt" -o "$RUNNER_TEMP/mcp-body.txt" \
-            http://localhost:8000/mcp \
+            http://localhost:8001/mcp \
             -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json, text/event-stream" \

--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -1,0 +1,198 @@
+name: Arch Smoke
+
+# Builds and boots the Docker image on both production architectures on
+# every PR — native runners, no QEMU. Motivated by v0.33.0–v0.33.4: the
+# arm64 image crash-looped (better-sqlite3 v13's linux-arm64 prebuild
+# needs glibc >= 2.38, the base had 2.36) and nothing at PR time ever
+# executed an arm64 artifact — trivy-pr builds amd64 only. Each leg:
+#   1. build --target local — natively executes the Dockerfile deps-stage
+#      native-binding assertion for its arch
+#   2. boot smoke — run the image against a small fixture vault; /healthz
+#      returning 200 proves better-sqlite3 + sqlite-vec loaded and the
+#      FTS index built (server.ts exits 1 on any startup failure), then
+#      an authenticated MCP initialize round-trip is asserted
+#   3. arm64 only: build --target remote as a compile check (build-only —
+#      trivy-pr already builds remote on amd64, and booting remote would
+#      need obsidian-sync credentials)
+#
+# EMBEDDING_ENABLED=false at runtime is fine: onnxruntime-node's dynamic
+# import is never reached, but the deps-stage assertion already executed
+# require('onnxruntime-node') for this arch at build time.
+#
+# The rendered job names — "arch-smoke (amd64)" / "arch-smoke (arm64)" —
+# are the required-status-check contexts in the branch ruleset; friendly
+# arch names keep those contexts stable if runner labels change.
+
+on:
+  pull_request:
+  push:
+    branches: [main] # seeds the per-arch build cache all PRs can restore
+
+concurrency:
+  group: arch-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  arch-smoke:
+    name: arch-smoke (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      # Arch failures are independent signals — never cancel the other leg.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # Same daily cache-bust as trivy-pr — an APT_UPGRADE_DATE that
+      # differs between the two workflows would change the base layer
+      # hash and stop the amd64 leg sharing trivy-pr's cache.
+      - name: Cache-bust date for apt-get upgrade
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      # Per-arch cache scope: the two legs here plus trivy-pr (which
+      # writes the default scope) would otherwise all write mode=max into
+      # one scope on one ref — last write wins and evicts the rest. The
+      # bare type=gha cache-from lets the amd64 leg still read trivy-pr's
+      # layers; it is a no-op on arm64 (no matching blobs).
+      - name: Build image from branch (local target)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: local
+          # Make the built image visible to the local Docker daemon so the
+          # boot step can run it by tag.
+          load: true
+          tags: vault-cortex:smoke
+          build-args: APT_UPGRADE_DATE=${{ steps.date.outputs.date }}
+          cache-from: |
+            type=gha,scope=arch-smoke-${{ matrix.arch }}
+            type=gha
+          cache-to: type=gha,mode=max,scope=arch-smoke-${{ matrix.arch }}
+
+      # Compile check only: nothing had ever built the remote target for
+      # arm64 before merge. No load/tags — the image is never run, and
+      # amd64 remote coverage is trivy-pr's job (building it here too
+      # would be pure redundancy in the same PR run).
+      - name: Build image from branch (remote target, arm64 compile check)
+        if: matrix.arch == 'arm64'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: remote
+          build-args: APT_UPGRADE_DATE=${{ steps.date.outputs.date }}
+          cache-from: |
+            type=gha,scope=arch-smoke-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=arch-smoke-${{ matrix.arch }}
+
+      # Two notes across two folders exercise the boot-time index build
+      # for real: frontmatter properties, tags, a wikilink pair (link
+      # extraction + backlinks), and a task line — all inserted into FTS
+      # by the blocking rebuildFromVault before /healthz can return 200.
+      - name: Create fixture vault
+        run: |
+          mkdir -p "$RUNNER_TEMP/smoke-vault/Projects" "$RUNNER_TEMP/smoke-vault/Daily"
+          cat > "$RUNNER_TEMP/smoke-vault/Projects/Arch Smoke.md" << 'EOF'
+          ---
+          tags: [ci, smoke]
+          status: active
+          ---
+
+          # Arch Smoke
+
+          Fixture note for the CI boot smoke — indexed at container start.
+          Links to [[2026-07-30]].
+
+          - [ ] boot the image on both architectures
+          EOF
+          cat > "$RUNNER_TEMP/smoke-vault/Daily/2026-07-30.md" << 'EOF'
+          # 2026-07-30
+
+          Daily fixture note linking back to [[Arch Smoke]]. #smoke
+          EOF
+
+      # MEMORY_ENABLED=false keeps the About Me/ bootstrap from writing
+      # into the mount, so the vault can be read-only (the container's
+      # UID-1000 'node' user couldn't write the runner-owned dir anyway).
+      # The token is generated per run — nothing token-shaped is committed.
+      # No --rm: the container must survive a failure so the diagnostics
+      # step can read its logs.
+      - name: Boot smoke (healthz + MCP initialize)
+        run: |
+          MCP_AUTH_TOKEN="$(openssl rand -hex 24)"
+
+          docker run -d --name smoke -p 8000:8000 \
+            -v "$RUNNER_TEMP/smoke-vault:/vault:ro" \
+            -e MCP_AUTH_TOKEN="$MCP_AUTH_TOKEN" \
+            -e PUBLIC_URL=http://localhost:8000 \
+            -e EMBEDDING_ENABLED=false \
+            -e MEMORY_ENABLED=false \
+            vault-cortex:smoke
+
+          for i in $(seq 1 30); do
+            if [ "$(docker inspect -f '{{.State.Running}}' smoke)" != "true" ]; then
+              echo "::error::container exited during startup (poll attempt $i)"
+              exit 1
+            fi
+            if curl -fsS http://localhost:8000/healthz > /dev/null 2>&1; then
+              echo "healthz ok (attempt $i)"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "::error::/healthz not ready within 60s"
+              exit 1
+            fi
+            sleep 2
+          done
+
+          curl -fsS --max-time 30 -D "$RUNNER_TEMP/mcp-headers.txt" -o "$RUNNER_TEMP/mcp-body.txt" \
+            http://localhost:8000/mcp \
+            -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci-smoke","version":"0.0.1"}}}'
+          if ! grep -qi '^mcp-session-id:' "$RUNNER_TEMP/mcp-headers.txt"; then
+            echo "::error::initialize response has no mcp-session-id header"
+            exit 1
+          fi
+          # A JSON-RPC *error* still returns HTTP 200 — serverInfo only
+          # appears in a successful initialize result.
+          if ! grep -q '"serverInfo"' "$RUNNER_TEMP/mcp-body.txt"; then
+            echo "::error::initialize response body has no serverInfo"
+            cat "$RUNNER_TEMP/mcp-body.txt"
+            exit 1
+          fi
+          echo "MCP initialize ok"
+
+      # Fires on any prior step's failure (build included — hence the
+      # container-existence guard) so a red run is diagnosable from the
+      # Actions log alone.
+      - name: Dump container diagnostics
+        if: failure()
+        run: |
+          docker ps -a
+          if docker inspect smoke > /dev/null 2>&1; then
+            docker inspect -f '{{json .State}}' smoke
+            docker logs smoke
+          fi
+
+      - name: Remove smoke container
+        if: always()
+        run: |
+          if docker inspect smoke > /dev/null 2>&1; then
+            docker rm -f smoke
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,8 +121,9 @@ truth. Key points:
 5. **Required checks must pass** — the `CI` workflow runs prettier, lint,
    test, and build on every PR. The `Arch Smoke` workflow builds the Docker
    image and boots it on native amd64 and arm64 runners (`arch-smoke (amd64)`
-   and `arch-smoke (arm64)` checks) — a native-binding or startup failure on
-   either architecture blocks the merge. Two security scans also gate merges:
+   and `arch-smoke (arm64)` checks), with the arm64 check also build-verifying
+   the remote image target — a native-binding, startup, or remote-build
+   failure on either architecture blocks the merge. Two security scans also gate merges:
    **Gitleaks** (secret detection) and **Trivy** (vulnerability scan of the
    Docker image built from your branch — a fixable CRITICAL/HIGH CVE fails
    the `trivy-pr` check and blocks the merge; the finding details are in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,10 @@ truth. Key points:
    ```
 4. **Fill out the PR template** — the checklist mirrors CI
 5. **Required checks must pass** — the `CI` workflow runs prettier, lint,
-   test, and build on every PR. Two security scans also gate merges:
+   test, and build on every PR. The `Arch Smoke` workflow builds the Docker
+   image and boots it on native amd64 and arm64 runners (`arch-smoke (amd64)`
+   and `arch-smoke (arm64)` checks) — a native-binding or startup failure on
+   either architecture blocks the merge. Two security scans also gate merges:
    **Gitleaks** (secret detection) and **Trivy** (vulnerability scan of the
    Docker image built from your branch — a fixable CRITICAL/HIGH CVE fails
    the `trivy-pr` check and blocks the merge; the finding details are in the


### PR DESCRIPTION
## Motivation

Every arm64 image from v0.33.0 through v0.33.4 crash-looped at startup (better-sqlite3 v13's linux-arm64 prebuild requires glibc >= 2.38; the bookworm base had 2.36) and stayed invisible for five days across four releases: prod is amd64, and trivy-pr — the only PR-time image build — builds amd64 only, so nothing ever *executed* an arm64 artifact before release. PR #384 fixed the image and added the deps-stage assertion that executes both native bindings per-arch at build time. This PR makes executed-per-arch a PR gate.

## What the job does

New `Arch Smoke` workflow, matrix over native runners (`ubuntu-latest` amd64, `ubuntu-24.04-arm` arm64 — no QEMU). Each leg:

1. **`docker build --target local`** — natively executes the Dockerfile deps-stage native-binding assertion for its arch (`new Database(':memory:')` + `require('onnxruntime-node')`).
2. **Boot smoke** — runs the image against a small inline fixture vault (frontmatter, tags, wikilink pair, task line — real FTS inserts) with `EMBEDDING_ENABLED=false` / `MEMORY_ENABLED=false` and a per-run generated token. `/healthz` 200 is a true proof of the incident class: `server.ts` opens the search DB, awaits the blocking FTS rebuild, and opens the OAuth DB before `app.listen`, exiting 1 on any failure. Then an authenticated MCP `initialize` round-trip is asserted (HTTP 2xx + `mcp-session-id` header + `serverInfo` in the body — a JSON-RPC error still returns 200, hence the body assertion).
3. **arm64 only**: `docker build --target remote` as a compile check — the first-ever arm64 build of the remote target at PR time. Build-only: booting remote needs Obsidian Sync credentials, and amd64 remote coverage is already trivy-pr's job.

## Design notes

- **Check contexts are `arch-smoke (amd64)` / `arch-smoke (arm64)`** — explicit job `name` with a friendly arch key, so the ruleset contexts stay stable if runner labels ever change. Adding them to the branch ruleset is a follow-up settings change after this merges.
- **Cache: explicit per-arch `scope=arch-smoke-<arch>`**, a deliberate divergence from the repo's bare `type=gha`: trivy-pr (two targets) plus both smoke legs writing `mode=max` into the one default scope would evict each other — worst for arm64, which shares no blobs with the amd64 writers. `cache-from` also lists the bare default scope so the amd64 leg piggybacks trivy-pr's layers (no-op on arm64). The `APT_UPGRADE_DATE` cache-bust step is reused verbatim from trivy.yml — a differing build-arg would change the apt-upgrade layer hash and break that sharing.
- **No path filters** — a required check gated by `paths:` leaves docs-only PRs stuck on "Expected" forever; trivy-pr also runs unconditionally.
- **`push: main` trigger** seeds the per-arch cache into the default-branch scope (readable by all PRs; PR-branch caches are not shared across PRs) and acts as a post-merge canary.
- **Crash-loop fast-fail**: the healthz poll checks `docker inspect '{{.State.Running}}'` each iteration, so the incident's exact failure mode (startup `process.exit(1)`) fails in ~2s instead of burning the 60s poll window. Diagnostics step (`if: failure()`) dumps `docker ps -a`, container state JSON, and logs.
- **`timeout-minutes: 20`** is a kill-switch cap (default is 360), not the expected runtime — expected ~3-5 min warm-cache, ~8-12 min cold, legs parallel.
- **`fail-fast: false`** — arch failures are independent signals; one leg must not cancel the other.

## Verification

- `actionlint`: zero findings on the new workflow; `npm run prettier:check` green.
- **Full smoke executed locally on native arm64** (Apple Silicon, the incident-class arch): the exact script block passes under `bash -e` in 2.2s — healthz ready on attempt 2, MCP initialize round-trip clean, and the initialize curl exits naturally when the SSE response stream closes (no `--max-time` timeout).
- **Failure path mutation-tested locally**: booting the container without `MCP_AUTH_TOKEN` (startup exit 1) trips the crash-detection branch on poll attempt 1 with the startup error visible in `docker logs`.
- On this PR: both legs run for the first time in CI (new `pull_request` workflows run from the PR branch). A deliberate red push (probe pointed at a wrong port) will verify the gate bites and the diagnostics render, then be reverted.

Also updates CONTRIBUTING.md's required-checks item to name the new checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated smoke testing for native amd64 and arm64 Docker builds.
  * Tests now boot images, verify health and authenticated initialization, and collect diagnostics on failure.

* **Documentation**
  * Updated pull request guidance to note that architecture smoke test failures block merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->