### PR TITLE
feat(cli): daily notes folder and format in the settings chooser

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -90,8 +90,9 @@ current values, saves your picks to `.env`, and offers to restart the
 container so they take effect.
 
 Settings not in the chooser live in `.env` too: edit the value there, then
-run [`restart`](#restart). That's also how you clear a daily notes setting
-back to your vault's own configuration — comment out or delete its line.
+run [`restart`](#restart). The daily notes settings can be updated the same
+way — and removing a line entirely puts the server back on your vault's own
+daily notes settings.
 
 Use `--dir <path>` if your config isn't in `./vault-cortex`.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -91,8 +91,8 @@ container so they take effect.
 
 Settings not in the chooser live in `.env` too: edit the value there, then
 run [`restart`](#restart). The daily notes settings can be updated the same
-way — and removing a line entirely puts the server back on your vault's own
-daily notes settings.
+way — and if you remove one from `.env`, the server goes back to your
+vault's own daily notes settings.
 
 Use `--dir <path>` if your config isn't in `./vault-cortex`.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -90,9 +90,8 @@ current values, saves your picks to `.env`, and offers to restart the
 container so they take effect.
 
 Settings not in the chooser live in `.env` too: edit the value there, then
-run [`restart`](#restart). The daily notes settings can be updated the same
-way — and if you remove one from `.env`, the server goes back to your
-vault's own daily notes settings.
+run [`restart`](#restart). That's also how you clear a daily notes setting
+back to your vault's own configuration — comment out or delete its line.
 
 Use `--dir <path>` if your config isn't in `./vault-cortex`.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -49,9 +49,9 @@ What it does:
    - **Remote** — a VPS with [Obsidian Sync](https://obsidian.md/sync),
      reachable from any device
 2. Offers the most common optional settings — memory layer and folder,
-   file tools, semantic search, port, timezone (plus sync direction for
-   remote) — press enter to keep the defaults, or pick the ones you want to
-   change
+   daily notes folder and format, file tools, semantic search, port,
+   timezone (plus sync direction for remote) — press enter to keep the
+   defaults, or pick the ones you want to change
 3. Generates a `.env` file with a securely generated `MCP_AUTH_TOKEN`
 4. Optionally starts the container and waits for the health check
 5. Prints your connection details — the MCP URL, your auth token, and how to
@@ -86,10 +86,13 @@ npx vault-cortex@latest configure
 ```
 
 Shows the same settings chooser as [`init`](#init) — memory layer and
-folder, file tools, semantic search, port, timezone (plus sync direction
-for remote) — pre-filled with your current values, saves your picks to
-`.env`, and offers to restart the container so they take effect. Settings not in the chooser
-live in `.env` too: edit the value there, then run [`restart`](#restart).
+folder, daily notes folder and format, file tools, semantic search, port,
+timezone (plus sync direction for remote) — pre-filled with your current
+values, saves your picks to `.env`, and offers to restart the container so
+they take effect. Settings not in the chooser live in `.env` too: edit the
+value there, then run [`restart`](#restart) — that's also how you clear a
+daily notes setting back to your vault's own configuration (comment out or
+delete its line).
 
 Use `--dir <path>` if your config isn't in `./vault-cortex`.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -85,14 +85,13 @@ Change optional settings on an existing setup:
 npx vault-cortex@latest configure
 ```
 
-Shows the same settings chooser as [`init`](#init) — memory layer and
-folder, daily notes folder and format, file tools, semantic search, port,
-timezone (plus sync direction for remote) — pre-filled with your current
-values, saves your picks to `.env`, and offers to restart the container so
-they take effect. Settings not in the chooser live in `.env` too: edit the
-value there, then run [`restart`](#restart) — that's also how you clear a
-daily notes setting back to your vault's own configuration (comment out or
-delete its line).
+Shows the same settings chooser as [`init`](#init), pre-filled with your
+current values, saves your picks to `.env`, and offers to restart the
+container so they take effect.
+
+Settings not in the chooser live in `.env` too: edit the value there, then
+run [`restart`](#restart). That's also how you clear a daily notes setting
+back to your vault's own configuration — comment out or delete its line.
 
 Use `--dir <path>` if your config isn't in `./vault-cortex`.
 

--- a/cli/src/__tests__/command-stubs.ts
+++ b/cli/src/__tests__/command-stubs.ts
@@ -10,7 +10,11 @@ export type ScriptedAnswer = string | boolean | string[]
 export type MultiselectCall = { message: string; options: SelectOption[] }
 export type ConfirmCall = { message: string; initialValue: boolean }
 export type SelectCall = { message: string; initialValue: string }
-export type TextCall = { message: string; defaultValue: string | undefined }
+export type TextCall = {
+  message: string
+  defaultValue: string | undefined
+  placeholder: string | undefined
+}
 
 export type ScriptedPrompts = {
   prompts: Prompts
@@ -115,7 +119,11 @@ export const createScriptedPrompts = (
       return answer
     },
     text: async (message, options) => {
-      textCalls.push({ message, defaultValue: options?.defaultValue })
+      textCalls.push({
+        message,
+        defaultValue: options?.defaultValue,
+        placeholder: options?.placeholder,
+      })
       const answer = nextStringAnswer(message)
       // Mirrors @clack/prompts: an empty submission resolves to defaultValue.
       if (answer === "" && options?.defaultValue !== undefined)

--- a/cli/src/__tests__/configure.test.ts
+++ b/cli/src/__tests__/configure.test.ts
@@ -231,6 +231,27 @@ describe("runConfigure with picked settings", () => {
     )
   })
 
+  it("replaces an active daily notes folder with a new value", async () => {
+    const targetDir = makeTempTargetDir()
+    const envFilePath = join(targetDir, ".env")
+    const envWithDailyNotes = `${LOCAL_ENV_CONTENT}DAILY_NOTES_FOLDER=Journal\n`
+    writeFileSync(envFilePath, envWithDailyNotes)
+    const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], "Planner"])
+
+    const exitCode = await runConfigure(
+      { dir: targetDir },
+      { prompts: scripted.prompts, docker: dockerDown, fetchFn: fetchNever },
+    )
+
+    expect(exitCode).toBe(0)
+    expect(readFileSync(envFilePath, "utf8")).toBe(
+      `${LOCAL_ENV_CONTENT}DAILY_NOTES_FOLDER=Planner\n`,
+    )
+    expect(scripted.logs).toEqual([
+      `Updated DAILY_NOTES_FOLDER in ${targetDir}/.env.`,
+    ])
+  })
+
   it("uncomments the template's daily notes folder line on a typed value", async () => {
     // The generated .env carries the var as a commented template line — the
     // chooser's value must land by uncommenting it, not by appending a

--- a/cli/src/__tests__/configure.test.ts
+++ b/cli/src/__tests__/configure.test.ts
@@ -231,6 +231,47 @@ describe("runConfigure with picked settings", () => {
     )
   })
 
+  it("uncomments the template's daily notes folder line on a typed value", async () => {
+    // The generated .env carries the var as a commented template line — the
+    // chooser's value must land by uncommenting it, not by appending a
+    // duplicate.
+    const targetDir = makeTempTargetDir()
+    const envFilePath = join(targetDir, ".env")
+    writeFileSync(
+      envFilePath,
+      `${LOCAL_ENV_CONTENT}\n# DAILY_NOTES_FOLDER=Journal\n# DAILY_NOTES_FORMAT=YYYY-MM-DD\n`,
+    )
+    const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], "Planner"])
+
+    const exitCode = await runConfigure(
+      { dir: targetDir },
+      { prompts: scripted.prompts, docker: dockerDown, fetchFn: fetchNever },
+    )
+
+    expect(exitCode).toBe(0)
+    expect(readFileSync(envFilePath, "utf8")).toBe(
+      `${LOCAL_ENV_CONTENT}\nDAILY_NOTES_FOLDER=Planner\n# DAILY_NOTES_FORMAT=YYYY-MM-DD\n`,
+    )
+  })
+
+  it("treats a picked-then-blanked daily notes setting as nothing selected", async () => {
+    const targetDir = makeTempTargetDir()
+    const envFilePath = writeLocalEnv(targetDir)
+    const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], ""])
+
+    const exitCode = await runConfigure(
+      { dir: targetDir },
+      { prompts: scripted.prompts, docker: dockerDown, fetchFn: fetchNever },
+    )
+
+    expect(exitCode).toBe(0)
+    expect(readFileSync(envFilePath, "utf8")).toBe(LOCAL_ENV_CONTENT)
+    expect(scripted.logs).toEqual([
+      "Left unset — the server keeps reading your vault's daily notes settings.",
+      "No settings selected — nothing changed.",
+    ])
+  })
+
   it("keeps the saved change and exits 1 when the .env cannot start a container", async () => {
     const targetDir = makeTempTargetDir()
     const envFilePath = join(targetDir, ".env")

--- a/cli/src/__tests__/configure.test.ts
+++ b/cli/src/__tests__/configure.test.ts
@@ -77,7 +77,7 @@ describe("runConfigure with nothing picked", () => {
 
     expect(exitCode).toBe(0)
     expect(readFileSync(envFilePath, "utf8")).toBe(LOCAL_ENV_CONTENT)
-    expect(scripted.logs).toEqual(["No settings selected — nothing changed."])
+    expect(scripted.logs).toEqual(["No changes to apply."])
     expect(scripted.asked).toEqual([
       "Any optional settings to change? (press enter to skip)",
     ])
@@ -275,7 +275,7 @@ describe("runConfigure with picked settings", () => {
     )
   })
 
-  it("treats a picked-then-blanked daily notes setting as nothing selected", async () => {
+  it("treats a picked-then-blanked daily notes setting as no changes to apply", async () => {
     const targetDir = makeTempTargetDir()
     const envFilePath = writeLocalEnv(targetDir)
     const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], ""])
@@ -289,7 +289,7 @@ describe("runConfigure with picked settings", () => {
     expect(readFileSync(envFilePath, "utf8")).toBe(LOCAL_ENV_CONTENT)
     expect(scripted.logs).toEqual([
       "Left unset — the server reads this setting from your vault's own config.",
-      "No settings selected — nothing changed.",
+      "No changes to apply.",
     ])
   })
 
@@ -311,7 +311,7 @@ describe("runConfigure with picked settings", () => {
     expect(readFileSync(envFilePath, "utf8")).toBe(envWithDailyNotes)
     expect(scripted.logs).toEqual([
       "Kept the current value (Journal).",
-      "No settings selected — nothing changed.",
+      "No changes to apply.",
     ])
     expect(scripted.warnings).toEqual([])
   })

--- a/cli/src/__tests__/configure.test.ts
+++ b/cli/src/__tests__/configure.test.ts
@@ -272,6 +272,29 @@ describe("runConfigure with picked settings", () => {
     ])
   })
 
+  it("neither claims an update nor offers a restart when a set daily notes folder is blank-kept", async () => {
+    // A blank submit on a set value keeps it — configure must not log
+    // "Updated ..." or offer a restart for a byte-identical file.
+    const targetDir = makeTempTargetDir()
+    const envFilePath = join(targetDir, ".env")
+    const envWithDailyNotes = `${LOCAL_ENV_CONTENT}DAILY_NOTES_FOLDER=Journal\n`
+    writeFileSync(envFilePath, envWithDailyNotes)
+    const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], ""])
+
+    const exitCode = await runConfigure(
+      { dir: targetDir },
+      { prompts: scripted.prompts, docker: dockerDown, fetchFn: fetchNever },
+    )
+
+    expect(exitCode).toBe(0)
+    expect(readFileSync(envFilePath, "utf8")).toBe(envWithDailyNotes)
+    expect(scripted.logs).toEqual([
+      "Kept the current value (Journal).",
+      "No settings selected — nothing changed.",
+    ])
+    expect(scripted.warnings).toEqual([])
+  })
+
   it("keeps the saved change and exits 1 when the .env cannot start a container", async () => {
     const targetDir = makeTempTargetDir()
     const envFilePath = join(targetDir, ".env")

--- a/cli/src/__tests__/configure.test.ts
+++ b/cli/src/__tests__/configure.test.ts
@@ -267,7 +267,7 @@ describe("runConfigure with picked settings", () => {
     expect(exitCode).toBe(0)
     expect(readFileSync(envFilePath, "utf8")).toBe(LOCAL_ENV_CONTENT)
     expect(scripted.logs).toEqual([
-      "Left unset — the server keeps reading your vault's daily notes settings.",
+      "Left unset — the server reads this setting from your vault's own config.",
       "No settings selected — nothing changed.",
     ])
   })

--- a/cli/src/__tests__/init.test.ts
+++ b/cli/src/__tests__/init.test.ts
@@ -86,7 +86,7 @@ describe("runInit --yes (non-interactive local)", () => {
     expect(envContent).toMatch(/^MCP_AUTH_TOKEN=[0-9a-f]{64}$/m)
     expect(envContent).toContain(`VAULT_PATH=${vaultDir}\n`)
     expect(scripted.prints[0]).toContain(
-      "Adjust optional settings (memory layer and folder, file tools,\nsemantic search, port, timezone):",
+      "Adjust optional settings (memory layer and folder, daily notes\nfolder and format, file tools, semantic search, port, timezone):",
     )
   })
 
@@ -544,7 +544,7 @@ describe("runInit remote flow", () => {
     expect(envContent).toContain("VAULT_NAME=MyVault\n")
     expect(envContent).toContain("OBSIDIAN_AUTH_TOKEN=sync-token-xyz\n")
     expect(scripted.prints[0]).toContain(
-      "Adjust optional settings (memory layer and folder, file tools,\nsemantic search, port, timezone, sync direction):",
+      "Adjust optional settings (memory layer and folder, daily notes\nfolder and format, file tools, semantic search, port, timezone,\nsync direction):",
     )
   })
 

--- a/cli/src/__tests__/optional-settings.test.ts
+++ b/cli/src/__tests__/optional-settings.test.ts
@@ -430,7 +430,7 @@ describe("askOptionalSettings per-setting prompts", () => {
     ])
     expect(overrides).toEqual({})
     expect(scripted.logs).toEqual([
-      "Left unset — the server keeps reading your vault's daily notes settings.",
+      "Left unset — the server reads this setting from your vault's own config.",
     ])
   })
 

--- a/cli/src/__tests__/optional-settings.test.ts
+++ b/cli/src/__tests__/optional-settings.test.ts
@@ -144,6 +144,8 @@ describe("askOptionalSettings chooser", () => {
     ).toEqual([
       "MEMORY_ENABLED",
       "MEMORY_DIR",
+      "DAILY_NOTES_FOLDER",
+      "DAILY_NOTES_FORMAT",
       "FILE_TOOLS_ENABLED",
       "EMBEDDING_ENABLED",
       "PORT",
@@ -164,6 +166,8 @@ describe("askOptionalSettings chooser", () => {
     ).toEqual([
       "MEMORY_ENABLED",
       "MEMORY_DIR",
+      "DAILY_NOTES_FOLDER",
+      "DAILY_NOTES_FORMAT",
       "FILE_TOOLS_ENABLED",
       "EMBEDDING_ENABLED",
       "PORT",
@@ -185,6 +189,8 @@ describe("askOptionalSettings chooser", () => {
     ).toEqual([
       "MEMORY_ENABLED · currently false",
       "MEMORY_DIR · currently not set · not used while Memory layer is off",
+      "DAILY_NOTES_FOLDER · currently not set",
+      "DAILY_NOTES_FORMAT · currently not set",
       "FILE_TOOLS_ENABLED · currently not set",
       "EMBEDDING_ENABLED · currently not set",
       "PORT · currently 9000",
@@ -402,5 +408,105 @@ describe("askOptionalSettings per-setting prompts", () => {
       '"Not/AZone" is not a recognized IANA timezone (e.g. America/New_York, Europe/London).',
     ])
     expect(overrides).toEqual({ TZ: "Europe/London" })
+  })
+
+  it("skips an unset daily notes folder left blank, writing nothing", async () => {
+    const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], ""])
+
+    const overrides = await askOptionalSettings(
+      { mode: "local", envContent: "" },
+      scripted.prompts,
+    )
+
+    // No pre-filled default when unset — the real default is the vault's
+    // own config, so the prompt must not offer a concrete value to accept.
+    expect(scripted.textCalls).toEqual([
+      { message: "Vault folder for daily notes:", defaultValue: undefined },
+    ])
+    expect(overrides).toEqual({})
+    expect(scripted.logs).toEqual([
+      "Left unset — the server keeps reading your vault's daily notes settings.",
+    ])
+  })
+
+  it("keeps the current daily notes folder on a blank submit", async () => {
+    // The prompt resolves an empty submit to its defaultValue (the current
+    // value), so blank never destroys an existing setting.
+    const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], ""])
+
+    const overrides = await askOptionalSettings(
+      { mode: "local", envContent: "DAILY_NOTES_FOLDER=Journal\n" },
+      scripted.prompts,
+    )
+
+    expect(scripted.textCalls).toEqual([
+      { message: "Vault folder for daily notes:", defaultValue: "Journal" },
+    ])
+    expect(overrides).toEqual({ DAILY_NOTES_FOLDER: "Journal" })
+  })
+
+  it("collects a typed daily notes format, trimmed", async () => {
+    const scripted = createScriptedPrompts([
+      ["DAILY_NOTES_FORMAT"],
+      "  DD-MM-YYYY  ",
+    ])
+
+    const overrides = await askOptionalSettings(
+      { mode: "local", envContent: "" },
+      scripted.prompts,
+    )
+
+    expect(scripted.textCalls).toEqual([
+      {
+        message: "Filename date format for daily notes (e.g. YYYY-MM-DD):",
+        defaultValue: undefined,
+      },
+    ])
+    expect(overrides).toEqual({ DAILY_NOTES_FORMAT: "DD-MM-YYYY" })
+  })
+
+  it("does not clobber a set daily notes folder on whitespace input", async () => {
+    // Whitespace defeats the empty-submit-resolves-to-default behavior and
+    // trims to empty — the skip path must leave the existing value alone
+    // rather than write an empty one.
+    const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], "   "])
+
+    const overrides = await askOptionalSettings(
+      { mode: "local", envContent: "DAILY_NOTES_FOLDER=Journal\n" },
+      scripted.prompts,
+    )
+
+    expect(overrides).toEqual({})
+  })
+
+  it("records only the typed setting when one of a pair is left blank", async () => {
+    const scripted = createScriptedPrompts([
+      ["DAILY_NOTES_FOLDER", "DAILY_NOTES_FORMAT"],
+      "", // folder left blank — skipped
+      "YYYY/MM/DD", // format typed
+    ])
+
+    const overrides = await askOptionalSettings(
+      { mode: "local", envContent: "" },
+      scripted.prompts,
+    )
+
+    expect(overrides).toEqual({ DAILY_NOTES_FORMAT: "YYYY/MM/DD" })
+  })
+
+  it("shows a set daily notes folder in its chooser hint", async () => {
+    const scripted = createScriptedPrompts([[]])
+
+    await askOptionalSettings(
+      { mode: "local", envContent: "DAILY_NOTES_FOLDER=Journal\n" },
+      scripted.prompts,
+    )
+
+    const dailyNotesFolderOption = scripted.multiselectCalls[0].options.find(
+      (option) => option.value === "DAILY_NOTES_FOLDER",
+    )
+    expect(dailyNotesFolderOption?.hint).toBe(
+      "DAILY_NOTES_FOLDER · currently Journal",
+    )
   })
 })

--- a/cli/src/__tests__/optional-settings.test.ts
+++ b/cli/src/__tests__/optional-settings.test.ts
@@ -344,6 +344,7 @@ describe("askOptionalSettings per-setting prompts", () => {
       {
         message: "Vault folder for the memory files:",
         defaultValue: "About Me",
+        placeholder: "About Me",
       },
     ])
     expect(overrides).toEqual({ MEMORY_DIR: "Memory Bank" })
@@ -421,7 +422,11 @@ describe("askOptionalSettings per-setting prompts", () => {
     // No pre-filled default when unset — the real default is the vault's
     // own config, so the prompt must not offer a concrete value to accept.
     expect(scripted.textCalls).toEqual([
-      { message: "Vault folder for daily notes:", defaultValue: undefined },
+      {
+        message: "Vault folder for daily notes:",
+        defaultValue: undefined,
+        placeholder: "blank = use your vault's daily notes settings",
+      },
     ])
     expect(overrides).toEqual({})
     expect(scripted.logs).toEqual([
@@ -429,9 +434,11 @@ describe("askOptionalSettings per-setting prompts", () => {
     ])
   })
 
-  it("keeps the current daily notes folder on a blank submit", async () => {
+  it("keeps a set daily notes folder on a blank submit without recording a no-op", async () => {
     // The prompt resolves an empty submit to its defaultValue (the current
-    // value), so blank never destroys an existing setting.
+    // value), so blank never destroys an existing setting — and the unchanged
+    // value is not recorded, so the caller won't rewrite the file or offer a
+    // restart for a no-op. The placeholder states what blank actually does.
     const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], ""])
 
     const overrides = await askOptionalSettings(
@@ -440,9 +447,14 @@ describe("askOptionalSettings per-setting prompts", () => {
     )
 
     expect(scripted.textCalls).toEqual([
-      { message: "Vault folder for daily notes:", defaultValue: "Journal" },
+      {
+        message: "Vault folder for daily notes:",
+        defaultValue: "Journal",
+        placeholder: "blank = keep the current value",
+      },
     ])
-    expect(overrides).toEqual({ DAILY_NOTES_FOLDER: "Journal" })
+    expect(overrides).toEqual({})
+    expect(scripted.logs).toEqual(["Kept the current value (Journal)."])
   })
 
   it("collects a typed daily notes format, trimmed", async () => {
@@ -460,6 +472,7 @@ describe("askOptionalSettings per-setting prompts", () => {
       {
         message: "Filename date format for daily notes (e.g. YYYY-MM-DD):",
         defaultValue: undefined,
+        placeholder: "blank = use your vault's daily notes settings",
       },
     ])
     expect(overrides).toEqual({ DAILY_NOTES_FORMAT: "DD-MM-YYYY" })
@@ -467,8 +480,9 @@ describe("askOptionalSettings per-setting prompts", () => {
 
   it("does not clobber a set daily notes folder on whitespace input", async () => {
     // Whitespace defeats the empty-submit-resolves-to-default behavior and
-    // trims to empty — the skip path must leave the existing value alone
-    // rather than write an empty one.
+    // trims to empty — the keep path must leave the existing value alone
+    // rather than write an empty one, and must say "kept", not "left unset":
+    // the override stays active in .env.
     const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], "   "])
 
     const overrides = await askOptionalSettings(
@@ -477,6 +491,19 @@ describe("askOptionalSettings per-setting prompts", () => {
     )
 
     expect(overrides).toEqual({})
+    expect(scripted.logs).toEqual(["Kept the current value (Journal)."])
+  })
+
+  it("does not record retyping the value a daily notes folder already has", async () => {
+    const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], "Journal"])
+
+    const overrides = await askOptionalSettings(
+      { mode: "local", envContent: "DAILY_NOTES_FOLDER=Journal\n" },
+      scripted.prompts,
+    )
+
+    expect(overrides).toEqual({})
+    expect(scripted.logs).toEqual(["Kept the current value (Journal)."])
   })
 
   it("records only the typed setting when one of a pair is left blank", async () => {

--- a/cli/src/__tests__/optional-settings.test.ts
+++ b/cli/src/__tests__/optional-settings.test.ts
@@ -494,6 +494,24 @@ describe("askOptionalSettings per-setting prompts", () => {
     expect(scripted.logs).toEqual(["Kept the current value (Journal)."])
   })
 
+  it("updates a set daily notes folder to a new value", async () => {
+    const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], "Planner"])
+
+    const overrides = await askOptionalSettings(
+      { mode: "local", envContent: "DAILY_NOTES_FOLDER=Journal\n" },
+      scripted.prompts,
+    )
+
+    expect(scripted.textCalls).toEqual([
+      {
+        message: "Vault folder for daily notes:",
+        defaultValue: "Journal",
+        placeholder: "blank = keep the current value",
+      },
+    ])
+    expect(overrides).toEqual({ DAILY_NOTES_FOLDER: "Planner" })
+  })
+
   it("does not record retyping the value a daily notes folder already has", async () => {
     const scripted = createScriptedPrompts([["DAILY_NOTES_FOLDER"], "Journal"])
 

--- a/cli/src/configure.ts
+++ b/cli/src/configure.ts
@@ -53,7 +53,10 @@ export const runConfigure = async (
     prompts,
   )
   if (Object.keys(pickedOverrides).length === 0) {
-    prompts.log("No settings selected — nothing changed.")
+    // Covers both empty-overrides paths: nothing picked in the chooser, and
+    // picked-but-kept (an optionalText prompt left blank logs its own
+    // "Kept the current value" line, which this must not contradict).
+    prompts.log("No changes to apply.")
     prompts.outro("Done.")
     return 0
   }

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -239,8 +239,8 @@ ${nonOauthBlocks}
 
 ${sectionRule("Settings")}
 
-Adjust optional settings (memory layer and folder, file tools,
-semantic search, port, timezone):
+Adjust optional settings (memory layer and folder, daily notes
+folder and format, file tools, semantic search, port, timezone):
   npx vault-cortex@latest configure --dir "${targetDir}"
 
 Or edit ${targetDir}/.env directly — change a value (uncommenting it
@@ -324,8 +324,9 @@ ${remoteHealthCheckBlock(`${publicUrl}/healthz`, started)}
 
 ${sectionRule("Settings")}
 
-Adjust optional settings (memory layer and folder, file tools,
-semantic search, port, timezone, sync direction):
+Adjust optional settings (memory layer and folder, daily notes
+folder and format, file tools, semantic search, port, timezone,
+sync direction):
   npx vault-cortex@latest configure --dir "${targetDir}"
 
 Or edit ${targetDir}/.env directly — change a value (uncommenting it

--- a/cli/src/optional-settings.ts
+++ b/cli/src/optional-settings.ts
@@ -19,7 +19,8 @@ type OptionalSettingBase = {
 /**
  * One optional .env setting the guided flow can change. `kind` selects the
  * prompt shape a picked setting gets: toggles use a yes/no confirm, port and
- * timezone use validated text inputs, and choice uses a single select.
+ * timezone use validated text inputs, folder requires a non-empty name,
+ * optionalText writes nothing when left blank, and choice uses a single select.
  */
 type OptionalSetting =
   | (OptionalSettingBase & { kind: "toggle"; question: string })

--- a/cli/src/optional-settings.ts
+++ b/cli/src/optional-settings.ts
@@ -34,10 +34,11 @@ type OptionalSetting =
       kind: "optionalText"
       question: string
       /**
-       * Ghost text for the input. Unlike `folder`, there is no defaultValue:
-       * an unset var means the server reads the vault's own config, so
-       * pre-filling a concrete value would write an override that silently
-       * shadows it. Blank when unset = skip (write nothing).
+       * Ghost text while the var is unset. Unlike `folder`, there is no
+       * defaultValue: an unset var means the server reads the vault's own
+       * config, so pre-filling a concrete value would write an override that
+       * silently shadows it. Once a value is set, the prompt shows a
+       * keep-current placeholder instead — blank then keeps, never clears.
        */
       placeholder: string
     })
@@ -288,8 +289,12 @@ const askFolder = async (
  * Text prompt for a setting whose absence is meaningful — the server falls
  * back to the vault's own config when the var is unset. Blank when unset =
  * skip (write nothing); blank when set keeps the current value (the prompt
- * resolves an empty submit to its defaultValue). There is no removal path —
- * clearing a set value stays a manual .env edit.
+ * resolves an empty submit to its defaultValue), and an unchanged value is
+ * also returned as undefined so the caller never rewrites the file or offers
+ * a restart for a no-op. The placeholder tells the truth for each state:
+ * "use your vault's settings" only while unset, "keep the current value"
+ * once set. There is no removal path — clearing a set value stays a manual
+ * .env edit.
  */
 const askOptionalText = async (
   params: {
@@ -299,16 +304,24 @@ const askOptionalText = async (
   },
   prompts: Prompts,
 ): Promise<string | undefined> => {
+  const { question, placeholder, currentValue } = params
   const answer = (
-    await prompts.text(params.question, {
-      defaultValue: params.currentValue,
-      placeholder: params.placeholder,
+    await prompts.text(question, {
+      defaultValue: currentValue,
+      placeholder:
+        currentValue === undefined
+          ? placeholder
+          : "blank = keep the current value",
     })
   ).trim()
-  if (answer !== "") return answer
-  prompts.log(
-    "Left unset — the server keeps reading your vault's daily notes settings.",
-  )
+  if (answer !== "" && answer !== currentValue) return answer
+  if (currentValue === undefined) {
+    prompts.log(
+      "Left unset — the server keeps reading your vault's daily notes settings.",
+    )
+    return undefined
+  }
+  prompts.log(`Kept the current value (${currentValue}).`)
   return undefined
 }
 

--- a/cli/src/optional-settings.ts
+++ b/cli/src/optional-settings.ts
@@ -31,6 +31,17 @@ type OptionalSetting =
       defaultValue: string
     })
   | (OptionalSettingBase & {
+      kind: "optionalText"
+      question: string
+      /**
+       * Ghost text for the input. Unlike `folder`, there is no defaultValue:
+       * an unset var means the server reads the vault's own config, so
+       * pre-filling a concrete value would write an override that silently
+       * shadows it. Blank when unset = skip (write nothing).
+       */
+      placeholder: string
+    })
+  | (OptionalSettingBase & {
       kind: "choice"
       question: string
       choices: SelectOption[]
@@ -54,6 +65,20 @@ const OPTIONAL_SETTINGS: OptionalSetting[] = [
     question: "Vault folder for the memory files:",
     defaultValue: "About Me",
     requiresToggle: "MEMORY_ENABLED",
+  },
+  {
+    kind: "optionalText",
+    name: "DAILY_NOTES_FOLDER",
+    label: "Daily notes folder",
+    question: "Vault folder for daily notes:",
+    placeholder: "blank = use your vault's daily notes settings",
+  },
+  {
+    kind: "optionalText",
+    name: "DAILY_NOTES_FORMAT",
+    label: "Daily notes format",
+    question: "Filename date format for daily notes (e.g. YYYY-MM-DD):",
+    placeholder: "blank = use your vault's daily notes settings",
   },
   {
     kind: "toggle",
@@ -259,11 +284,42 @@ const askFolder = async (
   return askFolder(params, prompts)
 }
 
-/** Routes a picked setting to its kind's prompt and returns the .env value. */
+/**
+ * Text prompt for a setting whose absence is meaningful — the server falls
+ * back to the vault's own config when the var is unset. Blank when unset =
+ * skip (write nothing); blank when set keeps the current value (the prompt
+ * resolves an empty submit to its defaultValue). There is no removal path —
+ * clearing a set value stays a manual .env edit.
+ */
+const askOptionalText = async (
+  params: {
+    question: string
+    placeholder: string
+    currentValue: string | undefined
+  },
+  prompts: Prompts,
+): Promise<string | undefined> => {
+  const answer = (
+    await prompts.text(params.question, {
+      defaultValue: params.currentValue,
+      placeholder: params.placeholder,
+    })
+  ).trim()
+  if (answer !== "") return answer
+  prompts.log(
+    "Left unset — the server keeps reading your vault's daily notes settings.",
+  )
+  return undefined
+}
+
+/**
+ * Routes a picked setting to its kind's prompt and returns the .env value —
+ * or undefined when an optionalText prompt was left blank (nothing to write).
+ */
 const askSettingValue = async (
   params: { setting: OptionalSetting; currentValue: string | undefined },
   prompts: Prompts,
-): Promise<string> => {
+): Promise<string | undefined> => {
   const { setting, currentValue } = params
   switch (setting.kind) {
     case "toggle": {
@@ -283,6 +339,15 @@ const askSettingValue = async (
           question: setting.question,
           currentValue,
           defaultValue: setting.defaultValue,
+        },
+        prompts,
+      )
+    case "optionalText":
+      return askOptionalText(
+        {
+          question: setting.question,
+          placeholder: setting.placeholder,
+          currentValue,
         },
         prompts,
       )
@@ -332,14 +397,16 @@ export const askOptionalSettings = async (
   )
 
   // Sequential prompting: answers are gathered one at a time in the curated
-  // order, so the record builds up inside an honest loop.
+  // order, so the record builds up inside an honest loop. An undefined answer
+  // (an optionalText prompt left blank) writes nothing.
   const overrides: Record<string, string> = {}
   for (const setting of offeredSettings) {
     if (!pickedNames.includes(setting.name)) continue
-    overrides[setting.name] = await askSettingValue(
+    const value = await askSettingValue(
       { setting, currentValue: readOptionalValue(envContent, setting.name) },
       prompts,
     )
+    if (value !== undefined) overrides[setting.name] = value
   }
   return overrides
 }

--- a/cli/src/optional-settings.ts
+++ b/cli/src/optional-settings.ts
@@ -33,13 +33,7 @@ type OptionalSetting =
   | (OptionalSettingBase & {
       kind: "optionalText"
       question: string
-      /**
-       * Ghost text while the var is unset. Unlike `folder`, there is no
-       * defaultValue: an unset var means the server reads the vault's own
-       * config, so pre-filling a concrete value would write an override that
-       * silently shadows it. Once a value is set, the prompt shows a
-       * keep-current placeholder instead — blank then keeps, never clears.
-       */
+      /** Ghost text while unset — no defaultValue because pre-filling would silently shadow the vault's own config. */
       placeholder: string
     })
   | (OptionalSettingBase & {
@@ -287,14 +281,10 @@ const askFolder = async (
 
 /**
  * Text prompt for a setting whose absence is meaningful — the server falls
- * back to the vault's own config when the var is unset. Blank when unset =
- * skip (write nothing); blank when set keeps the current value (the prompt
- * resolves an empty submit to its defaultValue), and an unchanged value is
- * also returned as undefined so the caller never rewrites the file or offers
- * a restart for a no-op. The placeholder tells the truth for each state:
- * "use your vault's settings" only while unset, "keep the current value"
- * once set. There is no removal path — clearing a set value stays a manual
- * .env edit.
+ * back to the vault's own config when the var is unset. Blank-when-unset
+ * writes nothing; blank-when-set keeps the current value. Returns undefined
+ * on skip or no-op so the caller never rewrites for nothing. No removal
+ * path — clearing is a manual .env edit.
  */
 const askOptionalText = async (
   params: {
@@ -317,7 +307,7 @@ const askOptionalText = async (
   if (answer !== "" && answer !== currentValue) return answer
   if (currentValue === undefined) {
     prompts.log(
-      "Left unset — the server keeps reading your vault's daily notes settings.",
+      "Left unset — the server reads this setting from your vault's own config.",
     )
     return undefined
   }


### PR DESCRIPTION
## What this adds

`DAILY_NOTES_FOLDER` and `DAILY_NOTES_FORMAT` (shipped in v0.36.2, #427) could only be set by hand-editing `.env`. This surfaces them in the init/configure settings chooser, the same convenience tier as the memory folder.

## Changes

- **New `optionalText` setting kind** — the first chooser settings whose default is "unset" (the server reads the vault's own `.obsidian/daily-notes.json`). The existing `folder` kind requires a concrete `defaultValue` and pre-fills it, which is wrong here: accepting a pre-filled value would write an override that silently shadows the vault config. `optionalText` carries a `question` + `placeholder` and no default.
  - Blank when unset = skip — nothing is written (never an empty `NAME=` line), with a log line making the skip legible.
  - Blank when set keeps the current value (the prompt resolves an empty submit to its default), so blank never destroys an existing setting — consistent with the memory folder, which also can't be cleared via the chooser. Clearing stays a manual `.env` edit; the README's configure section now says so.
- **Two chooser entries** inserted after Memory folder, offered in both modes: "Daily notes folder" and "Daily notes format" (question carries the `YYYY-MM-DD` token example; the shared placeholder says "blank = use your vault's daily notes settings"). The existing hint machinery shows "currently not set" / the current value with no code change.
- **No CLI-side validation beyond trim** — deliberate. The server's folder validation also normalizes (a partial mirror would drift or silently rewrite input), the format's probe-render validation lives server-side, and the CLI-validation precedent (TZ via `Intl`, port range) is "a local authoritative validator with zero drift risk exists" — none does here. A bad value fail-fasts at boot with a named-env-var error, and the restart path already health-probes and points at logs.
- **`askSettingValue` widens to `Promise<string | undefined>`**; the collection loop skips undefined. Module-private, single caller; the `Prompts` interface is untouched, so no test-stub churn.
- **Connect-message enumerations** (local + remote) and the cli/README init/configure enumerations gain the pair.

The write path needed no changes: both vars already exist as commented template lines in the generated `.env` (drift-guarded against `deploy/*/.env.example`), so `applyOptionalSettings`' existing uncomment branch lands the chosen value. Both vars already flow through every step of the env-var checklist — this PR adds no var and touches nothing outside `cli/`.

## Tests

- Chooser arrays (local 6→8, remote 7→9) and hint expectations updated; new hint test for a set value.
- New per-setting tests: blank-when-unset skips and writes nothing (asserting `defaultValue: undefined` was passed — the guard against pre-filling); blank-when-set keeps; typed value trimmed; whitespace-when-set doesn't clobber; mixed pick records only the typed setting.
- New configure integration tests: a typed value lands by uncommenting the template line (not appending a duplicate); pick-then-blank falls through to the "No settings selected" early-out with the file byte-identical.
- Mutation-verified: replacing the blank guard with the naive `return answer` fails 5 tests (the new blank-semantics tests plus the memory-folder empty-rejection test) for the intended reason.
- `npm run build` (both cli tsconfigs) green, full suite 2535 tests passing, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional daily notes folder and filename format settings to setup and configuration flows.
  - Daily notes settings now preserve existing values, support clearing unset values, and avoid unnecessary changes when left blank.
  - Configuration prompts now display clearer hints for available and unset options.

- **Bug Fixes**
  - Updated no-op configuration feedback to consistently report: “No changes to apply.”

- **Documentation**
  - Expanded setup and configuration guidance for daily notes settings, including environment-based reset instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->