### PR TITLE
fix(move): filesystem-verify backlinks under lock to close index-lag race

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -749,11 +749,13 @@ Docker hardening, and durability seatbelts above.
   locks in one synchronous tick — used by note-mover, which must lock the
   source, destination, and every backlink source for the whole
   read-plan-write span.
-- **Preflight-then-commit move** (`note-mover.ts`): `moveNote` reads
-  every affected file and computes every rewrite _before_ touching
-  anything. If any read fails, no file is mutated. Destination is written
-  first via exclusive create; source is deleted last — a failure at any
-  step leaves both copies rather than losing content.
+- **Verify-then-preflight-then-commit move** (`note-mover.ts`): under the
+  lock, `moveNote` first scans the filesystem for backlinks the search
+  index missed (closing a lag race); then reads every affected file and
+  computes every rewrite _before_ touching anything. If any read fails, no
+  file is mutated. Destination is written first via exclusive create;
+  source is deleted last — a failure at any step leaves both copies rather
+  than losing content.
 - **Content-hash gating** (`search-index.ts`): SHA-256 per chunk. Only
   changed content re-embeds on both incremental updates and full rebuilds
   — a correctness guarantee (not just performance).

--- a/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/vault-crud-tools.ts
@@ -809,6 +809,7 @@ Errors:
 - "path traversal blocked" — a path escapes the vault root; use vault-relative paths.
 - "hidden path blocked" — old_path or new_path targets a hidden (dot-prefixed) file or folder like ".obsidian/"; notes cannot be moved from or into hidden paths, matching Obsidian.
 - "concurrent write in progress" — a write is in flight on the note, the destination, or one of its backlink sources (the move locks all of them as one unit); retry the move.
+- "backlink set did not stabilize" — the vault was modified during the move and new backlink sources kept appearing across retries; nothing was written; retry the move.
 - Mid-move I/O failure (rare, e.g. a permission or disk error while writing) — the move aborts and the original note is deleted only after the destination and all backlinks are written, so a failure never loses data. The error message names what failed and the resulting state: if a backlink write failed, new_path exists and the original is intact (re-run the move, deleting the partial new_path first, to finish); if the final delete failed, both old_path and new_path exist (delete old_path to finish).
 
 Obsidian syntax: Link rewrites preserve each link's existing form — embed marker (!), heading anchor (#…), and alias (|…) are kept; a markdown link keeps its original extension and link text. Only the target path is changed.

--- a/src/vault-mcp/obsidian-markdown/__tests__/links.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/links.test.ts
@@ -592,60 +592,82 @@ describe("resolve", () => {
   ]
 
   it("resolves exact path match", () => {
-    expect(links.resolve("Projects/vault-cortex", allPaths)).toBe(
+    expect(links.resolve({ target: "Projects/vault-cortex", allPaths })).toBe(
       "Projects/vault-cortex.md",
     )
   })
 
   it("resolves exact path with .md extension", () => {
-    expect(links.resolve("Projects/vault-cortex.md", allPaths)).toBe(
-      "Projects/vault-cortex.md",
-    )
+    expect(
+      links.resolve({ target: "Projects/vault-cortex.md", allPaths }),
+    ).toBe("Projects/vault-cortex.md")
   })
 
   it("resolves basename match", () => {
-    expect(links.resolve("Principles", allPaths)).toBe("About Me/Principles.md")
+    expect(links.resolve({ target: "Principles", allPaths })).toBe(
+      "About Me/Principles.md",
+    )
   })
 
   it("resolves to shortest path when multiple basename matches exist", () => {
-    expect(links.resolve("note", allPaths)).toBe("note.md")
+    expect(links.resolve({ target: "note", allPaths })).toBe("note.md")
   })
 
   it("returns null for unresolvable target", () => {
-    expect(links.resolve("NonExistent", allPaths)).toBeNull()
+    expect(links.resolve({ target: "NonExistent", allPaths })).toBeNull()
   })
 
   it("resolves an upward relative path against the source note's directory", () => {
     const paths = ["A/C/target.md", "A/B/note.md"]
-    expect(links.resolve("../C/target", paths, "A/B/note.md")).toBe(
-      "A/C/target.md",
-    )
+    expect(
+      links.resolve({
+        target: "../C/target",
+        allPaths: paths,
+        sourcePath: "A/B/note.md",
+      }),
+    ).toBe("A/C/target.md")
   })
 
   it("resolves a descending relative path to the source's own subfolder over a shorter same-named path elsewhere", () => {
     // "X/sub/target.md" is the shorter basename/suffix match, but the link is
     // relative to Areas/note.md, so it must resolve into Areas/sub/.
     const paths = ["Areas/sub/target.md", "X/sub/target.md", "Areas/note.md"]
-    expect(links.resolve("sub/target", paths, "Areas/note.md")).toBe(
-      "Areas/sub/target.md",
-    )
+    expect(
+      links.resolve({
+        target: "sub/target",
+        allPaths: paths,
+        sourcePath: "Areas/note.md",
+      }),
+    ).toBe("Areas/sub/target.md")
   })
 
   it("prefers an exact vault-absolute path over a relative-to-source match", () => {
     const paths = ["Projects/other.md", "A/B/Projects/other.md", "A/B/note.md"]
-    expect(links.resolve("Projects/other", paths, "A/B/note.md")).toBe(
-      "Projects/other.md",
-    )
+    expect(
+      links.resolve({
+        target: "Projects/other",
+        allPaths: paths,
+        sourcePath: "A/B/note.md",
+      }),
+    ).toBe("Projects/other.md")
   })
 
   it("cannot resolve an upward relative path without a source note", () => {
-    expect(links.resolve("../C/target", ["A/C/target.md"])).toBeNull()
+    expect(
+      links.resolve({ target: "../C/target", allPaths: ["A/C/target.md"] }),
+    ).toBeNull()
   })
 
   it("does not let an upward ../ path escape to a same-named vault-root note", () => {
     // "secret.md" exists at the vault root, but "../secret" from a root note
     // points above the vault — it must stay unresolved, not collapse onto it.
-    expect(links.resolve("../secret", ["secret.md"], "note.md")).toBeNull()
+    expect(
+      links.resolve({
+        target: "../secret",
+        allPaths: ["secret.md"],
+        sourcePath: "note.md",
+      }),
+    ).toBeNull()
   })
 })
 

--- a/src/vault-mcp/obsidian-markdown/links.ts
+++ b/src/vault-mcp/obsidian-markdown/links.ts
@@ -274,7 +274,7 @@ const extractFromFrontmatter = (data: Record<string, unknown>): string[] => {
  *  Returns null if unresolvable. */
 const resolve = (params: {
   target: string
-  allPaths: string[]
+  allPaths: readonly string[]
   sourcePath?: string
 }): string | null => {
   const { target, allPaths, sourcePath } = params

--- a/src/vault-mcp/obsidian-markdown/links.ts
+++ b/src/vault-mcp/obsidian-markdown/links.ts
@@ -272,11 +272,12 @@ const extractFromFrontmatter = (data: Record<string, unknown>): string[] => {
  *  (exact), shortest path / basename, and — when the linking note's `sourcePath`
  *  is supplied — path from current file, including upward "../" segments.
  *  Returns null if unresolvable. */
-const resolve = (
-  target: string,
-  allPaths: string[],
-  sourcePath?: string,
-): string | null => {
+const resolve = (params: {
+  target: string
+  allPaths: string[]
+  sourcePath?: string
+}): string | null => {
+  const { target, allPaths, sourcePath } = params
   const targetWithExtension = target.endsWith(".md") ? target : `${target}.md`
 
   // Exact path match ("path from vault folder"): "folder/Note.md" or "Note.md"

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -1320,7 +1320,11 @@ export const createSearchIndex = (
 
       deleteLinksStmt.run(note.path)
       for (const rawTarget of links.extractAll(parsed.content, frontmatter)) {
-        const resolved = links.resolve(rawTarget, pathList, note.path)
+        const resolved = links.resolve({
+          target: rawTarget,
+          allPaths: pathList,
+          sourcePath: note.path,
+        })
         if (resolved !== null) {
           insertLinkStmt.run(note.path, resolved)
         } else {
@@ -1335,7 +1339,11 @@ export const createSearchIndex = (
       // Obsidian's "link first, create the note later" workflow.
       const unresolvedLinks = selectUnresolvedLinksStmt.all()
       for (const link of unresolvedLinks) {
-        const resolved = links.resolve(link.target, pathList, link.source)
+        const resolved = links.resolve({
+          target: link.target,
+          allPaths: pathList,
+          sourcePath: link.source,
+        })
         if (resolved !== null) {
           updateLinkTargetStmt.run({
             resolved,
@@ -1825,7 +1833,11 @@ export const createSearchIndex = (
       for (const note of noteContents) {
         const parsed = parseNote(note.content)
         for (const rawTarget of links.extractAll(parsed.content, parsed.data)) {
-          const resolved = links.resolve(rawTarget, pathList, note.relativePath)
+          const resolved = links.resolve({
+            target: rawTarget,
+            allPaths: pathList,
+            sourcePath: note.relativePath,
+          })
           if (resolved !== null) {
             insertLinkStmt.run(note.relativePath, resolved)
           } else {

--- a/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
@@ -1631,7 +1631,7 @@ describe("moveNote — filesystem backlink verification", () => {
   })
 
   it("does not false-positive on notes containing the basename as prose", async () => {
-    const { writeFixture, moveNote } = setupVault()
+    const { writeFixture, moveNote, logger } = setupVault()
     await writeFixture("Foo.md", "# Foo\n")
     // Contains "Foo" as prose text, not as a link
     await writeFixture("Prose.md", "The Foo concept is clear.\n")
@@ -1651,6 +1651,16 @@ describe("moveNote — filesystem backlink verification", () => {
       updated_notes: [],
       pruned_empty_folders: 0,
     })
+    // The retry log must NOT have fired with Prose.md — a scan that
+    // false-positives on prose would still produce the same result (the
+    // preflight finds no links, planned rewrite is filtered out), so the
+    // result assertion alone can't catch the regression.
+    expect(vi.mocked(logger.info)).not.toHaveBeenCalledWith(
+      "backlink verification discovered sources the index missed",
+      expect.objectContaining({
+        additionalSources: expect.arrayContaining(["Prose.md"]),
+      }),
+    )
   })
 
   it("skips unreadable notes during the scan without aborting", async () => {

--- a/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
@@ -1757,4 +1757,27 @@ describe("moveNote — filesystem backlink verification", () => {
       "See [here](Renamed%20Note.md) for info.\n",
     )
   })
+
+  it("discovers a markdown-link backlink whose target uses %28/%29 encoding", async () => {
+    const { writeFixture, moveNote, readNote } = setupVault()
+    await writeFixture("New (Draft).md", "# Draft\n")
+    // The rewriter's encodeMarkdownLinkPath encodes parentheses as %28/%29,
+    // so the raw content holds neither "New (Draft)" nor "New%20(Draft)".
+    // The pre-filter's parenEncodedStem check catches this.
+    await writeFixture("Hub.md", "See [x](New%20%28Draft%29.md).\n")
+
+    const result = await moveNote({
+      oldPath: "New (Draft).md",
+      newPath: "Finished.md",
+      backlinkSources: [],
+    })
+
+    expect(result).toEqual({
+      moved_to: "Finished.md",
+      links_updated: 1,
+      updated_notes: ["Hub.md"],
+      pruned_empty_folders: 0,
+    })
+    expect(await readNote("Hub.md")).toBe("See [x](Finished.md).\n")
+  })
 })

--- a/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
@@ -1578,3 +1578,115 @@ describe("moveNote — hidden paths", () => {
     expect(await readNote("Visible.md")).toBe("# Visible\n")
   })
 })
+
+describe("moveNote — filesystem backlink verification", () => {
+  it("discovers and rewrites a backlink the index missed", async () => {
+    const { writeFixture, moveNote, readNote } = setupVault()
+    await writeFixture("Foo.md", "# Foo\n")
+    await writeFixture("Linker.md", "See [[Foo]] for details.\n")
+
+    // Pass empty backlinkSources — simulates a stale index that hasn't
+    // indexed Linker.md's link yet. The filesystem scan should find it.
+    // Rename (not folder move) so the basename changes and the link needs
+    // rewriting — a folder move with unchanged basename keeps [[Foo]]
+    // resolvable via shortest-path matching and would be a no-op.
+    const result = await moveNote({
+      oldPath: "Foo.md",
+      newPath: "Bar.md",
+      backlinkSources: [],
+    })
+
+    expect(result.updated_notes).toEqual(["Linker.md"])
+    expect(result.links_updated).toBe(1)
+    const linkerContent = await readNote("Linker.md")
+    expect(linkerContent).toBe("See [[Bar]] for details.\n")
+  })
+
+  it("discovers backlinks in frontmatter the index missed", async () => {
+    const { writeFixture, moveNote, readNote } = setupVault()
+    await writeFixture("Foo.md", "# Foo\n")
+    await writeFixture(
+      "Related.md",
+      '---\nrelated:\n  - "[[Foo]]"\n---\nBody.\n',
+    )
+
+    const result = await moveNote({
+      oldPath: "Foo.md",
+      newPath: "Renamed.md",
+      backlinkSources: [],
+    })
+
+    expect(result.updated_notes).toEqual(["Related.md"])
+    const relatedContent = await readNote("Related.md")
+    expect(relatedContent).toContain("[[Renamed]]")
+  })
+
+  it("does not false-positive on notes containing the basename as prose", async () => {
+    const { writeFixture, moveNote } = setupVault()
+    await writeFixture("Foo.md", "# Foo\n")
+    // Contains "Foo" as prose text, not as a link
+    await writeFixture("Prose.md", "The Foo concept is clear.\n")
+
+    const result = await moveNote({
+      oldPath: "Foo.md",
+      newPath: "Bar.md",
+      backlinkSources: [],
+    })
+
+    // Prose.md passes the pre-filter (contains "Foo") but should NOT be
+    // identified as a backlink source because "Foo" is prose, not a link.
+    expect(result.updated_notes).toEqual([])
+  })
+
+  it("skips unreadable notes during the scan without aborting", async () => {
+    const { vault, writeFixture, readNote, logger } = setupVault()
+    await writeFixture("Foo.md", "# Foo\n")
+    await writeFixture("Good.md", "Link: [[Foo]]\n")
+
+    // Call moveNote directly with allNotePaths including "Ghost.md" — a path
+    // that doesn't exist on disk. The filesystem scan will try to read it,
+    // fail with ENOENT, log a warning, and skip it without aborting.
+    const result = await noteMover.moveNote(
+      {
+        vaultPath: vault,
+        oldPath: "Foo.md",
+        newPath: "Bar.md",
+        protectedPaths: PROTECTED,
+        backlinkSources: [],
+        allNotePaths: ["Foo.md", "Ghost.md", "Good.md"],
+        allAssetPaths: [],
+        pruneEmptyFolders: false,
+        windowsBindMount: false,
+      },
+      logger,
+    )
+
+    // Good.md should still be discovered and rewritten
+    expect(result.updated_notes).toEqual(["Good.md"])
+    const goodContent = await readNote("Good.md")
+    expect(goodContent).toBe("Link: [[Bar]]\n")
+    // The ghost note should have been logged as a warning
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "backlink scan: skipping unreadable note",
+      expect.objectContaining({ path: "Ghost.md" }),
+    )
+  })
+
+  it("handles index-known and filesystem-discovered sources together", async () => {
+    const { writeFixture, moveNote, readNote } = setupVault()
+    await writeFixture("Foo.md", "# Foo\n")
+    await writeFixture("Known.md", "Index knows: [[Foo]]\n")
+    await writeFixture("Unknown.md", "Index missed: [[Foo]]\n")
+
+    // Known.md is in backlinkSources (from the index); Unknown.md is not
+    const result = await moveNote({
+      oldPath: "Foo.md",
+      newPath: "Bar.md",
+      backlinkSources: ["Known.md"],
+    })
+
+    expect(result.updated_notes).toEqual(["Known.md", "Unknown.md"])
+    expect(await readNote("Known.md")).toBe("Index knows: [[Bar]]\n")
+    expect(await readNote("Unknown.md")).toBe("Index missed: [[Bar]]\n")
+  })
+})

--- a/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
@@ -1596,10 +1596,13 @@ describe("moveNote — filesystem backlink verification", () => {
       backlinkSources: [],
     })
 
-    expect(result.updated_notes).toEqual(["Linker.md"])
-    expect(result.links_updated).toBe(1)
-    const linkerContent = await readNote("Linker.md")
-    expect(linkerContent).toBe("See [[Bar]] for details.\n")
+    expect(result).toEqual({
+      moved_to: "Bar.md",
+      links_updated: 1,
+      updated_notes: ["Linker.md"],
+      pruned_empty_folders: 0,
+    })
+    expect(await readNote("Linker.md")).toBe("See [[Bar]] for details.\n")
   })
 
   it("discovers backlinks in frontmatter the index missed", async () => {
@@ -1616,9 +1619,15 @@ describe("moveNote — filesystem backlink verification", () => {
       backlinkSources: [],
     })
 
-    expect(result.updated_notes).toEqual(["Related.md"])
-    const relatedContent = await readNote("Related.md")
-    expect(relatedContent).toContain("[[Renamed]]")
+    expect(result).toEqual({
+      moved_to: "Renamed.md",
+      links_updated: 1,
+      updated_notes: ["Related.md"],
+      pruned_empty_folders: 0,
+    })
+    expect(await readNote("Related.md")).toBe(
+      '---\nrelated:\n  - "[[Renamed]]"\n---\nBody.\n',
+    )
   })
 
   it("does not false-positive on notes containing the basename as prose", async () => {
@@ -1635,7 +1644,13 @@ describe("moveNote — filesystem backlink verification", () => {
 
     // Prose.md passes the pre-filter (contains "Foo") but should NOT be
     // identified as a backlink source because "Foo" is prose, not a link.
-    expect(result.updated_notes).toEqual([])
+    // Full result assertion also proves the move executed (not a silent no-op).
+    expect(result).toEqual({
+      moved_to: "Bar.md",
+      links_updated: 0,
+      updated_notes: [],
+      pruned_empty_folders: 0,
+    })
   })
 
   it("skips unreadable notes during the scan without aborting", async () => {
@@ -1662,9 +1677,13 @@ describe("moveNote — filesystem backlink verification", () => {
     )
 
     // Good.md should still be discovered and rewritten
-    expect(result.updated_notes).toEqual(["Good.md"])
-    const goodContent = await readNote("Good.md")
-    expect(goodContent).toBe("Link: [[Bar]]\n")
+    expect(result).toEqual({
+      moved_to: "Bar.md",
+      links_updated: 1,
+      updated_notes: ["Good.md"],
+      pruned_empty_folders: 0,
+    })
+    expect(await readNote("Good.md")).toBe("Link: [[Bar]]\n")
     // The ghost note should have been logged as a warning
     expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
       "backlink scan: skipping unreadable note",
@@ -1673,7 +1692,7 @@ describe("moveNote — filesystem backlink verification", () => {
   })
 
   it("handles index-known and filesystem-discovered sources together", async () => {
-    const { writeFixture, moveNote, readNote } = setupVault()
+    const { writeFixture, moveNote, readNote, logger } = setupVault()
     await writeFixture("Foo.md", "# Foo\n")
     await writeFixture("Known.md", "Index knows: [[Foo]]\n")
     await writeFixture("Unknown.md", "Index missed: [[Foo]]\n")
@@ -1685,8 +1704,47 @@ describe("moveNote — filesystem backlink verification", () => {
       backlinkSources: ["Known.md"],
     })
 
-    expect(result.updated_notes).toEqual(["Known.md", "Unknown.md"])
+    expect(result).toEqual({
+      moved_to: "Bar.md",
+      links_updated: 2,
+      updated_notes: ["Known.md", "Unknown.md"],
+      pruned_empty_folders: 0,
+    })
     expect(await readNote("Known.md")).toBe("Index knows: [[Bar]]\n")
     expect(await readNote("Unknown.md")).toBe("Index missed: [[Bar]]\n")
+    // The retry loop fires because Unknown.md was not in backlinkSources
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
+      "backlink verification discovered sources the index missed",
+      expect.objectContaining({
+        from: "Foo.md",
+        to: "Bar.md",
+        additionalSources: ["Unknown.md"],
+      }),
+    )
+  })
+
+  it("discovers a markdown-link backlink via percent-encoded pre-filter", async () => {
+    const { writeFixture, moveNote, readNote } = setupVault()
+    await writeFixture("My Note.md", "# My Note\n")
+    // Markdown link with percent-encoded space — the raw content contains
+    // "My%20Note" but not "My Note" as a contiguous substring in the URL part.
+    // The pre-filter's encodedStem check catches this.
+    await writeFixture("Linker.md", "See [here](My%20Note.md) for info.\n")
+
+    const result = await moveNote({
+      oldPath: "My Note.md",
+      newPath: "Renamed Note.md",
+      backlinkSources: [],
+    })
+
+    expect(result).toEqual({
+      moved_to: "Renamed Note.md",
+      links_updated: 1,
+      updated_notes: ["Linker.md"],
+      pruned_empty_folders: 0,
+    })
+    expect(await readNote("Linker.md")).toBe(
+      "See [here](Renamed%20Note.md) for info.\n",
+    )
   })
 })

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -11,7 +11,8 @@
  *       (strings, arrays, nested objects). Markdown links are body-only.
  *    4. Whole-note rewriting — combines body + frontmatter into one call; returns
  *       null when nothing changed so the caller can skip the write.
- *    5. Orchestration (moveNote) — two-phase: preflight reads every affected
+ *    5. Orchestration (moveNote) — three-phase: filesystem verification scans
+ *       for backlinks the search index missed, preflight reads every affected
  *       note and computes its rewrite (aborting on any failure before touching
  *       the vault), then commit writes the destination, updates backlink sources,
  *       and deletes the original last. The whole span runs under a multi-file
@@ -504,13 +505,11 @@ const discoverBacklinksFromFilesystem = async (
         const parsed = parseNote(content)
         const frontmatter: Record<string, unknown> = parsed.data
         const rawTargets = links.extractAll(parsed.content, frontmatter)
+        const allNotePathsMutable = [...params.allNotePaths]
         const linksToTarget = rawTargets.some(
           (rawTarget) =>
-            links.resolve(
-              rawTarget,
-              [...params.allNotePaths],
-              candidatePath,
-            ) === params.targetPath,
+            links.resolve(rawTarget, allNotePathsMutable, candidatePath) ===
+            params.targetPath,
         )
         return linksToTarget ? candidatePath : null
       } catch (error) {

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -463,16 +463,81 @@ const isProtected = (
     .map((folder) => (folder.endsWith("/") ? folder : `${folder}/`))
     .some((prefix) => path.startsWith(prefix))
 
-/** Caps concurrent file handles during rewriting. */
+/** Caps concurrent file handles during rewriting and filesystem scanning. */
 const REWRITE_CONCURRENCY = 10
 
+/** Max retries when the filesystem scan discovers backlink sources the index
+ *  missed — each retry expands the lock set and re-verifies. */
+const MAX_BACKLINK_VERIFY_RETRIES = 3
+
+/** Scans vault notes for links that resolve to targetPath, returning paths the
+ *  caller didn't already know about. Uses a cheap string pre-filter (basename
+ *  substring check) before parsing — only notes whose content includes the
+ *  target's stem (or its percent-encoded form) are fully parsed and resolved.
+ *  Read failures on individual notes are logged and skipped. */
+const discoverBacklinksFromFilesystem = async (
+  params: {
+    vaultPath: string
+    targetPath: string
+    allNotePaths: readonly string[]
+    knownPaths: ReadonlySet<string>
+  },
+  logger: Logger,
+): Promise<string[]> => {
+  const targetStem = posix.basename(params.targetPath, ".md")
+  const encodedStem = encodeURIComponent(targetStem)
+  const candidates = params.allNotePaths.filter(
+    (notePath) =>
+      notePath !== params.targetPath && !params.knownPaths.has(notePath),
+  )
+
+  const discoveredSources = await mapWithConcurrency({
+    items: candidates,
+    concurrency: REWRITE_CONCURRENCY,
+    mapper: async (candidatePath): Promise<string | null> => {
+      try {
+        const fullPath = resolveSafePath(params.vaultPath, candidatePath)
+        const content = await readFile(fullPath, "utf8")
+        if (!content.includes(targetStem) && !content.includes(encodedStem)) {
+          return null
+        }
+        const parsed = parseNote(content)
+        const frontmatter: Record<string, unknown> = parsed.data
+        const rawTargets = links.extractAll(parsed.content, frontmatter)
+        const linksToTarget = rawTargets.some(
+          (rawTarget) =>
+            links.resolve(
+              rawTarget,
+              [...params.allNotePaths],
+              candidatePath,
+            ) === params.targetPath,
+        )
+        return linksToTarget ? candidatePath : null
+      } catch (error) {
+        logger.warn("backlink scan: skipping unreadable note", {
+          path: candidatePath,
+          error: describeError(error),
+        })
+        return null
+      }
+    },
+  })
+
+  return discoveredSources.filter(
+    (sourcePath): sourcePath is string => sourcePath !== null,
+  )
+}
+
 /** Moves a note and rewrites every link across the vault that resolves to it.
- *  Two phases: preflight reads all files and computes rewrites (aborting on any
- *  read failure before touching the vault), then commit writes everything and
- *  deletes the original last — so a failure never loses data. Both phases hold
- *  an exclusive multi-file lock on every affected file (moved note, destination,
- *  backlink sources); the move rejects fail-fast when any of them already has a
- *  write in flight, and vice versa. */
+ *  Three phases: filesystem verification confirms the backlink set is complete
+ *  (catching sources the search index hasn't indexed yet), preflight reads all
+ *  files and computes rewrites (aborting on any failure before touching the
+ *  vault), then commit writes everything and deletes the original last — so a
+ *  failure never loses data. All three phases hold an exclusive multi-file lock
+ *  on every affected file (moved note, destination, backlink sources); the move
+ *  rejects fail-fast when any of them already has a write in flight, and vice
+ *  versa. If verification discovers sources the caller missed, the lock releases,
+ *  the set expands, and the lock reacquires — capped at MAX_BACKLINK_VERIFY_RETRIES. */
 const moveNote = async (
   params: {
     vaultPath: string
@@ -519,243 +584,305 @@ const moveNote = async (
   const oldFullPath = resolveSafePath(vaultPath, oldPath)
   const newFullPath = resolveSafePath(vaultPath, newPath)
 
-  // Resolve every backlink source upfront so the lock set below covers each
-  // file the move reads or writes. A resolution failure aborts before anything
-  // is locked or written.
-  const resolvedBacklinkSources = params.backlinkSources.map((rawSource) => {
-    const source = toVaultRelativePath(rawSource)
-    try {
-      return { source, fullPath: resolveSafePath(vaultPath, source) }
-    } catch (error) {
-      logger.error(
-        "note move aborted: could not resolve a backlink source path",
-        {
-          source,
-          from: oldPath,
-          to: newPath,
-          error: describeError(error),
-        },
-      )
-      throw new Error(
-        `move aborted: could not resolve backlink source "${source}". Nothing was written.`,
-        { cause: error },
-      )
-    }
-  })
-  // Dedupe by resolved path: duplicate or alias spellings of the same file
-  // must not produce two rewrite plans (double writes, over-counted
-  // links_updated). The moved note is excluded by resolved path too, so an
-  // alias of old_path can't slip in as a backlink source and receive a
-  // wrong-context rewrite.
-  const backlinkSourcesByFullPath = new Map(
-    resolvedBacklinkSources
-      .filter((backlinkSource) => backlinkSource.fullPath !== oldFullPath)
-      .map((backlinkSource) => [backlinkSource.fullPath, backlinkSource]),
-  )
-  const backlinkSources = [...backlinkSourcesByFullPath.values()]
+  // ── Backlink verification + retry loop ──────────────────────────
+  // The index-derived backlink set (from the tool handler) may be stale: a
+  // note written moments ago might not be indexed yet. Under the lock, the
+  // filesystem is scanned to verify completeness. If new sources are found,
+  // the lock releases, the set expands, and the lock reacquires — capped at
+  // MAX_BACKLINK_VERIFY_RETRIES.
 
-  // Lock the moved note, its destination, and every backlink source as one
-  // unit for the whole read-plan-write span — a concurrent single-file write
-  // to any of them fails fast instead of racing the move (and losing), and the
-  // move fails fast when any of them already has a write in flight. Acquired
-  // before the existence checks so those also run against a stable vault.
-  const lockPaths = [
-    oldFullPath,
-    newFullPath,
-    ...backlinkSources.map((backlinkSource) => backlinkSource.fullPath),
-  ]
-  return withExclusiveMultiFileLock(lockPaths, async () => {
-    if (!(await fileExists(oldFullPath))) {
-      throw new Error(`note not found: "${oldPath}"`)
-    }
-    if (await fileExists(newFullPath)) {
-      throw new Error(`destination exists: "${newPath}"`)
-    }
+  let backlinkSourcePaths = [...params.backlinkSources]
 
-    const allNotePathsBefore = [...allNotePaths]
-    const allNotePathsAfter = allNotePaths.map((path) =>
-      path === oldPath ? newPath : path,
-    )
-
-    // Bind rewriteTarget to a context for one source note, producing a simple
-    // callback. Backlink sources stay put (before === after); the moved note
-    // shifts old → new.
-    const rewriteLinkForSource = (sourceLocation: {
-      before: string
-      after: string
-    }): RewriteLink => {
-      const context: RewriteContext = {
-        oldSourcePath: sourceLocation.before,
-        newSourcePath: sourceLocation.after,
-        oldTargetPath: oldPath,
-        newTargetPath: newPath,
-        allNotePaths: allNotePathsBefore,
-        allNotePathsAfter,
-        allAssetPaths,
-      }
-      return (rewriteParams) => rewriteTarget(rewriteParams, context)
-    }
-
-    // ── Preflight: read every file and compute its rewrite, mutating nothing. ──
-
-    // Rewrite the moved note's self-links and source-relative links so they still
-    // resolve from the new folder. A read failure aborts before any write.
-    const planMovedNote = async (): Promise<{
-      content: string
-      linksRewritten: number
-    }> => {
+  for (let attempt = 0; attempt <= MAX_BACKLINK_VERIFY_RETRIES; attempt++) {
+    const resolvedBacklinkSources = backlinkSourcePaths.map((rawSource) => {
+      const source = toVaultRelativePath(rawSource)
       try {
-        const rawContent = await readFile(oldFullPath, "utf8")
-        const rewrite = rewriteNoteContent(
-          rawContent,
-          rewriteLinkForSource({ before: oldPath, after: newPath }),
-        )
-        return {
-          content: rewrite?.content ?? rawContent,
-          linksRewritten: rewrite?.linksRewritten ?? 0,
-        }
+        return { source, fullPath: resolveSafePath(vaultPath, source) }
       } catch (error) {
-        logger.error("note move aborted: could not read the note being moved", {
-          from: oldPath,
-          to: newPath,
-          error: describeError(error),
-        })
+        logger.error(
+          "note move aborted: could not resolve a backlink source path",
+          {
+            source,
+            from: oldPath,
+            to: newPath,
+            error: describeError(error),
+          },
+        )
         throw new Error(
-          `move aborted: could not read "${oldPath}". Nothing was written.`,
+          `move aborted: could not resolve backlink source "${source}". Nothing was written.`,
           { cause: error },
         )
       }
-    }
-    const { content: movedContent, linksRewritten: movedLinksRewritten } =
-      await planMovedNote()
+    })
+    // Dedupe by resolved path: duplicate or alias spellings of the same file
+    // must not produce two rewrite plans (double writes, over-counted
+    // links_updated). The moved note is excluded by resolved path too, so an
+    // alias of old_path can't slip in as a backlink source and receive a
+    // wrong-context rewrite.
+    const backlinkSourcesByFullPath = new Map(
+      resolvedBacklinkSources
+        .filter((backlinkSource) => backlinkSource.fullPath !== oldFullPath)
+        .map((backlinkSource) => [backlinkSource.fullPath, backlinkSource]),
+    )
+    const backlinkSources = [...backlinkSourcesByFullPath.values()]
 
-    const plannedRewrites = (
-      await mapWithConcurrency({
-        items: backlinkSources,
-        concurrency: REWRITE_CONCURRENCY,
-        mapper: async ({ source, fullPath }) => {
+    const lockPaths = [
+      oldFullPath,
+      newFullPath,
+      ...backlinkSources.map((backlinkSource) => backlinkSource.fullPath),
+    ]
+
+    const lockResult:
+      | { retry: true; additionalSources: string[] }
+      | { retry: false; result: MoveResult } = await withExclusiveMultiFileLock(
+      lockPaths,
+      async () => {
+        // ── Filesystem verification: catch backlinks the index missed ──
+        const knownPaths = new Set([
+          oldPath,
+          newPath,
+          ...backlinkSources.map((backlinkSource) => backlinkSource.source),
+        ])
+        const additionalSources = await discoverBacklinksFromFilesystem(
+          { vaultPath, targetPath: oldPath, allNotePaths, knownPaths },
+          logger,
+        )
+        if (additionalSources.length > 0) {
+          if (attempt >= MAX_BACKLINK_VERIFY_RETRIES) {
+            throw new Error(
+              `move aborted: backlink set did not stabilize after ${MAX_BACKLINK_VERIFY_RETRIES} retries (${additionalSources.length} new sources on last attempt). Nothing was written.`,
+            )
+          }
+          logger.info(
+            "backlink verification discovered sources the index missed",
+            { from: oldPath, to: newPath, additionalSources, attempt },
+          )
+          return { retry: true as const, additionalSources }
+        }
+
+        // ── All backlinks accounted for — proceed with the move ──
+
+        if (!(await fileExists(oldFullPath))) {
+          throw new Error(`note not found: "${oldPath}"`)
+        }
+        if (await fileExists(newFullPath)) {
+          throw new Error(`destination exists: "${newPath}"`)
+        }
+
+        const allNotePathsBefore = [...allNotePaths]
+        const allNotePathsAfter = allNotePaths.map((path) =>
+          path === oldPath ? newPath : path,
+        )
+
+        // Bind rewriteTarget to a context for one source note, producing a simple
+        // callback. Backlink sources stay put (before === after); the moved note
+        // shifts old → new.
+        const rewriteLinkForSource = (sourceLocation: {
+          before: string
+          after: string
+        }): RewriteLink => {
+          const context: RewriteContext = {
+            oldSourcePath: sourceLocation.before,
+            newSourcePath: sourceLocation.after,
+            oldTargetPath: oldPath,
+            newTargetPath: newPath,
+            allNotePaths: allNotePathsBefore,
+            allNotePathsAfter,
+            allAssetPaths,
+          }
+          return (rewriteParams) => rewriteTarget(rewriteParams, context)
+        }
+
+        // ── Preflight: read every file and compute its rewrite, mutating nothing. ──
+
+        // Rewrite the moved note's self-links and source-relative links so they still
+        // resolve from the new folder. A read failure aborts before any write.
+        const planMovedNote = async (): Promise<{
+          content: string
+          linksRewritten: number
+        }> => {
           try {
-            const rawContent = await readFile(fullPath, "utf8")
+            const rawContent = await readFile(oldFullPath, "utf8")
             const rewrite = rewriteNoteContent(
               rawContent,
-              rewriteLinkForSource({ before: source, after: source }),
+              rewriteLinkForSource({ before: oldPath, after: newPath }),
             )
-            return rewrite === null
-              ? null
-              : {
-                  source,
-                  fullPath,
-                  content: rewrite.content,
-                  linksRewritten: rewrite.linksRewritten,
-                }
+            return {
+              content: rewrite?.content ?? rawContent,
+              linksRewritten: rewrite?.linksRewritten ?? 0,
+            }
           } catch (error) {
             logger.error(
-              "note move aborted: could not read/plan a backlink source",
+              "note move aborted: could not read the note being moved",
               {
-                source,
                 from: oldPath,
                 to: newPath,
                 error: describeError(error),
               },
             )
             throw new Error(
-              `move aborted: could not read backlink source "${source}". Nothing was written.`,
+              `move aborted: could not read "${oldPath}". Nothing was written.`,
               { cause: error },
             )
           }
-        },
-      })
-    ).filter((planned) => planned !== null)
+        }
+        const { content: movedContent, linksRewritten: movedLinksRewritten } =
+          await planMovedNote()
 
-    // ── Commit: all reads succeeded — write destination, update sources, delete original last. ──
-
-    await mkdir(dirname(newFullPath), { recursive: true })
-    try {
-      await atomicWriteFileExclusive(newFullPath, movedContent, {
-        hardLinksSupported: !params.windowsBindMount,
-      })
-    } catch (error) {
-      if (isErrnoException(error, "EEXIST")) {
-        throw new Error(`destination exists: "${newPath}"`, { cause: error })
-      }
-      logger.error(
-        "note move aborted: could not write the note to its new path",
-        { from: oldPath, to: newPath, error: describeError(error) },
-      )
-      throw new Error(
-        `move aborted: could not write to "${newPath}". Nothing was written.`,
-        { cause: error },
-      )
-    }
-
-    // Mutable: tracks progress so a mid-commit failure can report how far it got.
-    let sourcesWritten = 0
-    await mapWithConcurrency({
-      items: plannedRewrites,
-      concurrency: REWRITE_CONCURRENCY,
-      mapper: async (planned) => {
-        try {
-          await atomicWriteFile(planned.fullPath, planned.content)
-          sourcesWritten += 1
-        } catch (error) {
-          logger.error("note move failed while writing a backlink source", {
-            source: planned.source,
-            from: oldPath,
-            to: newPath,
-            sources_written: sourcesWritten,
-            sources_planned: plannedRewrites.length,
-            error: describeError(error),
+        const plannedRewrites = (
+          await mapWithConcurrency({
+            items: backlinkSources,
+            concurrency: REWRITE_CONCURRENCY,
+            mapper: async ({ source, fullPath }) => {
+              try {
+                const rawContent = await readFile(fullPath, "utf8")
+                const rewrite = rewriteNoteContent(
+                  rawContent,
+                  rewriteLinkForSource({ before: source, after: source }),
+                )
+                return rewrite === null
+                  ? null
+                  : {
+                      source,
+                      fullPath,
+                      content: rewrite.content,
+                      linksRewritten: rewrite.linksRewritten,
+                    }
+              } catch (error) {
+                logger.error(
+                  "note move aborted: could not read/plan a backlink source",
+                  {
+                    source,
+                    from: oldPath,
+                    to: newPath,
+                    error: describeError(error),
+                  },
+                )
+                throw new Error(
+                  `move aborted: could not read backlink source "${source}". Nothing was written.`,
+                  { cause: error },
+                )
+              }
+            },
           })
+        ).filter((planned) => planned !== null)
+
+        // ── Commit: all reads succeeded — write destination, update sources, delete original last. ──
+
+        await mkdir(dirname(newFullPath), { recursive: true })
+        try {
+          await atomicWriteFileExclusive(newFullPath, movedContent, {
+            hardLinksSupported: !params.windowsBindMount,
+          })
+        } catch (error) {
+          if (isErrnoException(error, "EEXIST")) {
+            throw new Error(`destination exists: "${newPath}"`, {
+              cause: error,
+            })
+          }
+          logger.error(
+            "note move aborted: could not write the note to its new path",
+            { from: oldPath, to: newPath, error: describeError(error) },
+          )
           throw new Error(
-            `move incomplete: failed updating "${planned.source}" (${sourcesWritten}/${plannedRewrites.length} sources written). Original not deleted — re-run to finish.`,
+            `move aborted: could not write to "${newPath}". Nothing was written.`,
             { cause: error },
           )
         }
+
+        // Mutable: tracks progress so a mid-commit failure can report how far it got.
+        let sourcesWritten = 0
+        await mapWithConcurrency({
+          items: plannedRewrites,
+          concurrency: REWRITE_CONCURRENCY,
+          mapper: async (planned) => {
+            try {
+              await atomicWriteFile(planned.fullPath, planned.content)
+              sourcesWritten += 1
+            } catch (error) {
+              logger.error("note move failed while writing a backlink source", {
+                source: planned.source,
+                from: oldPath,
+                to: newPath,
+                sources_written: sourcesWritten,
+                sources_planned: plannedRewrites.length,
+                error: describeError(error),
+              })
+              throw new Error(
+                `move incomplete: failed updating "${planned.source}" (${sourcesWritten}/${plannedRewrites.length} sources written). Original not deleted — re-run to finish.`,
+                { cause: error },
+              )
+            }
+          },
+        })
+        const linksUpdated =
+          movedLinksRewritten +
+          plannedRewrites.reduce(
+            (sum, planned) => sum + planned.linksRewritten,
+            0,
+          )
+
+        // Delete the original last — if this fails, both copies exist but no data is lost.
+        try {
+          await unlink(oldFullPath)
+        } catch (error) {
+          logger.error("note move failed while deleting the original note", {
+            from: oldPath,
+            to: newPath,
+            sources_updated: plannedRewrites.length,
+            links_updated: linksUpdated,
+            error: describeError(error),
+          })
+          throw new Error(
+            `move incomplete: "${newPath}" written but could not delete "${oldPath}". Delete "${oldPath}" manually to finish.`,
+            { cause: error },
+          )
+        }
+
+        // Prune from the OLD note's folder — a same-folder rename or a move into a
+        // subfolder leaves the source non-empty, so nothing is pruned in those cases.
+        const prunedEmptyFolders = pruneEmptyFolders
+          ? await pruneEmptyParents({ vaultPath, path: oldPath }, logger)
+          : 0
+
+        logger.info("note move complete", {
+          from: oldPath,
+          to: newPath,
+          links_updated: linksUpdated,
+          sources_updated: plannedRewrites.length,
+          sources_failed: 0,
+          pruned_empty_folders: prunedEmptyFolders,
+        })
+
+        return {
+          retry: false as const,
+          result: {
+            moved_to: newPath,
+            links_updated: linksUpdated,
+            updated_notes: plannedRewrites
+              .map((planned) => planned.source)
+              .sort(),
+            pruned_empty_folders: prunedEmptyFolders,
+          },
+        }
       },
-    })
-    const linksUpdated =
-      movedLinksRewritten +
-      plannedRewrites.reduce((sum, planned) => sum + planned.linksRewritten, 0)
+    )
 
-    // Delete the original last — if this fails, both copies exist but no data is lost.
-    try {
-      await unlink(oldFullPath)
-    } catch (error) {
-      logger.error("note move failed while deleting the original note", {
-        from: oldPath,
-        to: newPath,
-        sources_updated: plannedRewrites.length,
-        links_updated: linksUpdated,
-        error: describeError(error),
-      })
-      throw new Error(
-        `move incomplete: "${newPath}" written but could not delete "${oldPath}". Delete "${oldPath}" manually to finish.`,
-        { cause: error },
-      )
-    }
+    if (!lockResult.retry) return lockResult.result
 
-    // Prune from the OLD note's folder — a same-folder rename or a move into a
-    // subfolder leaves the source non-empty, so nothing is pruned in those cases.
-    const prunedEmptyFolders = pruneEmptyFolders
-      ? await pruneEmptyParents({ vaultPath, path: oldPath }, logger)
-      : 0
+    // Expand the backlink set with the newly-discovered sources and retry
+    // with the wider lock set.
+    backlinkSourcePaths = [
+      ...backlinkSourcePaths,
+      ...lockResult.additionalSources,
+    ]
+  }
 
-    logger.info("note move complete", {
-      from: oldPath,
-      to: newPath,
-      links_updated: linksUpdated,
-      sources_updated: plannedRewrites.length,
-      sources_failed: 0,
-      pruned_empty_folders: prunedEmptyFolders,
-    })
-
-    return {
-      moved_to: newPath,
-      links_updated: linksUpdated,
-      updated_notes: plannedRewrites.map((planned) => planned.source).sort(),
-      pruned_empty_folders: prunedEmptyFolders,
-    }
-  })
+  // Unreachable — the loop throws inside the lock on the last attempt when
+  // additionalSources is non-empty. Satisfies TypeScript's exhaustiveness check.
+  throw new Error(
+    `move aborted: backlink set did not stabilize after ${MAX_BACKLINK_VERIFY_RETRIES} retries. Nothing was written.`,
+  )
 }
 
 export const noteMover = {

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -611,7 +611,7 @@ const moveNote = async (
 
   const backlinkSourcePaths = [...params.backlinkSources]
 
-  for (let attempt = 0; attempt <= MAX_BACKLINK_VERIFY_RETRIES; attempt++) {
+  for (let attempt = 0; ; attempt++) {
     const resolvedBacklinkSources = backlinkSourcePaths.map((sourcePath) => {
       const source = toVaultRelativePath(sourcePath)
       try {
@@ -666,11 +666,6 @@ const moveNote = async (
           logger,
         )
         if (additionalSources.length > 0) {
-          if (attempt >= MAX_BACKLINK_VERIFY_RETRIES) {
-            throw new Error(
-              `move aborted: backlink set did not stabilize after ${MAX_BACKLINK_VERIFY_RETRIES} retries (${additionalSources.length} new sources on last attempt). Nothing was written.`,
-            )
-          }
           logger.info(
             "backlink verification discovered sources the index missed",
             { from: oldPath, to: newPath, additionalSources, attempt },
@@ -886,16 +881,16 @@ const moveNote = async (
 
     if (!lockResult.retry) return lockResult.result
 
+    if (attempt >= MAX_BACKLINK_VERIFY_RETRIES) {
+      throw new Error(
+        `move aborted: backlink set did not stabilize after ${MAX_BACKLINK_VERIFY_RETRIES} retries (${lockResult.additionalSources.length} new sources on last attempt). Nothing was written.`,
+      )
+    }
+
     // Expand the backlink set with the newly-discovered sources and retry
     // with the wider lock set.
     backlinkSourcePaths.push(...lockResult.additionalSources)
   }
-
-  // Unreachable — the loop throws inside the lock on the last attempt when
-  // additionalSources is non-empty. Satisfies TypeScript's exhaustiveness check.
-  throw new Error(
-    `move aborted: backlink set did not stabilize after ${MAX_BACKLINK_VERIFY_RETRIES} retries. Nothing was written.`,
-  )
 }
 
 export const noteMover = {

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -610,8 +610,9 @@ const moveNote = async (
   // MAX_BACKLINK_VERIFY_RETRIES.
 
   const backlinkSourcePaths = [...params.backlinkSources]
+  let attempt = 0
 
-  for (let attempt = 0; ; attempt++) {
+  while (true) {
     const resolvedBacklinkSources = backlinkSourcePaths.map((sourcePath) => {
       const source = toVaultRelativePath(sourcePath)
       try {
@@ -890,6 +891,7 @@ const moveNote = async (
     // Expand the backlink set with the newly-discovered sources and retry
     // with the wider lock set.
     backlinkSourcePaths.push(...lockResult.additionalSources)
+    attempt++
   }
 }
 

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -15,9 +15,10 @@
  *       for backlinks the search index missed, preflight reads every affected
  *       note and computes its rewrite (aborting on any failure before touching
  *       the vault), then commit writes the destination, updates backlink sources,
- *       and deletes the original last. The whole span runs under a multi-file
- *       write lock covering the moved note, its destination, and every backlink
- *       source, so concurrent single-file writes fail fast instead of racing. */
+ *       and deletes the original last. Each attempt's verify/preflight/commit
+ *       span runs under a multi-file write lock; the lock is released and
+ *       reacquired when verification discovers sources the initial set missed
+ *       (capped at MAX_BACKLINK_VERIFY_RETRIES). */
 
 import { readFile, mkdir, unlink } from "node:fs/promises"
 import { dirname, posix } from "node:path"
@@ -486,11 +487,15 @@ const discoverBacklinksFromFilesystem = async (
   logger: Logger,
 ): Promise<string[]> => {
   const targetStem = posix.basename(params.targetPath, ".md")
-  const encodedStem = encodeURIComponent(targetStem)
+  // Pre-filter stems are lowercased so a case-mismatched link (e.g. [[foo]]
+  // pointing at Foo.md) is never skipped — the resolver handles case, and the
+  // pre-filter must be at least as permissive.
+  const lowerStem = targetStem.toLowerCase()
+  const lowerEncodedStem = encodeURIComponent(lowerStem)
   // encodeURIComponent leaves parentheses unencoded, but the rewriter's
   // encodeMarkdownLinkPath encodes them as %28/%29 — a paren-bearing name
   // produces a markdown link the first two forms can't match.
-  const parenEncodedStem = encodedStem
+  const lowerParenEncodedStem = lowerEncodedStem
     .replace(/\(/g, "%28")
     .replace(/\)/g, "%29")
   const candidates = params.allNotePaths.filter(
@@ -508,10 +513,11 @@ const discoverBacklinksFromFilesystem = async (
       try {
         const fullPath = resolveSafePath(params.vaultPath, candidatePath)
         const content = await readFile(fullPath, "utf8")
+        const lowerContent = content.toLowerCase()
         if (
-          !content.includes(targetStem) &&
-          !content.includes(encodedStem) &&
-          !content.includes(parenEncodedStem)
+          !lowerContent.includes(lowerStem) &&
+          !lowerContent.includes(lowerEncodedStem) &&
+          !lowerContent.includes(lowerParenEncodedStem)
         ) {
           return null
         }

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -609,7 +609,7 @@ const moveNote = async (
   // the lock releases, the set expands, and the lock reacquires — capped at
   // MAX_BACKLINK_VERIFY_RETRIES.
 
-  let backlinkSourcePaths = [...params.backlinkSources]
+  const backlinkSourcePaths = [...params.backlinkSources]
 
   for (let attempt = 0; attempt <= MAX_BACKLINK_VERIFY_RETRIES; attempt++) {
     const resolvedBacklinkSources = backlinkSourcePaths.map((sourcePath) => {
@@ -888,10 +888,7 @@ const moveNote = async (
 
     // Expand the backlink set with the newly-discovered sources and retry
     // with the wider lock set.
-    backlinkSourcePaths = [
-      ...backlinkSourcePaths,
-      ...lockResult.additionalSources,
-    ]
+    backlinkSourcePaths.push(...lockResult.additionalSources)
   }
 
   // Unreachable — the loop throws inside the lock on the last attempt when

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -507,16 +507,17 @@ const discoverBacklinksFromFilesystem = async (
     concurrency: REWRITE_CONCURRENCY,
     mapper: async (candidatePath): Promise<string | null> => {
       try {
+        // Cheap substring pre-filter — skip notes that can't contain a link
         const fullPath = resolveSafePath(params.vaultPath, candidatePath)
         const content = await readFile(fullPath, "utf8")
         const lowercaseContent = content.toLowerCase()
-        if (
-          !lowercaseContent.includes(lowercaseStem) &&
-          !lowercaseContent.includes(lowercaseEncodedStem) &&
-          !lowercaseContent.includes(lowercaseParenEncodedStem)
-        ) {
-          return null
-        }
+        const couldContainLink =
+          lowercaseContent.includes(lowercaseStem) ||
+          lowercaseContent.includes(lowercaseEncodedStem) ||
+          lowercaseContent.includes(lowercaseParenEncodedStem)
+        if (!couldContainLink) return null
+
+        // Full parse + resolve — confirm the candidate actually links to the target
         const parsed = parseNote(content)
         const frontmatter: Record<string, unknown> = parsed.data
         const rawTargets = links.extractAll(parsed.content, frontmatter)

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -11,14 +11,10 @@
  *       (strings, arrays, nested objects). Markdown links are body-only.
  *    4. Whole-note rewriting — combines body + frontmatter into one call; returns
  *       null when nothing changed so the caller can skip the write.
- *    5. Orchestration (moveNote) — three-phase: filesystem verification scans
- *       for backlinks the search index missed, preflight reads every affected
- *       note and computes its rewrite (aborting on any failure before touching
- *       the vault), then commit writes the destination, updates backlink sources,
- *       and deletes the original last. Each attempt's verify/preflight/commit
- *       span runs under a multi-file write lock; the lock is released and
- *       reacquired when verification discovers sources the initial set missed
- *       (capped at MAX_BACKLINK_VERIFY_RETRIES). */
+ *    5. Orchestration (moveNote) — verify backlinks via filesystem scan,
+ *       preflight all rewrites, commit writes + delete original. Each
+ *       attempt runs under a multi-file lock; the lock releases and
+ *       reacquires when verification widens the source set. */
 
 import { readFile, mkdir, unlink } from "node:fs/promises"
 import { dirname, posix } from "node:path"
@@ -492,12 +488,12 @@ const discoverBacklinksFromFilesystem = async (
   // then lowercase — encodeURIComponent is codepoint-sensitive, so encoding
   // an already-lowered stem produces different percent sequences for non-ASCII
   // (É → %C3%89 vs é → %C3%A9).
-  const lowerStem = targetStem.toLowerCase()
-  const lowerEncodedStem = encodeURIComponent(targetStem).toLowerCase()
+  const lowercaseStem = targetStem.toLowerCase()
+  const lowercaseEncodedStem = encodeURIComponent(targetStem).toLowerCase()
   // encodeURIComponent leaves parentheses unencoded, but the rewriter's
   // encodeMarkdownLinkPath encodes them as %28/%29 — a paren-bearing name
   // produces a markdown link the first two forms can't match.
-  const lowerParenEncodedStem = lowerEncodedStem
+  const lowercaseParenEncodedStem = lowercaseEncodedStem
     .replace(/\(/g, "%28")
     .replace(/\)/g, "%29")
   const candidates = params.allNotePaths.filter(
@@ -515,23 +511,23 @@ const discoverBacklinksFromFilesystem = async (
       try {
         const fullPath = resolveSafePath(params.vaultPath, candidatePath)
         const content = await readFile(fullPath, "utf8")
-        const lowerContent = content.toLowerCase()
+        const lowercaseContent = content.toLowerCase()
         if (
-          !lowerContent.includes(lowerStem) &&
-          !lowerContent.includes(lowerEncodedStem) &&
-          !lowerContent.includes(lowerParenEncodedStem)
+          !lowercaseContent.includes(lowercaseStem) &&
+          !lowercaseContent.includes(lowercaseEncodedStem) &&
+          !lowercaseContent.includes(lowercaseParenEncodedStem)
         ) {
           return null
         }
         const parsed = parseNote(content)
         const frontmatter: Record<string, unknown> = parsed.data
         const rawTargets = links.extractAll(parsed.content, frontmatter)
-        const linksToTarget = rawTargets.some(
+        const hasLinkToTarget = rawTargets.some(
           (rawTarget) =>
             links.resolve(rawTarget, allNotePathsForResolve, candidatePath) ===
             params.targetPath,
         )
-        return linksToTarget ? candidatePath : null
+        return hasLinkToTarget ? candidatePath : null
       } catch (error) {
         logger.warn("backlink scan: skipping unreadable note", {
           path: candidatePath,
@@ -546,15 +542,20 @@ const discoverBacklinksFromFilesystem = async (
 }
 
 /** Moves a note and rewrites every link across the vault that resolves to it.
- *  Three phases: filesystem verification confirms the backlink set is complete
- *  (catching sources the search index hasn't indexed yet), preflight reads all
- *  files and computes rewrites (aborting on any failure before touching the
- *  vault), then commit writes everything and deletes the original last — so a
- *  failure never loses data. All three phases hold an exclusive multi-file lock
- *  on every affected file (moved note, destination, backlink sources); the move
- *  rejects fail-fast when any of them already has a write in flight, and vice
- *  versa. If verification discovers sources the caller missed, the lock releases,
- *  the set expands, and the lock reacquires — capped at MAX_BACKLINK_VERIFY_RETRIES. */
+ *
+ *  Three phases, each under an exclusive multi-file lock:
+ *    1. Verify — filesystem scan confirms the backlink set is complete,
+ *       catching sources the search index hasn't indexed yet.
+ *    2. Preflight — reads all files and computes rewrites, aborting on any
+ *       failure before touching the vault.
+ *    3. Commit — writes the destination, updates backlink sources, deletes
+ *       the original last (so a failure never loses data).
+ *
+ *  The lock covers every affected file (moved note, destination, backlink
+ *  sources); the move rejects fail-fast when any of them already has a write
+ *  in flight. If verification discovers sources the caller missed, the lock
+ *  releases, the set expands, and the lock reacquires — capped at
+ *  MAX_BACKLINK_VERIFY_RETRIES. */
 const moveNote = async (
   params: {
     vaultPath: string
@@ -611,8 +612,8 @@ const moveNote = async (
   let backlinkSourcePaths = [...params.backlinkSources]
 
   for (let attempt = 0; attempt <= MAX_BACKLINK_VERIFY_RETRIES; attempt++) {
-    const resolvedBacklinkSources = backlinkSourcePaths.map((rawSource) => {
-      const source = toVaultRelativePath(rawSource)
+    const resolvedBacklinkSources = backlinkSourcePaths.map((sourcePath) => {
+      const source = toVaultRelativePath(sourcePath)
       try {
         return { source, fullPath: resolveSafePath(vaultPath, source) }
       } catch (error) {

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -494,13 +494,13 @@ const discoverBacklinksFromFilesystem = async (
   const lowercaseParenEncodedStem = lowercaseEncodedStem
     .replace(/\(/g, "%28")
     .replace(/\)/g, "%29")
-  const candidates = params.allNotePaths.filter(
+  const pathsToScan = params.allNotePaths.filter(
     (notePath) =>
       notePath !== params.targetPath && !params.knownPaths.has(notePath),
   )
 
   const scanResults = await mapWithConcurrency({
-    items: candidates,
+    items: pathsToScan,
     concurrency: REWRITE_CONCURRENCY,
     mapper: async (candidatePath): Promise<string | null> => {
       try {

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -469,10 +469,8 @@ const REWRITE_CONCURRENCY = 10
 const MAX_BACKLINK_VERIFY_RETRIES = 3
 
 /** Scans vault notes for links that resolve to targetPath, returning paths the
- *  caller didn't already know about. Uses a cheap string pre-filter (basename
- *  substring check) before parsing — only notes whose content includes the
- *  target's stem (or its percent-encoded form) are fully parsed and resolved.
- *  Read failures on individual notes are logged and skipped. */
+ *  caller didn't already know about. Pre-filters by basename substring before
+ *  parsing. Read failures on individual notes are logged and skipped. */
 const discoverBacklinksFromFilesystem = async (
   params: {
     vaultPath: string

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -498,9 +498,6 @@ const discoverBacklinksFromFilesystem = async (
     (notePath) =>
       notePath !== params.targetPath && !params.knownPaths.has(notePath),
   )
-  // Mutable copy of allNotePaths for links.resolve (accepts string[], not readonly).
-  // Hoisted above the mapper so a single allocation is shared across all candidates.
-  const allNotePathsForResolve = [...params.allNotePaths]
 
   const scanResults = await mapWithConcurrency({
     items: candidates,
@@ -525,7 +522,7 @@ const discoverBacklinksFromFilesystem = async (
           return (
             links.resolve({
               target: linkTarget,
-              allPaths: allNotePathsForResolve,
+              allPaths: params.allNotePaths,
               sourcePath: candidatePath,
             }) === params.targetPath
           )

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -487,6 +487,12 @@ const discoverBacklinksFromFilesystem = async (
 ): Promise<string[]> => {
   const targetStem = posix.basename(params.targetPath, ".md")
   const encodedStem = encodeURIComponent(targetStem)
+  // encodeURIComponent leaves parentheses unencoded, but the rewriter's
+  // encodeMarkdownLinkPath encodes them as %28/%29 — a paren-bearing name
+  // produces a markdown link the first two forms can't match.
+  const parenEncodedStem = encodedStem
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29")
   const candidates = params.allNotePaths.filter(
     (notePath) =>
       notePath !== params.targetPath && !params.knownPaths.has(notePath),
@@ -502,7 +508,11 @@ const discoverBacklinksFromFilesystem = async (
       try {
         const fullPath = resolveSafePath(params.vaultPath, candidatePath)
         const content = await readFile(fullPath, "utf8")
-        if (!content.includes(targetStem) && !content.includes(encodedStem)) {
+        if (
+          !content.includes(targetStem) &&
+          !content.includes(encodedStem) &&
+          !content.includes(parenEncodedStem)
+        ) {
           return null
         }
         const parsed = parseNote(content)

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -487,11 +487,13 @@ const discoverBacklinksFromFilesystem = async (
   logger: Logger,
 ): Promise<string[]> => {
   const targetStem = posix.basename(params.targetPath, ".md")
-  // Pre-filter stems are lowercased so a case-mismatched link (e.g. [[foo]]
-  // pointing at Foo.md) is never skipped — the resolver handles case, and the
-  // pre-filter must be at least as permissive.
+  // Pre-filter stems are lowercased so a case-mismatched link is never
+  // skipped before the resolver runs. Encode the original-case stem FIRST,
+  // then lowercase — encodeURIComponent is codepoint-sensitive, so encoding
+  // an already-lowered stem produces different percent sequences for non-ASCII
+  // (É → %C3%89 vs é → %C3%A9).
   const lowerStem = targetStem.toLowerCase()
-  const lowerEncodedStem = encodeURIComponent(lowerStem)
+  const lowerEncodedStem = encodeURIComponent(targetStem).toLowerCase()
   // encodeURIComponent leaves parentheses unencoded, but the rewriter's
   // encodeMarkdownLinkPath encodes them as %28/%29 — a paren-bearing name
   // produces a markdown link the first two forms can't match.

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -167,11 +167,11 @@ const rewriteTarget = (
 ): string | null => {
   const { rawTarget, originalExtension, grammar } = params
 
-  const resolvedNoteBefore = links.resolve(
-    rawTarget,
-    context.allNotePaths,
-    context.oldSourcePath,
-  )
+  const resolvedNoteBefore = links.resolve({
+    target: rawTarget,
+    allPaths: context.allNotePaths,
+    sourcePath: context.oldSourcePath,
+  })
   const targetKind: TargetKind = resolvedNoteBefore ? "note" : "asset"
   const resolvedBefore =
     resolvedNoteBefore ??
@@ -194,11 +194,11 @@ const rewriteTarget = (
   // shared by the "already resolves" check and the candidate verifier.
   const resolveFromNewSource = (candidate: string): string | null =>
     targetKind === "note"
-      ? links.resolve(
-          candidate,
-          context.allNotePathsAfter,
-          context.newSourcePath,
-        )
+      ? links.resolve({
+          target: candidate,
+          allPaths: context.allNotePathsAfter,
+          sourcePath: context.newSourcePath,
+        })
       : links.resolveAsset({
           target: candidate,
           allAssetPaths: context.allAssetPaths,
@@ -520,13 +520,14 @@ const discoverBacklinksFromFilesystem = async (
         // Full parse + resolve — confirm the candidate actually links to the target
         const parsed = parseNote(content)
         const frontmatter: Record<string, unknown> = parsed.data
-        const rawTargets = links.extractAll(parsed.content, frontmatter)
-        const hasLinkToTarget = rawTargets.some(
-          (rawTarget) =>
-            links.resolve(rawTarget, allNotePathsForResolve, candidatePath) ===
-            params.targetPath,
-        )
-        return hasLinkToTarget ? candidatePath : null
+        const linkTargets = links.extractAll(parsed.content, frontmatter)
+        const resolvesToMovedNote = (linkTarget: string): boolean =>
+          links.resolve({
+            target: linkTarget,
+            allPaths: allNotePathsForResolve,
+            sourcePath: candidatePath,
+          }) === params.targetPath
+        return linkTargets.some(resolvesToMovedNote) ? candidatePath : null
       } catch (error) {
         logger.warn("backlink scan: skipping unreadable note", {
           path: candidatePath,
@@ -832,12 +833,10 @@ const moveNote = async (
             }
           },
         })
-        const linksUpdated =
-          movedLinksRewritten +
-          plannedRewrites.reduce(
-            (sum, planned) => sum + planned.linksRewritten,
-            0,
-          )
+        const backlinkLinksRewritten = plannedRewrites
+          .map((planned) => planned.linksRewritten)
+          .reduce((sum, count) => sum + count, 0)
+        const linksUpdated = movedLinksRewritten + backlinkLinksRewritten
 
         // Delete the original last — if this fails, both copies exist but no data is lost.
         try {

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -502,7 +502,7 @@ const discoverBacklinksFromFilesystem = async (
   // Hoisted above the mapper so a single allocation is shared across all candidates.
   const allNotePathsForResolve = [...params.allNotePaths]
 
-  const discoveredSources = await mapWithConcurrency({
+  const scanResults = await mapWithConcurrency({
     items: candidates,
     concurrency: REWRITE_CONCURRENCY,
     mapper: async (candidatePath): Promise<string | null> => {
@@ -536,7 +536,7 @@ const discoverBacklinksFromFilesystem = async (
     },
   })
 
-  return discoveredSources.filter((sourcePath) => sourcePath !== null)
+  return scanResults.filter((sourcePath) => sourcePath !== null)
 }
 
 /** Moves a note and rewrites every link across the vault that resolves to it.

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -491,6 +491,9 @@ const discoverBacklinksFromFilesystem = async (
     (notePath) =>
       notePath !== params.targetPath && !params.knownPaths.has(notePath),
   )
+  // Mutable copy of allNotePaths for links.resolve (accepts string[], not readonly).
+  // Hoisted above the mapper so a single allocation is shared across all candidates.
+  const allNotePathsForResolve = [...params.allNotePaths]
 
   const discoveredSources = await mapWithConcurrency({
     items: candidates,
@@ -505,10 +508,9 @@ const discoverBacklinksFromFilesystem = async (
         const parsed = parseNote(content)
         const frontmatter: Record<string, unknown> = parsed.data
         const rawTargets = links.extractAll(parsed.content, frontmatter)
-        const allNotePathsMutable = [...params.allNotePaths]
         const linksToTarget = rawTargets.some(
           (rawTarget) =>
-            links.resolve(rawTarget, allNotePathsMutable, candidatePath) ===
+            links.resolve(rawTarget, allNotePathsForResolve, candidatePath) ===
             params.targetPath,
         )
         return linksToTarget ? candidatePath : null
@@ -522,9 +524,7 @@ const discoverBacklinksFromFilesystem = async (
     },
   })
 
-  return discoveredSources.filter(
-    (sourcePath): sourcePath is string => sourcePath !== null,
-  )
+  return discoveredSources.filter((sourcePath) => sourcePath !== null)
 }
 
 /** Moves a note and rewrites every link across the vault that resolves to it.

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -521,12 +521,15 @@ const discoverBacklinksFromFilesystem = async (
         const parsed = parseNote(content)
         const frontmatter: Record<string, unknown> = parsed.data
         const linkTargets = links.extractAll(parsed.content, frontmatter)
-        const resolvesToMovedNote = (linkTarget: string): boolean =>
-          links.resolve({
-            target: linkTarget,
-            allPaths: allNotePathsForResolve,
-            sourcePath: candidatePath,
-          }) === params.targetPath
+        const resolvesToMovedNote = (linkTarget: string): boolean => {
+          return (
+            links.resolve({
+              target: linkTarget,
+              allPaths: allNotePathsForResolve,
+              sourcePath: candidatePath,
+            }) === params.targetPath
+          )
+        }
         return linkTargets.some(resolvesToMovedNote) ? candidatePath : null
       } catch (error) {
         logger.warn("backlink scan: skipping unreadable note", {


### PR DESCRIPTION
## Summary

- `vault_move_note` silently breaks backlinks when the search index lags the filesystem — a note written moments earlier whose backlink hasn't been indexed yet escapes both the lock set and the link rewrite
- Under the lock, `moveNote` now scans the filesystem directly for backlinks the index missed, using `links.extractAll` + `links.resolve` (leaf-layer parsers, no new cross-layer dependency)
- If new sources are found, the lock releases, the set expands, and the lock reacquires — capped at 3 retries
- Common-case overhead: ~50-100ms for a 1400-note vault (no retry needed when the index is fresh)

## Test plan

- [x] 5 new tests: stale-index discovery (body + frontmatter), prose false-positive rejection, unreadable-note resilience, mixed index+filesystem sources
- [x] Mutation check: disabling the scan → 4 of 5 new tests fail, existing 73 pass
- [x] Full suite: 2770 tests pass
- [x] Lint + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eCDN2Wen9jECB3jA5E94N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note moves by scanning vault files for backlinks that may be missing from the search index.
  * Preserved links in wikilinks, frontmatter, and percent-encoded Markdown references during moves.
  * Added safeguards for changing backlink sources, including retries and a clear error when sources do not stabilize.
  * Unreadable notes are skipped with a warning so moves can proceed safely when possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->