### PR TITLE
ci: bump umm-actually to v0.3.6 and wire the request timeout

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -77,7 +77,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@1fc198b584228f3130d1bdffd31b983e782917a4 # v0.3.5
+      - uses: aliasunder/umm-actually@33af5230ee6d083a01236d9155a3990d2817c5bd # v0.3.6
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}
@@ -87,6 +87,9 @@ jobs:
           # Same slug format; retried when the primary fails structured
           # output. Empty = no fallback
           fallback_model: ${{ vars.UMM_FALLBACK_MODEL }}
+          # Per-attempt cap on a single model request; a timed-out attempt
+          # aborts and advances the retry/fallback ladder. Empty = 600
+          request_timeout_seconds: ${{ vars.UMM_REQUEST_TIMEOUT_SECONDS }}
           # Positive integer cap on posted findings (highest severity
           # first). Empty = uncapped
           max_findings: ${{ vars.UMM_MAX_FINDINGS }}


### PR DESCRIPTION
Bumps the pinned umm-actually SHA to v0.3.6 (`33af523`), which adds a per-attempt model-request timeout so a hung provider call fails into the retry/fallback ladder instead of stalling the check until the runner's 6-hour kill — the hang was observed twice on vault-onboarding with deepseek-v4-flash (17–20-minute stalls).

- `request_timeout_seconds: ${{ vars.UMM_REQUEST_TIMEOUT_SECONDS }}` — bare-var wiring; v0.3.6 treats empty as its 600s default
- No repo variable set here: vault-cortex reviews are code-diff-sized, so the 600s default fits; set `UMM_REQUEST_TIMEOUT_SECONDS` in Settings → Variables anytime to tune

Same change already live on vault-onboarding (PR \#9 there, with a 900s override for its prose-heavy prompts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)