### PR TITLE
feat(daily-notes): extend moment→Luxon token map, reject all unsupported tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,11 @@ src/
     has-hidden-path-segment.ts         # Shared "is hidden path" predicate (listings, watcher, index, path guard)
     filter-valid-symlinks.ts           # Filters out broken symlinks from directory listings
     fit-image-to-byte-budget.ts        # Downscale/recompress an image buffer to fit a byte budget (sharp)
+  __tests__/
+    integration/                       # End-to-end: SDK Client + StreamableHTTPClientTransport over real HTTP
+      test-harness.ts                  #   Server lifecycle (spawn, healthz poll, cleanup) + client factory
+      server-integration.test.ts       #   Every tool + prompt exercised per config (default, READONLY, DISABLED_TOOLS, etc.)
+      fixtures/vault/                  #   Fixture vault copied to tempdir per server boot
   functions/
     authorizer.ts                      # Lambda: path-aware auth (OAuth pass-through, JWT + static)
   vault-mcp/
@@ -881,14 +886,6 @@ createTestIndex()` at the top of each test. `beforeEach` is only
   centralized test directory higher up the tree. Don't spawn a
   standalone test file just to mock differently; use
   `vi.mock(path, { spy: true })` to keep the real implementation.
-  **Exception:** `src/__tests__/integration/server-integration.test.ts`
-  is the end-to-end integration suite — SDK Client +
-  StreamableHTTPClientTransport over real HTTP against a real server
-  with a fixture vault on disk. Each top-level `describe` boots a
-  server with a specific env config (default, READONLY_MODE,
-  DISABLED_TOOLS, etc.) and exercises tools/prompts over the wire.
-  New features that change tool behavior under specific configs
-  (e.g. unsupported token rejection) get a `describe` block here.
 - Separate `it()` blocks over callback-pattern `it.each` when
   assertions are structurally different — `it.each` is for genuinely
   identical assertion shapes (input → expected).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -881,6 +881,14 @@ createTestIndex()` at the top of each test. `beforeEach` is only
   centralized test directory higher up the tree. Don't spawn a
   standalone test file just to mock differently; use
   `vi.mock(path, { spy: true })` to keep the real implementation.
+  **Exception:** `src/__tests__/integration/server-integration.test.ts`
+  is the end-to-end integration suite — SDK Client +
+  StreamableHTTPClientTransport over real HTTP against a real server
+  with a fixture vault on disk. Each top-level `describe` boots a
+  server with a specific env config (default, READONLY_MODE,
+  DISABLED_TOOLS, etc.) and exercises tools/prompts over the wire.
+  New features that change tool behavior under specific configs
+  (e.g. unsupported token rejection) get a `describe` block here.
 - Separate `it()` blocks over callback-pattern `it.each` when
   assertions are structurally different — `it.each` is for genuinely
   identical assertion shapes (input → expected).

--- a/README.md
+++ b/README.md
@@ -361,7 +361,9 @@ See [`templates/memory/`](./templates/memory/) for memory file examples and the 
 - **Local mode** reads the file straight from your bind-mounted vault — nothing to set up.
 - **Remote mode** receives it through Obsidian Sync's vault configuration syncing. The server pulls it by default (the `SYNC_CONFIGS` setting in `.env`), but you'll likely need to enable the push side: Obsidian Settings → Sync → **Vault configuration sync**, per device. Details: the [remote guide's Daily notes section](./deploy/remote/README.md#daily-notes).
 
-When the file isn't available — or you use the Periodic Notes plugin, whose settings it doesn't reflect — set `DAILY_NOTES_FOLDER` (any vault-relative path: `Journal`, `Planner/Daily`) and `DAILY_NOTES_FORMAT` (same tokens as Obsidian's date format setting: `YYYY-MM-DD-dddd`, `YYYY/MM/DD`, …). You can set one or both — a set value always wins over the config file. Without either source, the server falls back to `Daily Notes` and `YYYY-MM-DD`.
+When the file isn't available — or you use the Periodic Notes plugin, whose settings it doesn't reflect — set `DAILY_NOTES_FOLDER` (any vault-relative path: `Journal`, `Planner/Daily`) and `DAILY_NOTES_FORMAT` (same tokens as Obsidian's date format setting: `YYYY-MM-DD-dddd`, `YYYY/MM/DD`, `MMM D, YYYY`, …). You can set one or both — a set value always wins over the config file. Without either source, the server falls back to `Daily Notes` and `YYYY-MM-DD`.
+
+> **Note:** Most Moment.js tokens map directly to Luxon equivalents. The one exception is `Do` (ordinal day — "1st", "13th"): Luxon has no ordinal-suffix token, so the server renders the day number without the suffix. If your format uses `Do`, daily note filenames will differ from Obsidian's.
 
 ## Data Integrity
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ See [`templates/memory/`](./templates/memory/) for memory file examples and the 
 
 When the file isn't available — or you use the Periodic Notes plugin, whose settings it doesn't reflect — set `DAILY_NOTES_FOLDER` (any vault-relative path: `Journal`, `Planner/Daily`) and `DAILY_NOTES_FORMAT` (same tokens as Obsidian's date format setting: `YYYY-MM-DD-dddd`, `YYYY/MM/DD`, `MMM D, YYYY`, …). You can set one or both — a set value always wins over the config file. Without either source, the server falls back to `Daily Notes` and `YYYY-MM-DD`.
 
-> **Note:** Some Moment.js tokens have no Luxon equivalent and are unsupported — ordinals (`Do`, `Mo`, `DDDo`, `wo`), `dd` (2-letter weekday), `d` (weekday number), `e`, `k`/`kk`, and the localized formats (`L`–`LLLL`, `LT`, `LTS`). The server would produce filenames that don't match Obsidian's and could never find the notes. If your format uses any of these, `vault_get_daily_note` returns a clear error — change the format in Obsidian or set `DAILY_NOTES_FORMAT` to a supported alternative.
+> **Note:** A few date format tokens are unsupported — ordinals (`Do`, `Mo`, `DDDo`, `wo`), `dd` (2-letter weekday), `d` (weekday number), `e`, `k`/`kk`, and the localized formats (`L`–`LLLL`, `LT`, `LTS`). The server can't reproduce the filenames Obsidian creates with these tokens, so it could never find the notes. If your format uses any of them, `vault_get_daily_note` returns a clear error — change the format in Obsidian or set `DAILY_NOTES_FORMAT` to a supported alternative.
 
 ## Data Integrity
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ See [`templates/memory/`](./templates/memory/) for memory file examples and the 
 
 When the file isn't available — or you use the Periodic Notes plugin, whose settings it doesn't reflect — set `DAILY_NOTES_FOLDER` (any vault-relative path: `Journal`, `Planner/Daily`) and `DAILY_NOTES_FORMAT` (same tokens as Obsidian's date format setting: `YYYY-MM-DD-dddd`, `YYYY/MM/DD`, `MMM D, YYYY`, …). You can set one or both — a set value always wins over the config file. Without either source, the server falls back to `Daily Notes` and `YYYY-MM-DD`.
 
-> **Note:** Most Moment.js tokens map directly to Luxon equivalents. The notable exception is `Do` (ordinal day — "1st", "13th"): Luxon has no ordinal-suffix token, so the server renders the day number without the suffix. If your format uses `Do`, daily note filenames will differ from Obsidian's.
+> **Note:** Two Moment.js tokens are unsupported: `Do` (ordinal day — "1st", "13th") and `dd` (2-letter weekday — "Mo", "Tu"). Luxon has no equivalent for either, so filenames would differ from Obsidian's and the server could never find the notes. If your format uses `Do` or `dd`, the server rejects it with a clear error — change the format in Obsidian or set `DAILY_NOTES_FORMAT` to a supported alternative.
 
 ## Data Integrity
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ See [`templates/memory/`](./templates/memory/) for memory file examples and the 
 
 When the file isn't available — or you use the Periodic Notes plugin, whose settings it doesn't reflect — set `DAILY_NOTES_FOLDER` (any vault-relative path: `Journal`, `Planner/Daily`) and `DAILY_NOTES_FORMAT` (same tokens as Obsidian's date format setting: `YYYY-MM-DD-dddd`, `YYYY/MM/DD`, `MMM D, YYYY`, …). You can set one or both — a set value always wins over the config file. Without either source, the server falls back to `Daily Notes` and `YYYY-MM-DD`.
 
-> **Note:** Most Moment.js tokens map directly to Luxon equivalents. The one exception is `Do` (ordinal day — "1st", "13th"): Luxon has no ordinal-suffix token, so the server renders the day number without the suffix. If your format uses `Do`, daily note filenames will differ from Obsidian's.
+> **Note:** Most Moment.js tokens map directly to Luxon equivalents. The notable exception is `Do` (ordinal day — "1st", "13th"): Luxon has no ordinal-suffix token, so the server renders the day number without the suffix. If your format uses `Do`, daily note filenames will differ from Obsidian's.
 
 ## Data Integrity
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ See [`templates/memory/`](./templates/memory/) for memory file examples and the 
 
 When the file isn't available — or you use the Periodic Notes plugin, whose settings it doesn't reflect — set `DAILY_NOTES_FOLDER` (any vault-relative path: `Journal`, `Planner/Daily`) and `DAILY_NOTES_FORMAT` (same tokens as Obsidian's date format setting: `YYYY-MM-DD-dddd`, `YYYY/MM/DD`, `MMM D, YYYY`, …). You can set one or both — a set value always wins over the config file. Without either source, the server falls back to `Daily Notes` and `YYYY-MM-DD`.
 
-> **Note:** Two Moment.js tokens are unsupported: `Do` (ordinal day — "1st", "13th") and `dd` (2-letter weekday — "Mo", "Tu"). Luxon has no equivalent for either, so filenames would differ from Obsidian's and the server could never find the notes. If your format uses `Do` or `dd`, the server rejects it with a clear error — change the format in Obsidian or set `DAILY_NOTES_FORMAT` to a supported alternative.
+> **Note:** Some Moment.js tokens have no Luxon equivalent and are unsupported — ordinals (`Do`, `Mo`, `DDDo`, `wo`), `dd` (2-letter weekday), `d` (weekday number), `e`, `k`/`kk`, and the localized formats (`L`–`LLLL`, `LT`, `LTS`). The server would produce filenames that don't match Obsidian's and could never find the notes. If your format uses any of these, `vault_get_daily_note` returns a clear error — change the format in Obsidian or set `DAILY_NOTES_FORMAT` to a supported alternative.
 
 ## Data Integrity
 

--- a/src/__tests__/integration/server-integration.test.ts
+++ b/src/__tests__/integration/server-integration.test.ts
@@ -888,6 +888,43 @@ describe("FILE_TOOLS_ENABLED=false", () => {
 
 // ── Boot rejection ───────────────────────────────────────────
 
+describe("DAILY_NOTES_FORMAT with unsupported token", () => {
+  let client: Client
+  let cleanup: (() => Promise<void>) | undefined
+
+  beforeAll(async () => {
+    const port = randomPort()
+    const server = await startServer(port, {
+      DAILY_NOTES_FORMAT: "MMMM Do, YYYY",
+    })
+    cleanup = server.cleanup
+    client = await createTestClient(server.port)
+  }, 30_000)
+
+  afterAll(async () => {
+    try {
+      if (client) await client.close()
+    } finally {
+      if (cleanup) await cleanup()
+    }
+  })
+
+  it("server starts despite unsupported token in format", async () => {
+    const names = await toolNames(client)
+    expect(names).toContain("vault_get_daily_note")
+  })
+
+  it("vault_get_daily_note returns a tool error for unsupported Do token", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_get_daily_note",
+      args: { date: "2026-01-15" },
+    })
+    expect(result.isError).toBe(true)
+    expect(textContent(result)).toContain("unsupported token(s): Do")
+  })
+})
+
 describe("boot rejection", () => {
   it("unknown DISABLED_TOOLS name exits with error", async () => {
     const { exitCode, stderr } = await startServerExpectingFailure(

--- a/src/vault-mcp/__tests__/config.test.ts
+++ b/src/vault-mcp/__tests__/config.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi, onTestFinished } from "vitest"
 import { loadConfig } from "../config.js"
+import { logger } from "../../logger.js"
 
 const EMPTY_ENV: Record<string, string | undefined> = {}
 
@@ -255,15 +256,25 @@ describe("loadConfig", () => {
       )
     })
 
-    it("rejects a format containing Do (ordinal day)", () => {
-      expect(() => loadConfig({ DAILY_NOTES_FORMAT: "MMMM Do, YYYY" })).toThrow(
-        'env-var: "DAILY_NOTES_FORMAT" contains unsupported token(s): Do',
+    it("accepts a Do format and warns about unsupported token", () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+      onTestFinished(() => warnSpy.mockRestore())
+      const config = loadConfig({ DAILY_NOTES_FORMAT: "MMMM Do, YYYY" })
+      expect(config.dailyNotesFormat).toBe("MMMM Do, YYYY")
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("unsupported token(s): Do"),
       )
     })
 
-    it("rejects a format containing dd (2-letter weekday)", () => {
-      expect(() => loadConfig({ DAILY_NOTES_FORMAT: "YYYY-MM-DD dd" })).toThrow(
-        'env-var: "DAILY_NOTES_FORMAT" contains unsupported token(s): dd',
+    it("accepts a dd format and warns about unsupported token", () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+      onTestFinished(() => warnSpy.mockRestore())
+      const config = loadConfig({ DAILY_NOTES_FORMAT: "YYYY-MM-DD dd" })
+      expect(config.dailyNotesFormat).toBe("YYYY-MM-DD dd")
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("unsupported token(s): dd"),
       )
     })
   })

--- a/src/vault-mcp/__tests__/config.test.ts
+++ b/src/vault-mcp/__tests__/config.test.ts
@@ -254,6 +254,11 @@ describe("loadConfig", () => {
         'env-var: "DAILY_NOTES_FORMAT" renders to an empty filename',
       )
     })
+
+    it("accepts a Do format without throwing (lossy but structurally safe)", () => {
+      const config = loadConfig({ DAILY_NOTES_FORMAT: "MMMM Do, YYYY" })
+      expect(config.dailyNotesFormat).toBe("MMMM Do, YYYY")
+    })
   })
 
   describe("PROTECTED_PATHS (comma-separated)", () => {

--- a/src/vault-mcp/__tests__/config.test.ts
+++ b/src/vault-mcp/__tests__/config.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, vi, onTestFinished } from "vitest"
+import { describe, it, expect } from "vitest"
 import { loadConfig } from "../config.js"
-import { logger } from "../../logger.js"
 
 const EMPTY_ENV: Record<string, string | undefined> = {}
 
@@ -256,26 +255,16 @@ describe("loadConfig", () => {
       )
     })
 
-    it("accepts a Do format without throwing (lossy but structurally safe)", () => {
-      const config = loadConfig({ DAILY_NOTES_FORMAT: "MMMM Do, YYYY" })
-      expect(config.dailyNotesFormat).toBe("MMMM Do, YYYY")
-    })
-
-    it("warns when format contains Do (ordinal day)", () => {
-      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
-      onTestFinished(() => warnSpy.mockRestore())
-      loadConfig({ DAILY_NOTES_FORMAT: "MMMM Do, YYYY" })
-      expect(warnSpy).toHaveBeenCalledTimes(1)
-      expect(warnSpy).toHaveBeenCalledWith(
-        "DAILY_NOTES_FORMAT contains Do (ordinal day) — Luxon has no ordinal-suffix token; the server will use the day number without suffix, so filenames will differ from Obsidian's",
+    it("rejects a format containing Do (ordinal day)", () => {
+      expect(() => loadConfig({ DAILY_NOTES_FORMAT: "MMMM Do, YYYY" })).toThrow(
+        'env-var: "DAILY_NOTES_FORMAT" contains unsupported token(s): Do',
       )
     })
 
-    it("does not warn for a standard format without Do", () => {
-      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
-      onTestFinished(() => warnSpy.mockRestore())
-      loadConfig({ DAILY_NOTES_FORMAT: "YYYY-MM-DD" })
-      expect(warnSpy).not.toHaveBeenCalled()
+    it("rejects a format containing dd (2-letter weekday)", () => {
+      expect(() => loadConfig({ DAILY_NOTES_FORMAT: "YYYY-MM-DD dd" })).toThrow(
+        'env-var: "DAILY_NOTES_FORMAT" contains unsupported token(s): dd',
+      )
     })
   })
 

--- a/src/vault-mcp/__tests__/config.test.ts
+++ b/src/vault-mcp/__tests__/config.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi } from "vitest"
 import { loadConfig } from "../config.js"
+import { logger } from "../../logger.js"
 
 const EMPTY_ENV: Record<string, string | undefined> = {}
 
@@ -258,6 +259,23 @@ describe("loadConfig", () => {
     it("accepts a Do format without throwing (lossy but structurally safe)", () => {
       const config = loadConfig({ DAILY_NOTES_FORMAT: "MMMM Do, YYYY" })
       expect(config.dailyNotesFormat).toBe("MMMM Do, YYYY")
+    })
+
+    it("warns when format contains Do (ordinal day)", () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+      loadConfig({ DAILY_NOTES_FORMAT: "MMMM Do, YYYY" })
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(
+        "DAILY_NOTES_FORMAT contains Do (ordinal day) — Luxon has no ordinal-suffix token; the server will use the day number without suffix, so filenames will differ from Obsidian's",
+      )
+      warnSpy.mockRestore()
+    })
+
+    it("does not warn for a standard format without Do", () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+      loadConfig({ DAILY_NOTES_FORMAT: "YYYY-MM-DD" })
+      expect(warnSpy).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
     })
   })
 

--- a/src/vault-mcp/__tests__/config.test.ts
+++ b/src/vault-mcp/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, onTestFinished } from "vitest"
 import { loadConfig } from "../config.js"
 import { logger } from "../../logger.js"
 
@@ -263,19 +263,19 @@ describe("loadConfig", () => {
 
     it("warns when format contains Do (ordinal day)", () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+      onTestFinished(() => warnSpy.mockRestore())
       loadConfig({ DAILY_NOTES_FORMAT: "MMMM Do, YYYY" })
       expect(warnSpy).toHaveBeenCalledTimes(1)
       expect(warnSpy).toHaveBeenCalledWith(
         "DAILY_NOTES_FORMAT contains Do (ordinal day) — Luxon has no ordinal-suffix token; the server will use the day number without suffix, so filenames will differ from Obsidian's",
       )
-      warnSpy.mockRestore()
     })
 
     it("does not warn for a standard format without Do", () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+      onTestFinished(() => warnSpy.mockRestore())
       loadConfig({ DAILY_NOTES_FORMAT: "YYYY-MM-DD" })
       expect(warnSpy).not.toHaveBeenCalled()
-      warnSpy.mockRestore()
     })
   })
 

--- a/src/vault-mcp/config.ts
+++ b/src/vault-mcp/config.ts
@@ -5,9 +5,8 @@ import envVar from "env-var"
 import { DateTime } from "luxon"
 import {
   momentToLuxonFormat,
-  hasOrdinalDayToken,
+  findUnsupportedTokens,
 } from "./obsidian-markdown/moment-format.js"
-import { logger } from "../logger.js"
 import { isToolName } from "./mcp-core/tool-registry.js"
 import type { ToolName } from "./mcp-core/tool-registry.js"
 
@@ -68,9 +67,10 @@ const validateDailyNotesFormat = (momentFormat: string): string => {
       `env-var: "DAILY_NOTES_FORMAT" must not end with a path separator`,
     )
   }
-  if (hasOrdinalDayToken(momentFormat)) {
-    logger.warn(
-      "DAILY_NOTES_FORMAT contains Do (ordinal day) — Luxon has no ordinal-suffix token; the server will use the day number without suffix, so filenames will differ from Obsidian's",
+  const unsupportedTokens = findUnsupportedTokens(momentFormat)
+  if (unsupportedTokens.length > 0) {
+    throw new Error(
+      `env-var: "DAILY_NOTES_FORMAT" contains unsupported token(s): ${unsupportedTokens.join(", ")} — daily note filenames would differ from Obsidian's, so the server could never find the notes Obsidian creates`,
     )
   }
   return momentFormat

--- a/src/vault-mcp/config.ts
+++ b/src/vault-mcp/config.ts
@@ -41,9 +41,9 @@ const splitCommaSeparatedValues = (raw: string): string[] =>
 
 /** Validates a DAILY_NOTES_FORMAT value by probe-rendering a fixed date.
  *  Structural checks only — structurally unsafe results (traversal,
- *  separators, empty) are rejected. Warns when the format contains Do
- *  (ordinal day), which maps lossily (suffix dropped). Returns the raw
- *  moment string unchanged. */
+ *  separators, empty) are rejected. Warns when the format contains
+ *  unsupported tokens (Do, dd) whose Luxon mappings produce filenames
+ *  differing from Obsidian's. Returns the raw moment string unchanged. */
 const validateDailyNotesFormat = (momentFormat: string): string => {
   const renderedProbe = DateTime.fromISO("2026-01-31").toFormat(
     momentToLuxonFormat(momentFormat),

--- a/src/vault-mcp/config.ts
+++ b/src/vault-mcp/config.ts
@@ -42,8 +42,7 @@ const splitCommaSeparatedValues = (raw: string): string[] =>
 /** Validates a DAILY_NOTES_FORMAT value by probe-rendering a fixed date.
  *  Structural checks only — structurally unsafe results (traversal,
  *  separators, empty) are rejected. Warns when the format contains
- *  unsupported tokens (Do, dd) whose Luxon mappings produce filenames
- *  differing from Obsidian's. Returns the raw moment string unchanged. */
+ *  unsupported tokens. Returns the raw moment string unchanged. */
 const validateDailyNotesFormat = (momentFormat: string): string => {
   const renderedProbe = DateTime.fromISO("2026-01-31").toFormat(
     momentToLuxonFormat(momentFormat),

--- a/src/vault-mcp/config.ts
+++ b/src/vault-mcp/config.ts
@@ -3,7 +3,11 @@
 import { z } from "zod"
 import envVar from "env-var"
 import { DateTime } from "luxon"
-import { momentToLuxonFormat } from "./obsidian-markdown/moment-format.js"
+import {
+  momentToLuxonFormat,
+  hasOrdinalDayToken,
+} from "./obsidian-markdown/moment-format.js"
+import { logger } from "../logger.js"
 import { isToolName } from "./mcp-core/tool-registry.js"
 import type { ToolName } from "./mcp-core/tool-registry.js"
 
@@ -36,10 +40,10 @@ const splitCommaSeparatedValues = (raw: string): string[] =>
     .filter((entry) => entry.length > 0)
 
 /** Validates a DAILY_NOTES_FORMAT value by probe-rendering a fixed date.
- *  Structural checks only — moment tokens without a Luxon mapping pass
- *  through and may render differently than in Obsidian, so only
- *  structurally unsafe results (traversal, separators, empty) are
- *  rejected. Returns the raw moment string unchanged. */
+ *  Structural checks only — structurally unsafe results (traversal,
+ *  separators, empty) are rejected. Warns when the format contains Do
+ *  (ordinal day), which maps lossily (suffix dropped). Returns the raw
+ *  moment string unchanged. */
 const validateDailyNotesFormat = (momentFormat: string): string => {
   const renderedProbe = DateTime.fromISO("2026-01-31").toFormat(
     momentToLuxonFormat(momentFormat),
@@ -62,6 +66,11 @@ const validateDailyNotesFormat = (momentFormat: string): string => {
   if (momentFormat.endsWith("/") || renderedProbe.endsWith("/")) {
     throw new Error(
       `env-var: "DAILY_NOTES_FORMAT" must not end with a path separator`,
+    )
+  }
+  if (hasOrdinalDayToken(momentFormat)) {
+    logger.warn(
+      "DAILY_NOTES_FORMAT contains Do (ordinal day) — Luxon has no ordinal-suffix token; the server will use the day number without suffix, so filenames will differ from Obsidian's",
     )
   }
   return momentFormat

--- a/src/vault-mcp/config.ts
+++ b/src/vault-mcp/config.ts
@@ -7,6 +7,7 @@ import {
   momentToLuxonFormat,
   findUnsupportedTokens,
 } from "./obsidian-markdown/moment-format.js"
+import { logger } from "../logger.js"
 import { isToolName } from "./mcp-core/tool-registry.js"
 import type { ToolName } from "./mcp-core/tool-registry.js"
 
@@ -69,8 +70,8 @@ const validateDailyNotesFormat = (momentFormat: string): string => {
   }
   const unsupportedTokens = findUnsupportedTokens(momentFormat)
   if (unsupportedTokens.length > 0) {
-    throw new Error(
-      `env-var: "DAILY_NOTES_FORMAT" contains unsupported token(s): ${unsupportedTokens.join(", ")} — daily note filenames would differ from Obsidian's, so the server could never find the notes Obsidian creates`,
+    logger.warn(
+      `DAILY_NOTES_FORMAT contains unsupported token(s): ${unsupportedTokens.join(", ")} — daily note lookups will fail; vault_get_daily_note will return an error until the format is changed`,
     )
   }
   return momentFormat

--- a/src/vault-mcp/mcp-core/tools/daily-note-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/daily-note-tools.ts
@@ -30,6 +30,7 @@ Parameters:
 
 Errors:
 - "invalid date" — use YYYY-MM-DD format (e.g. "2026-05-13", not "May 13")
+- "unsupported token(s): ..." — the configured format contains Do (ordinal day) or dd (2-letter weekday), which Luxon cannot reproduce; change the format in Obsidian or set DAILY_NOTES_FORMAT to a supported alternative
 
 Returns: JSON with path (string — resolved vault-relative path), content (string|null — full note body, or null when the note doesn't exist), and exists (boolean). ${isToolEnabled("vault_write_note") ? "When exists is false, create the note with vault_write_note using the returned path." : "When exists is false, the note has not been created yet."}`,
       inputSchema: {

--- a/src/vault-mcp/mcp-core/tools/daily-note-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/daily-note-tools.ts
@@ -30,7 +30,7 @@ Parameters:
 
 Errors:
 - "invalid date" — use YYYY-MM-DD format (e.g. "2026-05-13", not "May 13")
-- "unsupported token(s): ..." — the configured format contains Do (ordinal day) or dd (2-letter weekday), which Luxon cannot reproduce; change the format in Obsidian or set DAILY_NOTES_FORMAT to a supported alternative
+- "unsupported token(s): ..." — the configured format contains Moment.js tokens Luxon cannot reproduce (ordinals like Do/Mo, dd, d, e, k/kk, or the L-family localized formats); change the format in Obsidian or set DAILY_NOTES_FORMAT to a supported alternative
 
 Returns: JSON with path (string — resolved vault-relative path), content (string|null — full note body, or null when the note doesn't exist), and exists (boolean). ${isToolEnabled("vault_write_note") ? "When exists is false, create the note with vault_write_note using the returned path." : "When exists is false, the note has not been created yet."}`,
       inputSchema: {

--- a/src/vault-mcp/mcp-core/tools/daily-note-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/daily-note-tools.ts
@@ -30,7 +30,7 @@ Parameters:
 
 Errors:
 - "invalid date" — use YYYY-MM-DD format (e.g. "2026-05-13", not "May 13")
-- "unsupported token(s): ..." — the configured format contains Moment.js tokens Luxon cannot reproduce (ordinals like Do/Mo, dd, d, e, k/kk, or the L-family localized formats); change the format in Obsidian or set DAILY_NOTES_FORMAT to a supported alternative
+- "daily note format contains unsupported token(s): ..." — the configured format uses tokens the server cannot reproduce (ordinals like Do/Mo, dd, d, e, k/kk, or the L-family localized formats); change the format in Obsidian or set DAILY_NOTES_FORMAT to a supported alternative
 
 Returns: JSON with path (string — resolved vault-relative path), content (string|null — full note body, or null when the note doesn't exist), and exists (boolean). ${isToolEnabled("vault_write_note") ? "When exists is false, create the note with vault_write_note using the returned path." : "When exists is false, the note has not been created yet."}`,
       inputSchema: {

--- a/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { momentToLuxonFormat, hasOrdinalDayToken } from "../moment-format.js"
+import { momentToLuxonFormat, findUnsupportedTokens } from "../moment-format.js"
 
 describe("momentToLuxonFormat", () => {
   const scenarios = [
@@ -121,20 +121,33 @@ describe("momentToLuxonFormat", () => {
   })
 })
 
-describe("hasOrdinalDayToken", () => {
-  it("returns true when Do appears in a format string", () => {
-    expect(hasOrdinalDayToken("MMMM Do, YYYY")).toBe(true)
+describe("findUnsupportedTokens", () => {
+  it("returns Do when ordinal day is in the format", () => {
+    expect(findUnsupportedTokens("MMMM Do, YYYY")).toEqual(["Do"])
   })
 
-  it("returns false for a standard format without Do", () => {
-    expect(hasOrdinalDayToken("YYYY-MM-DD")).toBe(false)
+  it("returns dd when 2-letter weekday is in the format", () => {
+    expect(findUnsupportedTokens("YYYY-MM-DD dd")).toEqual(["dd"])
   })
 
-  it("returns false when Do is inside a [literal] escape", () => {
-    expect(hasOrdinalDayToken("[Do] DD")).toBe(false)
+  it("returns both when both appear", () => {
+    expect(findUnsupportedTokens("Do dd")).toEqual(["Do", "dd"])
   })
 
-  it("returns true when Do is outside a literal even if a literal exists", () => {
-    expect(hasOrdinalDayToken("[Note] Do")).toBe(true)
+  it("returns empty array for a standard format", () => {
+    expect(findUnsupportedTokens("YYYY-MM-DD")).toEqual([])
+  })
+
+  it("ignores tokens inside [literal] escapes", () => {
+    expect(findUnsupportedTokens("[Do] DD")).toEqual([])
+  })
+
+  it("detects tokens outside a literal even when a literal exists", () => {
+    expect(findUnsupportedTokens("[Note] Do")).toEqual(["Do"])
+  })
+
+  it("does not false-positive on ddd or dddd (mapped tokens)", () => {
+    expect(findUnsupportedTokens("YYYY-MM-DD-ddd")).toEqual([])
+    expect(findUnsupportedTokens("YYYY-MM-DD-dddd")).toEqual([])
   })
 })

--- a/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
@@ -105,9 +105,9 @@ describe("momentToLuxonFormat", () => {
       expected: "MMMM MMM MM M",
     },
     {
-      name: "adjacency: unpadded month and day with comma",
-      input: "MMM D, YYYY",
-      expected: "MMM d, yyyy",
+      name: "adjacent tokens without separators resolve correctly",
+      input: "DDMM",
+      expected: "ddMM",
     },
     {
       name: "[literal] containing Do is preserved while token Do is converted",

--- a/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
@@ -110,7 +110,7 @@ describe("momentToLuxonFormat", () => {
       expected: "ddMM",
     },
     {
-      name: "[literal] containing Do is preserved while token Do is converted",
+      name: "[literal] Do is preserved while bare Do maps to d",
       input: "[Do] Do",
       expected: "'Do' d",
     },

--- a/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { momentToLuxonFormat } from "../moment-format.js"
+import { momentToLuxonFormat, hasOrdinalDayToken } from "../moment-format.js"
 
 describe("momentToLuxonFormat", () => {
   const scenarios = [
@@ -63,9 +63,78 @@ describe("momentToLuxonFormat", () => {
       input: "[DD] DD",
       expected: "'DD' dd",
     },
+    // ── New token mappings ──────────────────────────────────────
+    {
+      name: "unpadded day of month",
+      input: "MMM D, YYYY",
+      expected: "MMM d, yyyy",
+    },
+    {
+      name: "unpadded month",
+      input: "M/D/YYYY",
+      expected: "M/d/yyyy",
+    },
+    {
+      name: "day of year",
+      input: "YYYY-DDD",
+      expected: "yyyy-o",
+    },
+    {
+      name: "day of year zero-padded",
+      input: "YYYY-DDDD",
+      expected: "yyyy-ooo",
+    },
+    {
+      name: "ordinal day maps to unpadded day (lossy — suffix dropped)",
+      input: "MMMM Do, YYYY",
+      expected: "MMMM d, yyyy",
+    },
+    {
+      name: "D does not corrupt Do — tokenizer matches Do before D",
+      input: "Do-DD",
+      expected: "d-dd",
+    },
+    {
+      name: "all D-family tokens in one format resolve correctly",
+      input: "DDDD DDD DD Do D",
+      expected: "ooo o dd d d",
+    },
+    {
+      name: "all M-family tokens in one format resolve correctly",
+      input: "MMMM MMM MM M",
+      expected: "MMMM MMM MM M",
+    },
+    {
+      name: "adjacency: unpadded month and day with comma",
+      input: "MMM D, YYYY",
+      expected: "MMM d, yyyy",
+    },
+    {
+      name: "[literal] containing Do is preserved while token Do is converted",
+      input: "[Do] Do",
+      expected: "'Do' d",
+    },
   ]
 
   it.each(scenarios)("$name", ({ input, expected }) => {
     expect(momentToLuxonFormat(input)).toBe(expected)
+  })
+})
+
+describe("hasOrdinalDayToken", () => {
+  it("returns true when Do appears in a format string", () => {
+    expect(hasOrdinalDayToken("MMMM Do, YYYY")).toBe(true)
+  })
+
+  it("returns false for a standard format without Do", () => {
+    expect(hasOrdinalDayToken("YYYY-MM-DD")).toBe(false)
+  })
+
+  it("returns false when Do is inside a [literal] escape", () => {
+    expect(hasOrdinalDayToken("[Do] DD")).toBe(false)
+  })
+
+  it("returns true when Do is outside a literal even if a literal exists", () => {
+    expect(hasOrdinalDayToken("[Note] Do")).toBe(true)
   })
 })

--- a/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
@@ -85,19 +85,9 @@ describe("momentToLuxonFormat", () => {
       expected: "yyyy-ooo",
     },
     {
-      name: "ordinal day maps to unpadded day (lossy — suffix dropped)",
-      input: "MMMM Do, YYYY",
-      expected: "MMMM d, yyyy",
-    },
-    {
-      name: "D does not corrupt Do — tokenizer matches Do before D",
-      input: "Do-DD",
-      expected: "d-dd",
-    },
-    {
       name: "all D-family tokens in one format resolve correctly",
-      input: "DDDD DDD DD Do D",
-      expected: "ooo o dd d d",
+      input: "DDDD DDD DD D",
+      expected: "ooo o dd d",
     },
     {
       name: "all M-family tokens in one format resolve correctly",
@@ -141,8 +131,36 @@ describe("findUnsupportedTokens", () => {
     expect(findUnsupportedTokens("[Note] Do")).toEqual(["Do"])
   })
 
-  it("does not false-positive on ddd or dddd (mapped tokens)", () => {
+  it("does not false-positive on ddd or dddd (supported tokens)", () => {
     expect(findUnsupportedTokens("YYYY-MM-DD-ddd")).toEqual([])
     expect(findUnsupportedTokens("YYYY-MM-DD-dddd")).toEqual([])
+  })
+
+  it("detects ordinal tokens (Mo, DDDo, wo)", () => {
+    expect(findUnsupportedTokens("Mo")).toEqual(["Mo"])
+    expect(findUnsupportedTokens("DDDo")).toEqual(["DDDo"])
+    expect(findUnsupportedTokens("wo")).toEqual(["wo"])
+  })
+
+  it("detects weekday number d without false-positive on D or DD", () => {
+    expect(findUnsupportedTokens("YYYY-MM-DD d")).toContain("d")
+    expect(findUnsupportedTokens("YYYY-MM-DD")).not.toContain("d")
+    expect(findUnsupportedTokens("D")).not.toContain("d")
+  })
+
+  it("detects localized format tokens (L, LL, LLL, LLLL, LT, LTS)", () => {
+    expect(findUnsupportedTokens("L")).toEqual(["L"])
+    expect(findUnsupportedTokens("LLLL")).toEqual(["LLLL"])
+    expect(findUnsupportedTokens("LT")).toEqual(["LT"])
+    expect(findUnsupportedTokens("LTS")).toEqual(["LTS"])
+  })
+
+  it("detects k/kk (1-24 hour)", () => {
+    expect(findUnsupportedTokens("kk:mm")).toEqual(["kk"])
+    expect(findUnsupportedTokens("k:mm")).toEqual(["k"])
+  })
+
+  it("detects e (locale weekday number)", () => {
+    expect(findUnsupportedTokens("YYYY e")).toEqual(["e"])
   })
 })

--- a/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/moment-format.test.ts
@@ -109,11 +109,6 @@ describe("momentToLuxonFormat", () => {
       input: "DDMM",
       expected: "ddMM",
     },
-    {
-      name: "[literal] Do is preserved while bare Do maps to d",
-      input: "[Do] Do",
-      expected: "'Do' d",
-    },
   ]
 
   it.each(scenarios)("$name", ({ input, expected }) => {

--- a/src/vault-mcp/obsidian-markdown/moment-format.ts
+++ b/src/vault-mcp/obsidian-markdown/moment-format.ts
@@ -52,9 +52,9 @@ const convertMomentTokens = (formatSpan: string): string =>
 /** Converts a Moment.js format string to Luxon format tokens. [literal]
  *  escapes become Luxon 'literal' quotes (single quotes doubled), and token
  *  replacement runs only OUTSIDE literals so literal text containing token
- *  letters ("[Week A]") is preserved verbatim. Two Moment tokens have no
- *  Luxon equivalent — Do (ordinal day) and dd (2-letter weekday) — and are
- *  rejected by getDailyNotePath before the converter runs. */
+ *  letters ("[Week A]") is preserved verbatim. Moment tokens with no Luxon
+ *  equivalent (see findUnsupportedTokens) are rejected by getDailyNotePath
+ *  before the converter runs. */
 export const momentToLuxonFormat = (momentFormat: string): string => {
   return momentFormat
     .split(MOMENT_ESCAPE_RE)
@@ -99,6 +99,7 @@ const UNSUPPORTED_PATTERNS: ReadonlyArray<{ pattern: RegExp; token: string }> =
  *  of [literal] escapes, or an empty array if none. Standalone — does not
  *  depend on the supported-token table or its ordering. */
 export const findUnsupportedTokens = (momentFormat: string): string[] => {
+  // Join with \0 so tokens can't match across segment boundaries
   const formatSegments = momentFormat
     .split(MOMENT_ESCAPE_RE)
     .filter((_, segmentIndex) => segmentIndex % 2 === 0)

--- a/src/vault-mcp/obsidian-markdown/moment-format.ts
+++ b/src/vault-mcp/obsidian-markdown/moment-format.ts
@@ -21,6 +21,7 @@ const MOMENT_TO_LUXON: ReadonlyArray<readonly [string, string]> = [
   ["MM", "MM"],
   ["DD", "dd"],
   ["Do", "d"], // ordinal day — lossy: suffix ("st","nd","th") dropped
+  ["dd", "ccc"], // 2-letter weekday — no Luxon equivalent; mapped to 3-letter as closest
   ["HH", "HH"],
   ["hh", "hh"],
   ["mm", "mm"],
@@ -53,12 +54,10 @@ const convertMomentTokens = (formatSpan: string): string =>
 /** Converts a Moment.js format string to Luxon format tokens. [literal]
  *  escapes become Luxon 'literal' quotes (single quotes doubled), and token
  *  replacement runs only OUTSIDE literals so literal text containing token
- *  letters ("[Week A]") is preserved verbatim. Do (ordinal day) is mapped
- *  to d (day number) as a best-effort fallback — the ordinal suffix is
- *  lost, so filenames will differ from Obsidian's. Unmapped tokens (dd —
- *  Moment's 2-letter weekday abbreviation) pass through into Luxon's token
- *  grammar and may render differently than Obsidian would — config.ts's
- *  probe-render rejects only structurally unsafe results. */
+ *  letters ("[Week A]") is preserved verbatim. Two tokens are unsupported: Do (ordinal day, mapped to d — suffix
+ *  dropped) and dd (2-letter weekday, mapped to ccc — 3-letter). Both
+ *  produce filenames that differ from Obsidian's, so getDailyNotePath
+ *  rejects formats containing them before the converter runs. */
 export const momentToLuxonFormat = (momentFormat: string): string => {
   return momentFormat
     .split(MOMENT_ESCAPE_RE)
@@ -76,13 +75,23 @@ export const momentToLuxonFormat = (momentFormat: string): string => {
     .join("")
 }
 
-/** Returns true if the format contains the Moment `Do` (ordinal day) token
- *  outside of [literal] escapes. Do maps to `d` (day number without suffix)
- *  as a best-effort fallback — filenames will differ from Obsidian's. */
-export const hasOrdinalDayToken = (momentFormat: string): boolean =>
-  momentFormat
-    .split(MOMENT_ESCAPE_RE)
-    .some(
-      (segment, segmentIndex) =>
-        segmentIndex % 2 === 0 && segment.includes("Do"),
-    )
+/** Tokens that produce filenames differing from Obsidian's — Do is mapped
+ *  to d (suffix dropped), dd passes through as Luxon's dd (day-of-month,
+ *  not weekday). Neither can match the note Obsidian created. */
+const UNSUPPORTED_TOKEN_SET = new Set(["Do", "dd"])
+
+/** Returns unsupported tokens present in the format string outside of
+ *  [literal] escapes, or an empty array if none. Uses the same regex
+ *  tokenizer as the converter so ddd/dddd don't false-positive on dd. */
+export const findUnsupportedTokens = (momentFormat: string): string[] => {
+  const found = new Set<string>()
+  momentFormat.split(MOMENT_ESCAPE_RE).forEach((segment, segmentIndex) => {
+    if (segmentIndex % 2 === 1) return
+    for (const match of segment.matchAll(MOMENT_TOKEN_RE)) {
+      if (UNSUPPORTED_TOKEN_SET.has(match[0])) {
+        found.add(match[0])
+      }
+    }
+  })
+  return [...found]
+}

--- a/src/vault-mcp/obsidian-markdown/moment-format.ts
+++ b/src/vault-mcp/obsidian-markdown/moment-format.ts
@@ -1,43 +1,68 @@
 /** Moment.js → Luxon format-string conversion — Obsidian stores daily-note
- *  formats in moment tokens; the server renders with Luxon. Pure and
- *  zero-import so config.ts can validate formats without fs/logger deps. */
+ *  formats in moment tokens; the server renders with Luxon. A single-pass
+ *  regex tokenizer replaces tokens longest-first so overlapping families
+ *  (DDDD/DDD/DD/Do/D) resolve without partial-replacement collisions.
+ *  Pure and zero-import so config.ts can validate formats without
+ *  fs/logger deps. */
 
-/** Sorted longest-first to avoid partial replacement collisions
- *  (e.g. YYYY before YY, dddd before ddd). */
+/** Sorted longest-first so the regex alternation tries longer tokens before
+ *  shorter prefixes at each position (e.g. DDDD before DDD before DD
+ *  before Do before D). */
 const MOMENT_TO_LUXON: ReadonlyArray<readonly [string, string]> = [
+  // 4-char tokens
   ["YYYY", "yyyy"],
   ["dddd", "cccc"],
   ["MMMM", "MMMM"],
+  ["DDDD", "ooo"], // day of year, zero-padded (001–365)
+  // 3-char tokens
   ["ddd", "ccc"],
   ["MMM", "MMM"],
+  ["DDD", "o"], // day of year, minimum digits (1–365)
+  // 2-char tokens
   ["YY", "yy"],
   ["MM", "MM"],
   ["DD", "dd"],
+  ["Do", "d"], // ordinal day — lossy: suffix ("st","nd","th") dropped
   ["HH", "HH"],
   ["hh", "hh"],
   ["mm", "mm"],
   ["ss", "ss"],
+  // 1-char tokens
+  ["D", "d"], // day of month, no padding (1–31)
+  ["M", "M"], // month number, no padding (1–12) — identity, pinned
   ["A", "a"],
 ]
 
 /** Matches Moment.js [literal] escape groups — e.g. [Daily Note]. */
 const MOMENT_ESCAPE_RE = /\[([^\]]*)\]/g
 
-/** Replaces moment date/time tokens with their Luxon equivalents. */
+/** Regex built from all Moment tokens, longest-first — the regex engine
+ *  tries alternatives in listed order at each position, so longer tokens
+ *  match before shorter prefixes (DDDD before DDD before DD before D). */
+const MOMENT_TOKEN_RE = new RegExp(
+  MOMENT_TO_LUXON.map(([momentToken]) => momentToken).join("|"),
+  "g",
+)
+
+const MOMENT_TOKEN_MAP = new Map(MOMENT_TO_LUXON)
+
+/** Replaces moment date/time tokens with their Luxon equivalents via
+ *  single-pass regex — each position matches the longest token first. */
 const convertMomentTokens = (formatSpan: string): string =>
-  MOMENT_TO_LUXON.reduce(
-    (convertedSpan, [momentToken, luxonToken]) =>
-      convertedSpan.replaceAll(momentToken, luxonToken),
-    formatSpan,
+  formatSpan.replace(
+    MOMENT_TOKEN_RE,
+    (match) => MOMENT_TOKEN_MAP.get(match) ?? match,
   )
 
 /** Converts a Moment.js format string to Luxon format tokens. [literal]
  *  escapes become Luxon 'literal' quotes (single quotes doubled), and token
  *  replacement runs only OUTSIDE literals so literal text containing token
- *  letters ("[Week A]") is preserved verbatim. Moment tokens without a
- *  mapping (Do, dd, DDD) pass through into Luxon's token grammar and may
- *  render differently than Obsidian would — config.ts's probe-render
- *  rejects only structurally unsafe results. */
+ *  letters ("[Week A]") is preserved verbatim. Do (ordinal day) is mapped
+ *  to d (day number) as a best-effort fallback — the ordinal suffix is
+ *  lost, so filenames will differ from Obsidian's. Unmapped tokens (dd —
+ *  Moment's 2-letter weekday abbreviation) pass through into Luxon's token
+ *  grammar and may render differently than Obsidian would — config.ts's
+ *  probe-render rejects only structurally unsafe results. */
 export const momentToLuxonFormat = (momentFormat: string): string => {
   return momentFormat
     .split(MOMENT_ESCAPE_RE)
@@ -54,3 +79,14 @@ export const momentToLuxonFormat = (momentFormat: string): string => {
     })
     .join("")
 }
+
+/** Returns true if the format contains the Moment `Do` (ordinal day) token
+ *  outside of [literal] escapes. Do maps to `d` (day number without suffix)
+ *  as a best-effort fallback — filenames will differ from Obsidian's. */
+export const hasOrdinalDayToken = (momentFormat: string): boolean =>
+  momentFormat
+    .split(MOMENT_ESCAPE_RE)
+    .some(
+      (segment, segmentIndex) =>
+        segmentIndex % 2 === 0 && segment.includes("Do"),
+    )

--- a/src/vault-mcp/obsidian-markdown/moment-format.ts
+++ b/src/vault-mcp/obsidian-markdown/moment-format.ts
@@ -92,8 +92,7 @@ const UNSUPPORTED_PATTERNS: ReadonlyArray<{ pattern: RegExp; token: string }> =
   ]
 
 /** Returns unsupported Moment tokens present in the format string outside
- *  of [literal] escapes, or an empty array if none. Standalone — does not
- *  depend on the supported-token table or its ordering. */
+ *  of [literal] escapes, or an empty array if none. */
 export const findUnsupportedTokens = (momentFormat: string): string[] => {
   // Join with \0 so tokens can't match across segment boundaries
   const formatSegments = momentFormat

--- a/src/vault-mcp/obsidian-markdown/moment-format.ts
+++ b/src/vault-mcp/obsidian-markdown/moment-format.ts
@@ -5,9 +5,7 @@
  *  Pure and zero-import so config.ts can validate formats without
  *  fs/logger deps. */
 
-/** Sorted longest-first so the regex alternation tries longer tokens before
- *  shorter prefixes at each position (e.g. DDDD before DDD before DD
- *  before Do before D). */
+/** Moment token → Luxon token pairs, ordered longest-first. */
 const MOMENT_TO_LUXON: ReadonlyArray<readonly [string, string]> = [
   // 4-char tokens
   ["YYYY", "yyyy"],
@@ -36,9 +34,8 @@ const MOMENT_TO_LUXON: ReadonlyArray<readonly [string, string]> = [
 /** Matches Moment.js [literal] escape groups — e.g. [Daily Note]. */
 const MOMENT_ESCAPE_RE = /\[([^\]]*)\]/g
 
-/** Regex built from all Moment tokens, longest-first — the regex engine
- *  tries alternatives in listed order at each position, so longer tokens
- *  match before shorter prefixes (DDDD before DDD before DD before D). */
+/** Matches any known Moment token — alternation order is longest-first
+ *  (from MOMENT_TO_LUXON). */
 const MOMENT_TOKEN_RE = new RegExp(
   MOMENT_TO_LUXON.map(([momentToken]) => momentToken).join("|"),
   "g",
@@ -46,8 +43,7 @@ const MOMENT_TOKEN_RE = new RegExp(
 
 const MOMENT_TOKEN_MAP = new Map(MOMENT_TO_LUXON)
 
-/** Replaces moment date/time tokens with their Luxon equivalents via
- *  single-pass regex — each position matches the longest token first. */
+/** Replaces Moment tokens with their Luxon equivalents in a single pass. */
 const convertMomentTokens = (formatSpan: string): string =>
   formatSpan.replace(
     MOMENT_TOKEN_RE,

--- a/src/vault-mcp/obsidian-markdown/moment-format.ts
+++ b/src/vault-mcp/obsidian-markdown/moment-format.ts
@@ -76,8 +76,8 @@ export const momentToLuxonFormat = (momentFormat: string): string => {
 }
 
 /** Tokens that produce filenames differing from Obsidian's — Do is mapped
- *  to d (suffix dropped), dd passes through as Luxon's dd (day-of-month,
- *  not weekday). Neither can match the note Obsidian created. */
+ *  to d (suffix dropped), dd is mapped to ccc (3-letter weekday instead of
+ *  Moment's 2-letter). Neither can match the note Obsidian created. */
 const UNSUPPORTED_TOKEN_SET = new Set(["Do", "dd"])
 
 /** Returns unsupported tokens present in the format string outside of

--- a/src/vault-mcp/obsidian-markdown/moment-format.ts
+++ b/src/vault-mcp/obsidian-markdown/moment-format.ts
@@ -1,9 +1,9 @@
 /** Moment.js → Luxon format-string conversion — Obsidian stores daily-note
  *  formats in moment tokens; the server renders with Luxon. A single-pass
  *  regex tokenizer replaces tokens longest-first so overlapping families
- *  (DDDD/DDD/DD/D) resolve without partial-replacement collisions.
- *  Pure and zero-import so config.ts can validate formats without
- *  fs/logger deps. */
+ *  (DDDD/DDD/DD/D) resolve without partial-replacement collisions. Pure
+ *  and zero-import so config.ts can validate formats without fs/logger
+ *  deps. */
 
 /** Moment token → Luxon token pairs, ordered longest-first. */
 const MOMENT_TO_LUXON: ReadonlyArray<readonly [string, string]> = [

--- a/src/vault-mcp/obsidian-markdown/moment-format.ts
+++ b/src/vault-mcp/obsidian-markdown/moment-format.ts
@@ -1,7 +1,7 @@
 /** Moment.js → Luxon format-string conversion — Obsidian stores daily-note
  *  formats in moment tokens; the server renders with Luxon. A single-pass
  *  regex tokenizer replaces tokens longest-first so overlapping families
- *  (DDDD/DDD/DD/Do/D) resolve without partial-replacement collisions.
+ *  (DDDD/DDD/DD/D) resolve without partial-replacement collisions.
  *  Pure and zero-import so config.ts can validate formats without
  *  fs/logger deps. */
 
@@ -20,8 +20,6 @@ const MOMENT_TO_LUXON: ReadonlyArray<readonly [string, string]> = [
   ["YY", "yy"],
   ["MM", "MM"],
   ["DD", "dd"],
-  ["Do", "d"], // ordinal day — lossy: suffix ("st","nd","th") dropped
-  ["dd", "ccc"], // 2-letter weekday — no Luxon equivalent; mapped to 3-letter as closest
   ["HH", "HH"],
   ["hh", "hh"],
   ["mm", "mm"],
@@ -54,10 +52,9 @@ const convertMomentTokens = (formatSpan: string): string =>
 /** Converts a Moment.js format string to Luxon format tokens. [literal]
  *  escapes become Luxon 'literal' quotes (single quotes doubled), and token
  *  replacement runs only OUTSIDE literals so literal text containing token
- *  letters ("[Week A]") is preserved verbatim. Two tokens are unsupported: Do (ordinal day, mapped to d — suffix
- *  dropped) and dd (2-letter weekday, mapped to ccc — 3-letter). Both
- *  produce filenames that differ from Obsidian's, so getDailyNotePath
- *  rejects formats containing them before the converter runs. */
+ *  letters ("[Week A]") is preserved verbatim. Two Moment tokens have no
+ *  Luxon equivalent — Do (ordinal day) and dd (2-letter weekday) — and are
+ *  rejected by getDailyNotePath before the converter runs. */
 export const momentToLuxonFormat = (momentFormat: string): string => {
   return momentFormat
     .split(MOMENT_ESCAPE_RE)
@@ -75,23 +72,42 @@ export const momentToLuxonFormat = (momentFormat: string): string => {
     .join("")
 }
 
-/** Tokens that produce filenames differing from Obsidian's — Do is mapped
- *  to d (suffix dropped), dd is mapped to ccc (3-letter weekday instead of
- *  Moment's 2-letter). Neither can match the note Obsidian created. */
-const UNSUPPORTED_TOKEN_SET = new Set(["Do", "dd"])
+/** Moment tokens with no Luxon equivalent. Each entry is a standalone
+ *  regex pattern with boundary guards so it doesn't false-positive inside
+ *  a supported token (e.g. dd inside ddd, D inside DD, L inside LL).
+ *  Boundary guards use lookahead/lookbehind for the same letter family. */
+const UNSUPPORTED_PATTERNS: ReadonlyArray<{ pattern: RegExp; token: string }> =
+  [
+    { pattern: /DDDo/, token: "DDDo" },
+    { pattern: /(?<!D)Do/, token: "Do" },
+    { pattern: /Mo/, token: "Mo" },
+    { pattern: /wo/, token: "wo" },
+    { pattern: /(?<!d)dd(?!d)/, token: "dd" },
+    { pattern: /(?<!d)d(?!d)/, token: "d" },
+    { pattern: /(?<![A-Za-z])e(?![A-Za-z])/, token: "e" },
+    { pattern: /(?<!k)kk(?!k)/, token: "kk" },
+    { pattern: /(?<!k)k(?!k)/, token: "k" },
+    { pattern: /LLLL/, token: "LLLL" },
+    { pattern: /(?<!L)LLL(?!L)/, token: "LLL" },
+    { pattern: /(?<!L)LL(?!L)/, token: "LL" },
+    { pattern: /(?<!L)L(?![LT])/, token: "L" },
+    { pattern: /LTS/, token: "LTS" },
+    { pattern: /(?<!L)LT(?!S)/, token: "LT" },
+  ]
 
-/** Returns unsupported tokens present in the format string outside of
- *  [literal] escapes, or an empty array if none. Uses the same regex
- *  tokenizer as the converter so ddd/dddd don't false-positive on dd. */
+/** Returns unsupported Moment tokens present in the format string outside
+ *  of [literal] escapes, or an empty array if none. Standalone — does not
+ *  depend on the supported-token table or its ordering. */
 export const findUnsupportedTokens = (momentFormat: string): string[] => {
+  const formatSegments = momentFormat
+    .split(MOMENT_ESCAPE_RE)
+    .filter((_, segmentIndex) => segmentIndex % 2 === 0)
+    .join("\0")
   const found = new Set<string>()
-  momentFormat.split(MOMENT_ESCAPE_RE).forEach((segment, segmentIndex) => {
-    if (segmentIndex % 2 === 1) return
-    for (const match of segment.matchAll(MOMENT_TOKEN_RE)) {
-      if (UNSUPPORTED_TOKEN_SET.has(match[0])) {
-        found.add(match[0])
-      }
+  for (const { pattern, token } of UNSUPPORTED_PATTERNS) {
+    if (pattern.test(formatSegments)) {
+      found.add(token)
     }
-  })
+  }
   return [...found]
 }

--- a/src/vault-mcp/obsidian-markdown/moment-format.ts
+++ b/src/vault-mcp/obsidian-markdown/moment-format.ts
@@ -1,9 +1,5 @@
 /** Moment.js → Luxon format-string conversion — Obsidian stores daily-note
- *  formats in moment tokens; the server renders with Luxon. A single-pass
- *  regex tokenizer replaces tokens longest-first so overlapping families
- *  (DDDD/DDD/DD/D) resolve without partial-replacement collisions. Pure
- *  and zero-import so config.ts can validate formats without fs/logger
- *  deps. */
+ *  formats in Moment tokens; the server renders with Luxon. */
 
 /** Moment token → Luxon token pairs, ordered longest-first. */
 const MOMENT_TO_LUXON: ReadonlyArray<readonly [string, string]> = [

--- a/src/vault-mcp/obsidian-markdown/moment-format.ts
+++ b/src/vault-mcp/obsidian-markdown/moment-format.ts
@@ -89,6 +89,10 @@ const UNSUPPORTED_PATTERNS: ReadonlyArray<{ pattern: RegExp; token: string }> =
     { pattern: /(?<!L)L(?![LT])/, token: "L" },
     { pattern: /LTS/, token: "LTS" },
     { pattern: /(?<!L)LT(?!S)/, token: "LT" },
+    { pattern: /(?<!Z)ZZ/, token: "ZZ" },
+    { pattern: /(?<!Z)Z(?!Z)/, token: "Z" },
+    { pattern: /(?<![A-Za-z])Q(?![A-Za-z])/, token: "Q" },
+    { pattern: /(?<![A-Za-z])w(?![A-Za-z])/, token: "w" },
   ]
 
 /** Returns unsupported Moment tokens present in the format string outside

--- a/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
@@ -128,6 +128,26 @@ describe("readDailyNotesConfig", () => {
     expect(afterFix).toEqual({ folder: "Journal", format: "DD-MM-YYYY" })
   })
 
+  it("warns when daily-notes.json format contains Do (ordinal day)", async () => {
+    const loggerModule = await import("../../../logger.js")
+    const warnSpy = vi
+      .spyOn(loggerModule.logger, "warn")
+      .mockImplementation(() => {})
+    const { readDailyNotesConfig } = await import("../daily-notes.js")
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Journal", format: "MMMM Do, YYYY" }),
+      "utf8",
+    )
+    const config = await readDailyNotesConfig(vaultDir)
+    expect(config).toEqual({ folder: "Journal", format: "MMMM Do, YYYY" })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      "daily-notes.json format contains Do (ordinal day) — the server will use the day number without suffix, so filenames will differ from Obsidian's",
+    )
+    warnSpy.mockRestore()
+  })
+
   describe("overrides precedence", () => {
     it("folder-only override wins over the file's folder, file keeps format", async () => {
       const { readDailyNotesConfig } = await import("../daily-notes.js")

--- a/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-  vi,
-  onTestFinished,
-} from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { DateTime } from "luxon"
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { join } from "node:path"
@@ -134,45 +126,6 @@ describe("readDailyNotesConfig", () => {
     )
     const afterFix = await readDailyNotesConfig(vaultDir)
     expect(afterFix).toEqual({ folder: "Journal", format: "DD-MM-YYYY" })
-  })
-
-  it("warns once when daily-notes.json format contains unsupported tokens", async () => {
-    const loggerModule = await import("../../../logger.js")
-    const warnSpy = vi
-      .spyOn(loggerModule.logger, "warn")
-      .mockImplementation(() => {})
-    onTestFinished(() => warnSpy.mockRestore())
-    const { readDailyNotesConfig } = await import("../daily-notes.js")
-    await writeFile(
-      join(vaultDir, ".obsidian", "daily-notes.json"),
-      JSON.stringify({ folder: "Journal", format: "MMMM Do, YYYY" }),
-      "utf8",
-    )
-    const config = await readDailyNotesConfig(vaultDir)
-    expect(config).toEqual({ folder: "Journal", format: "MMMM Do, YYYY" })
-    expect(warnSpy).toHaveBeenCalledTimes(1)
-    expect(warnSpy).toHaveBeenCalledWith(
-      "daily note format contains unsupported token(s): Do — daily note lookups will fail until the format is changed",
-    )
-  })
-
-  it("does not warn about unsupported tokens when env format overrides", async () => {
-    const loggerModule = await import("../../../logger.js")
-    const warnSpy = vi
-      .spyOn(loggerModule.logger, "warn")
-      .mockImplementation(() => {})
-    onTestFinished(() => warnSpy.mockRestore())
-    const { readDailyNotesConfig } = await import("../daily-notes.js")
-    await writeFile(
-      join(vaultDir, ".obsidian", "daily-notes.json"),
-      JSON.stringify({ folder: "Journal", format: "MMMM Do, YYYY" }),
-      "utf8",
-    )
-    const config = await readDailyNotesConfig(vaultDir, {
-      format: "YYYY-MM-DD",
-    })
-    expect(config).toEqual({ folder: "Journal", format: "YYYY-MM-DD" })
-    expect(warnSpy).not.toHaveBeenCalled()
   })
 
   describe("overrides precedence", () => {

--- a/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
@@ -136,7 +136,7 @@ describe("readDailyNotesConfig", () => {
     expect(afterFix).toEqual({ folder: "Journal", format: "DD-MM-YYYY" })
   })
 
-  it("warns when daily-notes.json format contains Do (ordinal day)", async () => {
+  it("warns once when daily-notes.json format contains unsupported tokens", async () => {
     const loggerModule = await import("../../../logger.js")
     const warnSpy = vi
       .spyOn(loggerModule.logger, "warn")
@@ -152,11 +152,11 @@ describe("readDailyNotesConfig", () => {
     expect(config).toEqual({ folder: "Journal", format: "MMMM Do, YYYY" })
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(warnSpy).toHaveBeenCalledWith(
-      "daily-notes.json format contains Do (ordinal day) — the server will use the day number without suffix, so filenames will differ from Obsidian's",
+      "daily note format contains unsupported token(s): Do — daily note lookups will fail until the format is changed",
     )
   })
 
-  it("does not warn about Do in daily-notes.json when env format overrides it", async () => {
+  it("does not warn about unsupported tokens when env format overrides", async () => {
     const loggerModule = await import("../../../logger.js")
     const warnSpy = vi
       .spyOn(loggerModule.logger, "warn")
@@ -335,6 +335,30 @@ describe("getDailyNotePath", () => {
     await expect(
       getDailyNotePath({ vaultPath: vaultDir, date: "2026-05-13T14:30:00Z" }),
     ).rejects.toThrow("invalid date")
+  })
+
+  it("rejects a format containing unsupported tokens (Do)", async () => {
+    const { getDailyNotePath } = await import("../daily-notes.js")
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Journal", format: "MMMM Do, YYYY" }),
+      "utf8",
+    )
+    await expect(
+      getDailyNotePath({ vaultPath: vaultDir, date: "2026-05-13" }),
+    ).rejects.toThrow("unsupported token(s): Do")
+  })
+
+  it("rejects a format containing unsupported tokens (dd)", async () => {
+    const { getDailyNotePath } = await import("../daily-notes.js")
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Journal", format: "YYYY-MM-DD dd" }),
+      "utf8",
+    )
+    await expect(
+      getDailyNotePath({ vaultPath: vaultDir, date: "2026-05-13" }),
+    ).rejects.toThrow("unsupported token(s): dd")
   })
 })
 

--- a/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
@@ -148,6 +148,25 @@ describe("readDailyNotesConfig", () => {
     warnSpy.mockRestore()
   })
 
+  it("does not warn about Do in daily-notes.json when env format overrides it", async () => {
+    const loggerModule = await import("../../../logger.js")
+    const warnSpy = vi
+      .spyOn(loggerModule.logger, "warn")
+      .mockImplementation(() => {})
+    const { readDailyNotesConfig } = await import("../daily-notes.js")
+    await writeFile(
+      join(vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Journal", format: "MMMM Do, YYYY" }),
+      "utf8",
+    )
+    const config = await readDailyNotesConfig(vaultDir, {
+      format: "YYYY-MM-DD",
+    })
+    expect(config).toEqual({ folder: "Journal", format: "YYYY-MM-DD" })
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
   describe("overrides precedence", () => {
     it("folder-only override wins over the file's folder, file keeps format", async () => {
       const { readDailyNotesConfig } = await import("../daily-notes.js")

--- a/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/daily-notes.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  onTestFinished,
+} from "vitest"
 import { DateTime } from "luxon"
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { join } from "node:path"
@@ -133,6 +141,7 @@ describe("readDailyNotesConfig", () => {
     const warnSpy = vi
       .spyOn(loggerModule.logger, "warn")
       .mockImplementation(() => {})
+    onTestFinished(() => warnSpy.mockRestore())
     const { readDailyNotesConfig } = await import("../daily-notes.js")
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
@@ -145,7 +154,6 @@ describe("readDailyNotesConfig", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       "daily-notes.json format contains Do (ordinal day) — the server will use the day number without suffix, so filenames will differ from Obsidian's",
     )
-    warnSpy.mockRestore()
   })
 
   it("does not warn about Do in daily-notes.json when env format overrides it", async () => {
@@ -153,6 +161,7 @@ describe("readDailyNotesConfig", () => {
     const warnSpy = vi
       .spyOn(loggerModule.logger, "warn")
       .mockImplementation(() => {})
+    onTestFinished(() => warnSpy.mockRestore())
     const { readDailyNotesConfig } = await import("../daily-notes.js")
     await writeFile(
       join(vaultDir, ".obsidian", "daily-notes.json"),
@@ -164,7 +173,6 @@ describe("readDailyNotesConfig", () => {
     })
     expect(config).toEqual({ folder: "Journal", format: "YYYY-MM-DD" })
     expect(warnSpy).not.toHaveBeenCalled()
-    warnSpy.mockRestore()
   })
 
   describe("overrides precedence", () => {

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -3,7 +3,10 @@ import { join } from "node:path"
 import { DateTime } from "luxon"
 import { logger, type Logger } from "../../logger.js"
 import { vaultFs } from "./vault-filesystem.js"
-import { momentToLuxonFormat } from "../obsidian-markdown/moment-format.js"
+import {
+  momentToLuxonFormat,
+  hasOrdinalDayToken,
+} from "../obsidian-markdown/moment-format.js"
 import { describeError } from "../../utils/describe-error.js"
 import { isErrnoException } from "../../utils/is-errno-exception.js"
 
@@ -61,6 +64,11 @@ const readDailyNotesFileConfig = async (
         parsedConfig.format.length > 0
           ? parsedConfig.format
           : FALLBACK_CONFIG.format,
+    }
+    if (hasOrdinalDayToken(fileConfig.format)) {
+      logger.warn(
+        "daily-notes.json format contains Do (ordinal day) — the server will use the day number without suffix, so filenames will differ from Obsidian's",
+      )
     }
     cachedFileConfig = fileConfig
     return fileConfig

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -5,7 +5,7 @@ import { logger, type Logger } from "../../logger.js"
 import { vaultFs } from "./vault-filesystem.js"
 import {
   momentToLuxonFormat,
-  hasOrdinalDayToken,
+  findUnsupportedTokens,
 } from "../obsidian-markdown/moment-format.js"
 import { describeError } from "../../utils/describe-error.js"
 import { isErrnoException } from "../../utils/is-errno-exception.js"
@@ -38,9 +38,9 @@ const FALLBACK_CONFIG: DailyNotesConfig = {
 // remote deploy the config file can arrive after boot (initial sync still
 // running), and retrying each call picks it up without a restart.
 let cachedFileConfig: DailyNotesConfig | null = null
-// Tracks whether the Do ordinal warning has already been emitted — the
-// warning is meaningful once (the format doesn't change at runtime).
-let ordinalDayWarningEmitted = false
+// Tracks whether the unsupported-token warning has already been emitted —
+// the format doesn't change at runtime, so one warning suffices.
+let unsupportedTokenWarningEmitted = false
 
 /** Reads .obsidian/daily-notes.json, caching only successful reads.
  *  Returns the fallback config (uncached — see cache comment) when the
@@ -94,17 +94,17 @@ export const readDailyNotesConfig = async (
   }
 
   const fileConfig = await readDailyNotesFileConfig(vaultPath)
-  // Warn about Do only when the file format is the effective format —
-  // an env override makes the file's Do irrelevant.
-  if (
-    !ordinalDayWarningEmitted &&
-    !envSettings?.format &&
-    hasOrdinalDayToken(fileConfig.format)
-  ) {
-    logger.warn(
-      "daily-notes.json format contains Do (ordinal day) — the server will use the day number without suffix, so filenames will differ from Obsidian's",
-    )
-    ordinalDayWarningEmitted = true
+  const effectiveFormat = envSettings?.format ?? fileConfig.format
+  // Warn once in server logs — the throw in getDailyNotePath surfaces
+  // the error to MCP clients, but the log gives the operator visibility.
+  if (!unsupportedTokenWarningEmitted) {
+    const unsupportedTokens = findUnsupportedTokens(effectiveFormat)
+    if (unsupportedTokens.length > 0) {
+      logger.warn(
+        `daily note format contains unsupported token(s): ${unsupportedTokens.join(", ")} — daily note lookups will fail until the format is changed`,
+      )
+      unsupportedTokenWarningEmitted = true
+    }
   }
   return {
     folder: envSettings?.folder ?? fileConfig.folder,
@@ -127,6 +127,14 @@ export const getDailyNotePath = async (params: {
 }): Promise<string> => {
   const { vaultPath, date, envSettings } = params
   const config = await readDailyNotesConfig(vaultPath, envSettings)
+
+  const unsupportedTokens = findUnsupportedTokens(config.format)
+  if (unsupportedTokens.length > 0) {
+    throw new Error(
+      `daily note format contains unsupported token(s): ${unsupportedTokens.join(", ")} — Luxon cannot reproduce what Obsidian writes, so the server would never find the note; change the format in Obsidian or set DAILY_NOTES_FORMAT to a supported format`,
+    )
+  }
+
   const luxonFormat = momentToLuxonFormat(config.format)
 
   if (date && !STRICT_ISO_DATE_RE.test(date)) {

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -65,11 +65,6 @@ const readDailyNotesFileConfig = async (
           ? parsedConfig.format
           : FALLBACK_CONFIG.format,
     }
-    if (hasOrdinalDayToken(fileConfig.format)) {
-      logger.warn(
-        "daily-notes.json format contains Do (ordinal day) — the server will use the day number without suffix, so filenames will differ from Obsidian's",
-      )
-    }
     cachedFileConfig = fileConfig
     return fileConfig
   } catch (error) {
@@ -96,6 +91,13 @@ export const readDailyNotesConfig = async (
   }
 
   const fileConfig = await readDailyNotesFileConfig(vaultPath)
+  // Warn about Do only when the file format is the effective format —
+  // an env override makes the file's Do irrelevant.
+  if (!envSettings?.format && hasOrdinalDayToken(fileConfig.format)) {
+    logger.warn(
+      "daily-notes.json format contains Do (ordinal day) — the server will use the day number without suffix, so filenames will differ from Obsidian's",
+    )
+  }
   return {
     folder: envSettings?.folder ?? fileConfig.folder,
     format: envSettings?.format ?? fileConfig.format,

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -38,9 +38,6 @@ const FALLBACK_CONFIG: DailyNotesConfig = {
 // remote deploy the config file can arrive after boot (initial sync still
 // running), and retrying each call picks it up without a restart.
 let cachedFileConfig: DailyNotesConfig | null = null
-// Tracks whether the unsupported-token warning has already been emitted —
-// the format doesn't change at runtime, so one warning suffices.
-let unsupportedTokenWarningEmitted = false
 
 /** Reads .obsidian/daily-notes.json, caching only successful reads.
  *  Returns the fallback config (uncached — see cache comment) when the
@@ -94,18 +91,6 @@ export const readDailyNotesConfig = async (
   }
 
   const fileConfig = await readDailyNotesFileConfig(vaultPath)
-  const effectiveFormat = envSettings?.format ?? fileConfig.format
-  // Warn once in server logs — the throw in getDailyNotePath surfaces
-  // the error to MCP clients, but the log gives the operator visibility.
-  if (!unsupportedTokenWarningEmitted) {
-    const unsupportedTokens = findUnsupportedTokens(effectiveFormat)
-    if (unsupportedTokens.length > 0) {
-      logger.warn(
-        `daily note format contains unsupported token(s): ${unsupportedTokens.join(", ")} — daily note lookups will fail until the format is changed`,
-      )
-      unsupportedTokenWarningEmitted = true
-    }
-  }
   return {
     folder: envSettings?.folder ?? fileConfig.folder,
     format: envSettings?.format ?? fileConfig.format,

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -116,7 +116,7 @@ export const getDailyNotePath = async (params: {
   const unsupportedTokens = findUnsupportedTokens(config.format)
   if (unsupportedTokens.length > 0) {
     throw new Error(
-      `daily note format contains unsupported token(s): ${unsupportedTokens.join(", ")} — Luxon cannot reproduce what Obsidian writes, so the server would never find the note; change the format in Obsidian or set DAILY_NOTES_FORMAT to a supported format`,
+      `daily note format contains unsupported token(s): ${unsupportedTokens.join(", ")} — the server cannot reproduce the filenames Obsidian creates with these tokens; change the format in Obsidian or set DAILY_NOTES_FORMAT to a supported format`,
     )
   }
 

--- a/src/vault-mcp/vault-operations/daily-notes.ts
+++ b/src/vault-mcp/vault-operations/daily-notes.ts
@@ -38,6 +38,9 @@ const FALLBACK_CONFIG: DailyNotesConfig = {
 // remote deploy the config file can arrive after boot (initial sync still
 // running), and retrying each call picks it up without a restart.
 let cachedFileConfig: DailyNotesConfig | null = null
+// Tracks whether the Do ordinal warning has already been emitted — the
+// warning is meaningful once (the format doesn't change at runtime).
+let ordinalDayWarningEmitted = false
 
 /** Reads .obsidian/daily-notes.json, caching only successful reads.
  *  Returns the fallback config (uncached — see cache comment) when the
@@ -93,10 +96,15 @@ export const readDailyNotesConfig = async (
   const fileConfig = await readDailyNotesFileConfig(vaultPath)
   // Warn about Do only when the file format is the effective format —
   // an env override makes the file's Do irrelevant.
-  if (!envSettings?.format && hasOrdinalDayToken(fileConfig.format)) {
+  if (
+    !ordinalDayWarningEmitted &&
+    !envSettings?.format &&
+    hasOrdinalDayToken(fileConfig.format)
+  ) {
     logger.warn(
       "daily-notes.json format contains Do (ordinal day) — the server will use the day number without suffix, so filenames will differ from Obsidian's",
     )
+    ordinalDayWarningEmitted = true
   }
   return {
     folder: envSettings?.folder ?? fileConfig.folder,


### PR DESCRIPTION
## Summary

- Refactors the `momentToLuxonFormat` converter from sequential `reduce`+`replaceAll` to a single-pass regex tokenizer — tries tokens longest-first at each position, cleanly handling overlapping families (`DDDD`/`DDD`/`DD`/`D`) that the sequential approach could not
- Adds 4 new supported token mappings: `D`→`d`, `M`→`M`, `DDD`→`o`, `DDDD`→`ooo`
- Detects and rejects all Moment tokens that have no Luxon equivalent — ordinals (`Do`, `Mo`, `DDDo`, `wo`), `dd` (2-letter weekday), `d` (weekday number), `e`, `k`/`kk`, and the `L`-family localized formats (`L`–`LLLL`, `LT`, `LTS`). These would produce filenames that can never match what Obsidian writes:
  - **Env-var path:** warns at startup in `config.ts` (server keeps running; operator visibility)
  - **Both paths:** throws at `getDailyNotePath` with a clear error visible to MCP clients
- `findUnsupportedTokens` is standalone — uses its own boundary-guarded regex patterns, independent of the converter's token table

## Test plan

- [x] 8 new `momentToLuxonFormat` scenarios (new tokens, D-family/M-family ordering, adjacency)
- [x] 12 `findUnsupportedTokens` tests (ordinals, dd, d, e, k/kk, L-family, literals, ddd/dddd false-positive guard)
- [x] 2 config tests (Do and dd warn at startup)
- [x] 2 `getDailyNotePath` tests (Do and dd throw on path resolution)
- [x] 2 integration tests (server starts with unsupported format + tool call returns error)
- [x] 2 mutations verified (D↔Do ordering swap; DDD removal)
- [x] Full suite: 2790 tests pass
- [x] Manual Luxon probe: all new tokens render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uy4gPHmKzC9qBkTSeytBR