### PR TITLE
chore(deps): bump better-sqlite3 13.0.1 → 13.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@huggingface/transformers": "4.2.0",
         "@modelcontextprotocol/sdk": "1.30.0",
         "@napi-rs/canvas": "1.0.3",
-        "better-sqlite3": "13.0.1",
+        "better-sqlite3": "13.0.2",
         "chokidar": "5.0.0",
         "env-var": "7.5.0",
         "express": "5.2.1",
@@ -4039,10 +4039,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.1.tgz",
-      "integrity": "sha512-LYpmOXdkpQYf4wmlxkdzW01XGlOXNIbjLg45yNkh0FQ4814VbK9PdOFmhZpYbej+EZtR/i3FDdhEG98HqZdgnA==",
-      "hasInstallScript": true,
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.2.tgz",
+      "integrity": "sha512-jW6oufeDhXZaiX9Lw5A+oerVClx4iFrI6uDj1zu7SqUAjak9vbJvA0NEcKLNxHiQHb6kYCoFzzXYV0YOauhV3g==",
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
   "dependencies": {
     "@huggingface/transformers": "4.2.0",
     "@modelcontextprotocol/sdk": "1.30.0",
-    "better-sqlite3": "13.0.1",
+    "@napi-rs/canvas": "1.0.3",
+    "better-sqlite3": "13.0.2",
     "chokidar": "5.0.0",
     "env-var": "7.5.0",
     "express": "5.2.1",
@@ -77,7 +78,6 @@
     "picomatch": "4.0.5",
     "sharp": "0.35.3",
     "sqlite-vec": "0.1.9",
-    "@napi-rs/canvas": "1.0.3",
     "unpdf": "1.8.0",
     "yaml": "2.9.0",
     "zod": "4.4.3"


### PR DESCRIPTION
## Summary

- Bumps `better-sqlite3` from 13.0.1 to 13.0.2
- Upstream fix ([WiseLibs/better-sqlite3#1505](https://github.com/WiseLibs/better-sqlite3/pull/1505)): `gypfile: false` in package.json suppresses npm's injected `node-gyp rebuild` install script, so environments without `make` (like Glama's builder) no longer fail on `npm ci`
- The Glama admin `make` build step (added as a workaround) is harmless to keep as belt-and-suspenders

## Test plan

- [x] 2321 tests pass
- [x] Build clean
- [ ] CI green
- [ ] Glama build stays green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)