### PR TITLE
ci: push GHCR images with the built-in GITHUB_TOKEN; make instance GHCR auth optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ PUBLIC_URL=
 OBSIDIAN_AUTH_TOKEN=
 VAULT_NAME=
 VAULT_PASSWORD=              # only if vault has E2E encryption
-GHCR_TOKEN=
+GHCR_TOKEN=                  # only if your GHCR package is private (instance pull login)
 
 # Lightsail SSH — used by `npm run lightsail:up` for SCP/SSH.
 # Defaults to ~/.ssh/vault-cortex (the dedicated deploy key).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,13 +135,15 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
+      # The built-in GITHUB_TOKEN pushes to the repo-linked GHCR package
+      # (packages: write above) — no PAT to expire or rotate.
       - name: Log in to GHCR (build push)
         if: ${{ !inputs.skip_build }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
-          username: ${{ vars.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub (build push)
         if: ${{ !inputs.skip_build && env.IMAGE_HUB != '' }}
@@ -233,7 +235,7 @@ jobs:
             sleep 5
           done
 
-      - name: Bootstrap deploy directory and GHCR login on instance
+      - name: Bootstrap deploy directory and GHCR auth on instance
         if: ${{ !inputs.skip_instance }}
         env:
           IP: ${{ steps.ssh.outputs.host }}
@@ -242,8 +244,17 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
             'sudo mkdir -p /opt/vault-cortex && sudo chown ubuntu:ubuntu /opt/vault-cortex'
-          printf '%s' "$GHCR_TOKEN" | ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
-            "docker login ghcr.io -u '$GHCR_USER' --password-stdin"
+          # A public GHCR image pulls anonymously — GHCR_TOKEN is only needed
+          # when the package is private (a fork's first push defaults to
+          # private). Without one, clear any stored credential so a stale
+          # token can't 401 pulls that would succeed anonymously.
+          if [ -n "$GHCR_TOKEN" ]; then
+            printf '%s' "$GHCR_TOKEN" | ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
+              "docker login ghcr.io -u '$GHCR_USER' --password-stdin"
+          else
+            ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
+              'docker logout ghcr.io || true'
+          fi
 
       - name: Write Lightsail .env from secrets
         if: ${{ !inputs.skip_instance }}

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -127,13 +127,15 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
+      # The built-in GITHUB_TOKEN pushes to the repo-linked GHCR package
+      # (packages: write above) — no PAT to expire or rotate.
       - name: Log in to GHCR (build push)
         if: ${{ !inputs.skip_build }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
-          username: ${{ vars.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Labels rather than index annotations: a single-platform push may not
       # produce an image index to annotate, and the :test tag needs no GHCR
@@ -172,7 +174,7 @@ jobs:
             sleep 5
           done
 
-      - name: Bootstrap deploy directory and GHCR login on instance
+      - name: Bootstrap deploy directory and GHCR auth on instance
         env:
           IP: ${{ steps.ssh.outputs.host }}
           GHCR_USER: ${{ vars.GHCR_USER }}
@@ -180,8 +182,17 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
             'sudo mkdir -p /opt/vault-cortex && sudo chown ubuntu:ubuntu /opt/vault-cortex'
-          printf '%s' "$GHCR_TOKEN" | ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
-            "docker login ghcr.io -u '$GHCR_USER' --password-stdin"
+          # A public GHCR image pulls anonymously — GHCR_TOKEN is only needed
+          # when the package is private (a fork's first push defaults to
+          # private). Without one, clear any stored credential so a stale
+          # token can't 401 pulls that would succeed anonymously.
+          if [ -n "$GHCR_TOKEN" ]; then
+            printf '%s' "$GHCR_TOKEN" | ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
+              "docker login ghcr.io -u '$GHCR_USER' --password-stdin"
+          else
+            ssh -o StrictHostKeyChecking=accept-new ubuntu@"$IP" \
+              'docker logout ghcr.io || true'
+          fi
 
       - name: Write Lightsail .env from secrets
         env:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -14,7 +14,7 @@ SST manages the AWS infrastructure declared in `sst.config.ts`, with each develo
 
 - AWS credentials configured (`aws configure` or `AWS_PROFILE`)
 - Docker installed locally
-- A GitHub PAT with `read:packages` + `write:packages` scopes (for pushing and pulling Docker images from GitHub Container Registry)
+- A GitHub PAT with `read:packages` + `write:packages` scopes — only for pushing images from your machine with `npm run deploy:dev` (GitHub Actions uses its built-in `GITHUB_TOKEN` instead, and a public GHCR package pulls anonymously)
 - A dedicated deploy SSH keypair at `~/.ssh/vault-cortex`. If you don't have one: `ssh-keygen -t ed25519 -f ~/.ssh/vault-cortex -C vault-cortex-deploy -N ""`. SST uploads the public key to Lightsail. Both local dev and CI use the same key so deploys never trigger an instance replacement.
 - An [Obsidian](https://obsidian.md) vault (the data this server exposes)
 - An [Obsidian Sync](https://obsidian.md/sync) subscription (the remote deploy bundles a sync process that mirrors the vault between this VM and your Obsidian apps)
@@ -56,7 +56,7 @@ Then open `~/.config/vault-cortex/.env` and fill in the remaining values:
 | --------------------- | --------------------------------------------------------------------------------------------- |
 | `PUBLIC_URL`          | API Gateway URL (from `sst deploy` output) — or your [custom domain](#custom-domain-optional) |
 | `GHCR_USER`           | Your GitHub username                                                                          |
-| `GHCR_TOKEN`          | The GitHub PAT from prerequisites                                                             |
+| `GHCR_TOKEN`          | Optional — only if your GHCR package is private (used to log the instance in for pulls)       |
 | `VAULT_NAME`          | Your Obsidian vault name (exact, case-sensitive)                                              |
 | `VAULT_PASSWORD`      | Only if vault has E2E encryption                                                              |
 | `OBSIDIAN_AUTH_TOKEN` | Generate with the command below                                                               |
@@ -76,7 +76,7 @@ docker run --rm -it --entrypoint get-sync-token ghcr.io/aliasunder/vault-cortex:
 **4. Authenticate to GHCR** (once per machine):
 
 ```bash
-echo "<your-GHCR_TOKEN>" | docker login ghcr.io -u <your-github-username> --password-stdin
+echo "<your-github-pat>" | docker login ghcr.io -u <your-github-username> --password-stdin
 ```
 
 ## Deploy
@@ -342,22 +342,22 @@ To find your stage: `cat .sst/stage` (after your first deploy).
 
 **Secrets** (Settings → Secrets and variables → Actions → Secrets tab):
 
-| Secret                   | Purpose                                                                                                                                                                                                           |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AWS_DEPLOY_ROLE_ARN`    | IAM role ARN from the [OIDC setup](#github-oidc-setup-for-forkers) above.                                                                                                                                         |
-| `AWS_REGION`             | AWS region for SST deployment (default: `us-east-1`). Must match the region in `sst.config.ts`.                                                                                                                   |
-| `SST_STAGE`              | SST stage name — see [SST stage](#sst-stage) above. Must match your local `.sst/stage` so CI and laptop deploys target the same infrastructure.                                                                   |
-| `PUBLIC_URL`             | API Gateway URL (e.g. `https://<id>.execute-api.<region>.amazonaws.com`) or your [custom domain](#custom-domain-optional). Used for the healthcheck and written into the instance `.env` as the OAuth issuer URL. |
-| `VAULT_NAME`             | Exact (case-sensitive) Obsidian vault name.                                                                                                                                                                       |
-| `GHCR_TOKEN`             | Personal access token (classic) with `write:packages` + `read:packages`. Used by `docker login` both at build-push and on-instance pull. Persists across runs; rotate when stale.                                 |
-| `DOCKERHUB_TOKEN`        | Optional. Docker Hub access token with `Read & Write` repository permissions. Used by deploy (image push) and dockerhub-description (DOCKERHUB.md sync). Only needed when `DOCKERHUB_USERNAME` is set.            |
-| `MCP_AUTH_TOKEN`         | Same value as the SST secret of the same name. Written into the instance `.env` for the Express auth layer.                                                                                                       |
-| `OBSIDIAN_AUTH_TOKEN`    | Output of `npx vault-cortex@latest get-sync-token` — see [One-time setup](#one-time-setup).                                                                                                                       |
-| `VAULT_PASSWORD`         | Optional. Only set if your vault uses end-to-end encryption. Empty value is fine and ships through to `.env` as `VAULT_PASSWORD=`.                                                                                |
-| `SSH_PUBKEY`             | Public key contents of your `~/.ssh/vault-cortex.pub` (literal, single line). Same key local dev and CI use — see [Prerequisites](#prerequisites).                                                                |
-| `SSH_PRIVATE_KEY`        | Private half (`~/.ssh/vault-cortex`, full multi-line block including BEGIN/END markers). Loaded by `webfactory/ssh-agent` for SCP/SSH to the instance.                                                            |
-| `CUSTOM_DOMAIN`          | Optional. Custom domain for API Gateway (e.g. `mcp.example.com`) — see [Custom Domain](#custom-domain-optional). Set together with `CUSTOM_DOMAIN_CERT_ARN`.                                                      |
-| `CUSTOM_DOMAIN_CERT_ARN` | Optional. ARN of an **Issued** ACM certificate (same region as the API) covering `CUSTOM_DOMAIN`.                                                                                                                 |
+| Secret                   | Purpose                                                                                                                                                                                                                                                                                                             |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AWS_DEPLOY_ROLE_ARN`    | IAM role ARN from the [OIDC setup](#github-oidc-setup-for-forkers) above.                                                                                                                                                                                                                                           |
+| `AWS_REGION`             | AWS region for SST deployment (default: `us-east-1`). Must match the region in `sst.config.ts`.                                                                                                                                                                                                                     |
+| `SST_STAGE`              | SST stage name — see [SST stage](#sst-stage) above. Must match your local `.sst/stage` so CI and laptop deploys target the same infrastructure.                                                                                                                                                                     |
+| `PUBLIC_URL`             | API Gateway URL (e.g. `https://<id>.execute-api.<region>.amazonaws.com`) or your [custom domain](#custom-domain-optional). Used for the healthcheck and written into the instance `.env` as the OAuth issuer URL.                                                                                                   |
+| `VAULT_NAME`             | Exact (case-sensitive) Obsidian vault name.                                                                                                                                                                                                                                                                         |
+| `GHCR_TOKEN`             | Optional. Only needed when your GHCR package is private (a fork's first push defaults to private): a classic PAT with `read:packages`, used to log the instance in for pulls. Image pushes use the built-in `GITHUB_TOKEN`; when unset, the deploy clears any stored credential and the instance pulls anonymously. |
+| `DOCKERHUB_TOKEN`        | Optional. Docker Hub access token with `Read & Write` repository permissions. Used by deploy (image push) and dockerhub-description (DOCKERHUB.md sync). Only needed when `DOCKERHUB_USERNAME` is set.                                                                                                              |
+| `MCP_AUTH_TOKEN`         | Same value as the SST secret of the same name. Written into the instance `.env` for the Express auth layer.                                                                                                                                                                                                         |
+| `OBSIDIAN_AUTH_TOKEN`    | Output of `npx vault-cortex@latest get-sync-token` — see [One-time setup](#one-time-setup).                                                                                                                                                                                                                         |
+| `VAULT_PASSWORD`         | Optional. Only set if your vault uses end-to-end encryption. Empty value is fine and ships through to `.env` as `VAULT_PASSWORD=`.                                                                                                                                                                                  |
+| `SSH_PUBKEY`             | Public key contents of your `~/.ssh/vault-cortex.pub` (literal, single line). Same key local dev and CI use — see [Prerequisites](#prerequisites).                                                                                                                                                                  |
+| `SSH_PRIVATE_KEY`        | Private half (`~/.ssh/vault-cortex`, full multi-line block including BEGIN/END markers). Loaded by `webfactory/ssh-agent` for SCP/SSH to the instance.                                                                                                                                                              |
+| `CUSTOM_DOMAIN`          | Optional. Custom domain for API Gateway (e.g. `mcp.example.com`) — see [Custom Domain](#custom-domain-optional). Set together with `CUSTOM_DOMAIN_CERT_ARN`.                                                                                                                                                        |
+| `CUSTOM_DOMAIN_CERT_ARN` | Optional. ARN of an **Issued** ACM certificate (same region as the API) covering `CUSTOM_DOMAIN`.                                                                                                                                                                                                                   |
 
 Both halves come from the dedicated deploy keypair set up in [Prerequisites](#prerequisites). Generating a new keypair just for CI would cause SST to replace the Lightsail VM on the next deploy — that's why local and CI share the same key.
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -73,7 +73,7 @@ Or run the Docker image directly:
 docker run --rm -it --entrypoint get-sync-token ghcr.io/aliasunder/vault-cortex:remote
 ```
 
-**4. Authenticate to GHCR** (once per machine):
+**4. Authenticate to GHCR** (once per machine — only needed for pushing images from your machine with `npm run deploy:dev`; skip it if you deploy exclusively through CI, which authenticates with its built-in `GITHUB_TOKEN`):
 
 ```bash
 echo "<your-github-pat>" | docker login ghcr.io -u <your-github-username> --password-stdin

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -158,18 +158,23 @@ switch (sub) {
       `ssh ${id} ${sshOpts} ubuntu@${ip} 'sudo mkdir -p /opt/vault-cortex && sudo chown ubuntu:ubuntu /opt/vault-cortex'`,
     )
     waitForDocker(ip, id)
+    // A public GHCR image pulls anonymously — GHCR_TOKEN is only needed when
+    // the package is private (a fork's first push defaults to private).
+    // Without one, clear any stored credential so a stale token can't 401
+    // pulls that would succeed anonymously.
     const ghcrToken = env.GHCR_TOKEN
-    if (!ghcrToken) {
-      console.error(
-        `✕  GHCR_TOKEN not set in ${ENV_PATH}. Needed for docker login on the instance.`,
+    if (ghcrToken) {
+      console.log(`> docker login ghcr.io -u ${ghcrUser} (on ${ip})`)
+      execSync(
+        `ssh ${id} ${sshOpts} ubuntu@${ip} 'docker login ghcr.io -u ${ghcrUser} --password-stdin'`,
+        { input: ghcrToken, stdio: ["pipe", "pipe", "pipe"], env },
       )
-      process.exit(1)
+    } else {
+      console.log(
+        `> GHCR_TOKEN not set — clearing any stored GHCR credential on ${ip} (public images pull anonymously)`,
+      )
+      run(`ssh ${id} ${sshOpts} ubuntu@${ip} 'docker logout ghcr.io || true'`)
     }
-    console.log(`> docker login ghcr.io -u ${ghcrUser} (on ${ip})`)
-    execSync(
-      `ssh ${id} ${sshOpts} ubuntu@${ip} 'docker login ghcr.io -u ${ghcrUser} --password-stdin'`,
-      { input: ghcrToken, stdio: ["pipe", "pipe", "pipe"], env },
-    )
     run(
       `scp ${id} ${sshOpts} docker-compose.yml ubuntu@${ip}:/opt/vault-cortex/`,
     )

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -164,14 +164,14 @@ switch (sub) {
     // pulls that would succeed anonymously.
     const ghcrToken = env.GHCR_TOKEN
     if (ghcrToken) {
-      console.log(`> docker login ghcr.io -u ${ghcrUser} (on ${ip})`)
+      console.log("> docker login ghcr.io (on the instance)")
       execSync(
         `ssh ${id} ${sshOpts} ubuntu@${ip} 'docker login ghcr.io -u ${ghcrUser} --password-stdin'`,
         { input: ghcrToken, stdio: ["pipe", "pipe", "pipe"], env },
       )
     } else {
       console.log(
-        `> GHCR_TOKEN not set — clearing any stored GHCR credential on ${ip} (public images pull anonymously)`,
+        "> GHCR_TOKEN not set — clearing any stored GHCR credential on the instance (public images pull anonymously)",
       )
       run(`ssh ${id} ${sshOpts} ubuntu@${ip} 'docker logout ghcr.io || true'`)
     }


### PR DESCRIPTION
## Problem

The v0.35.1 release failed at **Log in to GHCR (build push)** with `denied: denied` — the classic PAT in the `GHCR_TOKEN` secret expired. Image pushes depended on a credential that silently goes stale.

## Changes

**Build-push login → built-in `GITHUB_TOKEN`** (`deploy.yml`, `test_deploy.yml`): both jobs already declare `packages: write`, and `ghcr-cleanup.yml` has been mutating the same package with `GITHUB_TOKEN` for weeks, proving the repo↔package Actions link. Nothing left to expire or rotate; on a fork, the first workflow push auto-creates a package linked to the fork.

**Instance-side GHCR auth → optional** (`deploy.yml`, `test_deploy.yml`, `scripts/dev.ts`): the instance login can't use `GITHUB_TOKEN` (it dies with the job), but it's only needed when the GHCR package is private — a fork's first push defaults to private. With `GHCR_TOKEN` set, the instance logs in as before; without it, the deploy runs `docker logout ghcr.io` so a stale stored credential can't 401 pulls that would succeed anonymously. This also means after this repo drops the secret, the next deploy self-heals the expired credential currently sitting in the instance's docker config.

**Docs** (`DEPLOY.md`, `.env.example`): `GHCR_TOKEN` documented as optional/private-package-only; the PAT prerequisite is scoped to local `npm run deploy:dev` pushes; the CI secrets table updated to match.

## Verification

- Instance auth snippet exercised under `bash -e` with ssh stubbed — both branches (token present/absent) complete under errexit
- `eslint scripts/dev.ts` clean, prettier clean
- Remaining `GHCR_TOKEN` references swept — all are the intentional optional path

## After merge

Re-releasing v0.35.1 without any new PAT: delete the tag (no release is attached to it) and re-push it at the post-merge main head. `auto_release`'s actor guard only skips tags pushed by the release App, so a manually re-pushed tag fires it, and its local `deploy.yml` reference resolves at the tag's commit — which then includes this fix. The `GHCR_TOKEN` secret can be deleted after that release goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)