### PR TITLE
chore(deps): resolve OSV advisories via in-range transitive bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1418,12 +1418,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -4103,9 +4103,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5294,9 +5294,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5381,9 +5381,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Problem

[Scorecard alert 105](https://github.com/aliasunder/vault-cortex/security/code-scanning/105) flags five OSV advisories, all in transitive dependencies. Practical exposure is low — `brace-expansion` is dev-only tooling, the vulnerable `hono` CORS middleware isn't in this server's request path (the HTTP layer is Express), and `ip-address` is used by express-rate-limit for client-IP parsing where the SSRF scenarios don't apply — but every fix is available within the parents' declared semver ranges, so clearing them is a lockfile-only refresh.

## Change

`npm update hono ip-address brace-expansion @hono/node-server` — no manifest changes:

| Package | From → To | Advisories | Parent |
|---|---|---|---|
| `ip-address` | 10.2.0 → 10.4.0 | GHSA-mwp4-54f8-5fhr (high), GHSA-4xrf-jv44-h6hh, GHSA-22jq-vg5j-6vgg | `express-rate-limit` |
| `hono` | 4.12.31 → 4.12.34 | GHSA-8j4g-w8fx-2239 | `@modelcontextprotocol/sdk` |
| `brace-expansion` | 5.0.8 → 5.0.9 | GHSA-rgw5-rvv9-x895 (high, dev-only) | `minimatch` |
| `@hono/node-server` | 1.19.14 → 2.0.12 | GHSA-frvp-7c67-39w9 (bonus from npm audit, not in the Scorecard list) | `@modelcontextprotocol/sdk` |

`@hono/node-server` crosses a major, but the SDK's declared range is `^1.19.9 || ^2.0.5` — both alternatives are supported by the SDK.

## Verification

- `npm audit`: 0 vulnerabilities (was 6 findings across 4 packages)
- Full suite: 2321 tests pass (66 files)
- `npm run build`: server + CLI configs both clean

The Scorecard alert clears on its next scheduled run against main after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)