### PR TITLE
chore: bump umm-actually to v0.3.9

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -77,7 +77,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@30e2afda3ffadb3e143c502e414ab907e6506b1f # v0.3.7
+      - uses: aliasunder/umm-actually@d110bf4c0e9c50aab5cd2e74da7c9bcf03707465 # v0.3.9
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
## Summary

- Bumps `umm-actually` action pin from `v0.3.7` → `v0.3.9` (`d110bf4c`)
- v0.3.9: application-level AbortController timeout (immune to GC-related timeout failures on Actions runners — nodejs/node#55428)
- v0.3.8: review instruction refresh (6 new rules from upstream skill drift)
- v0.3.7: SDK retry disabled, injectable retry delay, context dedup, conventions section suppression

## Test plan

- [x] SHA verified: `d110bf4c0e9c50aab5cd2e74da7c9bcf03707465` = v0.3.9 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)