### PR TITLE
feat(oauth): serve RFC 9728 path-suffixed discovery route for /mcp

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -478,6 +478,9 @@ healthchecks.
 ```text
 1. Client → POST /mcp (no token)                          → 401 → client starts OAuth
 2. Client → GET /.well-known/oauth-protected-resource     → discover auth server
+   (also served at the RFC 9728 path-suffixed URL
+   /.well-known/oauth-protected-resource/mcp — same document,
+   with resource: <origin>/mcp)
 3. Client → GET /.well-known/oauth-authorization-server   → discover endpoints
 4. Client → POST /register                                → dynamic client registration
 5. Client → GET /authorize?...&code_challenge=...         → consent page in browser
@@ -500,7 +503,7 @@ sequenceDiagram
     Note over C,E: First-time OAuth Authorization
     C->>AG: POST /mcp (no token — initial probe)
     AG-->>C: 401 Unauthorized (identity source missing — Lambda not invoked)
-    Note over C: 401 → client enters OAuth flow,<br/>falls back to default discovery location
+    Note over C: 401 → client enters OAuth flow<br/>(both the RFC 9728 path-suffixed URL<br/>…/oauth-protected-resource/mcp and the<br/>root discovery location are served)
     C->>AG: GET /.well-known/oauth-protected-resource
     Note over AG: Open route — no authorizer
     AG->>E: Forward

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -143,8 +143,9 @@ curl -H "Authorization: Bearer <your-token>" http://localhost:8000/mcp
 curl http://localhost:8000/healthz
 # → {"ok":true}
 
-# OAuth discovery (no auth required):
+# OAuth discovery (no auth required — root and RFC 9728 path-suffixed forms):
 curl http://localhost:8000/.well-known/oauth-protected-resource
+curl http://localhost:8000/.well-known/oauth-protected-resource/mcp
 ```
 
 ## Updating

--- a/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
@@ -651,12 +651,22 @@ describe("OAuth protected resource metadata", () => {
     expect(response.headers.get("allow")).toBe("GET, OPTIONS")
   })
 
-  it("answers OPTIONS preflight on the suffixed route", async () => {
+  it("answers a browser CORS preflight on the suffixed route", async () => {
     const response = await fetch(
       `${baseUrl}/.well-known/oauth-protected-resource/mcp`,
-      { method: "OPTIONS" },
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://claude.ai",
+          "Access-Control-Request-Method": "GET",
+        },
+      },
     )
     expect(response.status).toBe(204)
+    expect(response.headers.get("access-control-allow-origin")).toBe("*")
+    expect(response.headers.get("access-control-allow-methods")).toBe(
+      "GET,HEAD,PUT,PATCH,POST,DELETE",
+    )
   })
 
   it("leaves the suffixed discovery route unlimited past 5 requests", async () => {

--- a/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
@@ -6,6 +6,7 @@ import type { Server } from "node:http"
 import type { Response } from "express"
 import express from "express"
 import type { AuthorizationParams } from "@modelcontextprotocol/sdk/server/auth/provider.js"
+import { OAuthProtectedResourceMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js"
 import { createOAuthProvider } from "../oauth-provider.js"
 import type { OAuthProvider } from "../oauth-provider.js"
 import { createOAuthRoutes } from "../oauth-routes.js"
@@ -542,6 +543,126 @@ describe("OAuth endpoint rate limiting", () => {
     for (let i = 0; i < 6; i++) {
       const response = await fetch(
         `${baseUrl}/.well-known/oauth-authorization-server`,
+      )
+      expect(response.status).toBe(200)
+    }
+  })
+})
+
+describe("OAuth protected resource metadata", () => {
+  let dir: string
+  let server: Server
+  let baseUrl: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "oauth-metadata-test-"))
+    const oauth = createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      dbPath: join(dir, "oauth.db"),
+      logger,
+    })
+    const router = createOAuthRoutes({
+      authToken: AUTH_TOKEN,
+      serverUrl: new URL("http://localhost:8000"),
+      oauthProvider: oauth,
+      serviceDocumentationUrl: "https://example.com",
+      logger,
+    })
+    const app = express()
+    app.use(router)
+    server = await new Promise<Server>((resolve) => {
+      const listening = app.listen(0, () => resolve(listening))
+    })
+    baseUrl = `http://localhost:${getListeningPort(server)}`
+  })
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  // Test-owned expected document (drift-catching — not imported from
+  // production): the values are the harness inputs above after URL
+  // normalization, which appends a trailing slash to origin-only URLs.
+  const ROOT_DOCUMENT = {
+    resource: "http://localhost:8000/",
+    authorization_servers: ["http://localhost:8000/"],
+    scopes_supported: ["vault"],
+    resource_documentation: "https://example.com/",
+  }
+  const SUFFIXED_RESOURCE = "http://localhost:8000/mcp"
+
+  // Also the guard against a future `resourceServerUrl` pass to
+  // mcpAuthRouter: that would MOVE the SDK's metadata route to the suffixed
+  // path and this root fetch would 404.
+  it("serves the root discovery document unchanged", async () => {
+    const response = await fetch(
+      `${baseUrl}/.well-known/oauth-protected-resource`,
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(ROOT_DOCUMENT)
+  })
+
+  it("serves the RFC 9728 path-suffixed document with the /mcp resource identifier", async () => {
+    const response = await fetch(
+      `${baseUrl}/.well-known/oauth-protected-resource/mcp`,
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ...ROOT_DOCUMENT,
+      resource: SUFFIXED_RESOURCE,
+    })
+  })
+
+  // Relational guard that survives SDK bumps: if a future SDK adds a field
+  // to the root document, this fails until the suffixed document gains it.
+  it("keeps the suffixed document identical to the live root document except for resource", async () => {
+    const rootResponse = await fetch(
+      `${baseUrl}/.well-known/oauth-protected-resource`,
+    )
+    const suffixedResponse = await fetch(
+      `${baseUrl}/.well-known/oauth-protected-resource/mcp`,
+    )
+    const rootDocument = OAuthProtectedResourceMetadataSchema.parse(
+      await rootResponse.json(),
+    )
+    const suffixedDocument = OAuthProtectedResourceMetadataSchema.parse(
+      await suffixedResponse.json(),
+    )
+    expect(suffixedDocument).toEqual({
+      ...rootDocument,
+      resource: SUFFIXED_RESOURCE,
+    })
+  })
+
+  it("serves the suffixed route with CORS enabled for browser-based clients", async () => {
+    const response = await fetch(
+      `${baseUrl}/.well-known/oauth-protected-resource/mcp`,
+    )
+    expect(response.headers.get("access-control-allow-origin")).toBe("*")
+  })
+
+  it("rejects non-GET methods on the suffixed route with 405 and an Allow header", async () => {
+    const response = await fetch(
+      `${baseUrl}/.well-known/oauth-protected-resource/mcp`,
+      { method: "POST" },
+    )
+    expect(response.status).toBe(405)
+    expect(response.headers.get("allow")).toBe("GET, OPTIONS")
+  })
+
+  it("answers OPTIONS preflight on the suffixed route", async () => {
+    const response = await fetch(
+      `${baseUrl}/.well-known/oauth-protected-resource/mcp`,
+      { method: "OPTIONS" },
+    )
+    expect(response.status).toBe(204)
+  })
+
+  it("leaves the suffixed discovery route unlimited past 5 requests", async () => {
+    for (let i = 0; i < 6; i++) {
+      const response = await fetch(
+        `${baseUrl}/.well-known/oauth-protected-resource/mcp`,
       )
       expect(response.status).toBe(200)
     }

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -68,29 +68,20 @@ export const createOAuthRoutes = ({
 
   const scopesSupported = ["vault"]
 
-  // RFC 9728 §3.1: a protected-resource metadata document's `resource` must
-  // equal the resource identifier its well-known URL was derived from —
-  // clients derive /.well-known/oauth-protected-resource/mcp from the
-  // <origin>/mcp MCP endpoint, so this document advertises <origin>/mcp,
-  // not a byte-copy of the root document. The SDK router below registers
-  // only ONE metadata path (root here, since issuer = resource origin);
-  // steering it to the suffixed path via `resourceServerUrl` would MOVE the
-  // route and break every client that discovers via the root form, so the
-  // suffixed variant is served as an additive second mount instead. The
-  // absolute-path URL resolution deliberately keeps only serverUrl's origin,
-  // matching where the /mcp route is actually mounted.
+  // RFC 9728 §3.1: a metadata document's `resource` must equal the resource
+  // identifier its well-known URL derives from, so this suffixed document
+  // advertises <origin>/mcp rather than copying the root document. It is an
+  // additive second mount (before mcpAuthRouter, via the SDK's own
+  // metadataHandler so CORS/OPTIONS/405 behavior matches the root route)
+  // because the SDK registers only ONE metadata path — steering it via
+  // `resourceServerUrl` would move the route and break every client that
+  // discovers via the root form.
   const mcpResourceMetadata: OAuthProtectedResourceMetadata = {
     resource: new URL("/mcp", serverUrl).href,
     authorization_servers: [serverUrl.href],
     scopes_supported: scopesSupported,
     resource_documentation: new URL(serviceDocumentationUrl).href,
   }
-
-  // Mounted before mcpAuthRouter so the suffixed path never depends on the
-  // SDK's nested-router fall-through; the root path can't match this mount,
-  // so the SDK keeps sole ownership of the root variant. metadataHandler is
-  // the SDK's own discovery handler — CORS, OPTIONS, and 405 behavior stay
-  // identical across both routes.
   router.use(
     "/.well-known/oauth-protected-resource/mcp",
     metadataHandler(mcpResourceMetadata),

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -3,6 +3,8 @@
 import express, { Router } from "express"
 import type { NextFunction, Request, Response } from "express"
 import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js"
+import { metadataHandler } from "@modelcontextprotocol/sdk/server/auth/handlers/metadata.js"
+import type { OAuthProtectedResourceMetadata } from "@modelcontextprotocol/sdk/shared/auth.js"
 import { extractClientIp, safeEqual } from "../../auth.js"
 import { renderConsentPage } from "./consent-page.js"
 import type { OAuthProvider } from "./oauth-provider.js"
@@ -64,13 +66,43 @@ export const createOAuthRoutes = ({
     validate: false as const,
   }
 
+  const scopesSupported = ["vault"]
+
+  // RFC 9728 §3.1: a protected-resource metadata document's `resource` must
+  // equal the resource identifier its well-known URL was derived from —
+  // clients derive /.well-known/oauth-protected-resource/mcp from the
+  // <origin>/mcp MCP endpoint, so this document advertises <origin>/mcp,
+  // not a byte-copy of the root document. The SDK router below registers
+  // only ONE metadata path (root here, since issuer = resource origin);
+  // steering it to the suffixed path via `resourceServerUrl` would MOVE the
+  // route and break every client that discovers via the root form, so the
+  // suffixed variant is served as an additive second mount instead. The
+  // absolute-path URL resolution deliberately keeps only serverUrl's origin,
+  // matching where the /mcp route is actually mounted.
+  const mcpResourceMetadata: OAuthProtectedResourceMetadata = {
+    resource: new URL("/mcp", serverUrl).href,
+    authorization_servers: [serverUrl.href],
+    scopes_supported: scopesSupported,
+    resource_documentation: new URL(serviceDocumentationUrl).href,
+  }
+
+  // Mounted before mcpAuthRouter so the suffixed path never depends on the
+  // SDK's nested-router fall-through; the root path can't match this mount,
+  // so the SDK keeps sole ownership of the root variant. metadataHandler is
+  // the SDK's own discovery handler — CORS, OPTIONS, and 405 behavior stay
+  // identical across both routes.
+  router.use(
+    "/.well-known/oauth-protected-resource/mcp",
+    metadataHandler(mcpResourceMetadata),
+  )
+
   // SDK-managed OAuth routes — /.well-known/*, /authorize, /token, /register, /revoke
   router.use(
     mcpAuthRouter({
       provider,
       issuerUrl: serverUrl,
       serviceDocumentationUrl: new URL(serviceDocumentationUrl),
-      scopesSupported: ["vault"],
+      scopesSupported,
       authorizationOptions: { rateLimit },
       clientRegistrationOptions: { rateLimit },
       revocationOptions: { rateLimit },


### PR DESCRIPTION
## What does this PR do?

Serves `/.well-known/oauth-protected-resource/mcp` — the RFC 9728 spec-canonical protected-resource metadata URL for the `/mcp` endpoint — alongside the existing root variant. Standards correctness plus noise removal: MCP clients that implement RFC 9728 (Perplexity among them) probe the path-suffixed URL first on every cold start and previously got a 404 before falling back to the root variant.

**Design (one production file, ~30 lines):**
- The suffixed document advertises `resource: <origin>/mcp` per RFC 9728 §3.1 — the `resource` value must equal the identifier the metadata URL derives from — so it is *not* a byte-copy of the root document. All other fields are identical.
- Served through the SDK's own `metadataHandler`, so CORS, OPTIONS preflight, and 405-with-`Allow` behavior stay exactly parallel to the SDK-served root route.
- Mounted **before** `mcpAuthRouter`, and additive only: the SDK registers exactly one metadata path (root, since issuer = resource origin), and steering it via `resourceServerUrl` would *move* the route and break every client that discovers via the root form. The root route stays SDK-owned and byte-identical.
- **Zero infrastructure changes**: the API Gateway `/.well-known/{proxy+}` open route and the Lambda authorizer's `/.well-known/` prefix match already pass the suffixed path through unauthenticated.

**Tests (7 new, in the existing oauth-routes harness):**
- The root document is asserted in full for the first time — this also guards against a future `resourceServerUrl`/`baseUrl` option moving the SDK's route off the root path.
- The suffixed document is asserted in full, plus a relational consistency test (`suffixed === { ...root, resource: <origin>/mcp }`) that fails if a future SDK version adds a metadata field the suffixed document doesn't follow.
- CORS parity, POST → 405 + `Allow: GET, OPTIONS`, browser preflight → 204 + exact CORS headers, and rate-limit exemption.

**Docs:** ARCHITECTURE.md's OAuth flow and mermaid discovery note now mention both forms; deploy/local/README.md's Verify block gains the suffixed curl.

## Type of change

- [ ] New MCP tool
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / workflow change
- [ ] Infrastructure (SST, Docker)
- [x] Other: OAuth discovery endpoint (spec compliance)

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run prettier:check` passes
- [x] `npm run build` succeeds
- [ ] New MCP tools follow the naming and description conventions in AGENTS.md
- [x] README or ARCHITECTURE.md updated (if user-facing behavior changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by CodeRabbit

- **New Features**
  - Added OAuth protected-resource discovery for the `/mcp` endpoint.
  - Clients can now discover the correct `/mcp` resource, authorization server, supported scope, and service documentation through the standardized discovery URL.
  - Existing root-level discovery remains available, with consistent metadata and cross-origin support.

- **Documentation**
  - Updated architecture and local verification guides to cover both root and `/mcp` discovery endpoints.