### PR TITLE
chore: bump umm-actually to v0.3.7

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -77,7 +77,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@33af5230ee6d083a01236d9155a3990d2817c5bd # v0.3.6
+      - uses: aliasunder/umm-actually@30e2afda3ffadb3e143c502e414ab907e6506b1f # v0.3.7
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
## Summary

- Bump umm-actually from v0.3.6 (`33af523`) to v0.3.7 (`30e2afd`)
- v0.3.7 disables SDK-internal retry so `request_timeout_seconds` bounds the attempt (fixes the 15+ min hang observed on PR \#442), adds a 1s retry delay for transient failures, and narrows the retries type

## Test plan

- [ ] CI passes
- [ ] Self-review runs with the new pin