### PR TITLE
ci: bump umm-actually action to v0.3.5

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -77,7 +77,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@ada9e66c54519781e1cf9c1bfbf141278cad295c # v0.3.3
+      - uses: aliasunder/umm-actually@1fc198b584228f3130d1bdffd31b983e782917a4 # v0.3.5
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
Bumps the review action pin from v0.3.3 to v0.3.5 (commit `1fc198b`), picking up two releases:

- **v0.3.4** — `maxCompletionTokens: 128_000` set on the OpenRouter request, fixing truncated structured output (`Unexpected end of JSON input`) on large reviews
- **v0.3.5** — non-finding filter hardening: prior-finding resolution confirmations (e.g. the "Prior bot finding addressed: …" / "Not a finding — …" comment posted on PR `#429`) are now filtered before posting, and the prompt instructs the model not to emit them

🤖 Generated with [Claude Code](https://claude.com/claude-code)