### PR TITLE
docs: update SECURITY.md scope and container hardening

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -803,15 +803,15 @@ Docker hardening, and durability seatbelts above.
 
 **Local-only** is free — Docker on your machine, vault bind-mounted. No VPS, no Sync subscription.
 
-**Remote** adds a VPS (the reference deployment uses Lightsail) and [Obsidian Sync](https://obsidian.md/sync) ($5/mo). The server runs on modest hardware — a 2 GiB instance handles full semantic search for a typical vault (~1,000 notes); 4 GiB adds headroom for concurrent ONNX inference and larger vaults. Skip semantic search entirely (`EMBEDDING_ENABLED=false`) and even smaller instances work — the keyword-only footprint is under 200 MiB. Embeddings are generated locally by in-process ONNX models (~45 MB total) — no external API, no per-query cost.
+**Remote** adds a VPS (the reference deployment uses Lightsail) and [Obsidian Sync](https://obsidian.md/sync) ($4 USD/mo). The server runs on modest hardware — a 2 GiB instance handles full semantic search for a typical vault (~1,000 notes); 4 GiB adds headroom for concurrent ONNX inference and larger vaults. Skip semantic search entirely (`EMBEDDING_ENABLED=false`) and even smaller instances work — the keyword-only footprint is under 200 MiB. Embeddings are generated locally by in-process ONNX models (~45 MB total) — no external API, no per-query cost.
 
 | Component          | Cost                                               |
 | ------------------ | -------------------------------------------------- |
 | Lightsail instance | $12/mo (1 vCPU / 2 GiB) or $24/mo (2 vCPU / 4 GiB) |
 | Auto-snapshots     | ~$0.50–1.50/mo (used disk × 7d × $0.05/GiB)        |
 | API Gateway        | <$1/mo                                             |
-| Obsidian Sync      | $5/mo                                              |
-| **Total**          | **~$18–30/mo**                                     |
+| Obsidian Sync      | $4 USD/mo                                          |
+| **Total**          | **~$17–29/mo**                                     |
 
 Any VPS with comparable specs works — the table above prices the Lightsail reference deployment.
 

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ All three paths run the same image, `ghcr.io/aliasunder/vault-cortex` — `:late
 
 > **Also on Docker Hub:** the same images are mirrored to [`aliasunder/vault-cortex`](https://hub.docker.com/r/aliasunder/vault-cortex). GHCR is the primary source; Hub tags are identical.
 
-**Cost:** A remote setup needs a VPS and $5/mo for [Obsidian Sync](https://obsidian.md/sync). A 2 GiB instance handles semantic search fine for a typical vault; 4 GiB adds headroom for concurrent search and larger vaults. Skip semantic search entirely to go smaller still. Local-only is free. The [reference AWS deployment](./ARCHITECTURE.md#cost) runs ~$18–30/mo all-in.
+**Cost:** A remote setup needs a VPS and $4 USD/mo for [Obsidian Sync](https://obsidian.md/sync). A 2 GiB instance handles semantic search fine for a typical vault; 4 GiB adds headroom for concurrent search and larger vaults. Skip semantic search entirely to go smaller still. Local-only is free. The [reference AWS deployment](./ARCHITECTURE.md#cost) runs ~$17–29/mo all-in.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Vault Cortex writes to personal notes — the file safety layer is built to prev
 - **Per-file mutex** — concurrent MCP tool calls serialize or fail-fast per file. Moves lock the source, destination, and every backlink source as one unit.
 - **Path traversal blocked** — `resolveSafePath()` resolves then prefix-checks every path. Protected-path deletion is refused after normalization. Memory file names reject separators at the boundary.
 - **Injection prevention** — search queries are parameterized and FTS5-sanitized; prompt content is wrapped in XML data markers with closing-tag escaping to prevent tag-breakout injection.
-- **Container hardening** — non-root user, PID 1 init (`tini`), no package managers in the runtime image, digest-pinned base, log rotation.
+- **Container hardening** — non-root user, PID 1 init, no package managers in the runtime image, digest-pinned base, graceful shutdown.
 
 See [ARCHITECTURE.md → Data Integrity](./ARCHITECTURE.md#data-integrity) for mechanism details and [SECURITY.md → Runtime Hardening](./SECURITY.md#runtime-hardening) for the full attack-surface inventory.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,22 +3,35 @@
 ## Scope
 
 Vault Cortex is a remote MCP server that exposes an Obsidian vault over HTTPS.
-The attack surface includes:
+The attack surface below covers the server itself — what ships in the Docker
+image. Deployers bring their own TLS termination, reverse proxy, and CI/CD
+pipeline; those are outside vault-cortex's scope but the reference deployment
+notes below describe what the maintainer uses.
+
+### Server attack surface
 
 - **Authentication and authorization** — OAuth 2.1 (Authorization Code + PKCE),
-  JWT tokens (HS256), static bearer token fallback, Lambda authorizer, Express
-  middleware (defense in depth)
-- **API Gateway** — HTTP API fronting the Lightsail instance, path-aware
-  authorization (OAuth discovery endpoints pass through, `/mcp` requires valid
-  bearer)
+  JWT tokens (HS256), static bearer token fallback, Express middleware (defense
+  in depth)
 - **Express server** — handles MCP protocol messages, OAuth flows, consent page
 - **SQLite** — FTS5 search index and OAuth token persistence. User-supplied
   search queries are parameterized, not interpolated
 - **File system access** — vault reads and writes. Path traversal is blocked by
   `resolveSafePath()` (resolve + prefix check). Protected paths prevent deletion
   of sensitive folders
-- **Docker Compose** — two long-running containers on Lightsail sharing a
-  `/vault` volume (UID 1000)
+- **Docker image** — two targets from one Dockerfile: `:local` (tini + MCP
+  server) and `:remote` (s6-overlay supervising obsidian-sync + MCP server in
+  a single container, sharing a `/vault` volume at UID 1000)
+
+### Reference deployment (maintainer's IaC — not required by adopters)
+
+The maintainer runs the `:remote` image on AWS Lightsail behind API Gateway.
+These components are part of the maintainer's deployment, not the vault-cortex
+project itself — adopters may use any hosting, reverse proxy, and CI/CD setup:
+
+- **API Gateway + Lambda authorizer** — HTTP API fronting the Lightsail
+  instance, path-aware authorization (OAuth endpoints pass through, `/mcp`
+  requires valid bearer). IaC via SST v4
 - **CI/CD workflows** — GitHub Actions with OIDC AWS auth, SSH to Lightsail,
   GHCR image push
 
@@ -93,15 +106,16 @@ mechanism-level detail.
 
 ### Container hardening
 
-- Non-root user (`USER node`, UID 1000)
-- PID 1 init (`tini`) — forwards SIGTERM for clean SQLite WAL closure
+- Non-root user (UID 1000 — `node` on `:local`, `obsidian` on `:remote`)
+- PID 1 init — `:local` uses `tini`, `:remote` uses s6-overlay's `/init`;
+  both forward SIGTERM for clean SQLite WAL closure
 - Package-manager removal (`npm`/`npx`/`corepack`/`yarn` stripped from
-  runtime)
+  runtime in both targets)
 - Multi-stage build — build deps (`python3`, `make`, `g++`) never enter
   the runtime image
-- Digest-pinned base image (`node:24-slim@sha256:...`)
-- Debian security fixes applied at build time (`apt-get upgrade`)
-- Log rotation per service (Compose: `max-size: 10m`, `max-file: 3`)
+- Digest-pinned base image (`node:24-trixie-slim@sha256:...`)
+- Debian security fixes applied at build time (`apt-get upgrade`); daily
+  layer-cache bust in CI keeps patches current between base image rebuilds
 - Graceful shutdown: SIGTERM handler drains in-flight requests (10s
   timeout) before exiting
 

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -187,7 +187,7 @@ approach, which adds a Lambda authorizer for an extra auth layer.
 > **Need a VPS?** Any provider works — [AWS Lightsail](https://aws.amazon.com/lightsail/),
 > DigitalOcean, Hetzner, etc. A 2 GiB instance handles semantic search fine for
 > a typical vault; 4 GiB adds headroom for concurrent search and larger vaults.
-> Add $5/mo for [Obsidian Sync](https://obsidian.md/sync). For a fully automated
+> Add $4 USD/mo for [Obsidian Sync](https://obsidian.md/sync). For a fully automated
 > AWS setup, Vault Cortex also includes an [SST IaC deployment](../../DEPLOY.md)
 > that provisions Lightsail, API Gateway, and a Lambda authorizer in one command.
 


### PR DESCRIPTION
## Summary

- Split the Scope section into **Server attack surface** (what ships in the Docker image) and **Reference deployment** (the maintainer's IaC — API Gateway, Lambda, Lightsail, CI/CD). Adopters bring their own TLS termination, reverse proxy, and hosting — those aren't part of vault-cortex itself.
- Fixed stale container hardening details:
  - "two containers sharing a volume" → single container with s6-overlay (`:remote` target)
  - PID 1 init now documents both targets (`tini` for `:local`, s6's `/init` for `:remote`)
  - Base image corrected from `node:24-slim` to `node:24-trixie-slim`
  - Non-root user documents both user names (`node` on `:local`, `obsidian` on `:remote`)
  - Removed Compose-specific log rotation (deployer concern, not image hardening)
  - Added daily layer-cache bust note for Debian security patches

## Test plan

- [ ] Verify the Scope section reads correctly for both vault-cortex adopters and security researchers
- [ ] Confirm container hardening details match the current Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)