### PR TITLE
chore: bump umm-actually to v0.3.3

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -77,7 +77,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@0c52d8edf61fb145a11db5df9af3a9303c35be61 # v0.3.2
+      - uses: aliasunder/umm-actually@ada9e66c54519781e1cf9c1bfbf141278cad295c # v0.3.3
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
## Summary
- Bumps `aliasunder/umm-actually` action pin from v0.3.2 to v0.3.3
- v0.3.3 sets `maxCompletionTokens: 128_000` on the OpenRouter chat request, preventing providers from silently truncating structured JSON output
- Fixes the `Unexpected end of JSON input` failures seen with `deepseek/deepseek-v4-pro` on large PRs (PR [#44](https://github.com/aliasunder/umm-actually/pull/44))

## Test plan
- [x] Digest pin verified against v0.3.3 release commit
- [ ] Next PR triggers umm-actually review successfully with DeepSeek

🤖 Generated with [Claude Code](https://claude.com/claude-code)