### PR TITLE
test(integration): error contract tests for documented tool error paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ src/
     integration/                       # End-to-end: SDK Client + StreamableHTTPClientTransport over real HTTP
       test-harness.ts                  #   Server lifecycle (spawn, healthz poll, cleanup) + client factory
       server-integration.test.ts       #   Every tool + prompt exercised per config (default, READONLY, DISABLED_TOOLS, etc.)
-      server-error-contracts.test.ts   #   Documented error paths: exact messages, remediation text
+      server-error-contracts.test.ts   #   Documented error paths verified over real HTTP
       fixtures/vault/                  #   Fixture vault copied to tempdir per server boot
   functions/
     authorizer.ts                      # Lambda: path-aware auth (OAuth pass-through, JWT + static)
@@ -796,12 +796,14 @@ Two naming layers — MCP (JSON wire format) and TypeScript (internal):
 
 - **Note-path tool inputs must end in `.md`.** Inputs naming a single markdown
   note — `path` on read/write/patch/replace/delete/delete_span/update_properties,
-  `old_path`/`new_path` on move, `path` on backlinks/outgoing_links — require the
-  full filename with extension; a bare `Projects/Plan` is rejected. Enforced by
-  the generic `assertPathHasExtension(path, ".md")` util
+  `old_path`/`new_path` on move — require the full filename with extension; a bare
+  `Projects/Plan` is rejected. Enforced by the generic
+  `assertPathHasExtension(path, ".md")` util
   (`src/utils/assert-path-has-extension.ts`), called in the data-layer function
   each tool routes through (one rule, every layer). Folder, glob, and
-  memory-file (`file`) inputs are exempt.
+  memory-file (`file`) inputs are exempt. **Backlinks/outgoing_links accept
+  `.md` or `.canvas`** — both note and canvas paths are valid graph queries
+  (`assertPathHasExtension(path, [".md", ".canvas"])`).
 - **`vault_read_file` is the deliberate inverse.** Its `path` names any
   non-markdown file and **must not** end in `.md` — `vaultFs.readAsset`
   rejects notes so the `.md` boundary stays a single rule with two sides

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ src/
     integration/                       # End-to-end: SDK Client + StreamableHTTPClientTransport over real HTTP
       test-harness.ts                  #   Server lifecycle (spawn, healthz poll, cleanup) + client factory
       server-integration.test.ts       #   Every tool + prompt exercised per config (default, READONLY, DISABLED_TOOLS, etc.)
+      server-error-contracts.test.ts   #   Documented error paths: exact messages, remediation text
       fixtures/vault/                  #   Fixture vault copied to tempdir per server boot
   functions/
     authorizer.ts                      # Lambda: path-aware auth (OAuth pass-through, JWT + static)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -796,14 +796,18 @@ Two naming layers — MCP (JSON wire format) and TypeScript (internal):
 
 - **Note-path tool inputs must end in `.md`.** Inputs naming a single markdown
   note — `path` on read/write/patch/replace/delete/delete_span/update_properties,
-  `old_path`/`new_path` on move — require the full filename with extension; a bare
+  `new_path` on move — require the full filename with extension; a bare
   `Projects/Plan` is rejected. Enforced by the generic
   `assertPathHasExtension(path, ".md")` util
   (`src/utils/assert-path-has-extension.ts`), called in the data-layer function
   each tool routes through (one rule, every layer). Folder, glob, and
   memory-file (`file`) inputs are exempt. **Backlinks/outgoing_links accept
   `.md` or `.canvas`** — both note and canvas paths are valid graph queries
-  (`assertPathHasExtension(path, [".md", ".canvas"])`).
+  (`assertPathHasExtension(path, [".md", ".canvas"])`). **`vault_move_note`'s
+  `old_path`** also accepts `.md` or `.canvas` at the handler boundary — the
+  handler runs a backlinks lookup before the data-layer move, so `old_path`
+  is validated by the wider extension set; the data-layer `.md`-only check
+  runs second.
 - **`vault_read_file` is the deliberate inverse.** Its `path` names any
   non-markdown file and **must not** end in `.md` — `vaultFs.readAsset`
   rejects notes so the `.md` boundary stays a single rule with two sides

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -948,8 +948,8 @@ test.
 - Parser changes (pure, no I/O).
 - Search query changes (`search-index.test.ts` uses a real SQLite DB).
 - Config validation (`config.test.ts` tests `loadConfig` directly).
-- Tool registration/annotation (`tool-definitions.test.ts` with
-  InMemoryTransport covers the registration layer).
+- Tool registration/annotation (`tool-definitions.test.ts` covers
+  the registration layer via a mock server).
 
 **File structure:**
 
@@ -961,10 +961,11 @@ test.
 - `fixtures/vault/` — committed fixture vault; a PR that adds a tool
   also adds fixture data and a test case.
 
-**Splitting thresholds:** consider splitting at ~800 lines / ~60
-tests; must split at ~1,200 lines / ~100 tests. Split along natural
-seams (tool group, config combo, test concern), not arbitrary line
-counts.
+**When to split a test file:** when navigating the file requires
+scrolling past unrelated test groups to find what you need — the
+file has multiple distinct concerns that don't share setup or
+context. Split along concern boundaries (happy path vs error
+contracts, by tool group, by config combo), not arbitrary size.
 
 ## SST conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -922,6 +922,50 @@ createTestIndex()` at the top of each test. `beforeEach` is only
   Actions runs `run:` steps with errexit, so a failing
   `[ test ] && cmd` short-circuit aborts the job; use `if/then/fi`.
 
+### Integration tests — when to add
+
+Integration tests (`src/__tests__/integration/`) boot a real server
+and call tools over real HTTP via the MCP SDK Client. They catch what
+unit tests structurally can't — handler miscalls, config-gated surface
+mismatches, transport-layer bugs. The deciding question: **would this
+bug survive unit tests but break in production?** If the unit test
+already uses real I/O (temp dirs, real SQLite), skip the integration
+test.
+
+**Always add:**
+
+- New tool → happy-path test in `server-integration.test.ts` + fixture
+  data if needed.
+- New error path in a tool's `Errors:` section → test in
+  `server-error-contracts.test.ts` asserting the exact error message.
+- New config gating axis → config matrix test in
+  `server-integration.test.ts` (tool count + key behavior).
+- New prompt → assembly test verifying live vault data, not just the
+  instruction wrapper.
+
+**Never add:**
+
+- Parser changes (pure, no I/O).
+- Search query changes (`search-index.test.ts` uses a real SQLite DB).
+- Config validation (`config.test.ts` tests `loadConfig` directly).
+- Tool registration/annotation (`tool-definitions.test.ts` with
+  InMemoryTransport covers the registration layer).
+
+**File structure:**
+
+- `server-integration.test.ts` — happy paths + config gating (one
+  server per config combo).
+- `server-error-contracts.test.ts` — error paths, default config only
+  (errors are config-independent).
+- `test-harness.ts` — shared server lifecycle + client factory.
+- `fixtures/vault/` — committed fixture vault; a PR that adds a tool
+  also adds fixture data and a test case.
+
+**Splitting thresholds:** consider splitting at ~800 lines / ~60
+tests; must split at ~1,200 lines / ~100 tests. Split along natural
+seams (tool group, config combo, test concern), not arbitrary line
+counts.
+
 ## SST conventions
 
 - Secrets via `sst.Secret`, PascalCase names. Never hardcode.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -939,7 +939,9 @@ test.
 - New tool → happy-path test in `server-integration.test.ts` + fixture
   data if needed.
 - New error path in a tool's `Errors:` section → test in
-  `server-error-contracts.test.ts` asserting the exact error message.
+  `server-error-contracts.test.ts` asserting the distinctive message
+  prefix (include test-controlled variable parts like paths and
+  section names).
 - New config gating axis → config matrix test in
   `server-integration.test.ts` (tool count + key behavior).
 - New prompt → assembly test verifying live vault data, not just the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,25 @@
 
 
 
+
+## [0.37.4] — 2026-08-19
+
+### Bug Fixes
+
+- **init:** Guard against empty-vault deletion storm on partial volume wipe (#458)
+- **logger:** Resolve source locations to .ts via source maps (#459)
+
+### Documentation
+
+- Update CHANGELOG.md for v0.37.3
+
+### Maintenance
+
+- **deps:** Bump the production group with 2 updates (#455)
+- **deps-dev:** Bump puppeteer from 25.6.0 to 25.7.0 in the development group (#456)
+- **deps:** Bump github/codeql-action/upload-sarif from 4.37.6 to 4.37.7 (#457)
+- Add TypeScript 7 via dual-install with npm aliasing (#454)
+
 ## [0.37.3] — 2026-08-18
 
 ### Bug Fixes

--- a/src/__tests__/integration/fixtures/vault/Ambiguous Headings.md
+++ b/src/__tests__/integration/fixtures/vault/Ambiguous Headings.md
@@ -1,0 +1,21 @@
+---
+title: Ambiguous Headings
+type: test-fixture
+tags:
+  - test
+created: 2026-01-15T10:00:00-05:00
+---
+
+# Ambiguous Headings
+
+## Details
+
+First details section content.
+
+## Notes
+
+Some notes here.
+
+## Details
+
+Second details section — same heading text as the first.

--- a/src/__tests__/integration/server-error-contracts.test.ts
+++ b/src/__tests__/integration/server-error-contracts.test.ts
@@ -85,11 +85,47 @@ describe("path traversal blocked", () => {
     expectToolError(result, "path traversal blocked")
   })
 
+  it("vault_replace_in_note rejects path traversal", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_replace_in_note",
+      args: { path: "../outside.md", old_text: "old", new_text: "new" },
+    })
+    expectToolError(result, "path traversal blocked")
+  })
+
+  it("vault_delete_span rejects path traversal", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_delete_span",
+      args: { path: "../outside.md", start_anchor: "anything" },
+    })
+    expectToolError(result, "path traversal blocked")
+  })
+
+  it("vault_update_properties rejects path traversal", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_update_properties",
+      args: { path: "../outside.md", properties: { status: "active" } },
+    })
+    expectToolError(result, "path traversal blocked")
+  })
+
   it("vault_move_note rejects path traversal on old_path", async () => {
     const result = await callTool({
       client,
       name: "vault_move_note",
       args: { old_path: "../escape.md", new_path: "safe.md" },
+    })
+    expectToolError(result, "path traversal blocked")
+  })
+
+  it("vault_move_note rejects path traversal on new_path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_move_note",
+      args: { old_path: "Projects/alpha.md", new_path: "../escape.md" },
     })
     expectToolError(result, "path traversal blocked")
   })
@@ -116,11 +152,69 @@ describe("hidden path blocked", () => {
     expectToolError(result, "hidden path blocked")
   })
 
+  it("vault_patch_note rejects hidden paths", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_patch_note",
+      args: {
+        path: ".hidden/note.md",
+        operation: "append",
+        content: "injected",
+      },
+    })
+    expectToolError(result, "hidden path blocked")
+  })
+
+  it("vault_replace_in_note rejects hidden paths", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_replace_in_note",
+      args: { path: ".hidden/note.md", old_text: "old", new_text: "new" },
+    })
+    expectToolError(result, "hidden path blocked")
+  })
+
   it("vault_delete_note rejects hidden paths", async () => {
     const result = await callTool({
       client,
       name: "vault_delete_note",
       args: { path: ".obsidian/config.md" },
+    })
+    expectToolError(result, "hidden path blocked")
+  })
+
+  it("vault_delete_span rejects hidden paths", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_delete_span",
+      args: { path: ".hidden/note.md", start_anchor: "anything" },
+    })
+    expectToolError(result, "hidden path blocked")
+  })
+
+  it("vault_update_properties rejects hidden paths", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_update_properties",
+      args: { path: ".hidden/note.md", properties: { status: "active" } },
+    })
+    expectToolError(result, "hidden path blocked")
+  })
+
+  it("vault_move_note rejects hidden old_path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_move_note",
+      args: { old_path: ".hidden/note.md", new_path: "visible.md" },
+    })
+    expectToolError(result, "hidden path blocked")
+  })
+
+  it("vault_move_note rejects hidden new_path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_move_note",
+      args: { old_path: "Projects/alpha.md", new_path: ".hidden/moved.md" },
     })
     expectToolError(result, "hidden path blocked")
   })

--- a/src/__tests__/integration/server-error-contracts.test.ts
+++ b/src/__tests__/integration/server-error-contracts.test.ts
@@ -3,29 +3,16 @@
 
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest"
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { startServer, createTestClient, randomPort } from "./test-harness.js"
+import {
+  startServer,
+  createTestClient,
+  randomPort,
+  callTool,
+  textContent,
+} from "./test-harness.js"
+import type { ToolResult } from "./test-harness.js"
 
 vi.setConfig({ testTimeout: 15_000 })
-
-type TextBlock = { type: "text"; text: string }
-type ToolResult = { isError?: boolean; content: TextBlock[] }
-
-const callTool = async ({
-  client,
-  name,
-  args = {},
-}: {
-  client: Client
-  name: string
-  args?: Record<string, unknown>
-}): Promise<ToolResult> =>
-  client.callTool({ name, arguments: args }) as Promise<ToolResult>
-
-const textContent = (result: ToolResult): string =>
-  result.content
-    .filter((block) => block.type === "text")
-    .map((block) => block.text)
-    .join("\n")
 
 const expectToolError = (
   result: ToolResult,

--- a/src/__tests__/integration/server-error-contracts.test.ts
+++ b/src/__tests__/integration/server-error-contracts.test.ts
@@ -385,10 +385,43 @@ describe("path extension errors", () => {
     )
   })
 
+  it("vault_write_note rejects paths without .md extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_write_note",
+      args: { path: "Projects/plan", body: "content" },
+    })
+    expectToolError(result, 'path must end in ".md" (received "Projects/plan")')
+  })
+
+  it("vault_move_note rejects new_path without .md extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_move_note",
+      args: { old_path: "Projects/alpha.md", new_path: "Projects/moved" },
+    })
+    expectToolError(
+      result,
+      'path must end in ".md" (received "Projects/moved")',
+    )
+  })
+
   it("vault_get_backlinks rejects paths without .md or .canvas extension", async () => {
     const result = await callTool({
       client,
       name: "vault_get_backlinks",
+      args: { path: "Projects/alpha" },
+    })
+    expectToolError(
+      result,
+      'path must end in ".md" or ".canvas" (received "Projects/alpha")',
+    )
+  })
+
+  it("vault_get_outgoing_links rejects paths without .md or .canvas extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_get_outgoing_links",
       args: { path: "Projects/alpha" },
     })
     expectToolError(

--- a/src/__tests__/integration/server-error-contracts.test.ts
+++ b/src/__tests__/integration/server-error-contracts.test.ts
@@ -500,6 +500,80 @@ describe("path extension errors", () => {
     )
   })
 
+  it("vault_patch_note rejects paths without .md extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_patch_note",
+      args: { path: "Projects/alpha", operation: "append", content: "text" },
+    })
+    expectToolError(
+      result,
+      'path must end in ".md" (received "Projects/alpha")',
+    )
+  })
+
+  it("vault_replace_in_note rejects paths without .md extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_replace_in_note",
+      args: { path: "Projects/alpha", old_text: "old", new_text: "new" },
+    })
+    expectToolError(
+      result,
+      'path must end in ".md" (received "Projects/alpha")',
+    )
+  })
+
+  it("vault_delete_note rejects paths without .md extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_delete_note",
+      args: { path: "Projects/alpha" },
+    })
+    expectToolError(
+      result,
+      'path must end in ".md" (received "Projects/alpha")',
+    )
+  })
+
+  it("vault_delete_span rejects paths without .md extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_delete_span",
+      args: { path: "Projects/alpha", start_anchor: "anything" },
+    })
+    expectToolError(
+      result,
+      'path must end in ".md" (received "Projects/alpha")',
+    )
+  })
+
+  it("vault_update_properties rejects paths without .md extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_update_properties",
+      args: { path: "Projects/alpha", properties: { status: "active" } },
+    })
+    expectToolError(
+      result,
+      'path must end in ".md" (received "Projects/alpha")',
+    )
+  })
+
+  it("vault_move_note rejects old_path without extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_move_note",
+      args: { old_path: "Projects/alpha", new_path: "Projects/moved.md" },
+    })
+    // old_path is validated by the backlinks lookup that runs before the move,
+    // which accepts .md or .canvas — so the error uses the wider extension set
+    expectToolError(
+      result,
+      'path must end in ".md" or ".canvas" (received "Projects/alpha")',
+    )
+  })
+
   it("vault_get_backlinks rejects paths without .md or .canvas extension", async () => {
     const result = await callTool({
       client,
@@ -522,5 +596,23 @@ describe("path extension errors", () => {
       result,
       'path must end in ".md" or ".canvas" (received "Projects/alpha")',
     )
+  })
+
+  it("vault_get_backlinks accepts .canvas paths", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_get_backlinks",
+      args: { path: "Boards/roadmap.canvas" },
+    })
+    expect(result.isError).not.toBe(true)
+  })
+
+  it("vault_get_outgoing_links accepts .canvas paths", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_get_outgoing_links",
+      args: { path: "Boards/roadmap.canvas" },
+    })
+    expect(result.isError).not.toBe(true)
   })
 })

--- a/src/__tests__/integration/server-error-contracts.test.ts
+++ b/src/__tests__/integration/server-error-contracts.test.ts
@@ -1,0 +1,394 @@
+/** Error contract integration tests — every tool's documented error paths
+ *  verified over real HTTP transport against a real server. */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest"
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { startServer, createTestClient, randomPort } from "./test-harness.js"
+
+vi.setConfig({ testTimeout: 15_000 })
+
+type TextBlock = { type: "text"; text: string }
+type ToolResult = { isError?: boolean; content: TextBlock[] }
+
+const callTool = async ({
+  client,
+  name,
+  args = {},
+}: {
+  client: Client
+  name: string
+  args?: Record<string, unknown>
+}): Promise<ToolResult> =>
+  client.callTool({ name, arguments: args }) as Promise<ToolResult>
+
+const textContent = (result: ToolResult): string =>
+  result.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+
+const expectToolError = (
+  result: ToolResult,
+  expectedSubstring: string,
+): void => {
+  expect(result.isError).toBe(true)
+  expect(textContent(result)).toContain(expectedSubstring)
+}
+
+// ── Single server boot for all error contract tests ──────────
+
+let client: Client
+let cleanup: (() => Promise<void>) | undefined
+
+beforeAll(async () => {
+  const port = randomPort()
+  const server = await startServer(port)
+  cleanup = server.cleanup
+  client = await createTestClient(server.port)
+}, 30_000)
+
+afterAll(async () => {
+  try {
+    if (client) await client.close()
+  } finally {
+    if (cleanup) await cleanup()
+  }
+})
+
+// ── Path traversal ───────────────────────────────────────────
+
+describe("path traversal blocked", () => {
+  it("vault_read_note rejects paths escaping the vault root", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_read_note",
+      args: { path: "../escape.md" },
+    })
+    expectToolError(result, "path traversal blocked")
+  })
+
+  it("vault_write_note rejects path traversal", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_write_note",
+      args: { path: "../../escape.md", body: "malicious" },
+    })
+    expectToolError(result, "path traversal blocked")
+  })
+
+  it("vault_patch_note rejects path traversal", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_patch_note",
+      args: {
+        path: "../outside.md",
+        operation: "append",
+        content: "injected",
+      },
+    })
+    expectToolError(result, "path traversal blocked")
+  })
+
+  it("vault_delete_note rejects path traversal", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_delete_note",
+      args: { path: "../escape.md" },
+    })
+    expectToolError(result, "path traversal blocked")
+  })
+
+  it("vault_move_note rejects path traversal on old_path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_move_note",
+      args: { old_path: "../escape.md", new_path: "safe.md" },
+    })
+    expectToolError(result, "path traversal blocked")
+  })
+})
+
+// ── Hidden paths ─────────────────────────────────────────────
+
+describe("hidden path blocked", () => {
+  it("vault_read_note rejects dot-prefixed paths", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_read_note",
+      args: { path: ".obsidian/plugins.md" },
+    })
+    expectToolError(result, "hidden path blocked")
+  })
+
+  it("vault_write_note rejects hidden paths", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_write_note",
+      args: { path: ".hidden/secret.md", body: "hidden content" },
+    })
+    expectToolError(result, "hidden path blocked")
+  })
+
+  it("vault_delete_note rejects hidden paths", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_delete_note",
+      args: { path: ".obsidian/config.md" },
+    })
+    expectToolError(result, "hidden path blocked")
+  })
+})
+
+// ── Note not found ───────────────────────────────────────────
+
+describe("note not found", () => {
+  it("vault_read_note for a nonexistent path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_read_note",
+      args: { path: "does-not-exist.md" },
+    })
+    expectToolError(result, 'note not found: "does-not-exist.md"')
+  })
+
+  it("vault_patch_note for a nonexistent path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_patch_note",
+      args: {
+        path: "ghost.md",
+        operation: "append",
+        content: "appended",
+      },
+    })
+    expectToolError(result, 'note not found: "ghost.md"')
+  })
+
+  it("vault_replace_in_note for a nonexistent path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_replace_in_note",
+      args: {
+        path: "missing.md",
+        old_text: "old",
+        new_text: "new",
+      },
+    })
+    expectToolError(result, 'note not found: "missing.md"')
+  })
+
+  it("vault_delete_note for a nonexistent path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_delete_note",
+      args: { path: "nonexistent.md" },
+    })
+    expectToolError(result, 'note not found: "nonexistent.md"')
+  })
+
+  it("vault_update_properties for a nonexistent path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_update_properties",
+      args: { path: "nope.md", properties: { status: "active" } },
+    })
+    expectToolError(result, 'note not found: "nope.md"')
+  })
+
+  it("vault_delete_span for a nonexistent path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_delete_span",
+      args: { path: "gone.md", start_anchor: "anything" },
+    })
+    expectToolError(result, 'note not found: "gone.md"')
+  })
+})
+
+// ── Note already exists ──────────────────────────────────────
+
+describe("note already exists", () => {
+  it("vault_write_note without overwrite rejects existing path", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_write_note",
+      args: { path: "Projects/alpha.md", body: "overwrite attempt" },
+    })
+    expectToolError(result, 'note already exists: "Projects/alpha.md"')
+  })
+})
+
+// ── Heading not found ────────────────────────────────────────
+
+describe("heading not found", () => {
+  it("vault_read_note with a nonexistent heading", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_read_note",
+      args: { path: "Projects/alpha.md", heading: "Nonexistent Section" },
+    })
+    expectToolError(result, 'heading not found: "Nonexistent Section"')
+  })
+
+  it("vault_patch_note replace with a nonexistent heading", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_patch_note",
+      args: {
+        path: "Projects/alpha.md",
+        operation: "replace",
+        heading: "No Such Heading",
+        content: "replaced content",
+      },
+    })
+    expectToolError(result, 'heading not found: "No Such Heading"')
+  })
+})
+
+// ── Ambiguous heading ────────────────────────────────────────
+
+describe("ambiguous heading", () => {
+  it("vault_read_note with a heading that matches multiple sections", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_read_note",
+      args: { path: "Ambiguous Headings.md", heading: "Details" },
+    })
+    expectToolError(result, 'ambiguous heading: "Details"')
+  })
+
+  it("vault_patch_note with an ambiguous heading", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_patch_note",
+      args: {
+        path: "Ambiguous Headings.md",
+        operation: "append",
+        heading: "Details",
+        content: "which one?",
+      },
+    })
+    expectToolError(result, 'ambiguous heading: "Details"')
+  })
+})
+
+// ── Text not found ───────────────────────────────────────────
+
+describe("text not found", () => {
+  it("vault_replace_in_note with text that does not appear in the note", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_replace_in_note",
+      args: {
+        path: "Projects/alpha.md",
+        old_text: "this text does not exist in the note",
+        new_text: "replacement",
+      },
+    })
+    expectToolError(result, "text not found")
+  })
+})
+
+// ── Anchor not found / ambiguous ─────────────────────────────
+
+describe("anchor errors", () => {
+  it("vault_delete_span with a nonexistent anchor", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_delete_span",
+      args: {
+        path: "Projects/alpha.md",
+        start_anchor: "this anchor does not exist anywhere in the file",
+      },
+    })
+    expectToolError(result, "anchor not found")
+  })
+})
+
+// ── Memory errors ────────────────────────────────────────────
+
+describe("memory errors", () => {
+  it("vault_get_memory with a nonexistent file", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_get_memory",
+      args: { file: "Nonexistent" },
+    })
+    expectToolError(result, "memory file not found")
+  })
+
+  it("vault_get_memory with a nonexistent section", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_get_memory",
+      args: { file: "Preferences", section: "No Such Section" },
+    })
+    expectToolError(result, "section not found")
+  })
+
+  it("vault_update_memory rejects multi-line entries", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_update_memory",
+      args: {
+        file: "Preferences",
+        section: "Editor settings",
+        entry: "line one\nline two",
+      },
+    })
+    expectToolError(result, "entry must be a single line")
+  })
+
+  it("vault_delete_memory with a nonexistent section", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_delete_memory",
+      args: {
+        file: "Preferences",
+        section: "Missing Section",
+        date: "2026-01-01",
+        entry: "anything",
+      },
+    })
+    expectToolError(result, "section not found")
+  })
+})
+
+// ── Task errors ──────────────────────────────────────────────
+
+describe("task errors", () => {
+  it("vault_update_task with a nonexistent block_id", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_update_task",
+      args: {
+        path: "Projects/alpha.md",
+        block_id: "nonexistent-block-id",
+        status: "done",
+      },
+    })
+    expectToolError(result, 'block_id "nonexistent-block-id" not found')
+  })
+})
+
+// ── Path extension errors ────────────────────────────────────
+
+describe("path extension errors", () => {
+  it("vault_read_note rejects paths without .md extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_read_note",
+      args: { path: "Projects/alpha" },
+    })
+    expectToolError(result, "path must end in")
+  })
+
+  it("vault_get_backlinks rejects paths without .md or .canvas extension", async () => {
+    const result = await callTool({
+      client,
+      name: "vault_get_backlinks",
+      args: { path: "Projects/alpha" },
+    })
+    expectToolError(result, "path must end in")
+  })
+})

--- a/src/__tests__/integration/server-error-contracts.test.ts
+++ b/src/__tests__/integration/server-error-contracts.test.ts
@@ -272,7 +272,10 @@ describe("text not found", () => {
         new_text: "replacement",
       },
     })
-    expectToolError(result, "text not found")
+    expectToolError(
+      result,
+      'text not found in "Projects/alpha.md": "this text does not exist in the note"',
+    )
   })
 })
 
@@ -288,7 +291,10 @@ describe("anchor errors", () => {
         start_anchor: "this anchor does not exist anywhere in the file",
       },
     })
-    expectToolError(result, "anchor not found")
+    expectToolError(
+      result,
+      'start anchor not found in "Projects/alpha.md": "this anchor does not exist anywhere in the file"',
+    )
   })
 })
 
@@ -301,7 +307,7 @@ describe("memory errors", () => {
       name: "vault_get_memory",
       args: { file: "Nonexistent" },
     })
-    expectToolError(result, "memory file not found")
+    expectToolError(result, 'memory file not found: "About Me/Nonexistent.md"')
   })
 
   it("vault_get_memory with a nonexistent section", async () => {
@@ -310,7 +316,10 @@ describe("memory errors", () => {
       name: "vault_get_memory",
       args: { file: "Preferences", section: "No Such Section" },
     })
-    expectToolError(result, "section not found")
+    expectToolError(
+      result,
+      'section not found: "No Such Section" in About Me/Preferences.md',
+    )
   })
 
   it("vault_update_memory rejects multi-line entries", async () => {
@@ -337,7 +346,10 @@ describe("memory errors", () => {
         entry: "anything",
       },
     })
-    expectToolError(result, "section not found")
+    expectToolError(
+      result,
+      'section not found: "Missing Section" in About Me/Preferences.md',
+    )
   })
 })
 
@@ -367,7 +379,10 @@ describe("path extension errors", () => {
       name: "vault_read_note",
       args: { path: "Projects/alpha" },
     })
-    expectToolError(result, "path must end in")
+    expectToolError(
+      result,
+      'path must end in ".md" (received "Projects/alpha")',
+    )
   })
 
   it("vault_get_backlinks rejects paths without .md or .canvas extension", async () => {
@@ -376,6 +391,9 @@ describe("path extension errors", () => {
       name: "vault_get_backlinks",
       args: { path: "Projects/alpha" },
     })
-    expectToolError(result, "path must end in")
+    expectToolError(
+      result,
+      'path must end in ".md" or ".canvas" (received "Projects/alpha")',
+    )
   })
 })

--- a/src/__tests__/integration/server-integration.test.ts
+++ b/src/__tests__/integration/server-integration.test.ts
@@ -11,29 +11,11 @@ import {
   promptNames,
   randomPort,
   mcpInitStatus,
+  callTool,
+  textContent,
 } from "./test-harness.js"
 
 vi.setConfig({ testTimeout: 15_000 })
-
-type TextBlock = { type: "text"; text: string }
-type ToolResult = { isError?: boolean; content: TextBlock[] }
-
-const callTool = async ({
-  client,
-  name,
-  args = {},
-}: {
-  client: Client
-  name: string
-  args?: Record<string, unknown>
-}): Promise<ToolResult> =>
-  client.callTool({ name, arguments: args }) as Promise<ToolResult>
-
-const textContent = (result: ToolResult): string =>
-  result.content
-    .filter((block) => block.type === "text")
-    .map((block) => block.text)
-    .join("\n")
 
 /** Extract joined text from a prompt result's messages. */
 const promptText = (result: Awaited<ReturnType<Client["getPrompt"]>>): string =>

--- a/src/__tests__/integration/test-harness.ts
+++ b/src/__tests__/integration/test-harness.ts
@@ -8,7 +8,6 @@ import { join, resolve } from "node:path"
 import { randomInt } from "node:crypto"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
 import type { ChildProcess } from "node:child_process"
 
 const AUTH_TOKEN = "test-integration-token"
@@ -157,8 +156,9 @@ export const createTestClient = async (port: number): Promise<Client> => {
   const client = new Client({ name: "integration-test", version: "1.0.0" })
   // SDK's StreamableHTTPClientTransport.sessionId is `string | undefined` but
   // the Transport interface declares `sessionId?: string` — incompatible under
-  // exactOptionalPropertyTypes. The SDK types are misaligned; safe to widen.
-  await client.connect(transport as unknown as Transport)
+  // exactOptionalPropertyTypes. Self-cleans when the SDK fixes the type.
+  // @ts-expect-error — SDK type misalignment (sessionId optionality)
+  await client.connect(transport)
   return client
 }
 

--- a/src/__tests__/integration/test-harness.ts
+++ b/src/__tests__/integration/test-harness.ts
@@ -174,6 +174,30 @@ export const promptNames = async (client: Client): Promise<string[]> => {
   return result.prompts.map((prompt) => prompt.name).sort()
 }
 
+// ── Shared tool-call helpers ────────────────────────────────────
+
+export type TextBlock = { type: "text"; text: string }
+export type ToolResult = { isError?: boolean; content: TextBlock[] }
+
+/** Call a tool and cast the result to the common text-block shape. */
+export const callTool = async ({
+  client,
+  name,
+  args = {},
+}: {
+  client: Client
+  name: string
+  args?: Record<string, unknown>
+}): Promise<ToolResult> =>
+  client.callTool({ name, arguments: args }) as Promise<ToolResult>
+
+/** Join all text blocks from a tool result into a single string. */
+export const textContent = (result: ToolResult): string =>
+  result.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+
 /** Send an MCP initialize request with optional auth, return the HTTP status. */
 export const mcpInitStatus = async (
   port: number,

--- a/src/__tests__/integration/test-harness.ts
+++ b/src/__tests__/integration/test-harness.ts
@@ -176,10 +176,15 @@ export const promptNames = async (client: Client): Promise<string[]> => {
 
 // ── Shared tool-call helpers ────────────────────────────────────
 
-export type TextBlock = { type: "text"; text: string }
-export type ToolResult = { isError?: boolean; content: TextBlock[] }
+type SdkCallToolResult = Awaited<ReturnType<Client["callTool"]>>
 
-/** Call a tool and cast the result to the common text-block shape. */
+/** Content-response branch of the SDK's CallToolResult union. */
+export type ToolResult = Extract<SdkCallToolResult, { content: unknown[] }>
+
+const isContentResult = (result: SdkCallToolResult): result is ToolResult =>
+  Array.isArray(result.content)
+
+/** Call a tool and return the content-based result. */
 export const callTool = async ({
   client,
   name,
@@ -188,8 +193,15 @@ export const callTool = async ({
   client: Client
   name: string
   args?: Record<string, unknown>
-}): Promise<ToolResult> =>
-  client.callTool({ name, arguments: args }) as Promise<ToolResult>
+}): Promise<ToolResult> => {
+  const result = await client.callTool({ name, arguments: args })
+  if (!isContentResult(result)) {
+    throw new Error(
+      "unexpected toolResult response — server returned no content array",
+    )
+  }
+  return result
+}
 
 /** Join all text blocks from a tool result into a single string. */
 export const textContent = (result: ToolResult): string =>


### PR DESCRIPTION
## Summary

- 49 integration tests verifying every tool's documented `Errors:` section returns the correct error message over real HTTP transport
- Separate file from `server-integration.test.ts` — different test concern (failure modes vs success paths), runs against default config only
- One new fixture file (`Ambiguous Headings.md`) for heading ambiguity tests
- AGENTS.md structure tree and test conventions updated with integration test guidelines

## Error categories covered

| Category | Tests | Tools |
|---|---|---|
| Path traversal blocked | 9 | read, write, patch, replace, delete, delete_span, update_properties, move old_path, move new_path |
| Hidden path blocked | 9 | read, write, patch, replace, delete, delete_span, update_properties, move old_path, move new_path |
| Note not found | 6 | read, patch, replace, delete, update_properties, delete_span |
| Note already exists | 1 | write (without overwrite) |
| Heading not found | 2 | read_note, patch_note |
| Ambiguous heading | 2 | read_note, patch_note |
| Text not found | 1 | replace_in_note |
| Anchor not found | 1 | delete_span |
| Memory errors | 4 | get_memory (bad file/section), update_memory (multi-line), delete_memory |
| Task errors | 1 | update_task (bad block_id) |
| Path extension | 13 | 7 note-path tools (.md), move old_path/backlinks/outgoing_links (.md or .canvas rejection), 2 .canvas acceptance |

## Design decisions

- **Separate file, shared harness** — error contracts are a different test concern from happy-path verification. Single default-config server boot (errors are config-independent). Shared harness + per-concern files matches the established project pattern.
- **`toContain` over exact match** — error messages include variable content (paths, available headings), so substring matching on the distinctive prefix is the right assertion level. Test-controlled variable parts (paths, section names) are included in the assertion.
- **SDK-derived ToolResult type** — `ToolResult` is derived from `Client["callTool"]` via `Extract<>`, removing the manual `TextBlock` type and the `as` cast. A type guard (`isContentResult`) narrows the SDK union per project conventions.
- **Integration test guidelines added to AGENTS.md** — when to add integration vs unit tests, file structure, fixture management, and splitting guidance codified in the test conventions section.

## Test plan

- [x] All 49 error contract tests pass
- [x] Full suite: 2,862 tests pass (77 files)
- [x] Build clean (server + CLI)
- [x] Lint clean (0 errors, `as` cast warning resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)