### PR TITLE
ci(deploy): stamp the OCI revision label on release images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,6 +170,11 @@ jobs:
             ${{ env.IMAGE_HUB != '' && format('{0}:v{1}-remote', env.IMAGE_HUB, inputs.version) || '' }}
             ${{ env.IMAGE_HUB != '' && format('{0}:remote', env.IMAGE_HUB) || '' }}
           build-args: APT_UPGRADE_DATE=${{ steps.date.outputs.date }}
+          # The revision label records which commit this image was built from —
+          # `docker inspect` on the instance proves what the moving :remote tag
+          # currently runs, same verification test_deploy.yml enables for :test.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
           # Mirror the remote-stage Dockerfile LABEL description.
           annotations: |
             index:org.opencontainers.image.title=vault-cortex
@@ -195,6 +200,9 @@ jobs:
             ${{ env.IMAGE_HUB != '' && format('{0}:{1}', env.IMAGE_HUB, inputs.version) || '' }}
             ${{ env.IMAGE_HUB != '' && format('{0}:latest', env.IMAGE_HUB) || '' }}
           build-args: APT_UPGRADE_DATE=${{ steps.date.outputs.date }}
+          # Same commit-provenance label as the remote target above.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
           # GHCR shows a multi-arch package's description from the image *index*
           # annotation (a Dockerfile LABEL alone doesn't surface on the package
           # page). Mirror the server.json / Dockerfile description here.


### PR DESCRIPTION
## Problem

`test_deploy.yml` labels `:test` builds with `org.opencontainers.image.revision=${{ github.sha }}` so `docker inspect` on the instance can prove which commit a moving tag currently runs — the verification pattern established after the 2026-07-16 incident (a container re-created from `:remote` looks healthy but runs the released image).

The release build (`deploy.yml`) never got the same label. Its build steps carry `annotations:` (index-level, for the GHCR package-page description) but no `labels:`, so released images have an empty revision label. Prod's Compose pulls `:remote` — also a moving tag — so released deployments have exactly the same verification gap `:test` had. Observed after the v0.34.0 deploy: the label came back empty and the deployment had to be verified by feature probe instead.

## Change

Add the same `labels:` block to both `deploy.yml` build steps (remote + local targets), mirroring `test_deploy.yml:152`. `github.sha` resolves through the `workflow_call` from auto/manual release to the triggering commit on main.

No behavior change to the images beyond the added config label; annotations are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
