### PR TITLE
docs(readme): rewrite How It Works as a capability-led system overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,15 +161,23 @@ See [Authentication](#authentication) for both methods and token lifetimes.
 
 ## How It Works
 
+Everything runs in one Docker container. The MCP server works directly with the `.md` files on disk, and a file watcher keeps the search index (keywords + vectors) current as notes change. Your vault stays the source of truth: the server reads and writes plain Markdown, and the index is derived data it can rebuild from your notes at any time. In the remote image, a bundled Obsidian Sync service keeps the container's vault current with every device — edit a note on your phone and it's searchable moments later; an agent writes a note and it shows up in Obsidian.
+
 ```mermaid
 graph LR
-    Client["MCP Client"] -->|OAuth 2.1 / Bearer| Server["MCP server"]
-    Server -->|read/write| Vault[("/vault<br/>.md files")]
-    Server -->|FTS5 + vector| SQLite[("SQLite\nFTS5 + sqlite-vec")]
-    Sync["Obsidian Sync service"] <-->|Obsidian Sync| Vault
+    subgraph container ["One Docker container"]
+        Sync["sync service<br/>(remote image)"]
+        Vault[("/vault<br/>.md files — source of truth")]
+        Index[("search index<br/>keywords + vectors")]
+        Server["MCP server"]
+        Sync <-->|read/write| Vault
+        Vault -->|file watcher| Index
+        Server <-->|read/write| Vault
+        Server -->|query| Index
+    end
+    Obsidian["Your Obsidian apps<br/>(phone, laptop)"] <-->|Obsidian Sync| Sync
+    Client["Any MCP client<br/>(Claude, Cursor, claude.ai)"] -->|OAuth 2.1 / Bearer| Server
 ```
-
-The search index is rebuildable derived state — FTS5 keyword tables rebuild on startup, vector embeddings persist across restarts with content-hash gating (only changed notes re-embed). A file watcher keeps both current, and queries fuse both signals via Reciprocal Rank Fusion. The sync service keeps the vault in sync with your Obsidian apps — it ships inside the same container in the `:remote` image variant (remote deployments only; the default `:latest` image is the MCP server alone).
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design, auth flow diagrams, and component breakdown.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,11 @@ See [Authentication](#authentication) for both methods and token lifetimes.
 
 ## How It Works
 
-Everything runs in one Docker container. The MCP server works directly with the `.md` files on disk, and a file watcher keeps the search index (keywords + vectors) current as notes change. Your vault stays the source of truth: the server reads and writes plain Markdown, and the index is derived data it can rebuild from your notes at any time. In the remote image, a bundled Obsidian Sync service keeps the container's vault current with every device — edit a note on your phone and it's searchable moments later; an agent writes a note and it shows up in Obsidian.
+Everything runs in one Docker container, working directly with the `.md` files on disk:
+
+- **Your vault stays the source of truth** — the server reads and writes the same plain Markdown files your Obsidian apps do.
+- **Search is derived data** — a file watcher keeps the index (keywords + vectors) current as notes change, and it can be rebuilt from your notes at any time.
+- **The remote image adds a sync loop** — a bundled Obsidian Sync service keeps the container's vault current with every device: edit a note on your phone and it's searchable moments later; an agent writes a note and it shows up in Obsidian.
 
 ```mermaid
 graph LR


### PR DESCRIPTION
## What does this PR do?

Rewrites the README's **How It Works** section. The previous version explained search-index lifecycle details (rebuild-on-startup semantics, content-hash gating, image-variant packaging) — implementation detail rather than a system overview, and largely redundant with the Hybrid Search section.

The new section is capability-led (states what the system *is*, per the project's capability-forward docs framing — no contrast/negation patterns that skew generated wikis):

- A four-sentence overview: one container, the server works directly with the `.md` files on disk, the vault stays the source of truth with the index as derived/rebuildable data, and the remote image's sync loop keeps every device current.
- An expanded mermaid diagram showing the full loop — Obsidian apps ↔ Sync ↔ sync service ↔ vault files ↔ watcher-fed index ↔ MCP server ↔ any MCP client — replacing the 4-node fragment that omitted the user's devices entirely.
- The ARCHITECTURE.md pointer is unchanged.

No downstream surfaces affected: "How It Works" is excluded from the DOCKERHUB.md generator (verified — regenerated output is byte-identical at 24,366 bytes), and the `#how-it-works` anchor used by the "Plugin-free" bullet still resolves.

## Type of change

- [ ] New MCP tool
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] CI / workflow change
- [ ] Infrastructure (SST, Docker)
- [ ] Other:

## Checklist

- [ ] `npm test` passes
- [ ] `npm run lint` passes
- [x] `npm run prettier:check` passes
- [ ] `npm run build` succeeds
- [ ] New MCP tools follow the naming and description conventions in AGENTS.md
- [x] README or ARCHITECTURE.md updated (if user-facing behavior changed)

*(test/lint/build unchecked locally — README-only change, no source touched; CI runs the full suite.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8LcX6ZmE2KA119v7K2pDU)_