### PR TITLE
fix(security): bump js-yaml override to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4042,6 +4042,7 @@
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.2.tgz",
       "integrity": "sha512-jW6oufeDhXZaiX9Lw5A+oerVClx4iFrI6uDj1zu7SqUAjak9vbJvA0NEcKLNxHiQHb6kYCoFzzXYV0YOauhV3g==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"
@@ -5461,9 +5462,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "overrides": {
     "adm-zip": "0.6.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "@huggingface/transformers": {
       "onnxruntime-web": "npm:empty-npm-package@1.0.0",
       "sharp": "npm:empty-npm-package@1.0.0"


### PR DESCRIPTION
## Summary

Bumps the `overrides` pin for js-yaml from 4.3.0 to 4.3.1 to resolve [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (HIGH — quadratic CPU consumption in `!!omap` resolution, affecting js-yaml >= 4.0.0 < 4.3.1).

The advisory published 2026-08-06 20:27 UTC; since then every `trivy-pr` image scan fails regardless of what the PR touches, because the shipped image bundles js-yaml 4.3.0 (transitive via gray-matter, pinned by the override originally added in #138). Dependabot cannot bump it — the override wins over any lockfile update.

## Changes

- `package.json`: `overrides.js-yaml` 4.3.0 → 4.3.1
- `package-lock.json`: refreshed via `npm install`

## Verification

- `npm ls js-yaml` resolves to 4.3.1 under gray-matter
- `npm run build` — both server and CLI configs pass
- `npm test` — 67 files, 2347 tests pass
- `npm audit` — 0 vulnerabilities

Once merged, the open dependabot PRs need a rebase (`@dependabot rebase`) for their trivy-pr checks to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)