### PR TITLE
fix(search): pin ONNX threads to prevent healthz starvation during bulk embedding

### DIFF
--- a/src/vault-mcp/search/__tests__/embedder.test.ts
+++ b/src/vault-mcp/search/__tests__/embedder.test.ts
@@ -62,6 +62,23 @@ describe("createEmbedder", () => {
       infoSpy.mockRestore()
     })
 
+    it("pins ONNX to single-threaded execution to prevent CPU saturation", async () => {
+      const transformers = await import("@huggingface/transformers")
+      const mockedPipeline = vi.mocked(transformers.pipeline)
+
+      const embedder = await loadEmbedder()
+      await embedder.embedText("trigger load")
+
+      expect(mockedPipeline).toHaveBeenCalledWith(
+        "feature-extraction",
+        "Xenova/bge-small-en-v1.5",
+        {
+          dtype: "q8",
+          session_options: { intraOpNumThreads: 1, interOpNumThreads: 1 },
+        },
+      )
+    })
+
     it("throws a descriptive error when pipeline returns non-Float32Array data", async () => {
       const transformers = await import("@huggingface/transformers")
       const mockedPipeline = vi.mocked(transformers.pipeline)

--- a/src/vault-mcp/search/__tests__/reranker.test.ts
+++ b/src/vault-mcp/search/__tests__/reranker.test.ts
@@ -237,6 +237,24 @@ describe("createReranker", () => {
       })
     })
 
+    it("pins ONNX to single-threaded execution to prevent CPU saturation", async () => {
+      const transformers = await import("@huggingface/transformers")
+      const mockedAutoModel = vi.mocked(
+        transformers.AutoModelForSequenceClassification,
+      )
+
+      const reranker = await loadReranker()
+      await reranker.rerankPairs("trigger load", ["doc"])
+
+      expect(mockedAutoModel.from_pretrained).toHaveBeenCalledWith(
+        "Xenova/ms-marco-MiniLM-L-6-v2",
+        {
+          dtype: "q8",
+          session_options: { intraOpNumThreads: 1, interOpNumThreads: 1 },
+        },
+      )
+    })
+
     it("retries after a model load failure", async () => {
       const transformers = await import("@huggingface/transformers")
       const mockedAutoModel = vi.mocked(

--- a/src/vault-mcp/search/embedder.ts
+++ b/src/vault-mcp/search/embedder.ts
@@ -40,6 +40,10 @@ export const createEmbedder = (logger: Logger) => {
         const { pipeline } = await import("@huggingface/transformers")
         const instance = await pipeline("feature-extraction", MODEL_NAME, {
           dtype: "q8",
+          // Pin ONNX to 1 thread — bge-small-en-v1.5 Q8 is too small for
+          // intra-op parallelism to offset thread dispatch overhead, and the
+          // default (0 = all cores) saturates the CPU on low-vCPU hosts.
+          session_options: { intraOpNumThreads: 1, interOpNumThreads: 1 },
         })
         const elapsedMs = Math.round(performance.now() - startMs)
         logger.info("embedding model loaded", { model: MODEL_NAME, elapsedMs })

--- a/src/vault-mcp/search/reranker.ts
+++ b/src/vault-mcp/search/reranker.ts
@@ -55,6 +55,11 @@ export const createReranker = (logger: Logger) => {
           // pair scoring is robust to reduced precision).
           AutoModelForSequenceClassification.from_pretrained(RERANKER_MODEL, {
             dtype: "q8",
+            // Pin ONNX to 1 thread — ms-marco-MiniLM is scored one pair at
+            // a time and is too small for intra-op parallelism to help.
+            // Explicit pinning prevents CPU saturation on low-vCPU hosts
+            // (the default 0 = all cores).
+            session_options: { intraOpNumThreads: 1, interOpNumThreads: 1 },
           }),
         ])
         const elapsedMs = Math.round(performance.now() - startMs)

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -1970,6 +1970,12 @@ export const createSearchIndex = (
                 error: describeError(err),
               })
             }
+
+            // Yield to the event loop between notes so pending I/O callbacks
+            // (Express healthz, MCP tool handlers) can drain.
+            await new Promise<void>((resolve) => {
+              setImmediate(resolve)
+            })
           }
           logger.info("embedding pass complete", {
             notes: notesForEmbedding.length,

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -4,6 +4,7 @@ import * as sqliteVec from "sqlite-vec"
 import { readFile, readdir, stat } from "node:fs/promises"
 import type { Dirent } from "node:fs"
 import { join, basename, posix, relative, resolve } from "node:path"
+import { setImmediate as setImmediateAsync } from "node:timers/promises"
 import type { Logger } from "../../logger.js"
 import { parseNote } from "../obsidian-markdown/frontmatter.js"
 import { parseLeadingCallout } from "../obsidian-markdown/callouts.js"
@@ -1973,9 +1974,7 @@ export const createSearchIndex = (
 
             // Yield to the event loop between notes so pending I/O callbacks
             // (Express healthz, MCP tool handlers) can drain.
-            await new Promise<void>((resolve) => {
-              setImmediate(resolve)
-            })
+            await setImmediateAsync()
           }
           logger.info("embedding pass complete", {
             notes: notesForEmbedding.length,


### PR DESCRIPTION
## Summary

- Pin ONNX Runtime `intraOpNumThreads` and `interOpNumThreads` to 1 on both the embedder (bge-small-en-v1.5) and reranker (ms-marco-MiniLM) via `session_options`
- Add a `setImmediate` yield between notes in the rebuild embedding loop

## Problem

On a 2-vCPU Lightsail instance, a ~1,500-file sync burst causes the ONNX embedding pipeline to saturate both cores for 30+ minutes. During that window `/healthz` times out (5s Docker health check), the container flips unhealthy, and tool calls hit ~27s latency from event-loop starvation.

**Root cause:** ONNX Runtime defaults `intraOpNumThreads` to 0 (all available cores). On 2 vCPUs, each inference spawns 2 ONNX-internal threads plus 1 libuv worker = 3 threads competing for 2 cores, leaving nothing for Node.js. Compounded by the rebuild loop embedding ~1,500 notes back-to-back with no event-loop yielding.

## Design

**Thread pinning:** Both models (bge-small-en-v1.5 Q8, ms-marco-MiniLM Q8) are below the threshold where intra-op parallelism offsets thread dispatch overhead — single-text inference on <512-token inputs gains nothing from a second thread. No throughput cost; production logs confirm tool writes are 4–31ms during write-heavy sessions (embedding runs asynchronously via chokidar, tool handlers never block on ONNX).

**Event-loop yield:** `setImmediate` after each note's embedding in the rebuild loop lets pending I/O callbacks (Express healthz, MCP tool handlers) drain between iterations. Correct over `setTimeout(0)` — `setImmediate` fires after I/O callbacks in Node's event-loop phases.

## Test plan

- [x] All 2,797 tests pass (76 files)
- [x] TypeScript build passes (both configs)
- [ ] Live verification: on next deploy, rebuild during sync burst should show healthz staying responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved background search-index rebuilding so other requests and I/O remain responsive while embeddings are generated.
  * Reduced CPU contention during embedding and reranking by limiting model processing to a single thread.

* **Reliability**
  * Added coverage to verify consistent, resource-efficient model execution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->