### PR TITLE
fix(oauth): enforce the documented 5 req/min rate limit on flow endpoints

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -561,7 +561,9 @@ active sessions.
 `/revoke`) are rate-limited at 5 req/min per client IP. A custom key
 generator extracts the real client IP from API Gateway's `Forwarded` header
 (express-rate-limit's built-in validators are disabled — they assume
-direct-to-server traffic, not reverse-proxy deployments).
+direct-to-server traffic, not reverse-proxy deployments). A tripped limiter
+emits an `oauth_rate_limited` warn log with the client IP and endpoint path
+before returning the 429.
 
 **Rotating `MCP_AUTH_TOKEN`:** Update the SST secret AND the Lightsail `.env`, then redeploy
 both. Existing JWTs signed with the old key become invalid immediately.

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { safeEqual, parseBearer } from "../auth.js"
+import { extractClientIp, safeEqual, parseBearer } from "../auth.js"
 
 describe("safeEqual", () => {
   it("returns true for equal strings", () => {
@@ -51,5 +51,48 @@ describe("parseBearer", () => {
   it.each(scenarios)("$name", ({ input, expected }) => {
     const result = parseBearer(input)
     expect(result).toBe(expected)
+  })
+})
+
+describe("extractClientIp", () => {
+  const requestWith = (
+    headers: Record<string, string>,
+    ip?: string,
+  ): Parameters<typeof extractClientIp>[0] => ({ headers, ip })
+
+  it("extracts the IP from a plain Forwarded for= element", () => {
+    const request = requestWith({ forwarded: "for=203.0.113.7" }, "10.0.0.1")
+    expect(extractClientIp(request)).toBe("203.0.113.7")
+  })
+
+  it("extracts the IP from a quoted Forwarded for= element", () => {
+    const request = requestWith({ forwarded: 'for="203.0.113.7"' }, "10.0.0.1")
+    expect(extractClientIp(request)).toBe("203.0.113.7")
+  })
+
+  it("stops at parameter and element separators in the Forwarded value", () => {
+    const request = requestWith(
+      { forwarded: "for=203.0.113.7;proto=https, for=70.41.3.18" },
+      "10.0.0.1",
+    )
+    expect(extractClientIp(request)).toBe("203.0.113.7")
+  })
+
+  it("takes the first for= element of joined duplicate Forwarded headers", () => {
+    const request = requestWith(
+      { forwarded: "for=203.0.113.7, for=70.41.3.18" },
+      "10.0.0.1",
+    )
+    expect(extractClientIp(request)).toBe("203.0.113.7")
+  })
+
+  it("falls back to req.ip when no Forwarded header is present", () => {
+    const request = requestWith({}, "10.0.0.1")
+    expect(extractClientIp(request)).toBe("10.0.0.1")
+  })
+
+  it("returns 'unknown' when neither Forwarded nor req.ip is available", () => {
+    const request = requestWith({})
+    expect(extractClientIp(request)).toBe("unknown")
   })
 })

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -26,21 +26,22 @@ export const parseBearer = (header: string | undefined): string | null => {
   return match?.[1]?.trim() || null
 }
 
+/** Bare or quoted `for=` value; capture stops at `"`, `;`, or `,`. */
+const FORWARDED_FOR_CLIENT = /for="?([^";,]+)"?/i
+
 /**
- * Real client IP for logging and rate limiting. API Gateway conveys the
- * client IP in the RFC 7239 Forwarded header, which Express never reads —
- * behind the gateway, req.ip resolves to a gateway egress node (verified
- * live against AWS's published API_GATEWAY ranges), so every consumer of
- * a client IP must extract from Forwarded first and fall back to req.ip.
- * With duplicate Forwarded headers Node joins values with ", " and the
- * first `for=` element is the original client per RFC 7239.
+ * Real client IP for logging and rate limiting. API Gateway sends it in
+ * the RFC 7239 Forwarded header, which Express never reads — behind the
+ * gateway, req.ip is the gateway's own egress node. The first `for=`
+ * element is the original client (proxies append); req.ip is the
+ * fallback for proxies that don't send Forwarded.
  */
 export const extractClientIp = (
   req: Pick<Request, "headers" | "ip">,
 ): string => {
   const forwarded = req.headers["forwarded"]
   if (forwarded) {
-    const match = /for="?([^";,]+)"?/i.exec(forwarded)
+    const match = FORWARDED_FOR_CLIENT.exec(forwarded)
     if (match?.[1]) return match[1]
   }
   return req.ip ?? "unknown"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 /** Shared bearer-token auth utilities — used by both the Lambda authorizer and Express middleware. */
 
 import { timingSafeEqual } from "node:crypto"
+import type { Request } from "express"
 
 /** Constant-time string comparison. Compares against itself on length mismatch to avoid timing leaks. */
 export const safeEqual = (a: string, b: string): boolean => {
@@ -23,4 +24,24 @@ export const parseBearer = (header: string | undefined): string | null => {
   if (!header) return null
   const match = /^Bearer\s+(.+)$/i.exec(header.trim())
   return match?.[1]?.trim() || null
+}
+
+/**
+ * Real client IP for logging and rate limiting. API Gateway conveys the
+ * client IP in the RFC 7239 Forwarded header, which Express never reads —
+ * behind the gateway, req.ip resolves to a gateway egress node (verified
+ * live against AWS's published API_GATEWAY ranges), so every consumer of
+ * a client IP must extract from Forwarded first and fall back to req.ip.
+ * With duplicate Forwarded headers Node joins values with ", " and the
+ * first `for=` element is the original client per RFC 7239.
+ */
+export const extractClientIp = (
+  req: Pick<Request, "headers" | "ip">,
+): string => {
+  const forwarded = req.headers["forwarded"]
+  if (forwarded) {
+    const match = /for="?([^";,]+)"?/i.exec(forwarded)
+    if (match?.[1]) return match[1]
+  }
+  return req.ip ?? "unknown"
 }

--- a/src/vault-mcp/mcp-core/__tests__/mcp-router.test.ts
+++ b/src/vault-mcp/mcp-core/__tests__/mcp-router.test.ts
@@ -419,6 +419,21 @@ describe("createMcpRouter — POST /mcp", () => {
         method: "POST",
       })
     })
+
+    it("logs the RFC 7239 Forwarded client IP over x-forwarded-for", async () => {
+      const harness = await setupHarness()
+      const response = await fetch(harness.url(), {
+        method: "POST",
+        headers: { ...baseHeaders, forwarded: "for=198.51.100.9" },
+        body: JSON.stringify(initializeBody),
+      })
+      await response.arrayBuffer()
+      expect(mockedLogger.info).toHaveBeenCalledWith("mcp_request", {
+        sessionId: undefined,
+        clientIp: "198.51.100.9",
+        method: "POST",
+      })
+    })
   })
 
   it("logs a warn with the real status when the transport rejects the initialize request without creating a session", async () => {

--- a/src/vault-mcp/mcp-core/mcp-router.ts
+++ b/src/vault-mcp/mcp-core/mcp-router.ts
@@ -13,7 +13,7 @@ import type { VaultConfig } from "../config.js"
 import { registerTools } from "./tool-definitions.js"
 import { registerPrompts } from "./prompt-definitions.js"
 import { logger } from "../../logger.js"
-import { headerAsString } from "../../auth.js"
+import { extractClientIp, headerAsString } from "../../auth.js"
 
 type McpRouterOptions = {
   vaultPath: string
@@ -50,7 +50,7 @@ export const createMcpRouter = ({
 
   router.post("/mcp", bearerAuth, async (req: Request, res: Response) => {
     const sessionId = headerAsString(req.headers["mcp-session-id"])
-    const clientIp = req.ip
+    const clientIp = extractClientIp(req)
     logger.info("mcp_request", { sessionId, clientIp, method: "POST" })
 
     const existingTransport = sessionId ? transports.get(sessionId) : undefined
@@ -176,7 +176,7 @@ Vault content is Obsidian Flavored Markdown. Write tools pass content through wi
   // until an upstream proxy timeout kills it (surfacing as gateway 5xx).
   router.get("/mcp", bearerAuth, (req: Request, res: Response) => {
     const sessionId = headerAsString(req.headers["mcp-session-id"])
-    const clientIp = req.ip
+    const clientIp = extractClientIp(req)
     logger.info("mcp_request", { sessionId, clientIp, method: "GET" })
     logger.info("mcp_response", {
       sessionId,
@@ -192,7 +192,7 @@ Vault content is Obsidian Flavored Markdown. Write tools pass content through wi
 
   router.delete("/mcp", bearerAuth, async (req: Request, res: Response) => {
     const sessionId = headerAsString(req.headers["mcp-session-id"])
-    const clientIp = req.ip
+    const clientIp = extractClientIp(req)
     logger.info("mcp_request", { sessionId, clientIp, method: "DELETE" })
     const transport = sessionId ? transports.get(sessionId) : undefined
     if (!sessionId || !transport) {

--- a/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
@@ -78,7 +78,10 @@ describe("OAuth consent token submission", () => {
   // the provider (the HTTP /register and /authorize routes are rate-limited;
   // /oauth/decide, the route under test, is not).
   const startPendingRequest = async (): Promise<string> => {
-    const client = await oauth.provider.clientsStore!.registerClient!({
+    const clientsStore = oauth.provider.clientsStore
+    if (!clientsStore?.registerClient)
+      throw new Error("clientsStore.registerClient not available")
+    const client = await clientsStore.registerClient({
       client_name: "Test Client",
       redirect_uris: [REDIRECT_URI],
       grant_types: ["authorization_code", "refresh_token"],
@@ -137,11 +140,11 @@ describe("OAuth consent token submission", () => {
     const response = await submitToken(requestId, token)
     expect(response.status).toBe(302)
     const locationHeader = response.headers.get("location")
-    expect(locationHeader).not.toBeNull()
-    const location = new URL(locationHeader!)
+    if (!locationHeader) throw new Error("expected Location header on 302")
+    const location = new URL(locationHeader)
     const code = location.searchParams.get("code")
-    expect(typeof code).toBe("string")
-    expect(code!.length).toBeGreaterThan(0)
+    if (!code) throw new Error("expected code query param in redirect")
+    expect(code.length).toBeGreaterThan(0)
     expect(location.searchParams.get("state")).toBe("test-state")
   })
 
@@ -260,7 +263,10 @@ describe("OAuth consent audit logging", () => {
   })
 
   const startPendingRequest = async (): Promise<string> => {
-    const client = await oauth.provider.clientsStore!.registerClient!({
+    const clientsStore = oauth.provider.clientsStore
+    if (!clientsStore?.registerClient)
+      throw new Error("clientsStore.registerClient not available")
+    const client = await clientsStore.registerClient({
       client_name: "Audit Client",
       redirect_uris: [REDIRECT_URI],
       grant_types: ["authorization_code", "refresh_token"],
@@ -303,10 +309,14 @@ describe("OAuth consent audit logging", () => {
     })
 
     const event = logs.find((log) => log.message === "oauth_consent_completed")
-    expect(event).toBeDefined()
-    expect(event!.level).toBe("info")
-    expect(event!.data.requestId).toBe(requestId)
-    expect(event!.data.clientIp).toBeDefined()
+    expect(event).toMatchObject({
+      level: "info",
+      message: "oauth_consent_completed",
+      data: expect.objectContaining({
+        requestId,
+        clientIp: expect.any(String),
+      }),
+    })
   })
 
   it("logs oauth_consent_bad_token on invalid token submission", async () => {
@@ -325,9 +335,11 @@ describe("OAuth consent audit logging", () => {
     })
 
     const event = logs.find((log) => log.message === "oauth_consent_bad_token")
-    expect(event).toBeDefined()
-    expect(event!.level).toBe("warn")
-    expect(event!.data.requestId).toBe(requestId)
+    expect(event).toMatchObject({
+      level: "warn",
+      message: "oauth_consent_bad_token",
+      data: expect.objectContaining({ requestId }),
+    })
   })
 
   it("logs oauth_consent_denied_by_user on deny action", async () => {
@@ -348,9 +360,11 @@ describe("OAuth consent audit logging", () => {
     const event = logs.find(
       (log) => log.message === "oauth_consent_denied_by_user",
     )
-    expect(event).toBeDefined()
-    expect(event!.level).toBe("info")
-    expect(event!.data.requestId).toBe(requestId)
+    expect(event).toMatchObject({
+      level: "info",
+      message: "oauth_consent_denied_by_user",
+      data: expect.objectContaining({ requestId }),
+    })
   })
 
   it("logs oauth_consent_expired on expired request", async () => {
@@ -368,8 +382,13 @@ describe("OAuth consent audit logging", () => {
     })
 
     const event = logs.find((log) => log.message === "oauth_consent_expired")
-    expect(event).toBeDefined()
-    expect(event!.level).toBe("warn")
+    expect(event).toMatchObject({
+      level: "warn",
+      message: "oauth_consent_expired",
+      data: expect.objectContaining({
+        requestId: "nonexistent-id",
+      }),
+    })
   })
 })
 

--- a/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
@@ -446,4 +446,58 @@ describe("OAuth endpoint rate limiting", () => {
     const sixth = await register()
     expect(sixth.status).toBe(429)
   })
+
+  // Each flow endpoint mounts its own limiter with its own counter, so the
+  // per-endpoint tests below exercise four independent limiters — register
+  // passing does not prove authorize/token/revoke are limited. The requests
+  // are deliberately invalid: the limiter runs before request validation,
+  // so invalid requests still count toward the window, and the pre-limit
+  // status is each endpoint's own validation error.
+  it("rate-limits /authorize after 5 requests from one client IP", async () => {
+    for (let i = 0; i < 5; i++) {
+      const response = await fetch(`${baseUrl}/authorize?client_id=unknown`)
+      expect(response.status).toBe(400)
+    }
+    const sixth = await fetch(`${baseUrl}/authorize?client_id=unknown`)
+    expect(sixth.status).toBe(429)
+  })
+
+  it("rate-limits /token after 5 requests from one client IP", async () => {
+    const requestToken = () =>
+      fetch(`${baseUrl}/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ grant_type: "authorization_code" }),
+      })
+    for (let i = 0; i < 5; i++) {
+      const response = await requestToken()
+      expect(response.status).toBe(400)
+    }
+    const sixth = await requestToken()
+    expect(sixth.status).toBe(429)
+  })
+
+  it("rate-limits /revoke after 5 requests from one client IP", async () => {
+    const revoke = () =>
+      fetch(`${baseUrl}/revoke`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ token: "nonexistent-token" }),
+      })
+    for (let i = 0; i < 5; i++) {
+      const response = await revoke()
+      expect(response.status).toBe(400)
+    }
+    const sixth = await revoke()
+    expect(sixth.status).toBe(429)
+  })
+
+  it("leaves /.well-known discovery metadata unlimited past 5 requests", async () => {
+    for (let i = 0; i < 6; i++) {
+      const response = await fetch(
+        `${baseUrl}/.well-known/oauth-authorization-server`,
+      )
+      expect(response.status).toBe(200)
+    }
+  })
 })

--- a/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
@@ -403,22 +403,25 @@ describe("OAuth consent audit logging", () => {
 
 describe("OAuth endpoint rate limiting", () => {
   let dir: string
+  let logs: LogCall[]
   let server: Server
   let baseUrl: string
 
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), "oauth-rate-limit-"))
+    logs = []
+    const testLogger = recordingLogger(logs)
     const oauth = createOAuthProvider({
       authToken: AUTH_TOKEN,
       dbPath: join(dir, "oauth.db"),
-      logger,
+      logger: testLogger,
     })
     const router = createOAuthRoutes({
       authToken: AUTH_TOKEN,
       serverUrl: new URL("http://localhost:8000"),
       oauthProvider: oauth,
       serviceDocumentationUrl: "https://example.com",
-      logger,
+      logger: testLogger,
     })
     const app = express()
     app.use(router)
@@ -459,6 +462,24 @@ describe("OAuth endpoint rate limiting", () => {
     }
     const sixth = await register()
     expect(sixth.status).toBe(429)
+  })
+
+  it("logs oauth_rate_limited with the offending client IP when the limit trips", async () => {
+    for (let i = 0; i < 5; i++) {
+      await register("203.0.113.9")
+    }
+    logs.length = 0
+    const sixth = await register("203.0.113.9")
+    expect(sixth.status).toBe(429)
+    const event = logs.find((log) => log.message === "oauth_rate_limited")
+    expect(event).toMatchObject({
+      level: "warn",
+      message: "oauth_rate_limited",
+      data: expect.objectContaining({
+        clientIp: "203.0.113.9",
+        path: "/register",
+      }),
+    })
   })
 
   it("keys the limit by client IP, so exhausting one client leaves another unaffected", async () => {

--- a/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
@@ -222,28 +222,24 @@ describe("OAuth consent body validation", () => {
   })
 })
 
-describe("OAuth consent audit logging", () => {
+describe("OAuth endpoint rate limiting", () => {
   let dir: string
-  let logs: LogCall[]
-  let oauth: OAuthProvider
   let server: Server
   let baseUrl: string
 
   beforeEach(async () => {
-    dir = await mkdtemp(join(tmpdir(), "oauth-audit-routes-"))
-    logs = []
-    const testLogger = recordingLogger(logs)
-    oauth = createOAuthProvider({
+    dir = await mkdtemp(join(tmpdir(), "oauth-rate-limit-"))
+    const oauth = createOAuthProvider({
       authToken: AUTH_TOKEN,
       dbPath: join(dir, "oauth.db"),
-      logger: testLogger,
+      logger,
     })
     const router = createOAuthRoutes({
       authToken: AUTH_TOKEN,
       serverUrl: new URL("http://localhost:8000"),
       oauthProvider: oauth,
       serviceDocumentationUrl: "https://example.com",
-      logger: testLogger,
+      logger,
     })
     const app = express()
     app.use(router)
@@ -259,116 +255,25 @@ describe("OAuth consent audit logging", () => {
     await rm(dir, { recursive: true, force: true })
   })
 
-  const startPendingRequest = async (): Promise<string> => {
-    const client = await oauth.provider.clientsStore!.registerClient!({
-      client_name: "Audit Client",
-      redirect_uris: [REDIRECT_URI],
-      grant_types: ["authorization_code", "refresh_token"],
-      response_types: ["code"],
-      token_endpoint_auth_method: "none",
+  const register = () =>
+    fetch(`${baseUrl}/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        client_name: "Rate Limit Client",
+        redirect_uris: [REDIRECT_URI],
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+      }),
     })
-    const params: AuthorizationParams = {
-      codeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
-      redirectUri: REDIRECT_URI,
-      scopes: ["vault"],
-      state: "test-state",
+
+  it("serves 5 requests in a minute from one client IP, then returns 429", async () => {
+    for (let i = 0; i < 5; i++) {
+      const response = await register()
+      expect(response.status).toBe(201)
     }
-    let capturedHtml = ""
-    const res = {
-      type: () => res,
-      send: (html: string) => {
-        capturedHtml = html
-        return res
-      },
-    }
-    await oauth.provider.authorize(client, params, res as unknown as Response)
-    const requestId = REQUEST_ID_PATTERN.exec(capturedHtml)?.[1]
-    if (!requestId) throw new Error("no request_id in consent HTML")
-    return requestId
-  }
-
-  it("logs oauth_consent_completed on approved consent", async () => {
-    const requestId = await startPendingRequest()
-    logs.length = 0
-
-    await fetch(`${baseUrl}/oauth/decide`, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        request_id: requestId,
-        token: AUTH_TOKEN,
-        action: "approve",
-      }),
-      redirect: "manual",
-    })
-
-    const event = logs.find((log) => log.message === "oauth_consent_completed")
-    expect(event).toBeDefined()
-    expect(event!.level).toBe("info")
-    expect(event!.data.requestId).toBe(requestId)
-    expect(event!.data.clientIp).toBeDefined()
-  })
-
-  it("logs oauth_consent_bad_token on invalid token submission", async () => {
-    const requestId = await startPendingRequest()
-    logs.length = 0
-
-    await fetch(`${baseUrl}/oauth/decide`, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        request_id: requestId,
-        token: "wrong-token",
-        action: "approve",
-      }),
-      redirect: "manual",
-    })
-
-    const event = logs.find((log) => log.message === "oauth_consent_bad_token")
-    expect(event).toBeDefined()
-    expect(event!.level).toBe("warn")
-    expect(event!.data.requestId).toBe(requestId)
-  })
-
-  it("logs oauth_consent_denied_by_user on deny action", async () => {
-    const requestId = await startPendingRequest()
-    logs.length = 0
-
-    await fetch(`${baseUrl}/oauth/decide`, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        request_id: requestId,
-        token: AUTH_TOKEN,
-        action: "deny",
-      }),
-      redirect: "manual",
-    })
-
-    const event = logs.find(
-      (log) => log.message === "oauth_consent_denied_by_user",
-    )
-    expect(event).toBeDefined()
-    expect(event!.level).toBe("info")
-    expect(event!.data.requestId).toBe(requestId)
-  })
-
-  it("logs oauth_consent_expired on expired request", async () => {
-    logs.length = 0
-
-    await fetch(`${baseUrl}/oauth/decide`, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        request_id: "nonexistent-id",
-        token: AUTH_TOKEN,
-        action: "approve",
-      }),
-      redirect: "manual",
-    })
-
-    const event = logs.find((log) => log.message === "oauth_consent_expired")
-    expect(event).toBeDefined()
-    expect(event!.level).toBe("warn")
+    const sixth = await register()
+    expect(sixth.status).toBe(429)
   })
 })

--- a/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
@@ -3,7 +3,6 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import type { Server } from "node:http"
-import type { AddressInfo } from "node:net"
 import type { Response } from "express"
 import express from "express"
 import type { AuthorizationParams } from "@modelcontextprotocol/sdk/server/auth/provider.js"
@@ -40,6 +39,19 @@ const REDIRECT_URI = "http://localhost:9999/callback"
 /** Pulls the hidden request_id out of the rendered consent HTML. */
 const REQUEST_ID_PATTERN = /name="request_id"\s+value="([^"]+)"/
 
+/**
+ * Resolves a listening server's TCP port. A bound HTTP server always
+ * reports an object-form address, so string/null narrows to a throw
+ * instead of a type assertion.
+ */
+const getListeningPort = (server: Server): number => {
+  const serverAddress = server.address()
+  if (!serverAddress || typeof serverAddress === "string") {
+    throw new Error("expected a TCP address from a listening server")
+  }
+  return serverAddress.port
+}
+
 describe("OAuth consent token submission", () => {
   let dir: string
   let oauth: OAuthProvider
@@ -65,8 +77,7 @@ describe("OAuth consent token submission", () => {
     server = await new Promise<Server>((resolve) => {
       const listening = app.listen(0, () => resolve(listening))
     })
-    const { port } = server.address() as AddressInfo
-    baseUrl = `http://localhost:${port}`
+    baseUrl = `http://localhost:${getListeningPort(server)}`
   })
 
   afterEach(async () => {
@@ -193,8 +204,7 @@ describe("OAuth consent body validation", () => {
     server = await new Promise<Server>((resolve) => {
       const listening = app.listen(0, () => resolve(listening))
     })
-    const { port } = server.address() as AddressInfo
-    baseUrl = `http://localhost:${port}`
+    baseUrl = `http://localhost:${getListeningPort(server)}`
   })
 
   afterEach(async () => {
@@ -253,8 +263,7 @@ describe("OAuth consent audit logging", () => {
     server = await new Promise<Server>((resolve) => {
       const listening = app.listen(0, () => resolve(listening))
     })
-    const { port } = server.address() as AddressInfo
-    baseUrl = `http://localhost:${port}`
+    baseUrl = `http://localhost:${getListeningPort(server)}`
   })
 
   afterEach(async () => {
@@ -416,8 +425,7 @@ describe("OAuth endpoint rate limiting", () => {
     server = await new Promise<Server>((resolve) => {
       const listening = app.listen(0, () => resolve(listening))
     })
-    const { port } = server.address() as AddressInfo
-    baseUrl = `http://localhost:${port}`
+    baseUrl = `http://localhost:${getListeningPort(server)}`
   })
 
   afterEach(async () => {
@@ -425,10 +433,16 @@ describe("OAuth endpoint rate limiting", () => {
     await rm(dir, { recursive: true, force: true })
   })
 
-  const register = () =>
+  // Without forwardedClientIp all requests share the loopback peer; with it,
+  // the RFC 7239 Forwarded header drives extractClientIp, so distinct values
+  // are distinct rate-limit identities.
+  const register = (forwardedClientIp?: string) =>
     fetch(`${baseUrl}/register`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        ...(forwardedClientIp ? { forwarded: `for=${forwardedClientIp}` } : {}),
+      },
       body: JSON.stringify({
         client_name: "Rate Limit Client",
         redirect_uris: [REDIRECT_URI],
@@ -445,6 +459,17 @@ describe("OAuth endpoint rate limiting", () => {
     }
     const sixth = await register()
     expect(sixth.status).toBe(429)
+  })
+
+  it("keys the limit by client IP, so exhausting one client leaves another unaffected", async () => {
+    for (let i = 0; i < 5; i++) {
+      const response = await register("203.0.113.7")
+      expect(response.status).toBe(201)
+    }
+    const sixthFromSameClient = await register("203.0.113.7")
+    expect(sixthFromSameClient.status).toBe(429)
+    const firstFromOtherClient = await register("203.0.113.8")
+    expect(firstFromOtherClient.status).toBe(201)
   })
 
   // Each flow endpoint mounts its own limiter with its own counter, so the

--- a/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
@@ -222,6 +222,157 @@ describe("OAuth consent body validation", () => {
   })
 })
 
+describe("OAuth consent audit logging", () => {
+  let dir: string
+  let logs: LogCall[]
+  let oauth: OAuthProvider
+  let server: Server
+  let baseUrl: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "oauth-audit-routes-"))
+    logs = []
+    const testLogger = recordingLogger(logs)
+    oauth = createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      dbPath: join(dir, "oauth.db"),
+      logger: testLogger,
+    })
+    const router = createOAuthRoutes({
+      authToken: AUTH_TOKEN,
+      serverUrl: new URL("http://localhost:8000"),
+      oauthProvider: oauth,
+      serviceDocumentationUrl: "https://example.com",
+      logger: testLogger,
+    })
+    const app = express()
+    app.use(router)
+    server = await new Promise<Server>((resolve) => {
+      const listening = app.listen(0, () => resolve(listening))
+    })
+    const { port } = server.address() as AddressInfo
+    baseUrl = `http://localhost:${port}`
+  })
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  const startPendingRequest = async (): Promise<string> => {
+    const client = await oauth.provider.clientsStore!.registerClient!({
+      client_name: "Audit Client",
+      redirect_uris: [REDIRECT_URI],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    })
+    const params: AuthorizationParams = {
+      codeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      redirectUri: REDIRECT_URI,
+      scopes: ["vault"],
+      state: "test-state",
+    }
+    let capturedHtml = ""
+    const res = {
+      type: () => res,
+      send: (html: string) => {
+        capturedHtml = html
+        return res
+      },
+    }
+    await oauth.provider.authorize(client, params, res as unknown as Response)
+    const requestId = REQUEST_ID_PATTERN.exec(capturedHtml)?.[1]
+    if (!requestId) throw new Error("no request_id in consent HTML")
+    return requestId
+  }
+
+  it("logs oauth_consent_completed on approved consent", async () => {
+    const requestId = await startPendingRequest()
+    logs.length = 0
+
+    await fetch(`${baseUrl}/oauth/decide`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        request_id: requestId,
+        token: AUTH_TOKEN,
+        action: "approve",
+      }),
+      redirect: "manual",
+    })
+
+    const event = logs.find((log) => log.message === "oauth_consent_completed")
+    expect(event).toBeDefined()
+    expect(event!.level).toBe("info")
+    expect(event!.data.requestId).toBe(requestId)
+    expect(event!.data.clientIp).toBeDefined()
+  })
+
+  it("logs oauth_consent_bad_token on invalid token submission", async () => {
+    const requestId = await startPendingRequest()
+    logs.length = 0
+
+    await fetch(`${baseUrl}/oauth/decide`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        request_id: requestId,
+        token: "wrong-token",
+        action: "approve",
+      }),
+      redirect: "manual",
+    })
+
+    const event = logs.find((log) => log.message === "oauth_consent_bad_token")
+    expect(event).toBeDefined()
+    expect(event!.level).toBe("warn")
+    expect(event!.data.requestId).toBe(requestId)
+  })
+
+  it("logs oauth_consent_denied_by_user on deny action", async () => {
+    const requestId = await startPendingRequest()
+    logs.length = 0
+
+    await fetch(`${baseUrl}/oauth/decide`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        request_id: requestId,
+        token: AUTH_TOKEN,
+        action: "deny",
+      }),
+      redirect: "manual",
+    })
+
+    const event = logs.find(
+      (log) => log.message === "oauth_consent_denied_by_user",
+    )
+    expect(event).toBeDefined()
+    expect(event!.level).toBe("info")
+    expect(event!.data.requestId).toBe(requestId)
+  })
+
+  it("logs oauth_consent_expired on expired request", async () => {
+    logs.length = 0
+
+    await fetch(`${baseUrl}/oauth/decide`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        request_id: "nonexistent-id",
+        token: AUTH_TOKEN,
+        action: "approve",
+      }),
+      redirect: "manual",
+    })
+
+    const event = logs.find((log) => log.message === "oauth_consent_expired")
+    expect(event).toBeDefined()
+    expect(event!.level).toBe("warn")
+  })
+})
+
 describe("OAuth endpoint rate limiting", () => {
   let dir: string
   let server: Server

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -28,26 +28,23 @@ export const createOAuthRoutes = ({
     oauthProvider
   const router = Router()
 
-  // Explicit 5 req/min per client IP on each flow endpoint (/authorize,
-  // /token, /register, /revoke — each mounts its own limiter). The SDK's
-  // per-endpoint defaults are far looser (authorize 100/15 min, token +
-  // revoke 50/15 min, register 20/hr); for a single-user server a
-  // complete OAuth flow touches each endpoint at most twice per minute,
-  // so 5/min absorbs client reconnect storms while shutting down brute
-  // force.
-  // windowMs/max are the exact keys the SDK sets before spreading this
-  // config — overriding them (rather than `limit`) leaves no dual-key
-  // ambiguity about which value wins.
+  // 5 req/min per client IP on each flow endpoint (/authorize, /token,
+  // /register, /revoke — each mounts its own limiter), far tighter than
+  // the SDK's per-endpoint defaults: a complete OAuth flow touches each
+  // endpoint at most twice per minute, so 5/min absorbs reconnect storms
+  // while shutting down brute force. windowMs/max (not `limit`) override
+  // the exact keys the SDK sets before spreading this config, so there
+  // is no ambiguity about which value wins.
   const rateLimit = {
     windowMs: 60 * 1000,
     max: 5,
+    // Bucket by the Forwarded-header client IP: behind API Gateway the
+    // library default (req.ip) would merge every client into a single
+    // gateway-egress bucket.
     keyGenerator: extractClientIp,
-    // A tripped limiter is silent by default — express-rate-limit just
-    // sends the 429 — yet it's the brute-force signal the limit exists
-    // to catch. Log the offender, then send the SDK's per-endpoint 429
-    // message exactly as the default handler would. The path comes from
-    // originalUrl with the query string stripped: authorize carries
-    // client_id/state in its query, which doesn't belong in logs.
+    // The default handler sends the 429 silently — log the offender, then
+    // send the SDK's per-endpoint message unchanged. The query string is
+    // stripped from the logged path (authorize carries client_id/state).
     handler: (
       req: Request,
       res: Response,

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -46,8 +46,8 @@ export const createOAuthRoutes = ({
   // per-endpoint defaults are far looser (authorize 100/15 min, token +
   // revoke 50/15 min, register 20/hr); for a single-user server a
   // complete OAuth flow touches each endpoint at most twice per minute,
-  // so 5/min absorbs reconnect storms (observed worst case: 4
-  // registrations in 6 minutes) while shutting down brute force.
+  // so 5/min absorbs client reconnect storms while shutting down brute
+  // force.
   // windowMs/max are the exact keys the SDK sets before spreading this
   // config — overriding them (rather than `limit`) leaves no dual-key
   // ambiguity about which value wins.

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -3,7 +3,7 @@
 import express, { Router } from "express"
 import type { NextFunction, Request, Response } from "express"
 import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js"
-import { safeEqual } from "../../auth.js"
+import { extractClientIp, safeEqual } from "../../auth.js"
 import { renderConsentPage } from "./consent-page.js"
 import type { OAuthProvider } from "./oauth-provider.js"
 import type { Logger } from "../../logger.js"
@@ -27,19 +27,6 @@ export const createOAuthRoutes = ({
   const { provider, getPendingRequest, approveRequest, deletePendingRequest } =
     oauthProvider
   const router = Router()
-
-  // API Gateway sends the real client IP in the RFC 7239 Forwarded header,
-  // but Express only reads X-Forwarded-For. Extract from Forwarded first,
-  // falling back to req.ip. Used by both rate limiting and audit logging
-  // so both identify the same client.
-  const extractClientIp = (req: Request): string => {
-    const forwarded = req.headers["forwarded"]
-    if (forwarded) {
-      const match = /for="?([^";,]+)"?/i.exec(forwarded)
-      if (match?.[1]) return match[1]
-    }
-    return req.ip ?? "unknown"
-  }
 
   // Explicit 5 req/min per client IP on each flow endpoint (/authorize,
   // /token, /register, /revoke — each mounts its own limiter). The SDK's

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -54,7 +54,9 @@ export const createOAuthRoutes = ({
       _next: NextFunction,
       options: { statusCode: number; message: unknown },
     ) => {
-      const requestPath = req.originalUrl.split("?")[0] ?? req.originalUrl
+      const requestPath =
+        URL.parse(req.originalUrl, "http://localhost")?.pathname ??
+        req.originalUrl
       routeLogger.warn("oauth_rate_limited", {
         clientIp: extractClientIp(req),
         path: requestPath,

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -1,7 +1,7 @@
 /** OAuth HTTP routes — SDK auth router + consent form handler. */
 
 import express, { Router } from "express"
-import type { Request, Response } from "express"
+import type { NextFunction, Request, Response } from "express"
 import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js"
 import { safeEqual } from "../../auth.js"
 import { renderConsentPage } from "./consent-page.js"
@@ -55,6 +55,25 @@ export const createOAuthRoutes = ({
     windowMs: 60 * 1000,
     max: 5,
     keyGenerator: extractClientIp,
+    // A tripped limiter is silent by default — express-rate-limit just
+    // sends the 429 — yet it's the brute-force signal the limit exists
+    // to catch. Log the offender, then send the SDK's per-endpoint 429
+    // message exactly as the default handler would. The path comes from
+    // originalUrl with the query string stripped: authorize carries
+    // client_id/state in its query, which doesn't belong in logs.
+    handler: (
+      req: Request,
+      res: Response,
+      _next: NextFunction,
+      options: { statusCode: number; message: unknown },
+    ) => {
+      const requestPath = req.originalUrl.split("?")[0] ?? req.originalUrl
+      routeLogger.warn("oauth_rate_limited", {
+        clientIp: extractClientIp(req),
+        path: requestPath,
+      })
+      res.status(options.statusCode).send(options.message)
+    },
     validate: false as const,
   }
 

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -32,9 +32,10 @@ export const createOAuthRoutes = ({
   // /register, /revoke — each mounts its own limiter), far tighter than
   // the SDK's per-endpoint defaults: a complete OAuth flow touches each
   // endpoint at most twice per minute, so 5/min absorbs reconnect storms
-  // while shutting down brute force. windowMs/max (not `limit`) override
-  // the exact keys the SDK sets before spreading this config, so there
-  // is no ambiguity about which value wins.
+  // while shutting down brute force. windowMs/max mirror the exact keys
+  // the SDK sets before spreading this config, so the spread replaces
+  // them outright. Don't rename `max` to `limit` (its modern alias):
+  // the options would then carry both keys, with no guarantee ours wins.
   const rateLimit = {
     windowMs: 60 * 1000,
     max: 5,

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -41,7 +41,19 @@ export const createOAuthRoutes = ({
     return req.ip ?? "unknown"
   }
 
+  // Explicit 5 req/min per client IP on each flow endpoint (/authorize,
+  // /token, /register, /revoke — each mounts its own limiter). The SDK's
+  // per-endpoint defaults are far looser (authorize 100/15 min, token +
+  // revoke 50/15 min, register 20/hr); for a single-user server a
+  // complete OAuth flow touches each endpoint at most twice per minute,
+  // so 5/min absorbs reconnect storms (observed worst case: 4
+  // registrations in 6 minutes) while shutting down brute force.
+  // windowMs/max are the exact keys the SDK sets before spreading this
+  // config — overriding them (rather than `limit`) leaves no dual-key
+  // ambiguity about which value wins.
   const rateLimit = {
+    windowMs: 60 * 1000,
+    max: 5,
     keyGenerator: extractClientIp,
     validate: false as const,
   }

--- a/src/vault-mcp/server.ts
+++ b/src/vault-mcp/server.ts
@@ -15,7 +15,7 @@ import { createMcpRouter } from "./mcp-core/mcp-router.js"
 import { loadConfig } from "./config.js"
 import { readDailyNotesConfig } from "./vault-operations/daily-notes.js"
 import { logger } from "../logger.js"
-import { headerAsString } from "../auth.js"
+import { extractClientIp, headerAsString } from "../auth.js"
 import { describeError } from "../utils/describe-error.js"
 import env from "env-var"
 
@@ -24,7 +24,7 @@ export const createErrorMiddleware =
   (err: Error, req: Request, res: Response, _next: NextFunction): void => {
     logger.error("unhandled_error", {
       sessionId: headerAsString(req.headers["mcp-session-id"]),
-      clientIp: req.ip,
+      clientIp: extractClientIp(req),
       method: req.method,
       path: req.path,
       error: `[${err.name}]: ${err.message}`,


### PR DESCRIPTION
## What does this PR do?

Makes the OAuth rate limit match what the docs have claimed since May. ARCHITECTURE.md and the sst.config.ts open-routes comment both say "5 req/min per client IP", but the code passed only `{ keyGenerator, validate: false }` to `mcpAuthRouter`, so the SDK's per-endpoint defaults applied: authorize **100 req/15 min**, token + revoke **50/15 min**, register **20/hr** (verified in both v1.29.0 and v1.30.0 handler sources — each passes explicit `windowMs`/`max` before spreading the custom config).

Origin of the discrepancy: the May 8 comment ("SDK default: 5 req/min per IP", `ec07aac`) conflated **express-rate-limit's library default** (5 req per 60s window) with the MCP SDK's explicit handler defaults. The library default is never reached because the SDK always sets `windowMs`/`max` itself.

Fix: pass `windowMs: 60_000, max: 5` in the shared `rateLimit` object. `max` (not `limit`) is used because it overrides the exact key the SDK sets — no dual-key ambiguity. Each flow endpoint mounts its own limiter, and a complete OAuth flow touches each endpoint at most twice, so 5/min absorbs client reconnect storms while shutting down brute force. Discovery fan-out is unaffected — the `/.well-known/*` metadata routes carry no limiter.

New behavioral test: 5 registrations from one client IP succeed, the 6th returns 429.

## Type of change

- [ ] New MCP tool
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / workflow change
- [ ] Infrastructure (SST, Docker)
- [ ] Other:

## Checklist

- [ ] `npm test` passes
- [ ] `npm run lint` passes
- [ ] `npm run prettier:check` passes
- [ ] `npm run build` succeeds
- [ ] New MCP tools follow the naming and description conventions in AGENTS.md
- [x] README or ARCHITECTURE.md updated (if user-facing behavior changed) — ARCHITECTURE.md already documents 5 req/min; this PR makes the behavior match it, so no doc change needed.

🤖 Generated with Claude (Cowork)

## Added during review

- **429s are now logged**: a custom limiter `handler` emits `oauth_rate_limited` (warn) with the client IP and query-stripped endpoint path before sending the SDK's per-endpoint 429 message — previously a tripped limiter was invisible in logs.
- **Client IP unified across all log surfaces**: `extractClientIp` moved to the shared auth module and adopted by the MCP router (`mcp_request`, session/tool-call loggers) and the error middleware, which previously logged `req.ip`. Verified live: behind API Gateway, `req.ip` resolves to gateway egress nodes (sampled values sit in AWS's published `API_GATEWAY/us-east-1` ranges), while the RFC 7239 `Forwarded` header carries the true client IP end-to-end. `req.ip` remains the fallback for deployments without a Forwarded-sending proxy.
