### PR TITLE
docs(deploy): surface CLI lifecycle commands across the deploy guides

### DIFF
--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -31,7 +31,7 @@ What happens on first start:
 
 > **On Windows?** Set `WINDOWS_MODE=true` in your `.env` — then `VAULT_PATH` can point
 > at a normal Windows path like `C:\Users\you\MyVault`. With the CLI, edit the
-> generated `.env` after `init` and apply with `npx vault-cortex@latest upgrade`. See
+> generated `.env` after `init` and apply with `npx vault-cortex@latest restart`. See
 > [Windows (Docker Desktop)](#windows-docker-desktop) below.
 
 <details>
@@ -224,9 +224,13 @@ policy), Docker daemon restart, or system reboot.
 **Set up with the CLI?**
 
 ```bash
-# Stop (data persists in Docker volumes):
-docker stop vault-cortex
+# Stop and remove the container (data persists in Docker volumes):
+npx vault-cortex@latest down
 ```
+
+Start again any time with `npx vault-cortex@latest start` — your saved
+settings are reused ([`down`](../../cli/#down) · [`start`](../../cli/#start)
+in the CLI reference).
 
 **Set up with Docker Compose?**
 
@@ -289,8 +293,9 @@ Sync has attachment syncing disabled and no files exist on disk.
 ## Configuration
 
 Only `MCP_AUTH_TOKEN` and `VAULT_PATH` are required. For optional settings
-(memory folder, protected paths, orphan exclusions, file tools, timezone), see
-the [Configuration](../../README.md#configuration) section in the main README.
+(memory folder, protected paths, orphan exclusions, file tools, daily notes
+folder and format, timezone), see the
+[Configuration](../../README.md#configuration) section in the main README.
 
 ## Troubleshooting
 

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -223,9 +223,10 @@ docker compose down -v         # Compose
 docker stop vault-cortex
 ```
 
-Start again any time with `npx vault-cortex@latest start` — your saved
-settings are reused ([`down`](../../cli/#down) · [`start`](../../cli/#start)
-in the CLI reference).
+**Set up with the CLI?** Start again any time with
+`npx vault-cortex@latest start` — your saved settings are reused
+([`down`](../../cli/#down) · [`start`](../../cli/#start) in the CLI
+reference). Otherwise resume with `docker compose up -d`.
 
 ## Windows (Docker Desktop)
 

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -3,7 +3,7 @@
 Run Vault Cortex on your machine against a local Obsidian vault. No cloud, no
 Obsidian Sync — just Docker and a folder of `.md` files.
 
-**Contents** — [Prerequisites](#prerequisites) · [Setup](#setup) · [Connect](#connect-your-mcp-client) · [Verify](#verify) · [Updating](#updating) · [Stop](#stop) · [Windows](#windows-docker-desktop) · [Memory](#memory) · [File Tools](#file-tools) · [Config](#configuration) · [Troubleshooting](#troubleshooting)
+**Contents** — [Prerequisites](#prerequisites) · [Setup](#setup) · [Connect](#connect-your-mcp-client) · [Verify](#verify) · [Monitoring](#monitoring) · [Updating](#updating) · [Restart](#restart) · [Stop](#stop) · [Windows](#windows-docker-desktop) · [Memory](#memory) · [File Tools](#file-tools) · [Config](#configuration) · [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
 
@@ -146,7 +146,32 @@ curl http://localhost:8000/healthz
 # OAuth discovery (no auth required — root and RFC 9728 path-suffixed forms):
 curl http://localhost:8000/.well-known/oauth-protected-resource
 curl http://localhost:8000/.well-known/oauth-protected-resource/mcp
+
+# Server logs (structured JSON lines):
+npx vault-cortex@latest logs   # set up with the CLI (run from your init directory)
+docker logs vault-cortex       # Compose
 ```
+
+## Monitoring
+
+**Set up with the CLI?**
+
+```bash
+# Follow the server logs until ctrl-C:
+npx vault-cortex@latest logs --follow
+
+# Or just recent history:
+npx vault-cortex@latest logs --since 10m
+```
+
+**Set up with Docker Compose?**
+
+```bash
+docker logs -f vault-cortex
+```
+
+Either way, `docker ps` shows container status — "healthy" tracks the
+server's `/healthz`.
 
 ## Updating
 
@@ -170,6 +195,29 @@ and the `--dir` flag.
 ```bash
 docker compose pull && docker compose up -d
 ```
+
+## Restart
+
+The server runs startup tasks on every boot: it rebuilds the search index,
+creates memory template files if the memory folder doesn't exist, and starts
+the file watcher. Restarting the container re-runs this flow (useful when
+testing bootstrap behavior). The command is the same for both setup methods,
+since both name the container `vault-cortex`:
+
+```bash
+docker restart vault-cortex
+```
+
+> **Changed `.env`?** A restart does **not** re-read `.env` — the container
+> has to be re-created. Set up with the CLI? Run
+> [`npx vault-cortex@latest restart`](../../cli/#restart) — unlike
+> `docker restart`, it re-creates the container, so your edits take effect
+> ([`upgrade`](../../cli/#upgrade) also applies `.env` edits and pulls the
+> latest image on the way). Using Compose? Run `docker compose up -d` — it
+> re-creates services whose configuration changed.
+
+The container also restarts automatically on crash (`restart: unless-stopped`
+policy), Docker daemon restart, or system reboot.
 
 ## Stop
 

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -154,24 +154,14 @@ docker logs vault-cortex       # Compose
 
 ## Monitoring
 
-**Set up with the CLI?**
-
 ```bash
 # Follow the server logs until ctrl-C:
-npx vault-cortex@latest logs --follow
+npx vault-cortex@latest logs --follow   # set up with the CLI
+docker logs -f vault-cortex             # Compose
 
-# Or just recent history:
-npx vault-cortex@latest logs --since 10m
+# Container status — "healthy" tracks the server's /healthz:
+docker ps
 ```
-
-**Set up with Docker Compose?**
-
-```bash
-docker logs -f vault-cortex
-```
-
-Either way, `docker ps` shows container status — "healthy" tracks the
-server's `/healthz`.
 
 ## Updating
 
@@ -221,26 +211,21 @@ policy), Docker daemon restart, or system reboot.
 
 ## Stop
 
-**Set up with the CLI?**
-
 ```bash
 # Stop and remove the container (data persists in Docker volumes):
-npx vault-cortex@latest down
+npx vault-cortex@latest down   # set up with the CLI
+docker compose down            # Compose
+
+# Stop and delete all volumes (index rebuilds on next start):
+docker compose down -v         # Compose
+
+# Stop without removing (either setup method; docker start resumes):
+docker stop vault-cortex
 ```
 
 Start again any time with `npx vault-cortex@latest start` — your saved
 settings are reused ([`down`](../../cli/#down) · [`start`](../../cli/#start)
 in the CLI reference).
-
-**Set up with Docker Compose?**
-
-```bash
-# Stop (data persists in Docker volumes):
-docker compose down
-
-# Stop and delete all volumes (index rebuilds on next start):
-docker compose down -v
-```
 
 ## Windows (Docker Desktop)
 

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -149,7 +149,7 @@ curl http://localhost:8000/.well-known/oauth-protected-resource/mcp
 
 # Server logs (structured JSON lines):
 npx vault-cortex@latest logs   # set up with the CLI (run from your init directory)
-docker logs vault-cortex       # Compose
+docker logs vault-cortex       # Compose or docker run
 ```
 
 ## Monitoring
@@ -157,7 +157,7 @@ docker logs vault-cortex       # Compose
 ```bash
 # Follow the server logs until ctrl-C:
 npx vault-cortex@latest logs --follow   # set up with the CLI
-docker logs -f vault-cortex             # Compose
+docker logs -f vault-cortex             # Compose or docker run
 
 # Container status — "healthy" tracks the server's /healthz:
 docker ps
@@ -219,14 +219,15 @@ docker compose down            # Compose
 # Stop and delete all volumes (index rebuilds on next start):
 docker compose down -v         # Compose
 
-# Stop without removing (either setup method; docker start resumes):
+# Stop without removing (any setup method; docker start resumes):
 docker stop vault-cortex
 ```
 
 **Set up with the CLI?** Start again any time with
 `npx vault-cortex@latest start` — your saved settings are reused
 ([`down`](../../cli/#down) · [`start`](../../cli/#start) in the CLI
-reference). Otherwise resume with `docker compose up -d`.
+reference). Otherwise resume with `docker compose up -d` or
+`docker start vault-cortex`.
 
 ## Windows (Docker Desktop)
 

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -273,24 +273,14 @@ from any device: `curl <PUBLIC_URL>/healthz`.
 
 ## Monitoring
 
-**Set up with the CLI?**
-
 ```bash
 # Follow the container logs (sync + MCP server) until ctrl-C:
-npx vault-cortex@latest logs --follow
+npx vault-cortex@latest logs --follow   # set up with the CLI
+docker logs -f vault-cortex             # Compose or docker run
 
-# Or just recent history:
-npx vault-cortex@latest logs --since 10m
+# Container status — "healthy" tracks the MCP server's /healthz:
+docker ps
 ```
-
-**Set up with Compose or `docker run`?**
-
-```bash
-docker logs -f vault-cortex
-```
-
-Whichever method you use, `docker ps` shows container status — "healthy"
-tracks the MCP server's `/healthz`.
 
 ## Updating
 
@@ -355,33 +345,21 @@ policy), Docker daemon restart, or system reboot.
 
 ## Stop
 
-**Set up with the CLI?**
-
 ```bash
 # Stop and remove the container (data persists in Docker volumes):
-npx vault-cortex@latest down
+npx vault-cortex@latest down   # set up with the CLI
+docker compose down            # Compose
+
+# Stop and delete all volumes (vault re-syncs on next start; index rebuilds):
+docker compose down -v         # Compose
+
+# Stop without removing (any setup method; docker start resumes):
+docker stop vault-cortex
 ```
 
 Start again any time with `npx vault-cortex@latest start` — your saved
 settings are reused ([`down`](../../cli/#down) · [`start`](../../cli/#start)
 in the CLI reference).
-
-**Set up with Docker Compose?**
-
-```bash
-# Stop (data persists in Docker volumes):
-docker compose down
-
-# Stop and delete all volumes (vault re-syncs on next start; index rebuilds):
-docker compose down -v
-```
-
-**Set up with `docker run`?**
-
-```bash
-# Stop (data persists in Docker volumes):
-docker stop vault-cortex
-```
 
 ## Memory
 

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -357,9 +357,11 @@ docker compose down -v         # Compose
 docker stop vault-cortex
 ```
 
-Start again any time with `npx vault-cortex@latest start` — your saved
-settings are reused ([`down`](../../cli/#down) · [`start`](../../cli/#start)
-in the CLI reference).
+**Set up with the CLI?** Start again any time with
+`npx vault-cortex@latest start` — your saved settings are reused
+([`down`](../../cli/#down) · [`start`](../../cli/#start) in the CLI
+reference). Otherwise resume with `docker compose up -d` or
+`docker start vault-cortex`.
 
 ## Memory
 

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -262,8 +262,10 @@ curl http://localhost:8000/healthz
 
 # One log stream for both processes — MCP server lines are structured
 # JSON; init-chain lines carry an [obsidian-sync] prefix and the ongoing
-# sync output is plain text (filter with: docker logs vault-cortex 2>&1 | grep -v '^{'):
-docker logs vault-cortex
+# sync output is plain text:
+npx vault-cortex@latest logs   # set up with the CLI (run from your init directory)
+docker logs vault-cortex       # Compose or docker run
+# Sync output only: docker logs vault-cortex 2>&1 | grep -v '^{'
 ```
 
 Once [HTTPS access](#https-access) is set up, the same health check works
@@ -271,13 +273,24 @@ from any device: `curl <PUBLIC_URL>/healthz`.
 
 ## Monitoring
 
-```bash
-# Follow the container logs (sync + MCP server):
-docker logs -f vault-cortex
+**Set up with the CLI?**
 
-# Container status — "healthy" tracks the MCP server's /healthz:
-docker ps
+```bash
+# Follow the container logs (sync + MCP server) until ctrl-C:
+npx vault-cortex@latest logs --follow
+
+# Or just recent history:
+npx vault-cortex@latest logs --since 10m
 ```
+
+**Set up with Compose or `docker run`?**
+
+```bash
+docker logs -f vault-cortex
+```
+
+Whichever method you use, `docker ps` shows container status — "healthy"
+tracks the MCP server's `/healthz`.
 
 ## Updating
 
@@ -328,22 +341,30 @@ docker restart vault-cortex
 ```
 
 > **Changed `.env`?** A restart does **not** re-read `.env` — the container
-> has to be re-created. Set up with the CLI? Run `npx vault-cortex@latest upgrade`
-> (re-creates the container and also pulls the latest image). Using Compose?
-> Run `docker compose up -d` — it re-creates services whose configuration
-> changed.
+> has to be re-created. Set up with the CLI? Run
+> [`npx vault-cortex@latest restart`](../../cli/#restart) — unlike
+> `docker restart`, it re-creates the container, so your edits take effect
+> ([`upgrade`](../../cli/#upgrade) also applies `.env` edits and pulls the
+> latest image on the way). Using Compose? Run `docker compose up -d` — it
+> re-creates services whose configuration changed. Using `docker run`?
+> Remove the container (`docker rm -f vault-cortex`) and re-run the
+> `docker run` command from [Setup](#setup).
 
 The container also restarts automatically on crash (`restart: unless-stopped`
 policy), Docker daemon restart, or system reboot.
 
 ## Stop
 
-**Set up with the CLI (or `docker run`)?**
+**Set up with the CLI?**
 
 ```bash
-# Stop (data persists in Docker volumes):
-docker stop vault-cortex
+# Stop and remove the container (data persists in Docker volumes):
+npx vault-cortex@latest down
 ```
+
+Start again any time with `npx vault-cortex@latest start` — your saved
+settings are reused ([`down`](../../cli/#down) · [`start`](../../cli/#start)
+in the CLI reference).
 
 **Set up with Docker Compose?**
 
@@ -353,6 +374,13 @@ docker compose down
 
 # Stop and delete all volumes (vault re-syncs on next start; index rebuilds):
 docker compose down -v
+```
+
+**Set up with `docker run`?**
+
+```bash
+# Stop (data persists in Docker volumes):
+docker stop vault-cortex
 ```
 
 ## Memory
@@ -402,6 +430,11 @@ vault-relative path: `Journal`, `Planner/Daily`) and `DAILY_NOTES_FORMAT`
 (same tokens as Obsidian's date format setting) in `.env`. You can set one
 or both — a set value always wins over the config file. Without either
 source, the server falls back to the `Daily Notes` folder and `YYYY-MM-DD`.
+
+`.env` edits take effect when the container is re-created: set up with the
+CLI, run `npx vault-cortex@latest restart`; with Compose, `docker compose up -d`;
+with `docker run`, re-create the container as described in the
+**Changed `.env`?** note under [Restart](#restart).
 
 ## Configuration
 


### PR DESCRIPTION
## What this fixes

The deploy guides predate the CLI's lifecycle commands (`logs`/`restart`/`down`/`start`, PRs #381/#411): their operational sections routed CLI-path users to raw docker commands, and the remote "Changed `.env`?" callout recommended `upgrade` where `restart` is the designed answer — #381 fixed the CLI's own init output and `.env` header to say `restart`, but the guides missed that sweep.

## Changes

**Remote guide:**

- **Verify / Monitoring** — the log commands now offer `npx vault-cortex@latest logs` (`--follow`, `--since`) for the CLI path, keeping `docker logs` for Compose/`docker run`. `docker ps` stays as an explicitly method-independent status check.
- **Restart** — `docker restart` stays as the universal quick restart. The "Changed `.env`?" callout now routes the CLI path to `restart` (noting it re-creates the container, unlike `docker restart`), keeps `upgrade` as the also-pulls variant, and gains a `docker run` route (`docker rm -f` + re-run Setup) — the callout previously served only two of the section's three paths.
- **Stop** — the conflated "Set up with the CLI (or `docker run`)?" heading splits: the CLI path gets `down` with a pointer to `start`; `docker run` keeps `docker stop`.
- **Daily notes** — gains the missing apply step: `.env` edits take effect on re-create, per path.

**Local guide:**

- **New Monitoring and Restart sections** for skeleton parity with the remote guide (their absence was omission — logs and restart apply equally to local). Adapted for local: no sync-process content. Contents nav updated.
- **Verify** — gains a log check (it had none).
- **Stop** — CLI path gets `down`/`start`.
- **Windows note** — `.env` edits now route to `restart` instead of `upgrade`.
- **Configuration** — the optional-settings enumeration gains the daily notes folder and format settings shipped in v0.36.2.

## Verification

- Reader-persona walks of both guides (remote as CLI / Compose / `docker run` user, local as CLI / Compose user): every operational section now gives each persona a command or explicitly scopes itself.
- Greps: no `docker stop` outside the remote `docker run` heading; the conflated CLI-or-docker-run heading is gone; every `cli/#...` anchor matches a real heading in cli/README.md.
- Section-skeleton diff between the two guides is limited to genuine variants (remote-only: HTTPS access, Daily notes, Hardening; local-only: Windows, Building from source).
- Docs-only: `git diff --stat` is exactly the two deploy READMEs. Root README untouched, so no DOCKERHUB.md regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added monitoring instructions for CLI, Docker Compose, and Docker container logs.
  * Clarified container health checks and restart behavior after `.env` changes.
  * Documented updated stop, start, and container recreation procedures.
  * Added the daily notes folder to configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->