### PR TITLE
docs(deploy): signpost the one-shot token step and no-Compose path in remote manual setup

### DIFF
--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -74,7 +74,8 @@ captures the token for you:
 npx vault-cortex@latest get-sync-token
 ```
 
-Otherwise, run the Docker image directly:
+Otherwise, run the helper in a throwaway container — it prints the token
+and exits; nothing stays running:
 
 ```bash
 docker run --rm -it --entrypoint get-sync-token \
@@ -101,6 +102,9 @@ cp .env.example .env
 ```bash
 docker compose up -d
 ```
+
+No Compose? The **docker run (no Compose)** block below starts the same
+server directly.
 
 First start pulls the image, logs in to Obsidian Sync, and syncs your vault
 from Obsidian's servers. The initial sync takes 30–120 seconds depending on


### PR DESCRIPTION
Reading the remote guide's manual setup top to bottom, step 3's `docker run` fallback for `get-sync-token` looked like it started the server, which made step 6's `docker compose up -d` read as a conflicting second start method — the step that makes the flow coherent (downloading the Compose file) sits back in step 2.

Two signposts, no procedural changes:

- **Step 3** now describes the token fallback as a throwaway container that prints the token and exits, so it can't be mistaken for starting anything.
- **Step 6** adds a pointer after `docker compose up -d` directing no-Compose readers to the **docker run (no Compose)** block below, instead of stranding them at a command they can't run until they happen to read past the sync-timing paragraph.

The local guide's manual setup is Compose-only with no token step, so it doesn't have this shape and is unchanged. No downstream surfaces affected — `DOCKERHUB.md` generates from the root README, and no `.env.example` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)