### PR TITLE
chore(deps): bump nanoid to 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6001,9 +6001,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Lockfile-only bump of the transitive dev dependency `nanoid` (vitest > vite > postcss) from 3.3.16 to 3.3.18. 3.3.16 is below the 3.3.17 patch floor for [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (custom generators can loop indefinitely when size is zero, high severity), which the OSSF Scorecard Vulnerabilities check flags as code-scanning alert 105.

Dev-only chain — nanoid is not shipped in the Docker image or the CLI package. Scorecard re-runs on push to main, so the alert closes once this merges.

Verified: `npm ci` clean, full suite 2404/2404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)