### PR TITLE
ci: bump umm-actually to v0.3.1

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -77,7 +77,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@f453e8b29656803b7a39c41da9e49d7fd2f2cc1b # v0.3.0
+      - uses: aliasunder/umm-actually@ae654cc5717a3910d63d9c0ed8b73a127ae92dcc # v0.3.1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
Bumps the pinned action SHA to [v0.3.1](https://github.com/aliasunder/umm-actually/releases/tag/v0.3.1): self-describing finding headers — bold title first, then a plain-language metadata line (severity · category · confidence) replacing the `[severity/category]` code pack. Consumer repos have no access to the action's schema, so the label now carries its own decoder.

One-line change: `f453e8b` (v0.3.0) → `ae654cc` (v0.3.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)