### PR TITLE
fix(init): guard against empty-vault deletion storm on partial volume wipe

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -664,13 +664,18 @@ process has spawned. Two mechanisms with distinct jobs:
 - **The longrun dependency gates startup order only.** It does not wait for
   sync health, and a later sync crash restarts just that service, not the
   MCP server.
-- **`init-first-sync` gates vault state.** When it succeeds, the first sync
-  has run to completion before any service starts. When it fails while the
-  memory bootstrap could still overwrite real files (memory layer enabled,
-  memory folder absent), the services refuse to start. On its
-  warn-and-continue branches — memory folder present, memory disabled, or
-  `VAULT_NAME` unset — the server starts with whatever vault state exists
-  while continuous sync keeps retrying.
+- **`init-first-sync` gates vault state.** A pre-sync guard checks for the
+  exact precondition of a deletion storm: a sentinel file on the config
+  volume records that a prior sync completed, and if the vault volume is
+  empty (no visible files — dotfiles like `.obsidian/` excluded), the
+  container refuses to start before any sync attempt. When the guard
+  passes and sync succeeds, the first sync has run to completion before
+  any service starts. When sync fails while the memory bootstrap could
+  still overwrite real files (memory layer enabled, memory folder absent),
+  the services refuse to start. On its warn-and-continue branches —
+  memory folder present, memory disabled, or `VAULT_NAME` unset — the
+  server starts with whatever vault state exists while continuous sync
+  keeps retrying.
 
 On a fresh volume, the gate closes the memory-bootstrap race: either the vault
 already holds the user's real `About Me/` files when the server's bootstrap

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -664,18 +664,17 @@ process has spawned. Two mechanisms with distinct jobs:
 - **The longrun dependency gates startup order only.** It does not wait for
   sync health, and a later sync crash restarts just that service, not the
   MCP server.
-- **`init-first-sync` gates vault state.** A pre-sync guard checks for the
-  exact precondition of a deletion storm: a sentinel file on the config
-  volume records that a prior sync completed, and if the vault volume is
-  empty (no visible files — dotfiles like `.obsidian/` excluded), the
-  container refuses to start before any sync attempt. When the guard
-  passes and sync succeeds, the first sync has run to completion before
-  any service starts. When sync fails while the memory bootstrap could
-  still overwrite real files (memory layer enabled, memory folder absent),
-  the services refuse to start. On its warn-and-continue branches —
-  memory folder present, memory disabled, or `VAULT_NAME` unset — the
-  server starts with whatever vault state exists while continuous sync
-  keeps retrying.
+- **`init-first-sync` gates vault state.** Three outcomes, checked in order:
+  1. **Deletion-storm guard** (before sync runs): a sentinel on the config
+     volume records that a prior sync completed. If the sentinel exists but
+     the vault is empty (no visible files — dotfiles like `.obsidian/`
+     excluded), the container refuses to start.
+  2. **Sync succeeds**: the first sync runs to completion before any service
+     starts. The sentinel is written for subsequent boots.
+  3. **Sync fails**: FATAL when the memory bootstrap could still overwrite
+     real files (memory layer enabled, memory folder absent). Warn-and-continue
+     when the memory folder is present, memory is disabled, or `VAULT_NAME`
+     is unset — the server starts while continuous sync keeps retrying.
 
 On a fresh volume, the gate closes the memory-bootstrap race: either the vault
 already holds the user's real `About Me/` files when the server's bootstrap

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -128,6 +128,11 @@ mechanism-level detail.
 - First-sync gate (remote image): the init chain runs Obsidian Sync to
   completion before the server starts, so memory bootstrap can never race
   an incoming sync
+- Sync-state vault guard (remote image): a sentinel on the config volume
+  tracks prior sync completion — if the vault volume is empty but a prior
+  sync completed, the container refuses to start before any sync attempt,
+  preventing the sync engine from interpreting the empty vault as mass
+  local deletions
 - Memory shrink guard: refuses writes that would remove >50% of a file's
   bytes — defense-in-depth against bugs that would silently erase most of
   a memory file

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -362,7 +362,9 @@ npx vault-cortex@latest down   # set up with the CLI
 docker compose down            # Compose
 
 # Stop and delete all volumes (vault re-syncs on next start; index rebuilds):
-docker compose down -v         # Compose
+docker compose down -v                                                   # Compose
+docker rm -f vault-cortex && docker volume rm vault-cortex_vault_data \
+  vault-cortex_mcp_data vault-cortex_obsidian_config                     # docker run / CLI
 
 # Stop without removing (any setup method; docker start resumes):
 docker stop vault-cortex
@@ -371,7 +373,7 @@ docker stop vault-cortex
 > **Never delete just the vault volume while keeping `obsidian_config`.**
 > The container refuses to start to prevent the sync engine from pushing
 > mass deletions to every connected device. Restore the vault volume, or
-> delete all volumes together (`docker compose down -v`) to start fresh.
+> delete all volumes together to start fresh.
 
 **Set up with the CLI?** Start again any time with
 `npx vault-cortex@latest start` — your saved settings are reused

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -368,6 +368,11 @@ docker compose down -v         # Compose
 docker stop vault-cortex
 ```
 
+> **Never delete just the vault volume while keeping `obsidian_config`.**
+> The sync engine would interpret the empty vault as mass local deletions
+> and push them to every connected device. Delete all volumes together
+> (`docker compose down -v`) or none.
+
 **Set up with the CLI?** Start again any time with
 `npx vault-cortex@latest start` — your saved settings are reused
 ([`down`](../../cli/#down) · [`start`](../../cli/#start) in the CLI

--- a/deploy/remote/README.md
+++ b/deploy/remote/README.md
@@ -369,9 +369,9 @@ docker stop vault-cortex
 ```
 
 > **Never delete just the vault volume while keeping `obsidian_config`.**
-> The sync engine would interpret the empty vault as mass local deletions
-> and push them to every connected device. Delete all volumes together
-> (`docker compose down -v`) or none.
+> The container refuses to start to prevent the sync engine from pushing
+> mass deletions to every connected device. Restore the vault volume, or
+> delete all volumes together (`docker compose down -v`) to start fresh.
 
 **Set up with the CLI?** Start again any time with
 `npx vault-cortex@latest start` — your saved settings are reused

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -4,6 +4,12 @@
 # against a still-empty vault, bootstraps default About Me/ templates, and
 # bidirectional sync pushes them over the user's real memory files (#440).
 #
+# Pre-sync guard: if a prior sync completed (sentinel on the config volume)
+# but the vault is empty, the sync engine would interpret every previously-
+# synced file as a local deletion and push mass deletions upstream (#440
+# incident 2026-08-15). FATAL in this case — the user must restore the vault
+# volume or wipe the config volume to re-register as a fresh device.
+#
 # Failure policy once attempts are exhausted, keyed on whether that clobber
 # is possible — bootstrap writes templates only when the memory layer is
 # enabled AND the memory folder is missing (fresh volume, or partial sync
@@ -20,6 +26,31 @@ set -e
 VAULT_PATH="${VAULT_PATH:-/vault}"
 if ! cd "$VAULT_PATH"; then
   echo "[obsidian-sync] ERROR: Failed to change directory to VAULT_PATH='$VAULT_PATH'." >&2
+  exit 1
+fi
+
+# Sentinel on the config volume: written after the first successful sync,
+# cleared when obsidian_config is wiped (fresh device = no sentinel = safe).
+SYNC_SENTINEL="${HOME}/.config/.vault-synced"
+
+# Pre-sync guard: an empty vault with a prior-sync sentinel means the vault
+# volume was wiped while the config volume (device state) was kept — syncing
+# would push mass deletions. The glob excludes dotfiles, so .obsidian/ alone
+# counts as empty.
+vault_has_visible_files() {
+  for entry in "$VAULT_PATH"/*; do
+    [ -e "$entry" ] && return 0
+  done
+  return 1
+}
+
+if [ -f "$SYNC_SENTINEL" ] && ! vault_has_visible_files; then
+  echo "[obsidian-sync] ERROR: The vault is empty but this device has previously synced." >&2
+  echo "[obsidian-sync] Starting sync in this state would cause the sync engine to interpret" >&2
+  echo "[obsidian-sync] every previously-synced file as a local deletion, pushing mass" >&2
+  echo "[obsidian-sync] deletions to all connected devices." >&2
+  echo "[obsidian-sync] To restore the vault: re-attach the vault volume or restore from backup." >&2
+  echo "[obsidian-sync] To start fresh: remove the obsidian_config volume (re-registers the device)." >&2
   exit 1
 fi
 
@@ -46,6 +77,7 @@ ATTEMPT=1
 while :; do
   echo "[obsidian-sync] First sync (attempt ${ATTEMPT}/${MAX_ATTEMPTS}) — waiting for completion before starting services..."
   if s6-setuidgid obsidian ob sync; then
+    touch "$SYNC_SENTINEL"
     echo "[obsidian-sync] First sync complete."
     exit 0
   fi

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -356,10 +356,21 @@ describe("init-first-sync gate script", () => {
     expect(existsSync(run.sentinelPath)).toBe(true)
   })
 
-  it("does not write the sentinel file when sync fails", () => {
+  it("does not write the sentinel file when sync fails fatally", () => {
     const run = runGateScript({ syncOutcomes: [1], vaultName: "Test" })
 
     expect(run.status).toBe(1)
+    expect(existsSync(run.sentinelPath)).toBe(false)
+  })
+
+  it("does not write the sentinel file when sync fails but services start", () => {
+    const run = runGateScript({
+      syncOutcomes: [1],
+      vaultName: "Test",
+      vaultDirs: ["About Me"],
+    })
+
+    expect(run.status).toBe(0)
     expect(existsSync(run.sentinelPath)).toBe(false)
   })
 

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -1,5 +1,11 @@
 import { spawnSync } from "node:child_process"
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 
@@ -48,6 +54,8 @@ type GateRun = {
   stdout: string
   stderr: string
   syncCalls: number
+  /** Path to the sentinel file for post-run assertions. */
+  sentinelPath: string
 }
 
 type GateRunOptions = {
@@ -60,18 +68,27 @@ type GateRunOptions = {
   vaultDirs?: string[]
   /** When false, VAULT_PATH points at a directory that doesn't exist. */
   vaultExists?: boolean
+  /** When true, pre-creates the .vault-synced sentinel (simulates a prior sync). */
+  sentinel?: boolean
 }
 
 const runGateScript = (options: GateRunOptions): GateRun => {
   const tempDir = mkdtempSync(join(tmpdir(), "init-first-sync-"))
   const stubBinDir = join(tempDir, "bin")
   const vaultPath = join(tempDir, "vault")
+  const homeDir = join(tempDir, "home")
+  const configDir = join(homeDir, ".config")
+  const sentinelPath = join(configDir, ".vault-synced")
   mkdirSync(stubBinDir)
+  mkdirSync(configDir, { recursive: true })
   if (options.vaultExists ?? true) {
     mkdirSync(vaultPath)
   }
   for (const vaultDir of options.vaultDirs ?? []) {
     mkdirSync(join(vaultPath, vaultDir), { recursive: true })
+  }
+  if (options.sentinel) {
+    writeFileSync(sentinelPath, "")
   }
 
   writeFileSync(join(stubBinDir, "ob"), OB_STUB, { mode: 0o755 })
@@ -89,6 +106,7 @@ const runGateScript = (options: GateRunOptions): GateRun => {
     encoding: "utf8",
     env: {
       PATH: `${stubBinDir}:${process.env.PATH ?? ""}`,
+      HOME: homeDir,
       VAULT_PATH: vaultPath,
       OB_CALL_LOG: callLogPath,
       OB_SYNC_OUTCOMES: outcomesPath,
@@ -113,6 +131,7 @@ const runGateScript = (options: GateRunOptions): GateRun => {
     stdout: result.stdout,
     stderr: result.stderr,
     syncCalls,
+    sentinelPath,
   }
 }
 
@@ -276,6 +295,85 @@ describe("init-first-sync gate script", () => {
       "WARNING: First sync did not complete — starting services anyway.",
     )
   })
+
+  // -- Sync-state vault guard (empty vault + prior-sync sentinel) ----------
+
+  it("refuses to sync when the vault is empty but a prior sync completed", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      sentinel: true,
+    })
+
+    expect(run.status).toBe(1)
+    expect(run.syncCalls).toBe(0)
+    expect(run.stderr).toContain(
+      "ERROR: The vault is empty but this device has previously synced.",
+    )
+    expect(run.stderr).toContain("remove the obsidian_config volume")
+  })
+
+  it("refuses when the vault has only hidden entries and a prior sync completed", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      sentinel: true,
+      vaultDirs: [".obsidian"],
+    })
+
+    expect(run.status).toBe(1)
+    expect(run.syncCalls).toBe(0)
+    expect(run.stderr).toContain(
+      "ERROR: The vault is empty but this device has previously synced.",
+    )
+  })
+
+  it("allows sync when the vault has visible files and a prior sync completed", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      sentinel: true,
+      vaultDirs: ["About Me"],
+    })
+
+    expect(run.status).toBe(0)
+    expect(run.syncCalls).toBe(1)
+    expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
+  })
+
+  it("allows sync on a fresh device with an empty vault (no sentinel)", () => {
+    const run = runGateScript({ syncOutcomes: [0], vaultName: "Test" })
+
+    expect(run.status).toBe(0)
+    expect(run.syncCalls).toBe(1)
+    expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
+  })
+
+  it("writes the sentinel file after a successful sync", () => {
+    const run = runGateScript({ syncOutcomes: [0], vaultName: "Test" })
+
+    expect(run.status).toBe(0)
+    expect(existsSync(run.sentinelPath)).toBe(true)
+  })
+
+  it("does not write the sentinel file when sync fails", () => {
+    const run = runGateScript({ syncOutcomes: [1], vaultName: "Test" })
+
+    expect(run.status).toBe(1)
+    expect(existsSync(run.sentinelPath)).toBe(false)
+  })
+
+  it("fires the guard regardless of VAULT_NAME", () => {
+    const run = runGateScript({ syncOutcomes: [0], sentinel: true })
+
+    expect(run.status).toBe(1)
+    expect(run.syncCalls).toBe(0)
+    expect(run.stderr).toContain(
+      "ERROR: The vault is empty but this device has previously synced.",
+    )
+  })
+
+  // -- Drift guard -----------------------------------------------------------
 
   it("matches the server's config defaults for the memory layer", () => {
     // Drift guard: the script hardcodes fallbacks for MEMORY_DIR and


### PR DESCRIPTION
## Summary

- Adds a pre-sync guard in `init-first-sync` that detects the exact precondition for the 2026-08-15 deletion storm: vault volume empty + prior sync state present
- Uses a self-managed sentinel file (`.vault-synced`) on the `obsidian_config` volume — written after each successful sync, checked before the next. Sidesteps any dependency on obsidian-headless's undocumented internal file layout
- Guard fires regardless of `VAULT_NAME` — the deletion hazard depends on prior sync state (the device's file-tracking knowledge), not vault configuration
- Adds a callout warning in `deploy/remote/README.md` about never selectively deleting the vault volume

### How it works

1. After `ob sync` exits 0, `init-first-sync` writes `.vault-synced` to the config volume
2. On the next boot, before `ob sync` runs, the script checks: sentinel exists + vault has no visible files (dotfiles like `.obsidian/` excluded) → fatal exit
3. Wiping `obsidian_config` clears both the sentinel AND the device registration → fresh device → pure download (safe)

### Edge cases covered

| Scenario | Result |
|---|---|
| Fresh boot (all volumes new) | Guard passes → sync → sentinel written |
| Warm restart (all volumes kept) | Guard passes (vault has files) |
| **Vault wiped, config kept** | **Guard fires → FATAL** |
| Both volumes wiped | Guard passes → fresh device |
| Only `.obsidian/` in vault | Guard fires (no visible files) |
| First sync failed (no sentinel) | Guard passes |

## Test plan

- [x] 7 new test cases in `init-first-sync.test.ts` — all pass (21 total)
- [x] Mutation check: disabled the guard → exactly 3 tests fail (the guard tests)
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 76 files, 2806 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a startup safety check that prevents synchronization when a previously synced vault is unexpectedly empty, helping avoid accidental mass deletions across devices.
  * Synchronization now proceeds only after a successful initial sync; safely handled warning conditions preserve the current vault state.

* **Documentation**
  * Documented the new startup protection and recommended volume-management practices to prevent accidental data loss during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->