### PR TITLE
fix(locks): fold lock keys so path spellings of one file mutually exclude

### DIFF
--- a/src/utils/__tests__/file-write-lock.test.ts
+++ b/src/utils/__tests__/file-write-lock.test.ts
@@ -475,6 +475,105 @@ describe("withExclusiveMultiFileLock", () => {
   })
 })
 
+describe("case- and normalization-folded lock keys", () => {
+  const testDir = join(
+    import.meta.dirname,
+    "__fixtures__",
+    `folded-keys-${randomUUID()}`,
+  )
+
+  it("serializes two casings of the same path in queue order", async () => {
+    const executionOrder: number[] = []
+
+    // The first operation sleeps; the second doesn't. If the two casings got
+    // distinct lock keys the second would run concurrently and finish first
+    // ([2, 1]) — sharing a key forces queue order ([1, 2]).
+    const upperCaseWrite = withFileLock(join(testDir, "Note.md"), async () => {
+      await delay(20)
+      executionOrder.push(1)
+    })
+    const lowerCaseWrite = withFileLock(join(testDir, "note.md"), async () => {
+      executionOrder.push(2)
+    })
+
+    await Promise.all([upperCaseWrite, lowerCaseWrite])
+    expect(executionOrder).toEqual([1, 2])
+  })
+
+  it("rejects a fail-fast lock while another casing of the path is held", async () => {
+    const heldWrite = withExclusiveFileLock(
+      join(testDir, "Busy Note.md"),
+      async () => {
+        await delay(50)
+        return "held"
+      },
+    )
+
+    expect(() =>
+      withExclusiveFileLock(join(testDir, "busy note.md"), async () => "x"),
+    ).toThrow("concurrent write in progress")
+
+    expect(await heldWrite).toBe("held")
+  })
+
+  it("rejects a fail-fast lock while the NFD spelling of the held NFC path is in flight", async () => {
+    // "é" as one precomposed code point (NFC) vs "e" + combining acute (NFD)
+    // — one file on macOS APFS, so the two spellings must share a lock key.
+    // Escapes rather than literals: an editor or formatter could silently
+    // re-normalize two visually identical literals into one form and make
+    // this test vacuous.
+    const nfcPath = join(testDir, "caf\u00e9.md")
+    const nfdPath = join(testDir, "cafe\u0301.md")
+
+    const heldWrite = withExclusiveFileLock(nfcPath, async () => {
+      await delay(50)
+      return "held"
+    })
+
+    expect(() => withExclusiveFileLock(nfdPath, async () => "x")).toThrow(
+      "concurrent write in progress",
+    )
+
+    expect(await heldWrite).toBe("held")
+  })
+
+  it("still allows concurrent locks on genuinely different names", async () => {
+    const heldWrite = withExclusiveFileLock(
+      join(testDir, "First.md"),
+      async () => {
+        await delay(20)
+        return "first"
+      },
+    )
+
+    const differentNameResult = await withExclusiveFileLock(
+      join(testDir, "Second.md"),
+      async () => "second",
+    )
+
+    expect(differentNameResult).toBe("second")
+    expect(await heldWrite).toBe("first")
+  })
+
+  it("collapses two casings of one path in a multi-file lock to a single key", async () => {
+    // Both casings in one lock set must dedupe to one key rather than
+    // self-conflict, and while held, a third casing is locked out.
+    const multiWrite = withExclusiveMultiFileLock(
+      [join(testDir, "Moved.md"), join(testDir, "moved.md")],
+      async () => {
+        await delay(50)
+        return "moved"
+      },
+    )
+
+    expect(() =>
+      withExclusiveFileLock(join(testDir, "MOVED.MD"), async () => "x"),
+    ).toThrow("concurrent write in progress")
+
+    expect(await multiWrite).toBe("moved")
+  })
+})
+
 describe("cross-mode interaction", () => {
   const testDir = join(
     import.meta.dirname,

--- a/src/utils/__tests__/file-write-lock.test.ts
+++ b/src/utils/__tests__/file-write-lock.test.ts
@@ -537,6 +537,26 @@ describe("case- and normalization-folded lock keys", () => {
     expect(await heldWrite).toBe("held")
   })
 
+  it("rejects a fail-fast lock while the final-sigma spelling of the held normal-sigma path is in flight", async () => {
+    // Greek final sigma (U+03C2) lowercases to itself, so a bare toLowerCase
+    // would never fold it into normal sigma (U+03C3) — Unicode case folding
+    // (and case-folding filesystems) treat the two as one name. Escapes, not
+    // literals, so the two spellings stay visibly distinct in source.
+    const normalSigmaPath = join(testDir, "λόγο\u03c3.md")
+    const finalSigmaPath = join(testDir, "λόγο\u03c2.md")
+
+    const heldWrite = withExclusiveFileLock(normalSigmaPath, async () => {
+      await delay(50)
+      return "held"
+    })
+
+    expect(() =>
+      withExclusiveFileLock(finalSigmaPath, async () => "x"),
+    ).toThrow("concurrent write in progress")
+
+    expect(await heldWrite).toBe("held")
+  })
+
   it("still allows concurrent locks on genuinely different names", async () => {
     const heldWrite = withExclusiveFileLock(
       join(testDir, "First.md"),

--- a/src/utils/file-write-lock.ts
+++ b/src/utils/file-write-lock.ts
@@ -29,30 +29,15 @@ import { resolve } from "node:path"
 // forgetIfStillTail), so the map only holds files with a write in flight.
 const fileWriteLocks = new Map<string, Promise<unknown>>()
 
-/** Canonical lock-map key for a path: resolved, NFC-normalized, and
- *  case-folded — on every platform.
- *
- *  On case-insensitive filesystems (macOS APFS and Windows — the deploy/local
- *  bind-mount deployments), "Note.md" and "note.md" are ONE file, and APFS
- *  additionally treats NFC/NFD spellings of the same name as one file — so
- *  byte-exact keys would let two spellings of one file dodge each other's
- *  locks and lose updates. Folding unconditionally (rather than gating on a
- *  platform flag) is deliberate: keys never touch disk, and the failure modes
- *  are asymmetric. Under-merging silently loses data; over-merging — two
- *  genuinely distinct case-colliding files on a Linux vault sharing a key —
- *  costs at worst a spurious, self-remediating "concurrent write in progress"
- *  rejection or a harmless queue. Obsidian itself resolves links
- *  case-insensitively, so a vault relying on case-colliding names is already
- *  broken for Obsidian users.
- *
- *  Case folding is the upper-then-lower double map, not a bare toLowerCase:
- *  lowercasing alone leaves Unicode case-fold pairs apart (Greek final sigma
- *  "ς" lowercases to itself, never meeting "σ"; "ß" never meets "ss"), while
- *  routing through the shared uppercase form folds them together the way
- *  case-folding filesystems do. Both spellings of a name always pass through
- *  the same pipeline, so the double map can only coarsen key equivalence —
- *  and over-merging is the benign direction. The trailing NFC re-normalizes
- *  because case mapping does not always preserve normalization form. */
+/** Canonical lock-map key: resolved, NFC-normalized, case-folded — on every
+ *  platform. On case-insensitive filesystems (macOS/Windows bind mounts) two
+ *  spellings of one file must share a lock key or concurrent writes lose
+ *  updates. Folding unconditionally is safe because keys never touch disk
+ *  and over-merging is benign: genuinely distinct case-colliding files on a
+ *  Linux vault at worst hit a spurious fail-fast rejection or a harmless
+ *  queue. The upper-then-lower double map folds the pairs a bare toLowerCase
+ *  misses ("ς"/"σ", "ß"/"ss"); the trailing NFC re-normalizes because case
+ *  mapping does not always preserve normalization form. */
 const lockKeyForPath = (filePath: string): string =>
   resolve(filePath)
     .normalize("NFC")

--- a/src/utils/file-write-lock.ts
+++ b/src/utils/file-write-lock.ts
@@ -16,7 +16,11 @@
  *
  *  The lock map is a module-level singleton — all importers in the same
  *  process share it, so a vault_update_memory and a vault_replace_in_note
- *  targeting the same file correctly block/reject each other. */
+ *  targeting the same file correctly block/reject each other.
+ *
+ *  Lock keys are case- and Unicode-normalization-folded (see lockKeyForPath),
+ *  so two spellings of the same file mutually exclude on the filesystems
+ *  where they ARE the same file (macOS/Windows bind mounts). */
 
 import { resolve } from "node:path"
 
@@ -24,6 +28,24 @@ import { resolve } from "node:path"
 // removed once a file's writes settle and no later write is queued (see
 // forgetIfStillTail), so the map only holds files with a write in flight.
 const fileWriteLocks = new Map<string, Promise<unknown>>()
+
+/** Canonical lock-map key for a path: resolved, NFC-normalized, and
+ *  case-folded — on every platform.
+ *
+ *  On case-insensitive filesystems (macOS APFS and Windows — the deploy/local
+ *  bind-mount deployments), "Note.md" and "note.md" are ONE file, and APFS
+ *  additionally treats NFC/NFD spellings of the same name as one file — so
+ *  byte-exact keys would let two spellings of one file dodge each other's
+ *  locks and lose updates. Folding unconditionally (rather than gating on a
+ *  platform flag) is deliberate: keys never touch disk, and the failure modes
+ *  are asymmetric. Under-merging silently loses data; over-merging — two
+ *  genuinely distinct case-colliding files on a Linux vault sharing a key —
+ *  costs at worst a spurious, self-remediating "concurrent write in progress"
+ *  rejection or a harmless queue. Obsidian itself resolves links
+ *  case-insensitively, so a vault relying on case-colliding names is already
+ *  broken for Obsidian users. */
+const lockKeyForPath = (filePath: string): string =>
+  resolve(filePath).normalize("NFC").toLowerCase()
 
 /** Cleanup helper — removes the map entry once the write settles, but only
  *  if no later write has queued behind it (i.e. we're still the tail). */
@@ -49,7 +71,7 @@ export const withFileLock = <T>(
   filePath: string,
   operation: () => Promise<T>,
 ): Promise<T> => {
-  const key = resolve(filePath)
+  const key = lockKeyForPath(filePath)
   const previousWrite = fileWriteLocks.get(key) ?? Promise.resolve()
   const thisWrite = previousWrite.then(operation, operation)
   fileWriteLocks.set(key, thisWrite)
@@ -67,7 +89,7 @@ export const withExclusiveMultiFileLock = <T>(
   filePaths: readonly string[],
   operation: () => Promise<T>,
 ): Promise<T> => {
-  const keys = [...new Set(filePaths.map((filePath) => resolve(filePath)))]
+  const keys = [...new Set(filePaths.map(lockKeyForPath))]
   const anyFileBusy = keys.some((key) => fileWriteLocks.has(key))
   if (anyFileBusy) {
     throw new Error("concurrent write in progress")

--- a/src/utils/file-write-lock.ts
+++ b/src/utils/file-write-lock.ts
@@ -43,9 +43,22 @@ const fileWriteLocks = new Map<string, Promise<unknown>>()
  *  costs at worst a spurious, self-remediating "concurrent write in progress"
  *  rejection or a harmless queue. Obsidian itself resolves links
  *  case-insensitively, so a vault relying on case-colliding names is already
- *  broken for Obsidian users. */
+ *  broken for Obsidian users.
+ *
+ *  Case folding is the upper-then-lower double map, not a bare toLowerCase:
+ *  lowercasing alone leaves Unicode case-fold pairs apart (Greek final sigma
+ *  "ς" lowercases to itself, never meeting "σ"; "ß" never meets "ss"), while
+ *  routing through the shared uppercase form folds them together the way
+ *  case-folding filesystems do. Both spellings of a name always pass through
+ *  the same pipeline, so the double map can only coarsen key equivalence —
+ *  and over-merging is the benign direction. The trailing NFC re-normalizes
+ *  because case mapping does not always preserve normalization form. */
 const lockKeyForPath = (filePath: string): string =>
-  resolve(filePath).normalize("NFC").toLowerCase()
+  resolve(filePath)
+    .normalize("NFC")
+    .toUpperCase()
+    .toLowerCase()
+    .normalize("NFC")
 
 /** Cleanup helper — removes the map entry once the write settles, but only
  *  if no later write has queued behind it (i.e. we're still the tail). */


### PR DESCRIPTION
## What does this PR do?

Fixes `^lock-key-case-sensitivity`: `file-write-lock.ts` keyed its lock map with byte-exact resolved paths, so on case-insensitive filesystems (macOS APFS and Windows — the deploy/local bind-mount deployments) two casings of one file got distinct keys and dodged each other's locks, silently bypassing the lost-update/TOCTOU protection in all three modes (serializing, fail-fast, multi-file fail-fast). APFS is additionally Unicode-normalization-insensitive, so NFC and NFD spellings of `Résumé.md` had the same gap. Callers don't pre-normalize — the casing comes straight from client-supplied tool input.

**The fix:** a single `lockKeyForPath` helper — `resolve` → `normalize("NFC")` → `toLowerCase()` — used by both lock entry points, on every platform. The folded string is only the in-memory map key; file operations still use the original path.

**Why unconditional folding instead of a platform flag** (the task note's original framing): keys never touch disk, and the failure modes are asymmetric —

| | Consequence |
|---|---|
| Under-merge (status quo on macOS) | Silent lost update — invisible data loss |
| Over-merge (Linux vault with genuinely case-colliding names) | Serializing mode: writes queue — harmless. Fail-fast mode: a spurious "concurrent write in progress" whose message already instructs re-read-and-retry — visible and self-remediating |

And per the "design for the Obsidian user" rule: Obsidian resolves links case-insensitively, so a vault relying on `Note.md`/`note.md` coexisting is already broken for Obsidian users — case-insensitive lock semantics are the Obsidian-faithful behavior. A `WINDOWS_MODE`-style flag would add a six-surface env-var checklist and a user decision most users can't answer, with the wrong default trapping the most common deployment.

The multi-file mode's `Set` dedup now also correctly collapses two casings passed in one move operation.

## Type of change

- [ ] New MCP tool
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / workflow change
- [ ] Infrastructure (SST, Docker)
- [ ] Other:

## Checklist

- [x] `npm test` passes (2227 passed; the known `fit-image-to-byte-budget` WebP flake hit its 5s timeout under parallel load, passes in isolation)
- [x] `npm run lint` passes (0 errors)
- [x] `npm run prettier:check` passes
- [x] `npm run build` succeeds
- [ ] New MCP tools follow the naming and description conventions in AGENTS.md (N/A — no tool changes)
- [ ] README or ARCHITECTURE.md updated (N/A — internal lock-layer behavior; no config surface added)

Verification:
- 5 new tests: casing exclusion in serializing mode (queue-order proof) and fail-fast mode, NFC-vs-NFD exclusion (fixture spelled with `\u` escapes so a formatter can't silently re-normalize both literals into one form and make the test vacuous), multi-file dedup of two casings, and genuinely different names still running concurrently.
- Mutation-tested against the committed state: removing the fold fails exactly the 4 exclusion tests, while the distinct-names test — which must not depend on the fold — still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wotiYeKQ7HxZAKw3iZ21m

---
_Generated by [Claude Code](https://claude.ai/code/session_018wotiYeKQ7HxZAKw3iZ21m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-lock handling across case differences and Unicode path variations.
  * Prevented equivalent file paths from being treated as separate locks.
  * Preserved correct queuing and fail-fast behavior while allowing genuinely distinct files to operate concurrently.

* **Documentation**
  * Clarified cross-platform behavior for case-insensitive and Unicode-normalized file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->