### PR TITLE
feat(security): block hidden paths in all vault operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ src/
     fs.ts                              # readFileOrNull / readdirOrNull / fileExists / statOrNull (ENOENT-safe)
     assert-no-control-characters.ts    # Rejects C0 controls (except tab/LF/CR), DEL, and C1 controls in write params
     assert-path-has-extension.ts       # Generic path extension assertion (used by note-path validation)
+    has-hidden-path-segment.ts         # Shared "is hidden path" predicate (listings, watcher, index, path guard)
     filter-valid-symlinks.ts           # Filters out broken symlinks from directory listings
     fit-image-to-byte-budget.ts        # Downscale/recompress an image buffer to fit a byte budget (sharp)
   functions/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -274,7 +274,7 @@ Link queries use a `links` table populated during indexing:
 
 5. **Unknown types** return an error naming the readable set.
 
-The extension-to-representation routing above is implemented by the `vault-operations/asset-operations.ts` use-case. Beneath it, every read goes through `vaultFs.readAsset`, which applies the same `resolveSafePath` traversal guard as notes, rejects `.md` paths (notes belong to `vault_read_note`), and enforces a stat-before-read size cap (`MAX_FILE_BYTES`, default 50 MiB).
+The extension-to-representation routing above is implemented by the `vault-operations/asset-operations.ts` use-case. Beneath it, every read goes through `vaultFs.readAsset`, which applies the same `resolveSafePath` traversal + hidden-path guards as notes, rejects `.md` paths (notes belong to `vault_read_note`), and enforces a stat-before-read size cap (`MAX_FILE_BYTES`, default 50 MiB).
 
 `vault_list_files` is the discovery surface (also `vault-operations/asset-operations.ts`): a filesystem walk (`vaultFs.listAssets` — filesystem truth, deliberately not the index), folder and case-insensitive extension filters, per-extension counts computed over the full filtered set, and byte sizes statted only for the returned slice. Canvas, PDF, and text files (.txt, .csv, .json, .xml, .svg, .log, .yaml, .yml, .base) are indexed for full-text search in the `file_content` + `file_content_fts` tables — see Canvas entry above for the canvas-specific link graph integration. PDF text is extracted via `obsidian-markdown/pdf.ts` (structured markdown reconstruction) — this works on PDFs with embedded text content; scanned or image-only PDFs produce no indexable text and are silently skipped. Text files are indexed as raw UTF-8 content. Content exceeding 100 KiB is truncated before FTS insertion.
 
@@ -742,16 +742,27 @@ Docker hardening, and durability seatbelts above.
 
 - **`resolveSafePath()`** (`vault-filesystem.ts`): `resolve()` +
   prefix check. Every vault-relative path passes through it before any
-  filesystem access. Throws on traversal (`../../etc/passwd`).
+  filesystem access. Throws on traversal (`../../etc/passwd`) and on
+  hidden paths — any dot-prefixed segment (`.obsidian/x`, `.trash/y.md`),
+  checked on the resolved relative path so `a/../.obsidian/x` is caught
+  while `notes/./plan.md` passes. The predicate
+  (`utils/has-hidden-path-segment.ts`) is shared with the listing
+  filter, file watcher, and index rebuild — one definition of "hidden",
+  every layer ("one rule, every layer", like `assertPathHasExtension`).
+  The internal `.obsidian/` config readers (`daily-notes.ts`,
+  `task-format-config.ts`) deliberately bypass this guard via direct
+  `readFile`.
 - **`toVaultRelativePath()`** (`vault-filesystem.ts`): normalizes
   backslashes and collapses `../` _before_ the protected-path prefix
   check, so `X/../About Me/Principles.md` cannot evade protection.
 - **`vaultFolderName`** (Zod schema in `config.ts`): config-time
   validation rejects absolute paths, traversal (`..`), and blank names
   before they reach any file operation.
-- **Memory file separator rejection** (`memory-store.ts`):
+- **Memory file name rejection** (`memory-store.ts`):
   `memoryFilePath()` rejects `/` and `\` in memory file names — a name
-  like `../../outside` cannot escape the memory directory.
+  like `../../outside` cannot escape the memory directory — and leading
+  dots, which would create hidden files (memory paths are built via
+  `join`, bypassing `resolveSafePath`'s hidden-path guard).
 - **Protected paths**: `PROTECTED_PATHS` (default: `MEMORY_DIR`,
   `Daily Notes`) blocks deleting notes in, moving notes out of, and
   moving notes into configured folders, checked after normalization.

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -67,7 +67,7 @@ Your notes embed screenshots, reference architecture diagrams, and link out to c
 - **Canvases** — a [Canvas](https://help.obsidian.md/canvas) board arrives as a readable outline: its groups, each card's content in reading order, and the connections between them. Canvas content is full-text searchable, and file references on the board appear in the link graph — backlinks and outgoing links work just like note-to-note links. The exact JSON source is one flag away when full fidelity matters
 - **PDFs** — text is extracted with heading hierarchy, code blocks, and hyperlinks preserved; PDF content is full-text searchable alongside your notes. Set `raw: true` to render pages as images instead, showing layout, diagrams, and tables that text extraction can't preserve — scanned and image-only PDFs work in this mode
 - **Text and data files** — TXT, SVG, JSON, XML, CSV, YAML, logs, and [Bases](https://help.obsidian.md/bases) files return exactly as written; the first 100 KB of content is full-text searchable. Big data files and logs can be read a line range at a time, with each page reporting where you are and how much file remains
-- **Browse** — list any folder's files with per-extension counts and file sizes; files a note links to report their size in the link graph too
+- **Browse** — list any visible folder's files with per-extension counts and file sizes; files a note links to report their size in the link graph too
 
 Set `FILE_TOOLS_ENABLED=false` to hide the file tools — useful when your remote vault syncs without attachments.
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Vault Cortex writes to personal notes — the file safety layer is built to prev
 - **Atomic writes** — every file write stages to a temp file, then renames. Readers never see a partial or 0-byte note. Exclusive creates use `link()` (POSIX no-clobber) to close the TOCTOU window on note moves.
 - **Per-file mutex** — concurrent MCP tool calls serialize or fail-fast per file. Moves lock the source, destination, and every backlink source as one unit.
 - **Path traversal blocked** — `resolveSafePath()` resolves then prefix-checks every path. Protected-path deletion is refused after normalization. Memory file names reject separators at the boundary.
+- **Hidden paths are off-limits** — files and folders starting with a dot (`.obsidian/`, `.trash/`) are invisible to every tool, reads and writes alike, matching Obsidian. Plugin configs and their API keys stay out of reach.
 - **Injection prevention** — search queries are parameterized and FTS5-sanitized; prompt content is wrapped in XML data markers with closing-tag escaping to prevent tag-breakout injection.
 - **Container hardening** — non-root user, PID 1 init, no package managers in the runtime image, digest-pinned base, graceful shutdown.
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Vault Cortex writes to personal notes — the file safety layer is built to prev
 - **Atomic writes** — every file write stages to a temp file, then renames. Readers never see a partial or 0-byte note. Exclusive creates use `link()` (POSIX no-clobber) to close the TOCTOU window on note moves.
 - **Per-file mutex** — concurrent MCP tool calls serialize or fail-fast per file. Moves lock the source, destination, and every backlink source as one unit.
 - **Path traversal blocked** — `resolveSafePath()` resolves then prefix-checks every path. Protected-path deletion is refused after normalization. Memory file names reject separators at the boundary.
-- **Hidden paths are off-limits** — files and folders starting with a dot (`.obsidian/`, `.trash/`) are invisible to every tool, reads and writes alike, matching Obsidian. Plugin configs and their API keys stay out of reach.
+- **Hidden paths are off-limits** — files and folders starting with a dot (`.obsidian/`, `.trash/`) never appear in listings or search, and any tool call that targets one directly is rejected, matching Obsidian. Plugin configs and their API keys stay out of reach.
 - **Injection prevention** — search queries are parameterized and FTS5-sanitized; prompt content is wrapped in XML data markers with closing-tag escaping to prevent tag-breakout injection.
 - **Container hardening** — non-root user, PID 1 init, no package managers in the runtime image, digest-pinned base, graceful shutdown.
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Your notes embed screenshots, reference architecture diagrams, and link out to c
 - **Canvases** — a [Canvas](https://help.obsidian.md/canvas) board arrives as a readable outline: its groups, each card's content in reading order, and the connections between them. Canvas content is full-text searchable, and file references on the board appear in the link graph — backlinks and outgoing links work just like note-to-note links. The exact JSON source is one flag away when full fidelity matters
 - **PDFs** — text is extracted with heading hierarchy, code blocks, and hyperlinks preserved; PDF content is full-text searchable alongside your notes. Set `raw: true` to render pages as images instead, showing layout, diagrams, and tables that text extraction can't preserve — scanned and image-only PDFs work in this mode
 - **Text and data files** — TXT, SVG, JSON, XML, CSV, YAML, logs, and [Bases](https://help.obsidian.md/bases) files return exactly as written; the first 100 KB of content is full-text searchable. Big data files and logs can be read a line range at a time, with each page reporting where you are and how much file remains
-- **Browse** — list any folder's files with per-extension counts and file sizes; files a note links to report their size in the link graph too
+- **Browse** — list any visible folder's files with per-extension counts and file sizes; files a note links to report their size in the link graph too
 
 Set `FILE_TOOLS_ENABLED=false` to hide the file tools — useful when your remote vault syncs without attachments.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,7 @@ mechanism-level detail.
 - `resolveSafePath()` also rejects any path with a dot-prefixed segment
   (`.obsidian/`, `.trash/`, dotfiles) before filesystem access — every
   read, write, move, and delete refuses hidden paths, matching Obsidian,
-  which ignores them entirely. This also keeps the third-party API keys
+  which ignores them entirely. This also keeps any third-party API keys
   community plugins store in `.obsidian/plugins/*/data.json` out of a
   compromised MCP token's reach.
 - Keep the search index and OAuth databases **outside the vault** (the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,7 +71,7 @@ mechanism-level detail.
   _visible_ vault folder — there it is readable like any other vault
   file.
 - The hidden-path check is lexical: a visible symlink whose target is a
-  hidden path is followed. No tool can create symlinks, so planting one
+  hidden path is followed. No tool can create symlinks, so creating one
   requires filesystem access — which already reads hidden files
   directly — and Obsidian Sync does not propagate symlinks to remote
   deployments.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,8 +17,9 @@ notes below describe what the maintainer uses.
 - **SQLite** — FTS5 search index and OAuth token persistence. User-supplied
   search queries are parameterized, not interpolated
 - **File system access** — vault reads and writes. Path traversal is blocked by
-  `resolveSafePath()` (resolve + prefix check). Protected paths prevent deletion
-  of sensitive folders
+  `resolveSafePath()` (resolve + prefix check), and hidden paths (any
+  dot-prefixed segment, e.g. `.obsidian/`) are rejected for every read and
+  write. Protected paths prevent deletion of sensitive folders
 - **Docker image** — two targets from one Dockerfile: `:local` (tini + MCP
   server) and `:remote` (s6-overlay supervising obsidian-sync + MCP server in
   a single container, sharing a `/vault` volume at UID 1000)
@@ -53,7 +54,21 @@ mechanism-level detail.
 - `vaultFolderName` Zod schema rejects `..`, absolute paths, and blank
   names at config parse time
 - Memory file names reject `/` and `\` — prevents `../../outside`-style
-  escapes from the memory directory
+  escapes from the memory directory — and leading dots, which would
+  create hidden files
+
+### Hidden paths
+
+- `resolveSafePath()` also rejects any path with a dot-prefixed segment
+  (`.obsidian/`, `.trash/`, dotfiles) before filesystem access — every
+  read, write, move, and delete refuses hidden paths, matching Obsidian,
+  which ignores them entirely. Community plugin `data.json` files under
+  `.obsidian/plugins/` frequently contain API keys, so a leaked MCP token
+  does not extend to plugin credentials.
+- Keep the search index and OAuth databases **outside the vault** (the
+  default `/data` volume already is). A database placed in a _visible_
+  vault folder would be readable through the file tools like any other
+  vault file.
 
 ### TOCTOU race prevention
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,10 +71,10 @@ mechanism-level detail.
   _visible_ vault folder — there it is readable like any other vault
   file.
 - The hidden-path check is lexical: a visible symlink whose target is a
-  hidden path is followed. No tool can create symlinks, and creating one
-  requires filesystem access — which already reads hidden files
-  directly — and Obsidian Sync does not propagate symlinks to remote
-  deployments.
+  hidden path is followed. Creating such a symlink requires direct
+  filesystem access — no tool can create one, and anyone with that
+  access can already read hidden files. Obsidian Sync does not propagate
+  symlinks, so remote deployments never see them.
 
 ### TOCTOU race prevention
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,9 +62,10 @@ mechanism-level detail.
 - `resolveSafePath()` also rejects any path with a dot-prefixed segment
   (`.obsidian/`, `.trash/`, dotfiles) before filesystem access — every
   read, write, move, and delete refuses hidden paths, matching Obsidian,
-  which ignores them entirely. Community plugin `data.json` files under
-  `.obsidian/plugins/` frequently contain API keys, so a leaked MCP token
-  does not extend to plugin credentials.
+  which ignores them entirely. Community plugins often store their own
+  third-party API keys in `.obsidian/plugins/*/data.json`; with those
+  files unreachable, a leaked MCP token exposes vault content only, not
+  the keys inside plugin configs.
 - Keep the search index and OAuth databases **outside the vault** (the
   default `/data` volume already is). A database placed in a _visible_
   vault folder would be readable through the file tools like any other

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,10 +65,11 @@ mechanism-level detail.
   which ignores them entirely. This also keeps any third-party API keys
   community plugins store in `.obsidian/plugins/*/data.json` out of a
   compromised MCP token's reach.
-- Keep the search index and OAuth databases **outside the vault** (the
-  default `/data` volume already is). A database placed in a _visible_
-  vault folder would be readable through the file tools like any other
-  vault file.
+- The search index and OAuth databases live outside the vault (the
+  default `/data` volume), so the file tools can't reach them.
+  Hidden-path blocking does not cover a database relocated into a
+  _visible_ vault folder — there it is readable like any other vault
+  file.
 
 ### TOCTOU race prevention
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,8 +73,7 @@ mechanism-level detail.
 - The hidden-path check is lexical: a visible symlink whose target is a
   hidden path is followed. Creating such a symlink requires direct
   filesystem access — no tool can create one, and anyone with that
-  access can already read hidden files. Obsidian Sync does not propagate
-  symlinks, so remote deployments never see them.
+  access can already read hidden files.
 
 ### TOCTOU race prevention
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,7 +71,7 @@ mechanism-level detail.
   _visible_ vault folder — there it is readable like any other vault
   file.
 - The hidden-path check is lexical: a visible symlink whose target is a
-  hidden path is followed. No tool can create symlinks, so creating one
+  hidden path is followed. No tool can create symlinks, and creating one
   requires filesystem access — which already reads hidden files
   directly — and Obsidian Sync does not propagate symlinks to remote
   deployments.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,10 +62,9 @@ mechanism-level detail.
 - `resolveSafePath()` also rejects any path with a dot-prefixed segment
   (`.obsidian/`, `.trash/`, dotfiles) before filesystem access — every
   read, write, move, and delete refuses hidden paths, matching Obsidian,
-  which ignores them entirely. Community plugins often store their own
-  third-party API keys in `.obsidian/plugins/*/data.json`; with those
-  files unreachable, a leaked MCP token exposes vault content only, not
-  the keys inside plugin configs.
+  which ignores them entirely. This also keeps the third-party API keys
+  community plugins store in `.obsidian/plugins/*/data.json` out of a
+  compromised MCP token's reach.
 - Keep the search index and OAuth databases **outside the vault** (the
   default `/data` volume already is). A database placed in a _visible_
   vault folder would be readable through the file tools like any other

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,6 +70,11 @@ mechanism-level detail.
   Hidden-path blocking does not cover a database relocated into a
   _visible_ vault folder — there it is readable like any other vault
   file.
+- The hidden-path check is lexical: a visible symlink whose target is a
+  hidden path is followed. No tool can create symlinks, so planting one
+  requires filesystem access — which already reads hidden files
+  directly — and Obsidian Sync does not propagate symlinks to remote
+  deployments.
 
 ### TOCTOU race prevention
 

--- a/src/utils/__tests__/has-hidden-path-segment.test.ts
+++ b/src/utils/__tests__/has-hidden-path-segment.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+
+import { hasHiddenPathSegment } from "../has-hidden-path-segment.js"
+
+describe("hasHiddenPathSegment", () => {
+  it.each([
+    [".obsidian/app.json", true],
+    ["notes/.trash/x.md", true],
+    [".hidden.md", true],
+    [".obsidian", true],
+    ["a/.b/c", true],
+    ["notes/plan.md", false],
+    ["a.b/c.md", false],
+    ["dir./file", false],
+    ["", false],
+  ])("returns %s → %s", (relativePath, expected) => {
+    expect(hasHiddenPathSegment(relativePath)).toBe(expected)
+  })
+})

--- a/src/utils/has-hidden-path-segment.ts
+++ b/src/utils/has-hidden-path-segment.ts
@@ -1,12 +1,8 @@
 /**
- * True when any segment of a POSIX relative path is dot-prefixed — hidden
- * files and directories (".obsidian/", ".trash/", dotfiles).
- *
- * The single definition of "hidden" shared by listing filters, the file
- * watcher, index rebuilds, and the path-safety guard, so the layers can't
- * drift on what counts as hidden. Callers pass vault-relative paths with
- * "/" separators (path.relative output in this codebase is always POSIX —
- * the server runs in Linux Docker).
+ * True when any segment of a POSIX vault-relative path is dot-prefixed
+ * (".obsidian/", ".trash/", dotfiles). The single definition of "hidden",
+ * shared by listings, the watcher, index rebuilds, and the path-safety
+ * guard so they can't drift.
  */
 export const hasHiddenPathSegment = (relativePath: string): boolean => {
   return relativePath.split("/").some((segment) => segment.startsWith("."))

--- a/src/utils/has-hidden-path-segment.ts
+++ b/src/utils/has-hidden-path-segment.ts
@@ -1,0 +1,13 @@
+/**
+ * True when any segment of a POSIX relative path is dot-prefixed — hidden
+ * files and directories (".obsidian/", ".trash/", dotfiles).
+ *
+ * The single definition of "hidden" shared by listing filters, the file
+ * watcher, index rebuilds, and the path-safety guard, so the layers can't
+ * drift on what counts as hidden. Callers pass vault-relative paths with
+ * "/" separators (path.relative output in this codebase is always POSIX —
+ * the server runs in Linux Docker).
+ */
+export const hasHiddenPathSegment = (relativePath: string): boolean => {
+  return relativePath.split("/").some((segment) => segment.startsWith("."))
+}

--- a/src/vault-mcp/mcp-core/tools/asset-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/asset-tools.ts
@@ -115,6 +115,7 @@ When to use: whenever a note references a file you need to actually see or read 
 Errors:
 - "not a file" — the path ends in .md; read notes with vault_read_note
 - "file not found" — nothing exists at that path; discover valid paths via vault_list_files
+- "hidden path blocked" — the path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; hidden paths are not readable, matching Obsidian
 - "file too large" — the file exceeds the server's read cap (MAX_FILE_BYTES, default 50 MiB)
 - "text output too large" — a text file or PDF renders past the output cap; page it with start_line and limit, or reduce limit when a single window overflows
 - "start line past the end" — start_line exceeds the file's line count; the error states the total, so retry with a smaller start_line
@@ -238,8 +239,9 @@ Parameters:
 - limit: maximum entries returned (default 50). extension_counts and total always reflect the full filtered set, not just the returned page.
 
 Errors:
-- A folder containing no files — or a folder that doesn't exist — returns an empty listing, not an error.
+- A visible folder containing no files — or one that doesn't exist — returns an empty listing, not an error.
 - A folder path escaping the vault (e.g. "../elsewhere") is rejected with a path-traversal error.
+- "hidden path blocked" — the folder is hidden (dot-prefixed, like ".obsidian"); hidden folders are not listable, matching Obsidian.
 
 Returns: JSON with files (array of { path, extension, bytes }, sorted by path), extension_counts (per-extension totals over the full filtered set), total (full filtered count), and truncated (true when total exceeds limit). bytes is the on-disk file size, not the delivery cost: reading an image via vault_read_file returns a copy shrunk to fit when needed, so a large listed image is still cheap to read. Text formats return verbatim, so their listed size is what a read delivers. Files of supported types are readable via vault_read_file; vault_search covers markdown notes.`,
       inputSchema: {

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -38,6 +38,7 @@ Prefer vault_read_note for reading non-memory notes.
 Errors:
 - "section requires a file" — section was provided without file; pass both or just file
 - "memory file not found" — file does not exist in ${config.memoryDir}/; call vault_list_memory_files to discover valid names
+- "memory file must not start with a dot" — a dot-prefixed name would be a hidden file; memory files are always visible notes
 - "section not found: …" — no H2 heading matches; the error lists the file's available sections
 
 Returns: Raw markdown text.`,
@@ -116,6 +117,7 @@ Errors:
 - "section must be a single line" — section names become H2 headings; remove line breaks.
 - "date must be a real ISO calendar date" — options.date only accepts an existing calendar date in bare YYYY-MM-DD form (e.g. "2026-07-02"), not a timestamp.
 - "entry/section contains a control character" — entry or section includes a non-printable control byte; remove it before writing.
+- "memory file must not start with a dot" — a dot-prefixed name would create a hidden file (invisible in Obsidian and to every listing); choose a visible name.
 - "section not created: … is nearly identical to existing section …" — near-duplicate guard; pass the exact existing heading (listed in the error) to append there, or choose a clearly different name for a genuinely new section.
 
 Returns: Confirmation message (notes when an identical entry already existed and nothing was written).`,

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -258,6 +258,7 @@ Parameters:
 - section scopes the match — an identical entry under a different heading is not found. Section matching is case-insensitive, with or without the "(newest first)" suffix.
 
 Errors:
+- "memory file must not start with a dot" — a dot-prefixed name would target a hidden file; memory files are always visible notes.
 - "date must be a real ISO calendar date" — date only accepts an existing calendar date in bare YYYY-MM-DD form. A hand-edited bullet carrying an impossible date cannot be targeted by this tool — remove it with vault_delete_span or a manual edit.
 - "section not found: …" — no H2 heading matches; the error lists the file's available sections
 - "no entry matching …" — no bullet matched the given date and entry text; verify exact text via vault_get_memory(file, section).

--- a/src/vault-mcp/mcp-core/tools/task-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/task-tools.ts
@@ -267,6 +267,7 @@ Parameters:
 
 Errors:
 - "note not found" — path does not exist
+- "hidden path blocked" — the path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; hidden paths are not editable, matching Obsidian
 - "no task at line N" — line doesn't contain a task checkbox
 - "block_id not found" — no task line ends with ^block_id
 - "at least one mutation required" — none of status, priority, or lane provided

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -715,7 +715,7 @@ Parameters:
 
 Errors:
 - A nonexistent folder or no glob matches returns an empty array, not an error.
-- "hidden path blocked" — the folder is hidden (dot-prefixed, like ".obsidian"); hidden folders are not listable, matching Obsidian
+- "hidden path blocked" — the folder is hidden (dot-prefixed, like ".obsidian"); hidden folders are not listable, matching Obsidian.
 
 Returns: JSON array of vault-relative path strings (e.g. ["Projects/plan.md", "Notes/idea.md"]).`,
       inputSchema: {

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -78,6 +78,7 @@ Errors:
 - "line paging is not available in outline mode" / "... properties_only mode" — start_line/limit only work on text renditions (full read or heading section)
 - "start line past the end" — start_line exceeds the rendition's line count; error states the total
 - 'path must end in ".md"' — the path names a non-markdown file${config.fileToolsEnabled ? "; read files (images, .canvas, data files) with vault_read_file instead" : ""}
+- "hidden path blocked" — the path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; hidden paths are not accessible, matching Obsidian
 
 Returns: Raw markdown string (default); JSON object of properties (properties_only); JSON outline object (outline); raw markdown of the section, heading line included (heading). When start_line or limit is given, the result is preceded by a window-metadata text block ("path — lines 1–20 of 250 (continue with start_line: 21)").
 
@@ -325,6 +326,7 @@ Limitation: Writes the entire body. Do not use for surgical edits to large files
 
 Errors:
 - "note already exists" — a note already lives at this path; set overwrite: true to replace it, or use vault_patch_note / vault_replace_in_note for partial edits
+- "hidden path blocked" — the path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; hidden paths are not writable, matching Obsidian
 - "concurrent write in progress" — another write to this note is in flight; re-read the note and retry
 - "body contains a control character" — body includes a non-printable control byte; remove it before writing
 
@@ -425,6 +427,7 @@ Errors:
 - "ambiguous heading" — multiple headings match; use heading_level to disambiguate, or rename a heading if they share the same level
 - "operation … requires a heading target" — replace and insert_before need a heading
 - "content begins with the heading … which would duplicate it" — content's first line repeats the target heading; omit it (the matched heading is kept automatically)
+- "hidden path blocked" — the path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; hidden paths are not editable, matching Obsidian
 - "concurrent write in progress" — another write to this note is in flight; re-read the note and retry
 - "content contains a control character" — content includes a non-printable control byte; remove it before writing
 
@@ -531,6 +534,7 @@ Errors:
 - "note not found" — path does not exist; check vault_list_notes for valid paths
 - "text not found" — old_text does not appear in the note body; verify exact text with vault_read_note
 - "old_text cannot be empty" — old_text must be at least one character
+- "hidden path blocked" — the path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; hidden paths are not editable, matching Obsidian
 - "concurrent write in progress" — another write to this note is in flight; re-read the note and retry
 - "new_text contains a control character" — new_text includes a non-printable control byte; remove it before writing
 
@@ -624,6 +628,7 @@ Errors:
 - "note not found" — verify path with vault_list_notes
 - "anchor not found" — fragment not on any line; verify with vault_read_note
 - "ambiguous start anchor …" / "ambiguous end anchor …" — the anchor matches multiple lines; use a longer fragment or set first_match: true
+- "hidden path blocked" — the path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; hidden paths are not editable, matching Obsidian
 - "concurrent write in progress" — another write to this note is in flight; re-read the note and retry
 
 Returns: Confirmation with lines removed and a truncated preview of the deleted text.`,
@@ -710,6 +715,7 @@ Parameters:
 
 Errors:
 - A nonexistent folder or no glob matches returns an empty array, not an error.
+- "hidden path blocked" — the folder is hidden (dot-prefixed, like ".obsidian"); hidden folders are not listable, matching Obsidian
 
 Returns: JSON array of vault-relative path strings (e.g. ["Projects/plan.md", "Notes/idea.md"]).`,
       inputSchema: {
@@ -766,6 +772,7 @@ Behavior: With prune_empty_folders, pruning is best-effort and runs after the de
 Errors:
 - "cannot delete protected path" — the path sits under a protected folder${config.memoryEnabled ? "; use vault_delete_memory for memory entries" : ""}
 - "path traversal blocked" — path escapes the vault root; use a vault-relative path
+- "hidden path blocked" — the path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; hidden paths are not deletable, matching Obsidian
 - "concurrent write in progress" — another write to this note is in flight; retry
 - "note not found: …" — the note does not exist; verify the path with vault_list_notes before deleting
 
@@ -842,6 +849,7 @@ Errors:
 - "cannot move protected path …" / "cannot move into protected path …" — old_path or new_path sits under a protected folder.
 - "path must end in …" — old_path or new_path is missing the .md extension; both paths must end in .md.
 - "path traversal blocked" — a path escapes the vault root; use vault-relative paths.
+- "hidden path blocked" — old_path or new_path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; notes cannot be moved from or into hidden paths, matching Obsidian.
 - "concurrent write in progress" — a write is in flight on the note, the destination, or one of its backlink sources (the move locks all of them as one unit); retry the move.
 - Mid-move I/O failure (rare, e.g. a permission or disk error while writing) — the move aborts and the original note is deleted only after the destination and all backlinks are written, so a failure never loses data. The error message names what failed and the resulting state: if a backlink write failed, new_path exists and the original is intact (re-run the move, deleting the partial new_path first, to finish); if the final delete failed, both old_path and new_path exist (delete old_path to finish).
 
@@ -946,6 +954,7 @@ Prefer vault_write_note when creating a new note, or replacing the body (with ov
 Errors:
 - "note not found" — path does not exist; create the note first with vault_write_note
 - "path traversal blocked" — path escapes vault root
+- "hidden path blocked" — the path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; hidden paths are not editable, matching Obsidian
 - "concurrent write in progress" — another write to this note is in flight; re-read the note and retry
 
 Obsidian syntax: Use arrays for multi-value fields (tags: [a, b]), quote wikilinks ("[[Note]]"), keep types consistent (mismatches cause silent query failures).

--- a/src/vault-mcp/search/file-watcher.ts
+++ b/src/vault-mcp/search/file-watcher.ts
@@ -12,6 +12,7 @@ import { extractPdfText } from "../obsidian-markdown/pdf.js"
 import { logger } from "../../logger.js"
 import { describeError } from "../../utils/describe-error.js"
 import { readdirOrNull, statOrNull } from "../../utils/fs.js"
+import { hasHiddenPathSegment } from "../../utils/has-hidden-path-segment.js"
 import { isErrnoException } from "../../utils/is-errno-exception.js"
 
 /** ms between filesystem polls when usePolling is on. chokidar's raw default is
@@ -22,12 +23,6 @@ const POLLING_INTERVAL_MS = 300
 
 /** Default for FileWatcherOptions.stabilityThreshold (see its doc). */
 const DEFAULT_STABILITY_THRESHOLD_MS = 2000
-
-/** True when any segment of a vault-relative path is dot-prefixed — hidden
- *  files and directories (.obsidian/, .trash/, dotfiles) the watcher skips. */
-const hasHiddenPathSegment = (relativePath: string): boolean => {
-  return relativePath.split("/").some((segment) => segment.startsWith("."))
-}
 
 /** Resolves a path's realpath, returning null instead of throwing when the
  *  path no longer exists (ENOENT). Any other error propagates. */

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -28,6 +28,7 @@ import { extractPdfText } from "../obsidian-markdown/pdf.js"
 import { describeError } from "../../utils/describe-error.js"
 import { filterValidSymlinks } from "../../utils/filter-valid-symlinks.js"
 import { statOrNull } from "../../utils/fs.js"
+import { hasHiddenPathSegment } from "../../utils/has-hidden-path-segment.js"
 import { mapWithConcurrency } from "../../utils/map-with-concurrency.js"
 import {
   isString,
@@ -1625,7 +1626,7 @@ export const createSearchIndex = (
         }
       }
       const isVisiblePath = (file: { relativePath: string }): boolean =>
-        !file.relativePath.split("/").some((segment) => segment.startsWith("."))
+        !hasHiddenPathSegment(file.relativePath)
 
       return entries.filter(matchesKind).map(toFilePaths).filter(isVisiblePath)
     }

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -89,6 +89,22 @@ afterEach(async () => {
 })
 
 describe("getMemory", () => {
+  // A pre-existing hidden file on disk (created outside the server) must not
+  // leak through the concatenate-all read — the enumeration filter, not just
+  // the explicit-name rejection, is what excludes it.
+  it("excludes a pre-existing hidden memory file from the all-files read", async () => {
+    await writeFile(
+      join(vault, "About Me", ".secret.md"),
+      "# Hidden\n\nleaked-fixture-content\n",
+      "utf8",
+    )
+    const result = await getMemory({ vaultPath: vault }, logger)
+    expect(result).not.toContain("leaked-fixture-content")
+    // The visible files still come back — proves the read ran normally.
+    expect(result).toContain("# Opinions")
+    expect(result).toContain("# Principles")
+  })
+
   it("concatenates all memory files when no file specified", async () => {
     const result = await getMemory({ vaultPath: vault }, logger)
     expect(result).toContain("# Opinions")
@@ -1509,6 +1525,15 @@ title: Dupe
 })
 
 describe("listMemoryFiles", () => {
+  it("excludes a pre-existing hidden memory file from the outlines", async () => {
+    await writeFile(join(vault, "About Me", ".secret.md"), "# Hidden\n", "utf8")
+    const outlines = await listMemoryFiles({ vaultPath: vault }, logger)
+    expect(outlines.map((outline) => outline.file)).toEqual([
+      "Opinions",
+      "Principles",
+    ])
+  })
+
   it("returns outlines sorted by filename", async () => {
     const outlines = await listMemoryFiles({ vaultPath: vault }, logger)
     expect(outlines).toHaveLength(2)
@@ -1703,6 +1728,12 @@ describe("listMemoryFileNames", () => {
 
   it("ignores non-markdown files", async () => {
     await writeFile(join(vault, "About Me/notes.txt"), "ignore me", "utf8")
+    const names = await listMemoryFileNames({ vaultPath: vault }, logger)
+    expect(names).toEqual(["Opinions", "Principles"])
+  })
+
+  it("excludes a pre-existing hidden memory file", async () => {
+    await writeFile(join(vault, "About Me/.secret.md"), "# Hidden\n", "utf8")
     const names = await listMemoryFileNames({ vaultPath: vault }, logger)
     expect(names).toEqual(["Opinions", "Principles"])
   })

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -199,6 +199,20 @@ describe("getMemory", () => {
       'memory file must be a bare name without path separators: "../Outside"',
     )
   })
+
+  // A dot-prefixed name would create a file hidden from Obsidian, listings,
+  // and the index — memory paths bypass resolveSafePath's hidden-path guard,
+  // so the name gate is the only defense.
+  it("rejects a dot-prefixed file name instead of reading a hidden file", async () => {
+    // A real hidden memory file on disk — the guard, not a missing file,
+    // must be what rejects the read.
+    await writeFile(join(vault, "About Me", ".secret.md"), "# Hidden\n", "utf8")
+    await expect(
+      getMemory({ vaultPath: vault, file: ".secret" }, logger),
+    ).rejects.toThrow(
+      'memory file must not start with a dot: ".secret" would be a hidden file',
+    )
+  })
 })
 
 describe("updateMemory", () => {

--- a/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/memory-store.test.ts
@@ -7,7 +7,14 @@ import {
   vi,
   onTestFinished,
 } from "vitest"
-import { mkdtemp, rm, writeFile, mkdir, readFile } from "node:fs/promises"
+import {
+  mkdtemp,
+  rm,
+  writeFile,
+  mkdir,
+  readFile,
+  readdir,
+} from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { parseNote } from "../../obsidian-markdown/frontmatter.js"
@@ -216,6 +223,28 @@ describe("getMemory", () => {
 })
 
 describe("updateMemory", () => {
+  // Guards the dot-prefix rejection through the WRITE surface — a refactor of
+  // updateMemory's file access that bypassed memoryFilePath would silently
+  // start creating hidden files while the getMemory test stayed green.
+  it("rejects a dot-prefixed file name instead of creating a hidden file", async () => {
+    await expect(
+      updateMemory(
+        {
+          vaultPath: vault,
+          file: ".secret",
+          section: "Notes (newest first)",
+          entry: "hidden entry",
+          date: "2026-05-08",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'memory file must not start with a dot: ".secret" would be a hidden file',
+    )
+    const memoryDirEntries = await readdir(join(vault, "About Me"))
+    expect(memoryDirEntries).not.toContain(".secret.md")
+  })
+
   it("inserts entry at top of section by default", async () => {
     await updateMemory(
       {
@@ -1274,6 +1303,24 @@ describe("updateMemory near-duplicate section guard", () => {
 })
 
 describe("deleteMemory", () => {
+  // Same guard through the DELETE surface (see the updateMemory dot test).
+  it("rejects a dot-prefixed file name", async () => {
+    await expect(
+      deleteMemory(
+        {
+          vaultPath: vault,
+          file: ".secret",
+          section: "Notes (newest first)",
+          date: "2026-05-05",
+          entry: "hidden entry",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'memory file must not start with a dot: ".secret" would be a hidden file',
+    )
+  })
+
   it("deletes an exact matching entry", async () => {
     await deleteMemory(
       {

--- a/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
@@ -1553,3 +1553,28 @@ describe("moveNote — backlink source hygiene", () => {
     })
   })
 })
+
+describe("moveNote — hidden paths", () => {
+  it("rejects a hidden old_path", async () => {
+    const { writeFixture, moveNote } = setupVault()
+    // The note exists on disk so a removed guard would let the move succeed.
+    await writeFixture(".trash/secret.md", "# Secret\n")
+    await expect(
+      moveNote({ oldPath: ".trash/secret.md", newPath: "Rescued.md" }),
+    ).rejects.toThrow(
+      'hidden path blocked: ".trash/secret.md" targets a hidden file or folder',
+    )
+  })
+
+  it("rejects a hidden new_path and leaves the source note in place", async () => {
+    const { writeFixture, moveNote, noteExists, readNote } = setupVault()
+    await writeFixture("Visible.md", "# Visible\n")
+    await expect(
+      moveNote({ oldPath: "Visible.md", newPath: ".obsidian/hidden.md" }),
+    ).rejects.toThrow(
+      'hidden path blocked: ".obsidian/hidden.md" targets a hidden file or folder',
+    )
+    expect(await noteExists("Visible.md")).toBe(true)
+    expect(await readNote("Visible.md")).toBe("# Visible\n")
+  })
+})

--- a/src/vault-mcp/vault-operations/__tests__/task-updater.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/task-updater.test.ts
@@ -770,4 +770,27 @@ describe("task-updater", () => {
       )
     })
   })
+
+  describe("hidden paths", () => {
+    it("rejects a task note inside a hidden folder and leaves it unchanged", async () => {
+      const vault = await createVault()
+      // The note exists on disk so a removed guard would let the update
+      // succeed — the test then fails on the mutation, not a missing file.
+      await writeTestNote(vault, ".trash/tasks.md", SIMPLE_NOTE)
+      await expect(
+        taskUpdater.updateTask(
+          {
+            vaultPath: vault,
+            path: ".trash/tasks.md",
+            line: 5,
+            status: "done",
+          },
+          logger,
+        ),
+      ).rejects.toThrow(
+        'hidden path blocked: ".trash/tasks.md" targets a hidden file or folder',
+      )
+      expect(await readTestNote(vault, ".trash/tasks.md")).toBe(SIMPLE_NOTE)
+    })
+  })
 })

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -2032,7 +2032,9 @@ describe("hidden paths", () => {
         },
         logger,
       ),
-    ).rejects.toThrow("hidden path blocked")
+    ).rejects.toThrow(
+      'hidden path blocked: "notes/../.obsidian/plugins/some-plugin/data.json" targets a hidden file or folder',
+    )
   })
 
   it("accepts a './'-prefixed path to a visible note", async () => {

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -1882,3 +1882,180 @@ describe("statAssets", () => {
     expect(statted).toEqual([{ path: "kept.png", bytes: 4 }])
   })
 })
+
+describe("hidden paths", () => {
+  // Fixtures are created ON DISK so that if the guard were removed, every
+  // call below would succeed — the tests then fail because the operation
+  // resolved, never via a coincidental "not found" (wrong-error pass).
+  const createHiddenFixtures = async () => {
+    await mkdir(join(vault, ".obsidian", "plugins", "some-plugin"), {
+      recursive: true,
+    })
+    await writeFile(
+      join(vault, ".obsidian", "plugins", "some-plugin", "data.json"),
+      '{"apiKey":"fake-fixture-secret"}',
+      "utf8",
+    )
+    await mkdir(join(vault, ".trash"), { recursive: true })
+    await writeFile(join(vault, ".trash", "secret.md"), "# Secret\n", "utf8")
+  }
+
+  it("readNote rejects a note inside a hidden folder", async () => {
+    await createHiddenFixtures()
+    await expect(
+      readNote({ vaultPath: vault, path: ".trash/secret.md" }, logger),
+    ).rejects.toThrow(
+      'hidden path blocked: ".trash/secret.md" targets a hidden file or folder',
+    )
+  })
+
+  it("readNoteOutline rejects a note inside a hidden folder", async () => {
+    await createHiddenFixtures()
+    await expect(
+      readNoteOutline({ vaultPath: vault, path: ".trash/secret.md" }, logger),
+    ).rejects.toThrow(
+      'hidden path blocked: ".trash/secret.md" targets a hidden file or folder',
+    )
+  })
+
+  it("readNoteSection rejects a note inside a hidden folder", async () => {
+    await createHiddenFixtures()
+    await expect(
+      readNoteSection(
+        { vaultPath: vault, path: ".trash/secret.md", heading: "Secret" },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'hidden path blocked: ".trash/secret.md" targets a hidden file or folder',
+    )
+  })
+
+  it("readNoteProperties rejects a note inside a hidden folder", async () => {
+    await createHiddenFixtures()
+    await expect(
+      readNoteProperties(
+        { vaultPath: vault, path: ".trash/secret.md" },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'hidden path blocked: ".trash/secret.md" targets a hidden file or folder',
+    )
+  })
+
+  it("readAsset rejects a plugin data file inside .obsidian", async () => {
+    await createHiddenFixtures()
+    await expect(
+      readAsset(
+        {
+          vaultPath: vault,
+          path: ".obsidian/plugins/some-plugin/data.json",
+          maxBytes: 1024,
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'hidden path blocked: ".obsidian/plugins/some-plugin/data.json" targets a hidden file or folder',
+    )
+  })
+
+  it("writeNote rejects a hidden path and creates nothing on disk", async () => {
+    await expect(
+      writeNote(
+        { vaultPath: vault, path: ".secret/new.md", body: "# New\n" },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'hidden path blocked: ".secret/new.md" targets a hidden file or folder',
+    )
+    const entries = await readdir(vault)
+    expect(entries).not.toContain(".secret")
+  })
+
+  it("updateProperties rejects a note inside a hidden folder", async () => {
+    await createHiddenFixtures()
+    await expect(
+      updateProperties(
+        { vaultPath: vault, path: ".trash/secret.md", properties: { a: 1 } },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'hidden path blocked: ".trash/secret.md" targets a hidden file or folder',
+    )
+  })
+
+  it("deleteNote rejects a note inside a hidden folder and leaves it on disk", async () => {
+    await createHiddenFixtures()
+    await expect(
+      deleteNote(
+        {
+          vaultPath: vault,
+          path: ".trash/secret.md",
+          protectedPaths: [],
+          pruneEmptyFolders: false,
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'hidden path blocked: ".trash/secret.md" targets a hidden file or folder',
+    )
+    expect(await readFile(join(vault, ".trash", "secret.md"), "utf8")).toBe(
+      "# Secret\n",
+    )
+  })
+
+  it("listNotes rejects an explicitly hidden folder", async () => {
+    await createHiddenFixtures()
+    await expect(
+      listNotes({ vaultPath: vault, folder: ".obsidian" }, logger),
+    ).rejects.toThrow(
+      'hidden path blocked: ".obsidian" targets a hidden file or folder',
+    )
+  })
+
+  it("listAssets rejects an explicitly hidden folder", async () => {
+    await createHiddenFixtures()
+    await expect(
+      listAssets({ vaultPath: vault, folder: ".obsidian" }, logger),
+    ).rejects.toThrow(
+      'hidden path blocked: ".obsidian" targets a hidden file or folder',
+    )
+  })
+
+  it("rejects a traversal-normalized path that lands in a hidden folder", async () => {
+    await createHiddenFixtures()
+    await expect(
+      readAsset(
+        {
+          vaultPath: vault,
+          path: "notes/../.obsidian/plugins/some-plugin/data.json",
+          maxBytes: 1024,
+        },
+        logger,
+      ),
+    ).rejects.toThrow("hidden path blocked")
+  })
+
+  it("accepts a './'-prefixed path to a visible note", async () => {
+    await mkdir(join(vault, "notes"), { recursive: true })
+    await writeFile(join(vault, "notes", "plan.md"), "# Plan\n", "utf8")
+    const note = await readNote(
+      { vaultPath: vault, path: "notes/./plan.md" },
+      logger,
+    )
+    expect(note).toBe("# Plan\n")
+  })
+
+  it("accepts an interior-dot folder name as visible", async () => {
+    await mkdir(join(vault, "notes", "version.2"), { recursive: true })
+    await writeFile(
+      join(vault, "notes", "version.2", "file.md"),
+      "# V2\n",
+      "utf8",
+    )
+    const note = await readNote(
+      { vaultPath: vault, path: "notes/version.2/file.md" },
+      logger,
+    )
+    expect(note).toBe("# V2\n")
+  })
+})

--- a/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-patcher.test.ts
@@ -3136,3 +3136,60 @@ describe("concurrent writes (exclusive lock)", () => {
     )
   })
 })
+
+describe("hidden paths", () => {
+  // The note exists on disk so a removed guard would make the operations
+  // succeed — the tests then fail because the edit went through, never via
+  // a coincidental "note not found".
+  const HIDDEN_NOTE = ".trash/secret.md"
+  const HIDDEN_CONTENT = "# Secret\n\nBody line.\n"
+
+  it("patchNote rejects a note inside a hidden folder and leaves it unchanged", async () => {
+    await writeTestNote(HIDDEN_NOTE, HIDDEN_CONTENT)
+    await expect(
+      patchNote(
+        {
+          vaultPath: vault,
+          path: HIDDEN_NOTE,
+          operation: "append",
+          content: "injected",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'hidden path blocked: ".trash/secret.md" targets a hidden file or folder',
+    )
+    expect(await readTestNote(HIDDEN_NOTE)).toBe(HIDDEN_CONTENT)
+  })
+
+  it("replaceInNote rejects a note inside a hidden folder and leaves it unchanged", async () => {
+    await writeTestNote(HIDDEN_NOTE, HIDDEN_CONTENT)
+    await expect(
+      replaceInNote(
+        {
+          vaultPath: vault,
+          path: HIDDEN_NOTE,
+          oldText: "Body line.",
+          newText: "changed",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'hidden path blocked: ".trash/secret.md" targets a hidden file or folder',
+    )
+    expect(await readTestNote(HIDDEN_NOTE)).toBe(HIDDEN_CONTENT)
+  })
+
+  it("deleteSpan rejects a note inside a hidden folder and leaves it unchanged", async () => {
+    await writeTestNote(HIDDEN_NOTE, HIDDEN_CONTENT)
+    await expect(
+      deleteSpan(
+        { vaultPath: vault, path: HIDDEN_NOTE, startAnchor: "Body line." },
+        logger,
+      ),
+    ).rejects.toThrow(
+      'hidden path blocked: ".trash/secret.md" targets a hidden file or folder',
+    )
+    expect(await readTestNote(HIDDEN_NOTE)).toBe(HIDDEN_CONTENT)
+  })
+})

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -314,6 +314,14 @@ const listSectionHeadings = (sections: readonly ParsedSection[]): string => {
 export const createMemoryStore = (options: { memoryDir: string }) => {
   const { memoryDir } = options
 
+  /** True for the .md entries the memory layer serves — excludes dot-prefixed
+   *  (hidden) filenames so a pre-existing hidden file on disk never leaks
+   *  through the no-file read or the list surfaces, mirroring the write-side
+   *  rejection in memoryFilePath. */
+  const isVisibleMemoryFile = (filename: string): boolean => {
+    return filename.endsWith(".md") && !filename.startsWith(".")
+  }
+
   // A memory file is a bare name, never a path — a separator would let a
   // name like "../../outside" escape the memory directory (and the vault)
   // entirely, so reject it at the single point every memory path goes through.
@@ -549,9 +557,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         }
         throw err
       }
-      const mdFiles = entries
-        .filter((filename) => filename.endsWith(".md"))
-        .sort()
+      const mdFiles = entries.filter(isVisibleMemoryFile).sort()
       const contents = await Promise.all(
         mdFiles.map(async (filename) => {
           const raw = await readFile(join(dir, filename), "utf8")
@@ -794,9 +800,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       throw err
     }
 
-    const mdFiles = entries
-      .filter((filename) => filename.endsWith(".md"))
-      .sort()
+    const mdFiles = entries.filter(isVisibleMemoryFile).sort()
 
     const outlines = await Promise.all(
       mdFiles.map(async (filename) => {
@@ -850,7 +854,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
       throw err
     }
     const names = entries
-      .filter((filename) => filename.endsWith(".md"))
+      .filter(isVisibleMemoryFile)
       .map((filename) => basename(filename, ".md"))
       .sort()
     logger.debug("listed memory file names", { count: names.length })

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -317,10 +317,18 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
   // A memory file is a bare name, never a path — a separator would let a
   // name like "../../outside" escape the memory directory (and the vault)
   // entirely, so reject it at the single point every memory path goes through.
+  // A dot-prefixed name would create a hidden file (invisible in Obsidian,
+  // excluded from listings and the index), so it is rejected the same way —
+  // memory paths bypass resolveSafePath's hidden-path guard via direct join.
   const memoryFilePath = (vaultPath: string, file: string): string => {
     if (file.includes("/") || file.includes("\\")) {
       throw new Error(
         `memory file must be a bare name without path separators: "${file}"`,
+      )
+    }
+    if (file.startsWith(".")) {
+      throw new Error(
+        `memory file must not start with a dot: "${file}" would be a hidden file`,
       )
     }
     return join(vaultPath, memoryDir, `${file}.md`)

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -42,6 +42,7 @@ import {
 } from "../obsidian-markdown/lines.js"
 import { assertNoControlCharacters } from "../../utils/assert-no-control-characters.js"
 import { assertPathHasExtension } from "../../utils/assert-path-has-extension.js"
+import { hasHiddenPathSegment } from "../../utils/has-hidden-path-segment.js"
 import type { Logger } from "../../logger.js"
 
 /** Canonicalizes a path for the protected-path prefix check: converts Windows
@@ -51,7 +52,15 @@ import type { Logger } from "../../logger.js"
 export const toVaultRelativePath = (input: string): string =>
   posix.normalize(input.replace(/\\/g, "/"))
 
-/** Resolves a note path within the vault, throwing on traversal attempts. */
+/** Resolves a note path within the vault, throwing on traversal attempts and
+ *  on hidden paths (any dot-prefixed segment, e.g. ".obsidian/", ".trash/").
+ *  The hidden-path check runs on the resolved vault-relative path so "./a.md"
+ *  and "a/../b.md" normalize instead of false-positive rejecting, and fires
+ *  before any filesystem access — it rejects on path shape alone and reveals
+ *  nothing about what exists. Obsidian itself ignores dot-prefixed paths, so
+ *  every client-facing operation routing through here matches that. The
+ *  internal ".obsidian/" config readers (daily-notes, task-format-config)
+ *  deliberately bypass this via direct readFile. */
 export const resolveSafePath = (
   vaultPath: string,
   notePath: string,
@@ -60,6 +69,11 @@ export const resolveSafePath = (
   const resolved = resolve(normalizedVault, notePath)
   if (!resolved.startsWith(normalizedVault + "/")) {
     throw new Error(`path traversal blocked: "${notePath}" escapes vault root`)
+  }
+  if (hasHiddenPathSegment(relative(normalizedVault, resolved))) {
+    throw new Error(
+      `hidden path blocked: "${notePath}" targets a hidden file or folder`,
+    )
   }
   return resolved
 }
@@ -505,8 +519,7 @@ const listVaultFilePaths = async (
     relative(normalizedVault, join(entry.parentPath, entry.name)),
   )
   const visiblePaths = relativePaths.filter(
-    (relativePath) =>
-      !relativePath.split("/").some((segment) => segment.startsWith(".")),
+    (relativePath) => !hasHiddenPathSegment(relativePath),
   )
   return visiblePaths.sort()
 }

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -52,15 +52,13 @@ import type { Logger } from "../../logger.js"
 export const toVaultRelativePath = (input: string): string =>
   posix.normalize(input.replace(/\\/g, "/"))
 
-/** Resolves a note path within the vault, throwing on traversal attempts and
- *  on hidden paths (any dot-prefixed segment, e.g. ".obsidian/", ".trash/").
- *  The hidden-path check runs on the resolved vault-relative path so "./a.md"
- *  and "a/../b.md" normalize instead of false-positive rejecting, and fires
- *  before any filesystem access — it rejects on path shape alone and reveals
- *  nothing about what exists. Obsidian itself ignores dot-prefixed paths, so
- *  every client-facing operation routing through here matches that. The
- *  internal ".obsidian/" config readers (daily-notes, task-format-config)
- *  deliberately bypass this via direct readFile. */
+/** Resolves a note path within the vault, throwing on traversal and on
+ *  hidden paths (any dot-prefixed segment — matching Obsidian, which
+ *  ignores them). The hidden check runs on the resolved vault-relative path
+ *  ("./a.md" and "a/../b.md" normalize instead of false-rejecting) and
+ *  fires before any fs access, so it reveals nothing about what exists.
+ *  The internal ".obsidian/" config readers (daily-notes,
+ *  task-format-config) deliberately bypass this via direct readFile. */
 export const resolveSafePath = (
   vaultPath: string,
   notePath: string,

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -52,13 +52,11 @@ import type { Logger } from "../../logger.js"
 export const toVaultRelativePath = (input: string): string =>
   posix.normalize(input.replace(/\\/g, "/"))
 
-/** Resolves a note path within the vault, throwing on traversal and on
- *  hidden paths (any dot-prefixed segment — matching Obsidian, which
- *  ignores them). The hidden check runs on the resolved vault-relative path
- *  ("./a.md" and "a/../b.md" normalize instead of false-rejecting) and
- *  fires before any fs access, so it reveals nothing about what exists.
- *  The internal ".obsidian/" config readers (daily-notes,
- *  task-format-config) deliberately bypass this via direct readFile. */
+/** Resolves a note path within the vault; throws on traversal and hidden
+ *  paths (dot-prefixed segments — Obsidian ignores them). Hidden is checked
+ *  on the resolved relative path (so "./" and "../" normalize) before any
+ *  fs access (no existence leak). Internal ".obsidian/" config readers
+ *  deliberately bypass this via direct readFile. */
 export const resolveSafePath = (
   vaultPath: string,
   notePath: string,


### PR DESCRIPTION
## Summary

Hidden paths (any dot-prefixed segment — `.obsidian/`, `.trash/`, dotfiles) were excluded from listings, search, and the file watcher, but explicit paths were still served: `vault_read_file` would read `.obsidian/plugins/<plugin>/data.json` directly, and any write tool could create or modify `.md` files inside hidden folders. Community plugins often store their own third-party API keys in `data.json` files, so a leaked MCP token also exposed those keys. Reported in #427.

This PR blocks hidden paths in every client-facing vault operation, matching Obsidian, which ignores dot-prefixed paths entirely.

## Changes

- **Shared predicate** `src/utils/has-hidden-path-segment.ts` — consolidates three previously duplicated inline implementations (listing filter, file watcher, index rebuild), so the definition of "hidden" can't drift between layers.
- **Guard in `resolveSafePath`** — after the traversal check, the resolved vault-relative path is rejected if any segment is dot-prefixed. Checking the *resolved* path means `notes/./plan.md` and `a/../b.md` normalize cleanly while `a/../.obsidian/x` is caught. The guard fires before any filesystem access — it rejects on path shape alone and reveals nothing about what exists. Every read, write, patch, move, delete, and task update routes through it.
- **Internal config readers unaffected** — `daily-notes.ts` and `task-format-config.ts` read `.obsidian/` config via direct `readFile` and deliberately bypass the guard.
- **Memory file names reject leading dots** — memory paths are built via `join` (not `resolveSafePath`), so `memoryFilePath` gains its own check: a name like `.secret` would have created a hidden, unindexed file.
- **Docs** — `Errors:` bullets on every affected tool description, SECURITY.md (new Hidden paths section + database-placement note), README data-integrity bullet, ARCHITECTURE.md path-safety section.

## Behavior changes

Previously-succeeding calls that now return `hidden path blocked: "<path>" targets a hidden file or folder`:

- `vault_read_note` (all modes) / `vault_read_file` on paths inside hidden folders
- `vault_write_note`, `vault_patch_note`, `vault_replace_in_note`, `vault_delete_span`, `vault_update_properties`, `vault_delete_note`, `vault_update_task` on hidden paths
- `vault_move_note` with a hidden `old_path` **or** `new_path` (previously a note could be moved into `.obsidian/` and vanish from the index)
- `vault_list_notes` / `vault_list_files` with an explicitly hidden `folder` (previously returned an empty list; an explicit error beats a silent `[]` that reads as "folder is empty")
- `vault_update_memory` / `vault_get_memory` with a dot-prefixed `file` name

Graph and search tools are unchanged — they query the index, which has always excluded hidden paths.

## Tests

- Unit spec for the shared predicate (9 cases including interior-dot and trailing-dot names).
- Guardrail tests for every surface (18 new tests): hidden fixtures are created **on disk**, so removing the guard makes the operations succeed and the tests fail for that reason — not via a coincidental "not found". Write/delete/patch rejections also assert the file was not created or modified.
- Normalization pins: `a/../.obsidian/…` rejected; `notes/./plan.md` and `notes/version.2/file.md` accepted with content returned.
- Mutation-verified both directions: deleting the guard fails exactly the 17 resolveSafePath guardrail tests (because the calls succeed); weakening the predicate to `includes(".")` fails the accepted-path tests.

## Verification

`npm run lint` (0 errors), `npm run build`, `npm test` (2484 passed). DOCKERHUB.md regeneration produced no diff (the changed README section is not part of it).

Refs #427

BREAKING CHANGE: paths containing dot-prefixed segments (`.obsidian/`, `.trash/`, dotfiles) are now rejected by all vault read, write, move, delete, and listing operations. Clients that read or wrote files inside hidden folders must stop, or the operator should relocate that content into visible folders. This matches Obsidian, which does not surface hidden paths at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Blocked access to hidden dot-prefixed files and folders across vault reads, writes, edits, moves, deletes, listings, watching, and indexing.
  - Prevented creation or access of hidden memory files.
  - Continued allowing visible names that merely contain dots and safe relative paths.

- **Documentation**
  - Updated usage, architecture, and security guidance to describe hidden-path protections and related storage recommendations.

- **Tests**
  - Added coverage confirming blocked operations leave existing files unchanged and do not create hidden files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
