### PR TITLE
feat(search): embed non-markdown file content for semantic search

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -352,7 +352,7 @@ Both models lazy-load on first use (~1–2s cold start each, cached after). Tota
 4. **File content vector search** — same query embedding → KNN over `file_content_vectors` → deduplicate to best chunk per file (same skip condition as step 2)
 5. RRF fusion (`computeRrfScores`): score = Σ(1/(k+rank)) across all available lists, k=60, with top-rank bonuses (+0.05 rank 1, +0.02 ranks 2–3)
 6. Build merged results: FTS results keep their metadata and snippet (score replaced with RRF score); vector-only results get metadata from their respective tables and a snippet from their best-matching chunk text
-7. Apply user filters (folder, tags, type, related, properties) to vector-only note results — FTS results are already filtered via SQL
+7. Apply user filters (folder, tags, type, related, properties, created, modified) to vector-only note results — FTS results are already filtered via SQL
 
 ### Cross-encoder reranking
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -399,10 +399,12 @@ When no embedder is configured (`EMBEDDING_ENABLED=false`), no vectors are index
 
 **Embedding pipeline:** Controlled by `EMBEDDING_ENABLED` (default: `true`). Notes are chunked via heading-aware splitting (`chunker.ts`) with paragraph sub-splitting for oversized sections (MAX_CHUNK_TOKENS = 450). Markdown syntax is stripped before embedding (`plaintext.ts`). Each chunk is prefixed with the note title for context. Content-hash gating (SHA-256 per chunk) skips re-embedding unchanged content on both incremental file-watcher updates and full rebuilds.
 
-**Vector schema:** Two tables in the same SQLite database as FTS5 (which also holds the `tasks` table — see [Tasks](#tasks)):
+**Vector schema:** Four tables in the same SQLite database as FTS5 (which also holds the `tasks` table — see [Tasks](#tasks)):
 
 - `note_chunks`: stores chunk text, position index, and content hash per note
 - `note_vectors` (vec0): stores 384-dim Float32 embeddings keyed by chunk ID
+- `file_content_chunks`: stores chunk text, position index, and content hash per non-markdown file (canvas, PDF, text)
+- `file_content_vectors` (vec0): stores 384-dim Float32 embeddings keyed by chunk ID
 
 **New-directory rescan:** chokidar handles a newly-appeared directory in two steps: first it scans the directory's contents, then it registers the directory's `fs.watch`. A file created between the scan and the registration is silently lost ([chokidar#1471](https://github.com/paulmillr/chokidar/issues/1471)) — the scan didn't see it, and no watch existed to catch the event. The server's atomic write into a freshly created folder can hit exactly that window, leaving the note invisible to search. As a safety net, the watcher schedules a one-shot rescan of every new directory, delayed to twice chokidar's write-stability threshold (`awaitWriteFinish`, 2 s — a 4 s delay) so in-flight writes settle first. The rescan:
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,7 +115,7 @@ graph TB
 
 **Sync (from apps):** Obsidian app → Obsidian Sync → the sync service → `/vault/` → watcher → SQLite. Now searchable via MCP.
 
-**Hybrid query:** MCP client → `vault_search` → FTS5 BM25 ranks + sqlite-vec KNN ranks → RRF fusion → cross-encoder reranking → response.
+**Hybrid query:** MCP client → `vault_search` → FTS5 BM25 ranks (notes + file content) + sqlite-vec KNN ranks (notes + file content) → RRF fusion → cross-encoder reranking → response.
 
 **Invariant — vault is source of truth:** The vault `.md` files are canonical. SQLite FTS5 is derived — rebuildable from scratch. Never write to the index directly. The sqlite-vec embeddings are equally derived — they persist across rebuilds as an optimization but can always be regenerated from the vault.
 
@@ -344,13 +344,15 @@ Both models lazy-load on first use (~1–2s cold start each, cached after). Tota
 
 ### Query fusion
 
-`vault_search` calls `hybridSearch`, which runs FTS5 keyword search and vector similarity search, then merges results via RRF. The flow:
+`vault_search` calls `hybridSearch`, which runs up to four ranked retrieval legs and merges results via RRF. The flow:
 
-1. FTS5 keyword search (synchronous, existing `fullTextSearch`)
-2. Vector search: embed the query → sqlite-vec KNN → deduplicate to best chunk per note
-3. RRF fusion (`computeRrfScores`): score = Σ(1/(k+rank)) across both lists, k=60, with top-rank bonuses (+0.05 rank 1, +0.02 ranks 2–3)
-4. Build merged results: FTS results keep their metadata and snippet (score replaced with RRF score); vector-only results get metadata from the notes table and a snippet from their best-matching chunk text
-5. Apply user filters (folder, tags, type, related, properties) to vector-only results — FTS results are already filtered via SQL
+1. **Note FTS5** keyword search (synchronous, `fullTextSearch`)
+2. **File content FTS5** — linearized canvas, extracted PDF text, plain text files (skipped when note-specific filters are active)
+3. **Note vector search** — embed the query → sqlite-vec KNN over `note_vectors` → deduplicate to best chunk per note
+4. **File content vector search** — same query embedding → KNN over `file_content_vectors` → deduplicate to best chunk per file (same skip condition as step 2)
+5. RRF fusion (`computeRrfScores`): score = Σ(1/(k+rank)) across all available lists, k=60, with top-rank bonuses (+0.05 rank 1, +0.02 ranks 2–3)
+6. Build merged results: FTS results keep their metadata and snippet (score replaced with RRF score); vector-only results get metadata from their respective tables and a snippet from their best-matching chunk text
+7. Apply user filters (folder, tags, type, related, properties) to vector-only note results — FTS results are already filtered via SQL
 
 ### Cross-encoder reranking
 
@@ -366,11 +368,15 @@ Both scores are min-max normalized to [0, 1] before blending. Controlled by `RER
 
 ```mermaid
 flowchart LR
-    Q[Query] --> FTS[FTS5 BM25]
+    Q[Query] --> NoteFTS[Note FTS5 BM25]
+    Q --> FileFTS[File Content FTS5]
     Q --> EMB[Embed Query]
-    EMB --> KNN[sqlite-vec KNN]
-    FTS --> |ranked paths| RRF[RRF Fusion\nk=60 + bonuses]
-    KNN --> |ranked paths| RRF
+    EMB --> NoteKNN[Note KNN]
+    EMB --> FileKNN[File Content KNN]
+    NoteFTS --> |ranked paths| RRF[RRF Fusion\nk=60 + bonuses]
+    FileFTS --> |ranked paths| RRF
+    NoteKNN --> |ranked paths| RRF
+    FileKNN --> |ranked paths| RRF
     RRF --> |top candidates| CE[Cross-Encoder\nms-marco-MiniLM]
     RRF --> |RRF scores| BL[Position-Aware\nBlend]
     CE --> |rerank scores| BL
@@ -385,11 +391,11 @@ flowchart LR
 
 ### Graceful fallback
 
-When no embedder is configured (`EMBEDDING_ENABLED=false`), no vectors are indexed yet (startup), or the embedding model fails, `hybridSearch` returns FTS-only results silently. The response includes `search_mode: "hybrid" | "fts"` and `reranked: boolean` so clients know which ranking produced the scores. The tool description is also conditional — hybrid-aware when embeddings are enabled, keyword-only when disabled.
+When no embedder is configured (`EMBEDDING_ENABLED=false`), no vectors are indexed yet (startup), or both vector searches return empty, `hybridSearch` returns FTS-only results silently. The response includes `search_mode: "hybrid" | "fts"` and `reranked: boolean` so clients know which ranking produced the scores. The tool description is also conditional — hybrid-aware when embeddings are enabled, keyword-only when disabled.
 
 ### Indexing
 
-**Indexing flow:** `rebuildFromVault` runs three passes — Pass 1 (FTS + metadata), Pass 2 (links with complete path list), then returns so the server can start accepting requests. Pass 3 (embedding) runs in the background — search works with FTS-only until vectors are ready. Vector tables persist across both restarts and rebuilds (only FTS, notes, links, tasks, non-md, and file content tables are cleared): Pass 3 cleans up vectors for deleted notes, then embeds only new or modified chunks. The file watcher calls `embedNote` after `upsertNote`; `removeNote` cleans up both vectors and chunks.
+**Indexing flow:** `rebuildFromVault` runs three passes — Pass 1 (FTS + metadata), Pass 2 (links with complete path list), then returns so the server can start accepting requests. Pass 3 (embedding) runs in the background — search works with FTS-only until vectors are ready. Vector tables persist across both restarts and rebuilds (only FTS, notes, links, tasks, non-md, and file content tables are cleared): Pass 3 cleans up vectors for deleted notes and files, then embeds only new or modified chunks — first notes, then file content. The file watcher calls `embedNote` after `upsertNote` and `embedFileContent` after `upsertFileContent`; deletion cleans up both vectors and chunks.
 
 **Embedding pipeline:** Controlled by `EMBEDDING_ENABLED` (default: `true`). Notes are chunked via heading-aware splitting (`chunker.ts`) with paragraph sub-splitting for oversized sections (MAX_CHUNK_TOKENS = 450). Markdown syntax is stripped before embedding (`plaintext.ts`). Each chunk is prefixed with the note title for context. Content-hash gating (SHA-256 per chunk) skips re-embedding unchanged content on both incremental file-watcher updates and full rebuilds.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -395,7 +395,15 @@ When no embedder is configured (`EMBEDDING_ENABLED=false`), no vectors are index
 
 ### Indexing
 
-**Indexing flow:** `rebuildFromVault` runs three passes — Pass 1 (FTS + metadata), Pass 2 (links with complete path list), then returns so the server can start accepting requests. Pass 3 (embedding) runs in the background — search works with FTS-only until vectors are ready. Vector tables persist across both restarts and rebuilds (only FTS, notes, links, tasks, non-md, and file content tables are cleared): Pass 3 cleans up vectors for deleted notes and files, then embeds only new or modified chunks — first notes, then file content. The file watcher calls `embedNote` after `upsertNote` and `embedFileContent` after `upsertFileContent`; deletion cleans up both vectors and chunks.
+**Indexing flow:** `rebuildFromVault` runs three passes, then returns so the server can start accepting requests:
+
+1. **Pass 1** — index notes (FTS5 + metadata)
+2. **Pass 2** — extract links (with the complete path list for resolution), then index file content (canvas, PDF, text → FTS5)
+3. **Pass 3 (background)** — embed notes, then file content. Search works with FTS-only until vectors are ready
+
+Vector tables persist across restarts and rebuilds (only FTS, notes, links, tasks, non-md, and file content tables are cleared). Pass 3 cleans up vectors for deleted notes and files, then embeds only new or modified chunks via content-hash gating.
+
+**Incremental updates:** the file watcher calls `embedNote` after `upsertNote` and `embedFileContent` after `upsertFileContent`; deletion cleans up both vectors and chunks.
 
 **Embedding pipeline:** Controlled by `EMBEDDING_ENABLED` (default: `true`). Notes are chunked via heading-aware splitting (`chunker.ts`) with paragraph sub-splitting for oversized sections (MAX_CHUNK_TOKENS = 450). Markdown syntax is stripped before embedding (`plaintext.ts`). Each chunk is prefixed with the note title for context. Content-hash gating (SHA-256 per chunk) skips re-embedding unchanged content on both incremental file-watcher updates and full rebuilds.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -419,9 +419,11 @@ flowchart TD
     VF[Vault Files] --> RB[rebuildFromVault]
     RB --> P1[Pass 1: Index Notes\nFTS5 + metadata]
     P1 --> P2[Pass 2: Extract Links\nresolve with full path list]
-    P2 --> P3[Pass 3: Embed Notes\nchunk → hash → embed → store]
+    P2 --> FC[Index File Content\ncanvas + PDF + text → FTS5]
+    FC --> P3[Pass 3: Embed Notes\nchunk → hash → embed → store]
+    P3 --> P3F[Embed File Content\nchunk → hash → embed → store]
 
-    FW[File Watcher\nchokidar] --> |add/change| UP[upsertNote]
+    FW[File Watcher\nchokidar] --> |.md add/change| UP[upsertNote]
     UP --> FTS[Update FTS5]
     UP --> LK[Update Links]
     UP --> EM[embedAndStoreChunks]
@@ -430,14 +432,28 @@ flowchart TD
     CH --> |changed| EMB[Embed chunk\nbge-small q8]
     EMB --> VEC[Store in\nnote_vectors]
 
-    FW --> |delete| RM[removeNote]
+    FW --> |non-.md add/change| UFC[upsertFileContent]
+    UFC --> FFTS[Update file_content_fts]
+    UFC --> EFC[embedAndStoreFileChunks]
+    EFC --> FCH{Content\nhash match?}
+    FCH --> |unchanged| FSK[Skip]
+    FCH --> |changed| FEMB[Embed chunk]
+    FEMB --> FVEC[Store in\nfile_content_vectors]
+
+    FW --> |.md delete| RM[removeNote]
     RM --> D1[Delete FTS + links]
     RM --> D2[Delete chunks + vectors]
+
+    FW --> |non-.md delete| RMF[removeFileContent]
+    RMF --> FD1[Delete FTS + links]
+    RMF --> FD2[Delete file chunks + vectors]
 
     style VF fill:#f9f,stroke:#333
     style FW fill:#f9f,stroke:#333
     style CH fill:#ffd,stroke:#333
+    style FCH fill:#ffd,stroke:#333
     style SK fill:#dfd,stroke:#333
+    style FSK fill:#dfd,stroke:#333
 ```
 
 ### Module decomposition

--- a/src/vault-mcp/search/__tests__/file-watcher.test.ts
+++ b/src/vault-mcp/search/__tests__/file-watcher.test.ts
@@ -53,14 +53,16 @@ const waitFor = async (
   throw new Error(`waitFor timed out after ${timeoutMs}ms`)
 }
 
-/** Retry policy for suites that watch real temp dirs. On macOS, fs.watch
- *  rides libuv's FSEventStream, whose kernel-side capture starts
- *  asynchronously — a write landing right after the watcher reports ready
- *  can produce no event at all, so the test's waitFor times out (observed
- *  as bursty local-only failures; events either arrive in <1s or never).
- *  Linux (CI and every production deployment) registers inotify watches
- *  synchronously and has no such gap, so retries there only ever absorb a
- *  genuine environment hiccup — a code regression fails every attempt. */
+/** Retry policy for suites that watch real temp dirs.
+ *
+ *  Why: on macOS, fs.watch rides libuv's FSEventStream, whose kernel-side
+ *  capture starts asynchronously — a write landing right after the watcher
+ *  reports ready can produce no event at all, so waitFor times out
+ *  (observed as bursty local-only failures; events arrive in <1s or never).
+ *
+ *  Why it's safe: Linux (CI and every production deployment) registers
+ *  inotify watches synchronously and has no such gap, and a code
+ *  regression fails every attempt — retries only absorb the macOS race. */
 const REAL_WATCHER_RETRY = { retry: 2 }
 
 beforeEach(async () => {

--- a/src/vault-mcp/search/__tests__/file-watcher.test.ts
+++ b/src/vault-mcp/search/__tests__/file-watcher.test.ts
@@ -391,6 +391,34 @@ describe("file-watcher — file content indexing", () => {
     expect(pdfResult?.kind).toBe("file")
     expect(pdfResult?.extension).toBe(".pdf")
   })
+
+  it(
+    "calls embedFileContent when indexing a non-md file",
+    { timeout: 15000 },
+    async () => {
+      const fileIndex = createSearchIndex(":memory:", undefined, undefined, {
+        fileToolsEnabled: true,
+      })
+      const embedFileSpy = vi.spyOn(fileIndex, "embedFileContent")
+
+      await startFileWatcher(vault, fileIndex, {
+        stabilityThreshold: 200,
+        pollInterval: 50,
+      })
+
+      await writeFile(
+        join(vault, "data.csv"),
+        "id,name,value\n1,deploy,active\n",
+        "utf8",
+      )
+
+      await waitFor(() => embedFileSpy.mock.calls.length > 0)
+      expect(embedFileSpy).toHaveBeenCalledWith(
+        { filePath: "data.csv" },
+        expect.anything(), // logger — runtime child logger
+      )
+    },
+  )
 })
 
 describe("startFileWatcher — chokidar watch options", () => {

--- a/src/vault-mcp/search/__tests__/file-watcher.test.ts
+++ b/src/vault-mcp/search/__tests__/file-watcher.test.ts
@@ -53,6 +53,16 @@ const waitFor = async (
   throw new Error(`waitFor timed out after ${timeoutMs}ms`)
 }
 
+/** Retry policy for suites that watch real temp dirs. On macOS, fs.watch
+ *  rides libuv's FSEventStream, whose kernel-side capture starts
+ *  asynchronously — a write landing right after the watcher reports ready
+ *  can produce no event at all, so the test's waitFor times out (observed
+ *  as bursty local-only failures; events either arrive in <1s or never).
+ *  Linux (CI and every production deployment) registers inotify watches
+ *  synchronously and has no such gap, so retries there only ever absorb a
+ *  genuine environment hiccup — a code regression fails every attempt. */
+const REAL_WATCHER_RETRY = { retry: 2 }
+
 beforeEach(async () => {
   vault = await mkdtemp(join(tmpdir(), "watcher-test-"))
   index = createSearchIndex(":memory:")
@@ -62,7 +72,7 @@ afterEach(async () => {
   await rm(vault, { recursive: true })
 })
 
-describe("file-watcher", () => {
+describe("file-watcher", REAL_WATCHER_RETRY, () => {
   it("indexes a new .md file", { timeout: 15000 }, async () => {
     await startFileWatcher(vault, index, {
       stabilityThreshold: 200,
@@ -305,7 +315,7 @@ describe("file-watcher", () => {
   })
 })
 
-describe("file-watcher — file content indexing", () => {
+describe("file-watcher — file content indexing", REAL_WATCHER_RETRY, () => {
   it(
     "indexes a text file into file content FTS",
     { timeout: 15000 },
@@ -487,7 +497,7 @@ describe("startFileWatcher — chokidar watch options", () => {
 // outside, so these tests drive the reconciliation directly: a fake watcher
 // captures the addDir handler, reports test-controlled tracking via
 // getWatched(), and records add() calls — against a real temp vault and index.
-describe("startFileWatcher — new-directory rescan", () => {
+describe("startFileWatcher — new-directory rescan", REAL_WATCHER_RETRY, () => {
   const RESCAN_TEST_OPTIONS = {
     stabilityThreshold: 200,
     pollInterval: 50,

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -3551,7 +3551,7 @@ It has multiple sentences to verify chunking works correctly.
         logger,
       )
 
-      expect(mockEmbedder.embedText).toHaveBeenCalled()
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
     })
 
     it("content-hash gating skips unchanged chunks on re-embed", async () => {
@@ -3563,16 +3563,14 @@ It has multiple sentences to verify chunking works correctly.
         { notePath: "test.md", rawContent: NOTE_FOR_EMBEDDING },
         logger,
       )
-      const firstCallCount = mockEmbedder.embedText.mock.calls.length
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
 
       // Second embed with same content — should skip (hash match)
       await embeddingIndex.embedNote(
         { notePath: "test.md", rawContent: NOTE_FOR_EMBEDDING },
         logger,
       )
-      const secondCallCount = mockEmbedder.embedText.mock.calls.length
-
-      expect(secondCallCount).toBe(firstCallCount)
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
     })
 
     it("re-embeds when content changes", async () => {
@@ -3583,7 +3581,7 @@ It has multiple sentences to verify chunking works correctly.
         { notePath: "test.md", rawContent: NOTE_FOR_EMBEDDING },
         logger,
       )
-      const firstCallCount = mockEmbedder.embedText.mock.calls.length
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
 
       const updatedNote = NOTE_FOR_EMBEDDING.replace(
         "multiple sentences",
@@ -3593,9 +3591,7 @@ It has multiple sentences to verify chunking works correctly.
         { notePath: "test.md", rawContent: updatedNote },
         logger,
       )
-      const secondCallCount = mockEmbedder.embedText.mock.calls.length
-
-      expect(secondCallCount).toBeGreaterThan(firstCallCount)
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(2)
     })
 
     it("removeNote deletes associated chunks and vectors", async () => {
@@ -5682,7 +5678,7 @@ describe("file content vector embeddings", () => {
       )
       await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
 
-      expect(mockEmbedder.embedText).toHaveBeenCalled()
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
     })
 
     it("content-hash gating skips unchanged chunks on re-embed", async () => {
@@ -5701,12 +5697,10 @@ describe("file content vector embeddings", () => {
         logger,
       )
       await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
-      const firstCallCount = mockEmbedder.embedText.mock.calls.length
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
 
       await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
-      const secondCallCount = mockEmbedder.embedText.mock.calls.length
-
-      expect(secondCallCount).toBe(firstCallCount)
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
     })
 
     it("re-embeds when content changes", async () => {
@@ -5725,7 +5719,7 @@ describe("file content vector embeddings", () => {
         logger,
       )
       await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
-      const firstCallCount = mockEmbedder.embedText.mock.calls.length
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
 
       index.upsertFileContent(
         {
@@ -5737,9 +5731,7 @@ describe("file content vector embeddings", () => {
         logger,
       )
       await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
-      const secondCallCount = mockEmbedder.embedText.mock.calls.length
-
-      expect(secondCallCount).toBeGreaterThan(firstCallCount)
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(2)
     })
 
     it("is a no-op when file is not in file_content table", async () => {
@@ -5802,15 +5794,15 @@ describe("file content vector embeddings", () => {
     })
   })
 
-  describe("stale chunk cleanup", () => {
-    it("re-embeds fewer chunks when content shrinks", async () => {
+  describe("content shrink produces fewer chunks", () => {
+    it("embeds only one chunk after content shrinks from multi-chunk", async () => {
       const mockEmbedder = createMockEmbedder()
       const index = createSearchIndex(":memory:", mockEmbedder, undefined, {
         fileToolsEnabled: true,
       })
 
       // Generate content that exceeds CHUNK_THRESHOLD_TOKENS (500) to produce multiple chunks.
-      // Each paragraph needs ~50 words to produce ~10 paragraphs × 50 words = 500+ words.
+      // Each paragraph needs ~50 words to produce ~10 paragraphs x 50 words = 500+ words.
       const longContent = Array.from(
         { length: 15 },
         (_, paragraphIndex) =>
@@ -5830,11 +5822,13 @@ describe("file content vector embeddings", () => {
         logger,
       )
       await index.embedFileContent({ filePath: "docs/long.txt" }, logger)
-      const firstCallCount = mockEmbedder.embedText.mock.calls.length
+      // Long content produces multiple chunks — verify more than 1
+      const longChunkCount = mockEmbedder.embedText.mock.calls.length
+      expect(longChunkCount).toBeGreaterThan(1)
 
       mockEmbedder.embedText.mockClear()
 
-      // Replace with short content — fewer chunks, and the stale ones are cleaned up
+      // Replace with short content — produces exactly 1 chunk
       index.upsertFileContent(
         {
           filePath: "docs/long.txt",
@@ -5844,9 +5838,171 @@ describe("file content vector embeddings", () => {
         logger,
       )
       await index.embedFileContent({ filePath: "docs/long.txt" }, logger)
-      const secondCallCount = mockEmbedder.embedText.mock.calls.length
-
-      expect(secondCallCount).toBeLessThan(firstCallCount)
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
     })
+  })
+})
+
+// ── hybridSearch — file content vector search integration ─────
+
+describe("hybridSearch — file content vector search", () => {
+  const EMBEDDING_DIMENSIONS = 384
+
+  const createHybridMockEmbedder = () => ({
+    embedText: vi
+      .fn()
+      .mockResolvedValue(new Float32Array(EMBEDDING_DIMENSIONS).fill(0.1)),
+    embedBatch: vi
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(
+          texts.map(() => new Float32Array(EMBEDDING_DIMENSIONS).fill(0.1)),
+        ),
+      ),
+  })
+
+  it("includes file content vector hits in hybrid results", async () => {
+    const mockEmbedder = createHybridMockEmbedder()
+    const fileIndex = createSearchIndex(":memory:", mockEmbedder, undefined, {
+      fileToolsEnabled: true,
+    })
+
+    // Seed a note (FTS + vector) and a text file (FTS + vector)
+    fileIndex.upsertNote(
+      {
+        filePath: "notes/career.md",
+        rawContent:
+          "---\ntitle: Career\ntags: [personal]\n---\n\nCareer goals and aspirations.\n",
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    await fileIndex.embedNote(
+      {
+        notePath: "notes/career.md",
+        rawContent:
+          "---\ntitle: Career\ntags: [personal]\n---\n\nCareer goals and aspirations.\n",
+      },
+      logger,
+    )
+
+    fileIndex.upsertNonMdFile("docs/guide.txt", 200)
+    fileIndex.upsertFileContent(
+      {
+        filePath: "docs/guide.txt",
+        rawContent:
+          "Comprehensive deployment guide covering infrastructure and monitoring setup.",
+        fileStat: testStat(2000, 200),
+      },
+      logger,
+    )
+    await fileIndex.embedFileContent({ filePath: "docs/guide.txt" }, logger)
+
+    // Query that matches the text file via FTS ("deployment guide") and both
+    // items via vector (all embeddings are identical)
+    const { results, search_mode } = await fileIndex.hybridSearch(
+      { query: "deployment guide" },
+      logger,
+    )
+
+    expect(search_mode).toBe("hybrid")
+    // Both should appear — the text file via FTS+vector, the note via vector-only
+    expect(results.length).toBeGreaterThanOrEqual(1)
+    const fileResult = results.find(
+      (result) => result.path === "docs/guide.txt",
+    )
+    expect(fileResult).toBeDefined()
+    expect(fileResult?.kind).toBe("file")
+    expect(fileResult?.extension).toBe(".txt")
+  })
+
+  it("file-only vector hit appears with metadata when no FTS match exists", async () => {
+    const mockEmbedder = createHybridMockEmbedder()
+    const fileIndex = createSearchIndex(":memory:", mockEmbedder, undefined, {
+      fileToolsEnabled: true,
+    })
+
+    // Seed ONLY a text file — no note matches the query via FTS
+    fileIndex.upsertNonMdFile("specs/api-spec.yaml", 300)
+    fileIndex.upsertFileContent(
+      {
+        filePath: "specs/api-spec.yaml",
+        rawContent:
+          "openapi: 3.0.0\npaths:\n  /users:\n    get:\n      summary: List users",
+        fileStat: testStat(3000, 300),
+      },
+      logger,
+    )
+    await fileIndex.embedFileContent(
+      { filePath: "specs/api-spec.yaml" },
+      logger,
+    )
+
+    // Query using a term NOT in the file content FTS (triggers vector-only path)
+    // but the mock embedder returns identical embeddings so KNN matches
+    const { results, search_mode } = await fileIndex.hybridSearch(
+      { query: "user management endpoints" },
+      logger,
+    )
+
+    // The file should appear via file content vector search even without FTS match
+    // (note: FTS may also partially match "users" — check result presence regardless)
+    const fileResult = results.find(
+      (result) => result.path === "specs/api-spec.yaml",
+    )
+    expect(fileResult).toBeDefined()
+    expect(fileResult?.kind).toBe("file")
+    expect(fileResult?.extension).toBe(".yaml")
+    expect(fileResult?.folder).toBe("specs")
+    expect(search_mode).toBe("hybrid")
+  })
+
+  it("skips file content vector search when note-specific filters are active", async () => {
+    const mockEmbedder = createHybridMockEmbedder()
+    const fileIndex = createSearchIndex(":memory:", mockEmbedder, undefined, {
+      fileToolsEnabled: true,
+    })
+
+    fileIndex.upsertNote(
+      {
+        filePath: "notes/tagged.md",
+        rawContent:
+          "---\ntitle: Tagged\ntags: [important]\n---\n\nTagged content here.\n",
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    await fileIndex.embedNote(
+      {
+        notePath: "notes/tagged.md",
+        rawContent:
+          "---\ntitle: Tagged\ntags: [important]\n---\n\nTagged content here.\n",
+      },
+      logger,
+    )
+
+    fileIndex.upsertNonMdFile("data/report.csv", 100)
+    fileIndex.upsertFileContent(
+      {
+        filePath: "data/report.csv",
+        rawContent: "tagged content in a file",
+        fileStat: testStat(2000, 100),
+      },
+      logger,
+    )
+    await fileIndex.embedFileContent({ filePath: "data/report.csv" }, logger)
+
+    // Tag filter is note-specific — file content (FTS and vector) should be excluded
+    const { results } = await fileIndex.hybridSearch(
+      { query: "tagged content", filters: { tags: ["important"] } },
+      logger,
+    )
+
+    const fileResult = results.find(
+      (result) => result.path === "data/report.csv",
+    )
+    expect(fileResult).toBeUndefined()
+    // Note should still appear
+    expect(results.map((result) => result.path)).toContain("notes/tagged.md")
   })
 })

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -126,6 +126,41 @@ const installStatementPoison = (sqlFragment: string) => {
   }
 }
 
+/** Query-side sibling of installStatementPoison: patches the matching
+ *  statement's .all (read queries) to throw while armed. Must likewise be
+ *  installed BEFORE createSearchIndex — query statements are prepared at
+ *  factory scope. */
+const installQueryPoison = (sqlFragment: string) => {
+  const message = `injected failure on: ${sqlFragment}`
+  const realPrepare: (
+    this: Database.Database,
+    source: string,
+  ) => Database.Statement = Database.prototype.prepare
+  // Mutable arming flag: the patched .all closes over this object so tests
+  // can trigger the failure long after the statement was prepared.
+  const poisonState = { armed: false }
+  const prepareSpy = vi
+    .spyOn(Database.prototype, "prepare")
+    .mockImplementation(function (this: Database.Database, source: string) {
+      const statement = realPrepare.call(this, source)
+      if (source.includes(sqlFragment)) {
+        const realAll = statement.all.bind(statement)
+        statement.all = (...queryParams: unknown[]) => {
+          if (poisonState.armed) throw new Error(message)
+          return realAll(...queryParams)
+        }
+      }
+      return statement
+    })
+  onTestFinished(() => prepareSpy.mockRestore())
+  return {
+    message,
+    arm: () => {
+      poisonState.armed = true
+    },
+  }
+}
+
 /** Version A of the atomicity-test note: distinct title, tag, body term,
  *  one task (so the poisoned tasks statement provably fires), one link. */
 const ATOMIC_NOTE_VERSION_A = `---
@@ -6101,6 +6136,101 @@ describe("hybridSearch — file content vector search", () => {
     expect(results[0]?.kind).toBe("file")
     expect(results[0]?.extension).toBe(".yaml")
     expect(results[0]?.folder).toBe("specs")
+  })
+
+  it("returns note results when the file content KNN query throws", async () => {
+    const knnPoison = installQueryPoison("FROM file_content_vectors")
+    const mockEmbedder = createHybridMockEmbedder()
+    const fileIndex = createSearchIndex(":memory:", mockEmbedder, undefined, {
+      fileToolsEnabled: true,
+    })
+
+    fileIndex.upsertNote(
+      {
+        filePath: "notes/career.md",
+        rawContent:
+          "---\ntitle: Career\n---\n\nCareer goals and aspirations.\n",
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    await fileIndex.embedNote(
+      {
+        notePath: "notes/career.md",
+        rawContent:
+          "---\ntitle: Career\n---\n\nCareer goals and aspirations.\n",
+      },
+      logger,
+    )
+    fileIndex.upsertNonMdFile("docs/guide.txt", 200)
+    fileIndex.upsertFileContent(
+      {
+        filePath: "docs/guide.txt",
+        rawContent: "Deployment guide covering infrastructure setup.",
+        fileStat: testStat(2000, 200),
+      },
+      logger,
+    )
+    await fileIndex.embedFileContent({ filePath: "docs/guide.txt" }, logger)
+
+    const warnSpy = vi.spyOn(logger, "warn")
+    onTestFinished(() => warnSpy.mockRestore())
+    knnPoison.arm()
+
+    const { results } = await fileIndex.hybridSearch(
+      { query: "career goals" },
+      logger,
+    )
+
+    // The file KNN throw is caught (warn logged), the file leg contributes
+    // nothing, and note results still come back instead of an error
+    expect(warnSpy).toHaveBeenCalledWith(
+      "file content vector search failed",
+      expect.objectContaining({ error: `[Error]: ${knnPoison.message}` }),
+    )
+    expect(results.map((result) => result.path)).toEqual(["notes/career.md"])
+  })
+
+  it("falls back to FTS ordering when the note KNN query throws", async () => {
+    const knnPoison = installQueryPoison("FROM note_vectors")
+    const mockEmbedder = createHybridMockEmbedder()
+    const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+    hybridIndex.upsertNote(
+      {
+        filePath: "notes/career.md",
+        rawContent:
+          "---\ntitle: Career\n---\n\nCareer goals and aspirations.\n",
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    await hybridIndex.embedNote(
+      {
+        notePath: "notes/career.md",
+        rawContent:
+          "---\ntitle: Career\n---\n\nCareer goals and aspirations.\n",
+      },
+      logger,
+    )
+
+    const warnSpy = vi.spyOn(logger, "warn")
+    onTestFinished(() => warnSpy.mockRestore())
+    knnPoison.arm()
+
+    const { results, search_mode } = await hybridIndex.hybridSearch(
+      { query: "career goals" },
+      logger,
+    )
+
+    // The note KNN throw is caught (warn logged) and the search degrades to
+    // FTS-only ordering instead of propagating the error
+    expect(warnSpy).toHaveBeenCalledWith(
+      "vector search failed, falling back to FTS-only",
+      expect.objectContaining({ error: `[Error]: ${knnPoison.message}` }),
+    )
+    expect(search_mode).toBe("fts")
+    expect(results.map((result) => result.path)).toEqual(["notes/career.md"])
   })
 
   it("applies the folder filter to file-content vector-only hits at segment boundaries", async () => {

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -4174,7 +4174,7 @@ the Lightsail budget estimates for next quarter.
       expect(results.map((result) => result.path)).toEqual(["a.md"])
       expect(search_mode).toBe("fts")
       expect(warnSpy).toHaveBeenCalledWith(
-        "vector search failed, falling back to FTS-only",
+        "query embedding failed",
         expect.objectContaining({ error: "[Error]: model unavailable" }),
       )
     })
@@ -5640,6 +5640,213 @@ describe("canvas file content and links", () => {
       const paths = results.map((result) => result.path)
       expect(paths).toContain("Projects/plan.md")
       expect(paths).not.toContain("Diagrams/arch.canvas")
+    })
+  })
+})
+
+// ── File content vector embeddings ────────────────────────────
+
+describe("file content vector embeddings", () => {
+  const DIMENSIONS = 384
+  const createMockEmbedder = () => ({
+    embedText: vi
+      .fn()
+      .mockResolvedValue(new Float32Array(DIMENSIONS).fill(0.1)),
+    embedBatch: vi
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(
+          texts.map(() => new Float32Array(DIMENSIONS).fill(0.1)),
+        ),
+      ),
+  })
+
+  const TEXT_FILE_CONTENT =
+    "System design overview with diagrams and architecture notes."
+
+  describe("embedFileContent", () => {
+    it("calls the embedder when file content is in the FTS table", async () => {
+      const mockEmbedder = createMockEmbedder()
+      const index = createSearchIndex(":memory:", mockEmbedder, undefined, {
+        fileToolsEnabled: true,
+      })
+
+      index.upsertNonMdFile("docs/overview.txt", 100)
+      index.upsertFileContent(
+        {
+          filePath: "docs/overview.txt",
+          rawContent: TEXT_FILE_CONTENT,
+          fileStat: testStat(1000, 100),
+        },
+        logger,
+      )
+      await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
+
+      expect(mockEmbedder.embedText).toHaveBeenCalled()
+    })
+
+    it("content-hash gating skips unchanged chunks on re-embed", async () => {
+      const mockEmbedder = createMockEmbedder()
+      const index = createSearchIndex(":memory:", mockEmbedder, undefined, {
+        fileToolsEnabled: true,
+      })
+
+      index.upsertNonMdFile("docs/overview.txt", 100)
+      index.upsertFileContent(
+        {
+          filePath: "docs/overview.txt",
+          rawContent: TEXT_FILE_CONTENT,
+          fileStat: testStat(1000, 100),
+        },
+        logger,
+      )
+      await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
+      const firstCallCount = mockEmbedder.embedText.mock.calls.length
+
+      await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
+      const secondCallCount = mockEmbedder.embedText.mock.calls.length
+
+      expect(secondCallCount).toBe(firstCallCount)
+    })
+
+    it("re-embeds when content changes", async () => {
+      const mockEmbedder = createMockEmbedder()
+      const index = createSearchIndex(":memory:", mockEmbedder, undefined, {
+        fileToolsEnabled: true,
+      })
+
+      index.upsertNonMdFile("docs/overview.txt", 100)
+      index.upsertFileContent(
+        {
+          filePath: "docs/overview.txt",
+          rawContent: TEXT_FILE_CONTENT,
+          fileStat: testStat(1000, 100),
+        },
+        logger,
+      )
+      await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
+      const firstCallCount = mockEmbedder.embedText.mock.calls.length
+
+      index.upsertFileContent(
+        {
+          filePath: "docs/overview.txt",
+          rawContent:
+            "Completely different content about networking protocols.",
+          fileStat: testStat(2000, 100),
+        },
+        logger,
+      )
+      await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
+      const secondCallCount = mockEmbedder.embedText.mock.calls.length
+
+      expect(secondCallCount).toBeGreaterThan(firstCallCount)
+    })
+
+    it("is a no-op when file is not in file_content table", async () => {
+      const mockEmbedder = createMockEmbedder()
+      const index = createSearchIndex(":memory:", mockEmbedder, undefined, {
+        fileToolsEnabled: true,
+      })
+
+      await index.embedFileContent({ filePath: "nonexistent.txt" }, logger)
+
+      expect(mockEmbedder.embedText).not.toHaveBeenCalled()
+    })
+
+    it("is a no-op when no embedder is provided", async () => {
+      const index = createSearchIndex(":memory:", undefined, undefined, {
+        fileToolsEnabled: true,
+      })
+
+      index.upsertNonMdFile("docs/overview.txt", 100)
+      index.upsertFileContent(
+        {
+          filePath: "docs/overview.txt",
+          rawContent: TEXT_FILE_CONTENT,
+          fileStat: testStat(1000, 100),
+        },
+        logger,
+      )
+
+      await expect(
+        index.embedFileContent({ filePath: "docs/overview.txt" }, logger),
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe("removeFileContent cleans up vectors", () => {
+    it("re-embed after removal produces no embedder calls", async () => {
+      const mockEmbedder = createMockEmbedder()
+      const index = createSearchIndex(":memory:", mockEmbedder, undefined, {
+        fileToolsEnabled: true,
+      })
+
+      index.upsertNonMdFile("docs/overview.txt", 100)
+      index.upsertFileContent(
+        {
+          filePath: "docs/overview.txt",
+          rawContent: TEXT_FILE_CONTENT,
+          fileStat: testStat(1000, 100),
+        },
+        logger,
+      )
+      await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
+      expect(mockEmbedder.embedText).toHaveBeenCalled()
+
+      index.removeFileContent({ filePath: "docs/overview.txt" }, logger)
+      mockEmbedder.embedText.mockClear()
+
+      // After removal, embedding the same path is a no-op (file_content row gone)
+      await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
+      expect(mockEmbedder.embedText).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("stale chunk cleanup", () => {
+    it("re-embeds fewer chunks when content shrinks", async () => {
+      const mockEmbedder = createMockEmbedder()
+      const index = createSearchIndex(":memory:", mockEmbedder, undefined, {
+        fileToolsEnabled: true,
+      })
+
+      // Generate content that exceeds CHUNK_THRESHOLD_TOKENS (500) to produce multiple chunks.
+      // Each paragraph needs ~50 words to produce ~10 paragraphs × 50 words = 500+ words.
+      const longContent = Array.from(
+        { length: 15 },
+        (_, paragraphIndex) =>
+          `Paragraph ${String(paragraphIndex)} discusses advanced architecture and system design patterns ` +
+          `including microservices communication protocols and event-driven messaging architectures ` +
+          `with distributed tracing observability and structured logging for production monitoring ` +
+          `plus container orchestration deployment strategies and infrastructure provisioning automation.`,
+      ).join("\n\n")
+
+      index.upsertNonMdFile("docs/long.txt", 2000)
+      index.upsertFileContent(
+        {
+          filePath: "docs/long.txt",
+          rawContent: longContent,
+          fileStat: testStat(1000, 2000),
+        },
+        logger,
+      )
+      await index.embedFileContent({ filePath: "docs/long.txt" }, logger)
+      const firstCallCount = mockEmbedder.embedText.mock.calls.length
+
+      mockEmbedder.embedText.mockClear()
+
+      // Replace with short content — fewer chunks, and the stale ones are cleaned up
+      index.upsertFileContent(
+        {
+          filePath: "docs/long.txt",
+          rawContent: "Short content.",
+          fileStat: testStat(2000, 100),
+        },
+        logger,
+      )
+      await index.embedFileContent({ filePath: "docs/long.txt" }, logger)
+      const secondCallCount = mockEmbedder.embedText.mock.calls.length
+
+      expect(secondCallCount).toBeLessThan(firstCallCount)
     })
   })
 })

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -6120,21 +6120,18 @@ describe("hybridSearch — file content vector search", () => {
     )
     await fileIndex.embedFileContent({ filePath: "Docs/inside.txt" }, logger)
 
-    // "Documents" shares the "Docs" prefix but is a different folder — a
-    // bare string-prefix match would wrongly include it
-    fileIndex.upsertNonMdFile("Documents/outside.txt", 100)
+    // "Docs2" starts with "Docs" as a bare string — only a segment-boundary
+    // check (folder + "/") keeps it out of a "Docs" filter
+    fileIndex.upsertNonMdFile("Docs2/outside.txt", 100)
     fileIndex.upsertFileContent(
       {
-        filePath: "Documents/outside.txt",
+        filePath: "Docs2/outside.txt",
         rawContent: "Weekly operations checklist for the deployment crew.",
         fileStat: testStat(1000, 100),
       },
       logger,
     )
-    await fileIndex.embedFileContent(
-      { filePath: "Documents/outside.txt" },
-      logger,
-    )
+    await fileIndex.embedFileContent({ filePath: "Docs2/outside.txt" }, logger)
 
     // No lexical overlap with the seeded content — both files can only
     // surface through the vector leg (identical mock embeddings), so the
@@ -6144,8 +6141,6 @@ describe("hybridSearch — file content vector search", () => {
       logger,
     )
 
-    // Exactly the in-folder file — presence proves the vector leg ran,
-    // absence of Documents/outside.txt proves the segment-boundary filter
     expect(results.map((result) => result.path)).toEqual(["Docs/inside.txt"])
   })
 

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -5928,14 +5928,13 @@ describe("hybridSearch — file content vector search", () => {
     )
 
     expect(search_mode).toBe("hybrid")
-    // Both should appear — the text file via FTS+vector, the note via vector-only
-    expect(results.length).toBeGreaterThanOrEqual(1)
-    const fileResult = results.find(
-      (result) => result.path === "docs/guide.txt",
-    )
-    expect(fileResult).toBeDefined()
-    expect(fileResult?.kind).toBe("file")
-    expect(fileResult?.extension).toBe(".txt")
+    // Both should appear — guide.txt via FTS+file vector, career.md via note vector
+    expect(results.map((result) => result.path)).toEqual([
+      "docs/guide.txt",
+      "notes/career.md",
+    ])
+    expect(results[0]?.kind).toBe("file")
+    expect(results[0]?.extension).toBe(".txt")
   })
 
   it("file-only vector hit appears with metadata when no FTS match exists", async () => {

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -3765,6 +3765,109 @@ It has multiple sentences to verify chunking works correctly.
       expect(mockEmbedder.embedText).toHaveBeenCalledTimes(2)
       warnSpy.mockRestore()
     })
+
+    it("embeds file content during rebuild Pass 3", async () => {
+      const mockEmbedder = createMockEmbedder()
+      const vaultDir = await mkdtemp(join(tmpdir(), "embed-file-rebuild-"))
+      const dbDir = await mkdtemp(join(tmpdir(), "embed-file-rebuild-db-"))
+      onTestFinished(async () => {
+        await rm(vaultDir, { recursive: true })
+        await rm(dbDir, { recursive: true })
+      })
+      const dbPath = join(dbDir, "search.db")
+      const embeddingIndex = createSearchIndex(
+        dbPath,
+        mockEmbedder,
+        undefined,
+        { fileToolsEnabled: true },
+      )
+
+      await writeFile(
+        join(vaultDir, "note1.md"),
+        "---\ntitle: Note 1\n---\nFirst note content here.",
+      )
+      await writeFile(
+        join(vaultDir, "guide.txt"),
+        "Comprehensive deployment guide covering infrastructure setup.",
+      )
+
+      const { embedding } = await embeddingIndex.rebuildFromVault(
+        { vaultPath: vaultDir },
+        logger,
+      )
+      await embedding
+
+      const inspectDb = new Database(dbPath, { readonly: true })
+      sqliteVec.load(inspectDb)
+      onTestFinished(() => {
+        inspectDb.close()
+      })
+      const fileChunks = inspectDb
+        .prepare<[string], { count: number }>(
+          "SELECT COUNT(*) as count FROM file_content_chunks WHERE file_path = ?",
+        )
+        .get("guide.txt")
+      expect(fileChunks?.count).toBe(1)
+      const fileVectors = inspectDb
+        .prepare<unknown[], { count: number }>(
+          "SELECT COUNT(*) as count FROM file_content_vectors",
+        )
+        .get()
+      expect(fileVectors?.count).toBe(1)
+    })
+
+    it("removes chunks and vectors for a file deleted while the server was down", async () => {
+      const mockEmbedder = createMockEmbedder()
+      const vaultDir = await mkdtemp(join(tmpdir(), "embed-file-deleted-"))
+      const dbDir = await mkdtemp(join(tmpdir(), "embed-file-deleted-db-"))
+      onTestFinished(async () => {
+        await rm(vaultDir, { recursive: true })
+        await rm(dbDir, { recursive: true })
+      })
+      const dbPath = join(dbDir, "search.db")
+      const embeddingIndex = createSearchIndex(
+        dbPath,
+        mockEmbedder,
+        undefined,
+        { fileToolsEnabled: true },
+      )
+
+      await writeFile(join(vaultDir, "ephemeral.txt"), "Transient file body.")
+
+      const firstRebuild = await embeddingIndex.rebuildFromVault(
+        { vaultPath: vaultDir },
+        logger,
+      )
+      await firstRebuild.embedding
+
+      const inspectDb = new Database(dbPath, { readonly: true })
+      sqliteVec.load(inspectDb)
+      onTestFinished(() => {
+        inspectDb.close()
+      })
+      const selectChunkCountStmt = inspectDb.prepare<
+        [string],
+        { count: number }
+      >("SELECT COUNT(*) as count FROM file_content_chunks WHERE file_path = ?")
+      // Trigger guard: the first rebuild actually embedded the file, so the
+      // cleanup assertion below can't pass by the file never being indexed
+      expect(selectChunkCountStmt.get("ephemeral.txt")?.count).toBe(1)
+
+      await rm(join(vaultDir, "ephemeral.txt"))
+      const secondRebuild = await embeddingIndex.rebuildFromVault(
+        { vaultPath: vaultDir },
+        logger,
+      )
+      await secondRebuild.embedding
+
+      expect(selectChunkCountStmt.get("ephemeral.txt")?.count).toBe(0)
+      const fileVectors = inspectDb
+        .prepare<unknown[], { count: number }>(
+          "SELECT COUNT(*) as count FROM file_content_vectors",
+        )
+        .get()
+      expect(fileVectors?.count).toBe(0)
+    })
   })
 })
 
@@ -6041,11 +6144,8 @@ describe("hybridSearch — file content vector search", () => {
       logger,
     )
 
-    const fileResult = results.find(
-      (result) => result.path === "data/report.csv",
-    )
-    expect(fileResult).toBeUndefined()
-    // Note should still appear
-    expect(results.map((result) => result.path)).toContain("notes/tagged.md")
+    // Exactly the tagged note — the file is excluded from both the FTS and
+    // vector legs, and nothing else was seeded
+    expect(results.map((result) => result.path)).toEqual(["notes/tagged.md"])
   })
 })

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -5990,15 +5990,14 @@ describe("hybridSearch — file content vector search", () => {
       logger,
     )
 
-    // The file appears via file content vector search only (no FTS match)
-    const fileResult = results.find(
-      (result) => result.path === "specs/api-spec.yaml",
-    )
-    expect(fileResult).toBeDefined()
-    expect(fileResult?.kind).toBe("file")
-    expect(fileResult?.extension).toBe(".yaml")
-    expect(fileResult?.folder).toBe("specs")
+    // Exactly one result — the file via vector-only (no FTS match)
     expect(search_mode).toBe("hybrid")
+    expect(results.map((result) => result.path)).toEqual([
+      "specs/api-spec.yaml",
+    ])
+    expect(results[0]?.kind).toBe("file")
+    expect(results[0]?.extension).toBe(".yaml")
+    expect(results[0]?.folder).toBe("specs")
   })
 
   it("skips file content vector search when note-specific filters are active", async () => {

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -5767,9 +5767,13 @@ describe("file content vector embeddings", () => {
   })
 
   describe("removeFileContent cleans up vectors", () => {
-    it("re-embed after removal produces no embedder calls", async () => {
+    it("deletes chunk and vector rows from the database", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "file-chunk-remove-"))
+      onTestFinished(() => rm(dir, { recursive: true }))
+      const dbPath = join(dir, "search.db")
+
       const mockEmbedder = createMockEmbedder()
-      const index = createSearchIndex(":memory:", mockEmbedder, undefined, {
+      const index = createSearchIndex(dbPath, mockEmbedder, undefined, {
         fileToolsEnabled: true,
       })
 
@@ -5783,14 +5787,34 @@ describe("file content vector embeddings", () => {
         logger,
       )
       await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
-      expect(mockEmbedder.embedText).toHaveBeenCalled()
+      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
+
+      const inspectDb = new Database(dbPath, { readonly: true })
+      sqliteVec.load(inspectDb)
+      onTestFinished(() => {
+        inspectDb.close()
+      })
+
+      const chunksBefore = inspectDb
+        .prepare(
+          "SELECT COUNT(*) as count FROM file_content_chunks WHERE file_path = ?",
+        )
+        .get("docs/overview.txt") as { count: number }
+      expect(chunksBefore.count).toBe(1)
 
       index.removeFileContent({ filePath: "docs/overview.txt" }, logger)
-      mockEmbedder.embedText.mockClear()
 
-      // After removal, embedding the same path is a no-op (file_content row gone)
-      await index.embedFileContent({ filePath: "docs/overview.txt" }, logger)
-      expect(mockEmbedder.embedText).not.toHaveBeenCalled()
+      const chunksAfter = inspectDb
+        .prepare(
+          "SELECT COUNT(*) as count FROM file_content_chunks WHERE file_path = ?",
+        )
+        .get("docs/overview.txt") as { count: number }
+      expect(chunksAfter.count).toBe(0)
+
+      const vectorsAfter = inspectDb
+        .prepare("SELECT COUNT(*) as count FROM file_content_vectors")
+        .get() as { count: number }
+      expect(vectorsAfter.count).toBe(0)
     })
   })
 
@@ -5943,13 +5967,13 @@ describe("hybridSearch — file content vector search", () => {
       fileToolsEnabled: true,
     })
 
-    // Seed ONLY a text file — no note matches the query via FTS
+    // Seed ONLY a text file with no lexical overlap with the query
     fileIndex.upsertNonMdFile("specs/api-spec.yaml", 300)
     fileIndex.upsertFileContent(
       {
         filePath: "specs/api-spec.yaml",
         rawContent:
-          "openapi: 3.0.0\npaths:\n  /users:\n    get:\n      summary: List users",
+          "openapi: 3.0.0\npaths:\n  /accounts:\n    get:\n      summary: List ledger entries",
         fileStat: testStat(3000, 300),
       },
       logger,
@@ -5959,15 +5983,14 @@ describe("hybridSearch — file content vector search", () => {
       logger,
     )
 
-    // Query using a term NOT in the file content FTS (triggers vector-only path)
+    // Query shares no stems with the file content — FTS returns nothing,
     // but the mock embedder returns identical embeddings so KNN matches
     const { results, search_mode } = await fileIndex.hybridSearch(
-      { query: "user management endpoints" },
+      { query: "quarterly budget forecast" },
       logger,
     )
 
-    // The file should appear via file content vector search even without FTS match
-    // (note: FTS may also partially match "users" — check result presence regardless)
+    // The file appears via file content vector search only (no FTS match)
     const fileResult = results.find(
       (result) => result.path === "specs/api-spec.yaml",
     )

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -5795,14 +5795,16 @@ describe("file content vector embeddings", () => {
   })
 
   describe("content shrink produces fewer chunks", () => {
-    it("embeds only one chunk after content shrinks from multi-chunk", async () => {
+    it("deletes stale chunk and vector rows when content shrinks", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "file-chunk-stale-"))
+      onTestFinished(() => rm(dir, { recursive: true }))
+      const dbPath = join(dir, "search.db")
+
       const mockEmbedder = createMockEmbedder()
-      const index = createSearchIndex(":memory:", mockEmbedder, undefined, {
+      const index = createSearchIndex(dbPath, mockEmbedder, undefined, {
         fileToolsEnabled: true,
       })
 
-      // Generate content that exceeds CHUNK_THRESHOLD_TOKENS (500) to produce multiple chunks.
-      // Each paragraph needs ~50 words to produce ~10 paragraphs x 50 words = 500+ words.
       const longContent = Array.from(
         { length: 15 },
         (_, paragraphIndex) =>
@@ -5822,11 +5824,20 @@ describe("file content vector embeddings", () => {
         logger,
       )
       await index.embedFileContent({ filePath: "docs/long.txt" }, logger)
-      // Long content produces multiple chunks — verify more than 1
-      const longChunkCount = mockEmbedder.embedText.mock.calls.length
-      expect(longChunkCount).toBeGreaterThan(1)
 
-      mockEmbedder.embedText.mockClear()
+      // Verify multiple chunks were created via a read-only inspection connection
+      const inspectDb = new Database(dbPath, { readonly: true })
+      sqliteVec.load(inspectDb)
+      onTestFinished(() => {
+        inspectDb.close()
+      })
+
+      const chunkCountBefore = inspectDb
+        .prepare(
+          "SELECT COUNT(*) as count FROM file_content_chunks WHERE file_path = ?",
+        )
+        .get("docs/long.txt") as { count: number }
+      expect(chunkCountBefore.count).toBeGreaterThan(1)
 
       // Replace with short content — produces exactly 1 chunk
       index.upsertFileContent(
@@ -5838,7 +5849,18 @@ describe("file content vector embeddings", () => {
         logger,
       )
       await index.embedFileContent({ filePath: "docs/long.txt" }, logger)
-      expect(mockEmbedder.embedText).toHaveBeenCalledTimes(1)
+
+      const chunkCountAfter = inspectDb
+        .prepare(
+          "SELECT COUNT(*) as count FROM file_content_chunks WHERE file_path = ?",
+        )
+        .get("docs/long.txt") as { count: number }
+      expect(chunkCountAfter.count).toBe(1)
+
+      const vectorCount = inspectDb
+        .prepare("SELECT COUNT(*) as count FROM file_content_vectors")
+        .get() as { count: number }
+      expect(vectorCount.count).toBe(1)
     })
   })
 })

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -6103,6 +6103,52 @@ describe("hybridSearch — file content vector search", () => {
     expect(results[0]?.folder).toBe("specs")
   })
 
+  it("applies the folder filter to file-content vector-only hits at segment boundaries", async () => {
+    const mockEmbedder = createHybridMockEmbedder()
+    const fileIndex = createSearchIndex(":memory:", mockEmbedder, undefined, {
+      fileToolsEnabled: true,
+    })
+
+    fileIndex.upsertNonMdFile("Docs/inside.txt", 100)
+    fileIndex.upsertFileContent(
+      {
+        filePath: "Docs/inside.txt",
+        rawContent: "Weekly operations checklist for the deployment crew.",
+        fileStat: testStat(1000, 100),
+      },
+      logger,
+    )
+    await fileIndex.embedFileContent({ filePath: "Docs/inside.txt" }, logger)
+
+    // "Documents" shares the "Docs" prefix but is a different folder — a
+    // bare string-prefix match would wrongly include it
+    fileIndex.upsertNonMdFile("Documents/outside.txt", 100)
+    fileIndex.upsertFileContent(
+      {
+        filePath: "Documents/outside.txt",
+        rawContent: "Weekly operations checklist for the deployment crew.",
+        fileStat: testStat(1000, 100),
+      },
+      logger,
+    )
+    await fileIndex.embedFileContent(
+      { filePath: "Documents/outside.txt" },
+      logger,
+    )
+
+    // No lexical overlap with the seeded content — both files can only
+    // surface through the vector leg (identical mock embeddings), so the
+    // folder filter on vector-only hits is the behavior under test
+    const { results } = await fileIndex.hybridSearch(
+      { query: "quarterly budget forecast", filters: { folder: "Docs" } },
+      logger,
+    )
+
+    // Exactly the in-folder file — presence proves the vector leg ran,
+    // absence of Documents/outside.txt proves the segment-boundary filter
+    expect(results.map((result) => result.path)).toEqual(["Docs/inside.txt"])
+  })
+
   it("skips file content vector search when note-specific filters are active", async () => {
     const mockEmbedder = createHybridMockEmbedder()
     const fileIndex = createSearchIndex(":memory:", mockEmbedder, undefined, {

--- a/src/vault-mcp/search/file-watcher.ts
+++ b/src/vault-mcp/search/file-watcher.ts
@@ -188,12 +188,15 @@ export const startFileWatcher = (
           ),
         )
       pendingEmbeds.set(relativePath, currentEmbed)
-      currentEmbed.finally(() => {
+      // Await the .finally()-derived promise, not currentEmbed itself —
+      // .finally() returns a new promise that rejects with the same error,
+      // and awaiting it routes that rejection into the outer catch instead
+      // of leaving a second, unhandled rejection.
+      await currentEmbed.finally(() => {
         if (pendingEmbeds.get(relativePath) === currentEmbed) {
           pendingEmbeds.delete(relativePath)
         }
       })
-      await currentEmbed
     } catch (err) {
       logger.error("failed to process file change", {
         path: relativePath,

--- a/src/vault-mcp/search/file-watcher.ts
+++ b/src/vault-mcp/search/file-watcher.ts
@@ -110,6 +110,31 @@ export const startFileWatcher = (
             },
             logger,
           )
+
+          // Embed file content vectors — serialized per path via the same
+          // pendingEmbeds map (note paths end in .md, file paths don't).
+          // Reads the processed content from the file_content table.
+          const previousEmbed =
+            pendingEmbeds.get(relativePath) ?? Promise.resolve()
+          const currentEmbed = previousEmbed
+            .catch((previousError) => {
+              logger.debug(
+                "previous file embed failed, proceeding with current",
+                {
+                  path: relativePath,
+                  error: describeError(previousError),
+                },
+              )
+            })
+            .then(() =>
+              search.embedFileContent({ filePath: relativePath }, logger),
+            )
+          pendingEmbeds.set(relativePath, currentEmbed)
+          currentEmbed.finally(() => {
+            if (pendingEmbeds.get(relativePath) === currentEmbed) {
+              pendingEmbeds.delete(relativePath)
+            }
+          })
         } catch (error) {
           logger.warn("file content indexing failed", {
             path: relativePath,

--- a/src/vault-mcp/search/file-watcher.ts
+++ b/src/vault-mcp/search/file-watcher.ts
@@ -130,11 +130,18 @@ export const startFileWatcher = (
               search.embedFileContent({ filePath: relativePath }, logger),
             )
           pendingEmbeds.set(relativePath, currentEmbed)
-          currentEmbed.finally(() => {
-            if (pendingEmbeds.get(relativePath) === currentEmbed) {
-              pendingEmbeds.delete(relativePath)
-            }
-          })
+          currentEmbed
+            .catch((embedError) => {
+              logger.warn("file content embedding failed", {
+                path: relativePath,
+                error: describeError(embedError),
+              })
+            })
+            .finally(() => {
+              if (pendingEmbeds.get(relativePath) === currentEmbed) {
+                pendingEmbeds.delete(relativePath)
+              }
+            })
         } catch (error) {
           logger.warn("file content indexing failed", {
             path: relativePath,

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -2192,8 +2192,16 @@ export const createSearchIndex = (
             deleteFileVectorsForPathStmt &&
             deleteFileChunksForPathStmt
           ) {
+            // Query the live table instead of the pre-loop snapshot — files
+            // the watcher indexed during the note embedding loop are in the
+            // table but absent from the snapshot.
             const currentFilePaths = new Set(
-              filesForEmbedding.map((file) => file.path),
+              db
+                .prepare<unknown[], { path: string }>(
+                  "SELECT path FROM file_content",
+                )
+                .all()
+                .map((row) => row.path),
             )
             const indexedFileChunkPaths = db
               .prepare<unknown[], { file_path: string }>(

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -1677,7 +1677,10 @@ export const createSearchIndex = (
     const existingHashes = new Map(
       selectFileChunkHashesStmt
         .all(params.filePath)
-        .map((row) => [row.chunk_index, row.content_hash]),
+        .map((chunkHashRow) => [
+          chunkHashRow.chunk_index,
+          chunkHashRow.content_hash,
+        ]),
     )
 
     let embeddedCount = 0
@@ -1745,10 +1748,16 @@ export const createSearchIndex = (
     logger: Logger,
   ): Promise<void> => {
     if (!embedder || !selectFileContentForEmbeddingStmt) return
-    const row = selectFileContentForEmbeddingStmt.get(params.filePath)
-    if (!row) return
+    const fileContentRow = selectFileContentForEmbeddingStmt.get(
+      params.filePath,
+    )
+    if (!fileContentRow) return
     await embedAndStoreFileChunks(
-      { filePath: params.filePath, title: row.title, content: row.content },
+      {
+        filePath: params.filePath,
+        title: fileContentRow.title,
+        content: fileContentRow.content,
+      },
       logger,
     )
   }
@@ -2214,14 +2223,14 @@ export const createSearchIndex = (
                   "SELECT path FROM file_content",
                 )
                 .all()
-                .map((row) => row.path),
+                .map((fileContentPathRow) => fileContentPathRow.path),
             )
             const indexedFileChunkPaths = db
               .prepare<unknown[], { file_path: string }>(
                 "SELECT DISTINCT file_path FROM file_content_chunks",
               )
               .all()
-              .map((row) => row.file_path)
+              .map((chunkPathRow) => chunkPathRow.file_path)
 
             const deletedFilePaths = indexedFileChunkPaths.filter(
               (path) => !currentFilePaths.has(path),

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -696,6 +696,20 @@ export const createSearchIndex = (
          ORDER BY rank LIMIT ?`,
       )
     : null
+  const selectFileContentMetadataStmt = fileToolsEnabled
+    ? db.prepare<
+        [string],
+        {
+          path: string
+          title: string
+          folder: string
+          mtime: number
+          bytes: number
+        }
+      >(
+        "SELECT path, title, folder, mtime, bytes FROM file_content WHERE path = ?",
+      )
+    : null
 
   // ── Vector prepared statements (conditional on embedder) ──────
   const upsertChunkStmt = embedder
@@ -781,6 +795,12 @@ export const createSearchIndex = (
   const deleteStaleFileVectorsStmt = fileContentVectorEnabled
     ? db.prepare(
         `DELETE FROM file_content_vectors WHERE chunk_id IN (SELECT id FROM file_content_chunks WHERE file_path = ? AND chunk_index >= ?)`,
+      )
+    : null
+  // Reads the processed content from file_content for embedding.
+  const selectFileContentForEmbeddingStmt = fileContentVectorEnabled
+    ? db.prepare<[string], { title: string; content: string }>(
+        "SELECT title, content FROM file_content WHERE path = ?",
       )
     : null
 
@@ -1716,13 +1736,6 @@ export const createSearchIndex = (
     return embeddedCount
   }
 
-  /** Reads the processed content from file_content for embedding. */
-  const selectFileContentForEmbeddingStmt = fileContentVectorEnabled
-    ? db.prepare<[string], { title: string; content: string }>(
-        "SELECT title, content FROM file_content WHERE path = ?",
-      )
-    : null
-
   /** Embed a file's rendered content into vector storage. Reads the processed
    *  content from the file_content table (already linearized/truncated by
    *  upsertFileContent). No-op when the embedding pipeline or file tools are
@@ -2312,20 +2325,7 @@ export const createSearchIndex = (
           selectFirstFileChunkStmt,
         }
       : null,
-    selectFileContentMetadataStmt: fileToolsEnabled
-      ? db.prepare<
-          [string],
-          {
-            path: string
-            title: string
-            folder: string
-            mtime: number
-            bytes: number
-          }
-        >(
-          "SELECT path, title, folder, mtime, bytes FROM file_content WHERE path = ?",
-        )
-      : null,
+    selectFileContentMetadataStmt,
   }
 
   /** Binds the query context as the first argument of a query function,

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -516,6 +516,24 @@ export const createSearchIndex = (
         path UNINDEXED, title, content, tokenize='porter unicode61'
       );
     `)
+    if (embedder) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS file_content_chunks (
+          id           INTEGER PRIMARY KEY AUTOINCREMENT,
+          file_path    TEXT NOT NULL,
+          chunk_index  INTEGER NOT NULL,
+          chunk_text   TEXT NOT NULL,
+          content_hash TEXT NOT NULL,
+          UNIQUE(file_path, chunk_index)
+        );
+        CREATE INDEX IF NOT EXISTS idx_file_content_chunks_path ON file_content_chunks(file_path);
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS file_content_vectors USING vec0(
+          chunk_id  INTEGER PRIMARY KEY,
+          embedding float[384]
+        );
+      `)
+    }
   }
 
   // CREATE TABLE IF NOT EXISTS is a no-op on a pre-existing DB file, so a warm
@@ -721,6 +739,51 @@ export const createSearchIndex = (
       )
     : null
 
+  // ── File content vector prepared statements (conditional on fileToolsEnabled + embedder) ──
+  const fileContentVectorEnabled = fileToolsEnabled && Boolean(embedder)
+  const upsertFileChunkStmt = fileContentVectorEnabled
+    ? db.prepare(
+        `INSERT OR REPLACE INTO file_content_chunks (file_path, chunk_index, chunk_text, content_hash)
+         VALUES (@file_path, @chunk_index, @chunk_text, @content_hash)`,
+      )
+    : null
+  const selectFileChunkHashesStmt = fileContentVectorEnabled
+    ? db.prepare<unknown[], { chunk_index: number; content_hash: string }>(
+        `SELECT chunk_index, content_hash FROM file_content_chunks WHERE file_path = ?`,
+      )
+    : null
+  const selectFileChunkIdStmt = fileContentVectorEnabled
+    ? db.prepare<[string, number], { id: number }>(
+        `SELECT id FROM file_content_chunks WHERE file_path = ? AND chunk_index = ?`,
+      )
+    : null
+  const deleteStaleFileChunksStmt = fileContentVectorEnabled
+    ? db.prepare(
+        `DELETE FROM file_content_chunks WHERE file_path = ? AND chunk_index >= ?`,
+      )
+    : null
+  const insertFileVectorStmt = fileContentVectorEnabled
+    ? db.prepare(
+        `INSERT INTO file_content_vectors (chunk_id, embedding) VALUES (?, ?)`,
+      )
+    : null
+  const deleteFileVectorByChunkIdStmt = fileContentVectorEnabled
+    ? db.prepare(`DELETE FROM file_content_vectors WHERE chunk_id = ?`)
+    : null
+  const deleteFileVectorsForPathStmt = fileContentVectorEnabled
+    ? db.prepare(
+        `DELETE FROM file_content_vectors WHERE chunk_id IN (SELECT id FROM file_content_chunks WHERE file_path = ?)`,
+      )
+    : null
+  const deleteFileChunksForPathStmt = fileContentVectorEnabled
+    ? db.prepare(`DELETE FROM file_content_chunks WHERE file_path = ?`)
+    : null
+  const deleteStaleFileVectorsStmt = fileContentVectorEnabled
+    ? db.prepare(
+        `DELETE FROM file_content_vectors WHERE chunk_id IN (SELECT id FROM file_content_chunks WHERE file_path = ? AND chunk_index >= ?)`,
+      )
+    : null
+
   // ── Memory-entry prepared statements (conditional on memoryDir) ──
   const insertMemoryEntryStmt = memoryDir
     ? db.prepare(
@@ -834,6 +897,28 @@ export const createSearchIndex = (
   const selectFirstChunkStmt = embedder
     ? db.prepare<[string], { chunk_text: string }>(
         `SELECT chunk_text FROM note_chunks WHERE note_path = ? AND chunk_index = 0`,
+      )
+    : null
+
+  /** KNN search over file content vectors — finds the k nearest file chunks. */
+  const fileContentKnnSearchStmt = fileContentVectorEnabled
+    ? db.prepare<
+        unknown[],
+        { file_path: string; chunk_text: string; distance: number }
+      >(
+        `SELECT fc.file_path, fc.chunk_text, fv.distance
+         FROM file_content_vectors fv
+         JOIN file_content_chunks fc ON fc.id = fv.chunk_id
+         WHERE fv.embedding MATCH ?
+           AND fv.k = ?
+         ORDER BY fv.distance`,
+      )
+    : null
+
+  /** First chunk text for a file — reranker fallback for FTS-only file hits. */
+  const selectFirstFileChunkStmt = fileContentVectorEnabled
+    ? db.prepare<[string], { chunk_text: string }>(
+        `SELECT chunk_text FROM file_content_chunks WHERE file_path = ? AND chunk_index = 0`,
       )
     : null
 
@@ -1064,6 +1149,10 @@ export const createSearchIndex = (
       if (deleteFileContentStmt && deleteFileContentFtsStmt) {
         deleteFileContentFtsStmt.run(params.filePath)
         deleteFileContentStmt.run(params.filePath)
+      }
+      if (deleteFileVectorsForPathStmt && deleteFileChunksForPathStmt) {
+        deleteFileVectorsForPathStmt.run(params.filePath)
+        deleteFileChunksForPathStmt.run(params.filePath)
       }
       deleteLinksStmt.run(params.filePath)
     })()
@@ -1544,6 +1633,113 @@ export const createSearchIndex = (
     }
   }
 
+  /** Chunks and embeds file content into file_content_chunks / file_content_vectors.
+   *  Mirrors embedAndStoreChunks for notes: content-hash gated, transaction-wrapped,
+   *  stale chunks cleaned up. Returns the number of chunks actually (re-)embedded. */
+  const embedAndStoreFileChunks = async (
+    params: { filePath: string; title: string; content: string },
+    logger: Logger,
+  ): Promise<number> => {
+    if (
+      !embedder ||
+      !upsertFileChunkStmt ||
+      !selectFileChunkHashesStmt ||
+      !selectFileChunkIdStmt ||
+      !deleteStaleFileChunksStmt ||
+      !insertFileVectorStmt ||
+      !deleteFileVectorByChunkIdStmt
+    ) {
+      return 0
+    }
+
+    const chunks = chunkNoteContent(params.title, params.content)
+
+    const existingHashes = new Map(
+      selectFileChunkHashesStmt
+        .all(params.filePath)
+        .map((row) => [row.chunk_index, row.content_hash]),
+    )
+
+    let embeddedCount = 0
+
+    for (const chunk of chunks) {
+      const hash = contentHash(chunk.text)
+
+      if (existingHashes.get(chunk.index) === hash) continue
+
+      const embedding = await embedder.embedText(chunk.text)
+
+      db.transaction(() => {
+        const existingChunk = selectFileChunkIdStmt.get(
+          params.filePath,
+          chunk.index,
+        )
+        if (existingChunk) {
+          deleteFileVectorByChunkIdStmt.run(BigInt(existingChunk.id))
+        }
+
+        upsertFileChunkStmt.run({
+          file_path: params.filePath,
+          chunk_index: chunk.index,
+          chunk_text: chunk.text,
+          content_hash: hash,
+        })
+
+        const chunkRow = selectFileChunkIdStmt.get(params.filePath, chunk.index)
+        if (!chunkRow) {
+          throw new Error(
+            `file chunk row missing after upsert: ${params.filePath} chunk ${String(chunk.index)}`,
+          )
+        }
+        insertFileVectorStmt.run(
+          BigInt(chunkRow.id),
+          Buffer.from(
+            embedding.buffer,
+            embedding.byteOffset,
+            embedding.byteLength,
+          ),
+        )
+      })()
+      embeddedCount++
+    }
+
+    if (deleteStaleFileVectorsStmt) {
+      deleteStaleFileVectorsStmt.run(params.filePath, chunks.length)
+    }
+    deleteStaleFileChunksStmt.run(params.filePath, chunks.length)
+
+    logger.debug("embedded file content", {
+      path: params.filePath,
+      totalChunks: chunks.length,
+      embeddedCount,
+    })
+    return embeddedCount
+  }
+
+  /** Reads the processed content from file_content for embedding. */
+  const selectFileContentForEmbeddingStmt = fileContentVectorEnabled
+    ? db.prepare<[string], { title: string; content: string }>(
+        "SELECT title, content FROM file_content WHERE path = ?",
+      )
+    : null
+
+  /** Embed a file's rendered content into vector storage. Reads the processed
+   *  content from the file_content table (already linearized/truncated by
+   *  upsertFileContent). No-op when the embedding pipeline or file tools are
+   *  disabled, or the file is not in the FTS index. Safe to call unconditionally. */
+  const embedFileContent = async (
+    params: { filePath: string },
+    logger: Logger,
+  ): Promise<void> => {
+    if (!embedder || !selectFileContentForEmbeddingStmt) return
+    const row = selectFileContentForEmbeddingStmt.get(params.filePath)
+    if (!row) return
+    await embedAndStoreFileChunks(
+      { filePath: params.filePath, title: row.title, content: row.content },
+      logger,
+    )
+  }
+
   /** Removes a note from the notes table, FTS index, links, tasks, vectors,
    *  and — for memory files — the entry-granular index. A watcher rename
    *  arrives as unlink+add, so a renamed memory file behaves as delete+create:
@@ -1898,6 +2094,17 @@ export const createSearchIndex = (
       snapshotMtimeMs: note.modifiedAtMs,
     }))
 
+    // File content for embedding — read the processed text from file_content
+    // (already linearized/extracted/truncated by upsertFileContent above).
+    const filesForEmbedding = fileContentVectorEnabled
+      ? db
+          .prepare<
+            unknown[],
+            { path: string; title: string; content: string; mtime: number }
+          >("SELECT path, title, content, mtime FROM file_content")
+          .all()
+      : []
+
     // Pass 3 runs in the background — the server can start accepting requests
     // immediately after FTS indexing (Passes 1+2) finishes. Embedding is a
     // progressive enhancement: search works with FTS-only until vectors are ready.
@@ -1976,6 +2183,74 @@ export const createSearchIndex = (
             // (Express healthz, MCP tool handlers) can drain.
             await setImmediateAsync()
           }
+          // ── File content embedding ──────────────────────────────
+          if (filesForEmbedding.length > 0) {
+            // Clean up vectors for files that no longer exist
+            const currentFilePaths = new Set(
+              filesForEmbedding.map((file) => file.path),
+            )
+            const indexedFileChunkPaths = db
+              .prepare<unknown[], { file_path: string }>(
+                "SELECT DISTINCT file_path FROM file_content_chunks",
+              )
+              .all()
+              .map((row) => row.file_path)
+
+            const deletedFilePaths = indexedFileChunkPaths.filter(
+              (path) => !currentFilePaths.has(path),
+            )
+            if (
+              deletedFilePaths.length > 0 &&
+              deleteFileVectorsForPathStmt &&
+              deleteFileChunksForPathStmt
+            ) {
+              for (const path of deletedFilePaths) {
+                deleteFileVectorsForPathStmt.run(path)
+                deleteFileChunksForPathStmt.run(path)
+              }
+              logger.info("cleaned up vectors for deleted files", {
+                count: deletedFilePaths.length,
+              })
+            }
+
+            const selectFileMtimeStmt = db.prepare<[string], { mtime: number }>(
+              "SELECT mtime FROM file_content WHERE path = ?",
+            )
+
+            let fileChunksEmbedded = 0
+            let fileEmbedErrors = 0
+            for (const file of filesForEmbedding) {
+              const currentFile = selectFileMtimeStmt.get(file.path)
+              const fileIsStale =
+                !currentFile || currentFile.mtime !== file.mtime
+              if (fileIsStale) continue
+
+              try {
+                fileChunksEmbedded += await embedAndStoreFileChunks(
+                  {
+                    filePath: file.path,
+                    title: file.title,
+                    content: file.content,
+                  },
+                  logger,
+                )
+              } catch (err) {
+                fileEmbedErrors++
+                logger.warn("failed to embed file content", {
+                  path: file.path,
+                  error: describeError(err),
+                })
+              }
+
+              await setImmediateAsync()
+            }
+            logger.info("file content embedding pass complete", {
+              files: filesForEmbedding.length,
+              fileChunksEmbedded,
+              ...(fileEmbedErrors > 0 ? { fileEmbedErrors } : {}),
+            })
+          }
+
           logger.info("embedding pass complete", {
             notes: notesForEmbedding.length,
             chunksEmbedded,
@@ -2019,6 +2294,26 @@ export const createSearchIndex = (
     fileContentFts: searchFileContentFtsStmt
       ? { searchStmt: searchFileContentFtsStmt }
       : null,
+    fileContentVector: fileContentKnnSearchStmt
+      ? {
+          knnSearchStmt: fileContentKnnSearchStmt,
+          selectFirstFileChunkStmt,
+        }
+      : null,
+    selectFileContentMetadataStmt: fileToolsEnabled
+      ? db.prepare<
+          [string],
+          {
+            path: string
+            title: string
+            folder: string
+            mtime: number
+            bytes: number
+          }
+        >(
+          "SELECT path, title, folder, mtime, bytes FROM file_content WHERE path = ?",
+        )
+      : null,
   }
 
   /** Binds the query context as the first argument of a query function,
@@ -2038,6 +2333,7 @@ export const createSearchIndex = (
     removeNonMdFile,
     upsertFileContent,
     removeFileContent,
+    embedFileContent,
     fullTextSearch: bindQueryContext(queries.fullTextSearch),
     hybridSearch: bindQueryContext(queries.hybridSearch),
     memoryRecall: bindQueryContext(queries.memoryRecall),

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -2184,8 +2184,14 @@ export const createSearchIndex = (
             await setImmediateAsync()
           }
           // ── File content embedding ──────────────────────────────
-          if (filesForEmbedding.length > 0) {
-            // Clean up vectors for files that no longer exist
+          // Clean up vectors for files that no longer exist — runs
+          // unconditionally so deletions while the server was down are caught
+          // even when filesForEmbedding is empty (mirroring the note-side cleanup).
+          if (
+            fileContentVectorEnabled &&
+            deleteFileVectorsForPathStmt &&
+            deleteFileChunksForPathStmt
+          ) {
             const currentFilePaths = new Set(
               filesForEmbedding.map((file) => file.path),
             )
@@ -2199,11 +2205,7 @@ export const createSearchIndex = (
             const deletedFilePaths = indexedFileChunkPaths.filter(
               (path) => !currentFilePaths.has(path),
             )
-            if (
-              deletedFilePaths.length > 0 &&
-              deleteFileVectorsForPathStmt &&
-              deleteFileChunksForPathStmt
-            ) {
+            if (deletedFilePaths.length > 0) {
               for (const path of deletedFilePaths) {
                 deleteFileVectorsForPathStmt.run(path)
                 deleteFileChunksForPathStmt.run(path)
@@ -2212,7 +2214,9 @@ export const createSearchIndex = (
                 count: deletedFilePaths.length,
               })
             }
+          }
 
+          if (filesForEmbedding.length > 0) {
             const selectFileMtimeStmt = db.prepare<[string], { mtime: number }>(
               "SELECT mtime FROM file_content WHERE path = ?",
             )

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -126,6 +126,12 @@ type FileContentMetadataRow = {
   bytes: number
 }
 
+/** Maps one search leg's results to the identifier shape computeRrfScores
+ *  fuses on — path is the identity all four hybrid-search legs share. */
+const toRankedList = (
+  items: readonly { path: string }[],
+): { identifier: string }[] => items.map((item) => ({ identifier: item.path }))
+
 // ── Vector search (internal) ───────────────────────────────────
 
 /** Embeds the query text and returns the Buffer for KNN queries. Null when
@@ -509,10 +515,7 @@ export const hybridSearch = async (
     }
     // Merge note FTS + file content FTS via 2-list RRF
     const fallbackRrf = computeRrfScores({
-      rankedLists: [
-        ftsResults.map((result) => ({ identifier: result.path })),
-        fileContentResults.map((result) => ({ identifier: result.path })),
-      ],
+      rankedLists: [toRankedList(ftsResults), toRankedList(fileContentResults)],
     })
     const ftsResultsByPath = new Map(
       ftsResults.map((result) => [result.path, result]),
@@ -542,18 +545,13 @@ export const hybridSearch = async (
     return { results: fallbackSliced, search_mode: "fts", reranked: false }
   }
 
-  // Compute RRF scores from all available ranked lists
+  // Compute RRF scores from all four ranked lists — an empty list
+  // contributes no scores, so each leg is passed unconditionally
   const rankedLists = [
-    ftsResults.map((result) => ({ identifier: result.path })),
-    ...(vectorHits.length > 0
-      ? [vectorHits.map((hit) => ({ identifier: hit.path }))]
-      : []),
-    ...(fileContentResults.length > 0
-      ? [fileContentResults.map((result) => ({ identifier: result.path }))]
-      : []),
-    ...(fileContentVectorHits.length > 0
-      ? [fileContentVectorHits.map((hit) => ({ identifier: hit.path }))]
-      : []),
+    toRankedList(ftsResults),
+    toRankedList(vectorHits),
+    toRankedList(fileContentResults),
+    toRankedList(fileContentVectorHits),
   ]
   const rrfScores = computeRrfScores({ rankedLists })
 

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -165,24 +165,27 @@ const vectorSearch = (
   if (!knnSearchStmt) return []
 
   try {
-    const rows = knnSearchStmt.all(params.queryEmbeddingBuffer, params.limit)
+    const noteKnnRows = knnSearchStmt.all(
+      params.queryEmbeddingBuffer,
+      params.limit,
+    )
 
     // Deduplicate to best chunk per note — rows are ordered by distance
     // ascending, so the first occurrence of each path is the closest match.
     const bestChunkPerNote = new Map<string, VectorHit>()
-    for (const row of rows) {
-      if (!bestChunkPerNote.has(row.note_path)) {
-        bestChunkPerNote.set(row.note_path, {
-          path: row.note_path,
-          distance: row.distance,
-          chunkText: row.chunk_text,
+    for (const knnRow of noteKnnRows) {
+      if (!bestChunkPerNote.has(knnRow.note_path)) {
+        bestChunkPerNote.set(knnRow.note_path, {
+          path: knnRow.note_path,
+          distance: knnRow.distance,
+          chunkText: knnRow.chunk_text,
         })
       }
     }
 
     logger.info("vector search", {
       query: params.query,
-      knnHits: rows.length,
+      knnHits: noteKnnRows.length,
       uniqueNotes: bestChunkPerNote.size,
     })
     return [...bestChunkPerNote.values()]
@@ -194,8 +197,9 @@ const vectorSearch = (
   }
 }
 
-/** KNN over file content vectors. Accepts a pre-computed query embedding buffer
- *  to avoid re-embedding the same query text that vectorSearch already embedded. */
+/** KNN over file content vectors — returns the best-matching chunk per file
+ *  for a pre-computed query embedding. Empty when file content vectors are
+ *  disabled or the KNN query fails. */
 const fileContentVectorSearch = (
   context: SearchQueryContext,
   params: { query: string; queryEmbeddingBuffer: Buffer; limit: number },
@@ -205,22 +209,25 @@ const fileContentVectorSearch = (
   if (!knnSearchStmt) return []
 
   try {
-    const rows = knnSearchStmt.all(params.queryEmbeddingBuffer, params.limit)
+    const fileKnnRows = knnSearchStmt.all(
+      params.queryEmbeddingBuffer,
+      params.limit,
+    )
 
     const bestChunkPerFile = new Map<string, VectorHit>()
-    for (const row of rows) {
-      if (!bestChunkPerFile.has(row.file_path)) {
-        bestChunkPerFile.set(row.file_path, {
-          path: row.file_path,
-          distance: row.distance,
-          chunkText: row.chunk_text,
+    for (const knnRow of fileKnnRows) {
+      if (!bestChunkPerFile.has(knnRow.file_path)) {
+        bestChunkPerFile.set(knnRow.file_path, {
+          path: knnRow.file_path,
+          distance: knnRow.distance,
+          chunkText: knnRow.chunk_text,
         })
       }
     }
 
     logger.info("file content vector search", {
       query: params.query,
-      knnHits: rows.length,
+      knnHits: fileKnnRows.length,
       uniqueFiles: bestChunkPerFile.size,
     })
     return [...bestChunkPerFile.values()]

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -613,20 +613,32 @@ export const hybridSearch = async (
     const fileVectorHit = fileContentVectorHitsByPath.get(path)
     if (fileVectorHit && context.selectFileContentMetadataStmt) {
       const fileMetadata = context.selectFileContentMetadataStmt.get(path)
-      if (fileMetadata) {
-        mergedResults.push(
-          fileContentRowToSearchResult(
-            {
-              ...fileMetadata,
-              snippet: buildSnippetFromChunkText(
-                fileVectorHit.chunkText,
-                snippetTokens,
-              ),
-            },
-            score,
-          ),
-        )
+      if (!fileMetadata) continue
+
+      // Apply folder filter — file content FTS applies it via SQL, but
+      // vector-only results bypass FTS and need the check here.
+      if (
+        params.filters?.folder &&
+        !fileMetadata.folder.startsWith(
+          stripTrailingSlashes(params.filters.folder),
+        ) &&
+        fileMetadata.folder !== stripTrailingSlashes(params.filters.folder)
+      ) {
+        continue
       }
+
+      mergedResults.push(
+        fileContentRowToSearchResult(
+          {
+            ...fileMetadata,
+            snippet: buildSnippetFromChunkText(
+              fileVectorHit.chunkText,
+              snippetTokens,
+            ),
+          },
+          score,
+        ),
+      )
     }
   }
 

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -152,7 +152,7 @@ const embedQuery = async (
 
 const vectorSearch = (
   context: SearchQueryContext,
-  params: { queryEmbeddingBuffer: Buffer; limit: number },
+  params: { query: string; queryEmbeddingBuffer: Buffer; limit: number },
   logger: Logger,
 ): VectorHit[] => {
   const { knnSearchStmt } = context.vector
@@ -175,6 +175,7 @@ const vectorSearch = (
     }
 
     logger.info("vector search", {
+      query: params.query,
       knnHits: rows.length,
       uniqueNotes: bestChunkPerNote.size,
     })
@@ -191,7 +192,7 @@ const vectorSearch = (
  *  to avoid re-embedding the same query text that vectorSearch already embedded. */
 const fileContentVectorSearch = (
   context: SearchQueryContext,
-  params: { queryEmbeddingBuffer: Buffer; limit: number },
+  params: { query: string; queryEmbeddingBuffer: Buffer; limit: number },
   logger: Logger,
 ): VectorHit[] => {
   const knnSearchStmt = context.fileContentVector?.knnSearchStmt
@@ -212,6 +213,7 @@ const fileContentVectorSearch = (
     }
 
     logger.info("file content vector search", {
+      query: params.query,
       knnHits: rows.length,
       uniqueFiles: bestChunkPerFile.size,
     })
@@ -476,7 +478,7 @@ export const hybridSearch = async (
   const vectorHits = queryEmbeddingBuffer
     ? vectorSearch(
         context,
-        { queryEmbeddingBuffer, limit: candidateLimit },
+        { query: params.query, queryEmbeddingBuffer, limit: candidateLimit },
         logger,
       )
     : []
@@ -487,7 +489,7 @@ export const hybridSearch = async (
       ? []
       : fileContentVectorSearch(
           context,
-          { queryEmbeddingBuffer, limit: candidateLimit },
+          { query: params.query, queryEmbeddingBuffer, limit: candidateLimit },
           logger,
         )
 

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -616,15 +616,14 @@ export const hybridSearch = async (
       if (!fileMetadata) continue
 
       // Apply folder filter — file content FTS applies it via SQL, but
-      // vector-only results bypass FTS and need the check here.
-      if (
-        params.filters?.folder &&
-        !fileMetadata.folder.startsWith(
-          stripTrailingSlashes(params.filters.folder),
-        ) &&
-        fileMetadata.folder !== stripTrailingSlashes(params.filters.folder)
-      ) {
-        continue
+      // vector-only results bypass FTS and need the check here. Uses a
+      // segment boundary (folder + "/") so "Docs" doesn't match "Documents".
+      if (params.filters?.folder) {
+        const folderPrefix = stripTrailingSlashes(params.filters.folder) + "/"
+        const folderMatch =
+          fileMetadata.folder === stripTrailingSlashes(params.filters.folder) ||
+          (fileMetadata.folder + "/").startsWith(folderPrefix)
+        if (!folderMatch) continue
       }
 
       mergedResults.push(

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -48,6 +48,11 @@ import type { Embedder } from "./embedder.js"
 // ── Context ────────────────────────────────────────────────────
 
 type VectorHitRow = { note_path: string; chunk_text: string; distance: number }
+type FileContentVectorHitRow = {
+  file_path: string
+  chunk_text: string
+  distance: number
+}
 
 /** One memory_entries row — hydrated whole so recall never needs a second
  *  lookup per entry. */
@@ -94,28 +99,67 @@ export type SearchQueryContext = {
       FileContentFtsRow
     >
   } | null
+  /** Null when FILE_TOOLS_ENABLED or embedder is off — hybridSearch skips
+   *  the file content vector leg. */
+  readonly fileContentVector: {
+    readonly knnSearchStmt: Database.Statement<
+      unknown[],
+      FileContentVectorHitRow
+    >
+    readonly selectFirstFileChunkStmt: Database.Statement<
+      [string],
+      { chunk_text: string }
+    > | null
+  } | null
+  /** Metadata lookup for files found only via vector search (no FTS hit). */
+  readonly selectFileContentMetadataStmt: Database.Statement<
+    [string],
+    FileContentMetadataRow
+  > | null
+}
+
+type FileContentMetadataRow = {
+  path: string
+  title: string
+  folder: string
+  mtime: number
+  bytes: number
 }
 
 // ── Vector search (internal) ───────────────────────────────────
 
-const vectorSearch = async (
+/** Embeds the query text and returns the Buffer for KNN queries. Null when
+ *  no embedder is available or the embedding fails. */
+const embedQuery = async (
   context: SearchQueryContext,
-  params: { query: string; limit: number },
+  query: string,
   logger: Logger,
-): Promise<VectorHit[]> => {
-  const { embedder, knnSearchStmt } = context.vector
-  if (!embedder || !knnSearchStmt) return []
+): Promise<Buffer | null> => {
+  const { embedder } = context.vector
+  if (!embedder) return null
+  try {
+    const queryEmbedding = await embedder.embedText(query)
+    return Buffer.from(
+      queryEmbedding.buffer,
+      queryEmbedding.byteOffset,
+      queryEmbedding.byteLength,
+    )
+  } catch (error) {
+    logger.warn("query embedding failed", { error: describeError(error) })
+    return null
+  }
+}
+
+const vectorSearch = (
+  context: SearchQueryContext,
+  params: { queryEmbeddingBuffer: Buffer; limit: number },
+  logger: Logger,
+): VectorHit[] => {
+  const { knnSearchStmt } = context.vector
+  if (!knnSearchStmt) return []
 
   try {
-    const queryEmbedding = await embedder.embedText(params.query)
-    const rows = knnSearchStmt.all(
-      Buffer.from(
-        queryEmbedding.buffer,
-        queryEmbedding.byteOffset,
-        queryEmbedding.byteLength,
-      ),
-      params.limit,
-    )
+    const rows = knnSearchStmt.all(params.queryEmbeddingBuffer, params.limit)
 
     // Deduplicate to best chunk per note — rows are ordered by distance
     // ascending, so the first occurrence of each path is the closest match.
@@ -131,13 +175,49 @@ const vectorSearch = async (
     }
 
     logger.info("vector search", {
-      query: params.query,
       knnHits: rows.length,
       uniqueNotes: bestChunkPerNote.size,
     })
     return [...bestChunkPerNote.values()]
   } catch (error) {
     logger.warn("vector search failed, falling back to FTS-only", {
+      error: describeError(error),
+    })
+    return []
+  }
+}
+
+/** KNN over file content vectors. Accepts a pre-computed query embedding buffer
+ *  to avoid re-embedding the same query text that vectorSearch already embedded. */
+const fileContentVectorSearch = (
+  context: SearchQueryContext,
+  params: { queryEmbeddingBuffer: Buffer; limit: number },
+  logger: Logger,
+): VectorHit[] => {
+  const knnSearchStmt = context.fileContentVector?.knnSearchStmt
+  if (!knnSearchStmt) return []
+
+  try {
+    const rows = knnSearchStmt.all(params.queryEmbeddingBuffer, params.limit)
+
+    const bestChunkPerFile = new Map<string, VectorHit>()
+    for (const row of rows) {
+      if (!bestChunkPerFile.has(row.file_path)) {
+        bestChunkPerFile.set(row.file_path, {
+          path: row.file_path,
+          distance: row.distance,
+          chunkText: row.chunk_text,
+        })
+      }
+    }
+
+    logger.info("file content vector search", {
+      knnHits: rows.length,
+      uniqueFiles: bestChunkPerFile.size,
+    })
+    return [...bestChunkPerFile.values()]
+  } catch (error) {
+    logger.warn("file content vector search failed", {
       error: describeError(error),
     })
     return []
@@ -389,15 +469,33 @@ export const hybridSearch = async (
         params.filters?.folder,
       )
 
-  // Attempt vector search — returns [] on any failure
-  const vectorHits = await vectorSearch(
-    context,
-    { query: params.query, limit: candidateLimit },
-    logger,
-  )
+  // Embed the query once — shared by note and file content vector searches
+  const queryEmbeddingBuffer = await embedQuery(context, params.query, logger)
 
-  // FTS-only fallback when no vectors are available
-  if (vectorHits.length === 0) {
+  // Attempt vector search — returns [] when embedding or KNN is unavailable
+  const vectorHits = queryEmbeddingBuffer
+    ? vectorSearch(
+        context,
+        { queryEmbeddingBuffer, limit: candidateLimit },
+        logger,
+      )
+    : []
+
+  // File content vector search — same skip condition as file content FTS
+  const fileContentVectorHits =
+    hasNoteSpecificFilters || !queryEmbeddingBuffer
+      ? []
+      : fileContentVectorSearch(
+          context,
+          { queryEmbeddingBuffer, limit: candidateLimit },
+          logger,
+        )
+
+  const hasAnyVectorHits =
+    vectorHits.length > 0 || fileContentVectorHits.length > 0
+
+  // FTS-only fallback when no vectors are available from either source
+  if (!hasAnyVectorHits) {
     if (fileContentResults.length === 0) {
       const fallbackResults = ftsResults.slice(0, userLimit)
       logger.info("hybrid search", {
@@ -442,17 +540,22 @@ export const hybridSearch = async (
     return { results: fallbackSliced, search_mode: "fts", reranked: false }
   }
 
-  // Compute RRF scores from all ranked lists (notes FTS + vector + file content)
+  // Compute RRF scores from all available ranked lists
   const rankedLists = [
     ftsResults.map((result) => ({ identifier: result.path })),
-    vectorHits.map((hit) => ({ identifier: hit.path })),
+    ...(vectorHits.length > 0
+      ? [vectorHits.map((hit) => ({ identifier: hit.path }))]
+      : []),
     ...(fileContentResults.length > 0
       ? [fileContentResults.map((result) => ({ identifier: result.path }))]
+      : []),
+    ...(fileContentVectorHits.length > 0
+      ? [fileContentVectorHits.map((hit) => ({ identifier: hit.path }))]
       : []),
   ]
   const rrfScores = computeRrfScores({ rankedLists })
 
-  // Index FTS results, vector hits, and file content by path for O(1) lookup
+  // Index all result sources by path for O(1) lookup
   const ftsResultsByPath = new Map(
     ftsResults.map((result) => [result.path, result]),
   )
@@ -460,45 +563,71 @@ export const hybridSearch = async (
   const fileContentByPath = new Map(
     fileContentResults.map((result) => [result.path, result]),
   )
+  const fileContentVectorHitsByPath = new Map(
+    fileContentVectorHits.map((hit) => [hit.path, hit]),
+  )
 
   // Build the merged result set, ordered by RRF score
   const mergedResults: SearchResult[] = []
   for (const { identifier: path, score } of rrfScores) {
     const ftsResult = ftsResultsByPath.get(path)
     if (ftsResult) {
-      // Path found via note FTS — use its metadata and snippet, replace score
       mergedResults.push({ ...ftsResult, score })
       continue
     }
 
-    // Check file content results before falling through to vector-only
+    // Check file content FTS results
     const fileResult = fileContentByPath.get(path)
     if (fileResult) {
       mergedResults.push(fileContentRowToSearchResult(fileResult, score))
       continue
     }
 
-    // Vector-only result — look up metadata from the notes table
+    // Note vector-only result — look up metadata from the notes table
     const noteRow = context.vector.selectNoteMetadataStmt.get(path)
-    if (!noteRow) continue
+    if (noteRow) {
+      if (
+        params.filters &&
+        !noteMatchesSearchFilters(noteRow, params.filters)
+      ) {
+        continue
+      }
 
-    // Apply filters that FTS would have applied via SQL
-    if (params.filters && !noteMatchesSearchFilters(noteRow, params.filters))
+      const vectorHit = vectorHitsByPath.get(path)
+      const snippet = vectorHit
+        ? buildSnippetFromChunkText(vectorHit.chunkText, snippetTokens)
+        : ""
+
+      mergedResults.push(
+        noteRowToSearchResult({
+          row: noteRow,
+          snippet,
+          score,
+          includeLeadingCallout,
+        }),
+      )
       continue
+    }
 
-    const vectorHit = vectorHitsByPath.get(path)
-    const snippet = vectorHit
-      ? buildSnippetFromChunkText(vectorHit.chunkText, snippetTokens)
-      : ""
-
-    mergedResults.push(
-      noteRowToSearchResult({
-        row: noteRow,
-        snippet,
-        score,
-        includeLeadingCallout,
-      }),
-    )
+    // File content vector-only result — look up metadata from file_content
+    const fileVectorHit = fileContentVectorHitsByPath.get(path)
+    if (fileVectorHit && context.selectFileContentMetadataStmt) {
+      const fileMetadata = context.selectFileContentMetadataStmt.get(path)
+      if (fileMetadata) {
+        mergedResults.push(
+          fileContentRowToSearchResult(
+            {
+              ...fileMetadata,
+              snippet: buildSnippetFromChunkText(
+                fileVectorHit.chunkText,
+                snippetTokens,
+              ),
+            },
+            score,
+          ),
+        )
+      }
+    }
   }
 
   // Apply cross-encoder reranking with position-aware score blending.
@@ -512,7 +641,10 @@ export const hybridSearch = async (
           query: params.query,
           mergedResults: rerankCandidates,
           vectorHitsByPath,
+          fileContentVectorHitsByPath,
           selectFirstChunkStmt: context.selectFirstChunkStmt,
+          selectFirstFileChunkStmt:
+            context.fileContentVector?.selectFirstFileChunkStmt ?? null,
           logger,
         })
       : null
@@ -526,6 +658,7 @@ export const hybridSearch = async (
     reranked,
     ftsResults: ftsResults.length,
     vectorHits: vectorHits.length,
+    fileContentVectorHits: fileContentVectorHits.length,
     fileContentResults: fileContentResults.length,
     mergedResults: mergedResults.length,
     returnedResults: Math.min(finalResults.length, userLimit),
@@ -966,23 +1099,38 @@ const tryRerank = async (params: {
   query: string
   mergedResults: readonly SearchResult[]
   vectorHitsByPath: ReadonlyMap<string, VectorHit>
+  fileContentVectorHitsByPath: ReadonlyMap<string, VectorHit>
   selectFirstChunkStmt: Database.Statement<
+    [string],
+    { chunk_text: string }
+  > | null
+  selectFirstFileChunkStmt: Database.Statement<
     [string],
     { chunk_text: string }
   > | null
   logger: Logger
 }): Promise<{ results: SearchResult[] } | null> => {
   try {
-    // Collect document text for each candidate
+    // Collect document text for each candidate — cascade through sources
     const documentTexts = params.mergedResults.map((result) => {
-      // Prefer vector chunk text (best semantic match for this note)
+      // Prefer note vector chunk text (best semantic match for this note)
       const vectorHit = params.vectorHitsByPath.get(result.path)
       if (vectorHit) return vectorHit.chunkText
+
+      // File content vector chunk text
+      const fileVectorHit = params.fileContentVectorHitsByPath.get(result.path)
+      if (fileVectorHit) return fileVectorHit.chunkText
 
       // FTS-only note: use chunk index 0 (title + intro) from note_chunks
       if (params.selectFirstChunkStmt) {
         const chunkRow = params.selectFirstChunkStmt.get(result.path)
         if (chunkRow) return chunkRow.chunk_text
+      }
+
+      // FTS-only file: use chunk index 0 from file_content_chunks
+      if (params.selectFirstFileChunkStmt) {
+        const fileChunkRow = params.selectFirstFileChunkStmt.get(result.path)
+        if (fileChunkRow) return fileChunkRow.chunk_text
       }
 
       // Fallback: use the snippet (truncated, but better than nothing —

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -577,6 +577,7 @@ export const hybridSearch = async (
   // Build the merged result set, ordered by RRF score
   const mergedResults: SearchResult[] = []
   for (const { identifier: path, score } of rrfScores) {
+    // Path found via note FTS — use its metadata and snippet, replace score
     const ftsResult = ftsResultsByPath.get(path)
     if (ftsResult) {
       mergedResults.push({ ...ftsResult, score })

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -594,6 +594,7 @@ export const hybridSearch = async (
     // Note vector-only result — look up metadata from the notes table
     const noteRow = context.vector.selectNoteMetadataStmt.get(path)
     if (noteRow) {
+      // Apply filters that FTS would have applied via SQL
       if (
         params.filters &&
         !noteMatchesSearchFilters(noteRow, params.filters)


### PR DESCRIPTION
## Summary

- Add file content vector embeddings (canvas, PDF, text files) as a fourth RRF input list in `hybridSearch`, alongside note FTS, file content FTS, and note vectors
- Reuse the existing `bge-small-en-v1.5` embedding pipeline and heading-aware chunker — no new models or config variables
- Extract query embedding once and share across note and file content KNN searches

## Details

**Schema:** `file_content_chunks` + `file_content_vectors` tables gated on `fileToolsEnabled && embedder`, mirroring the `note_chunks`/`note_vectors` pattern with content-hash gating, transaction-wrapped writes, and stale chunk cleanup.

**Write path:** `embedAndStoreFileChunks` replicates the `embedAndStoreChunks` algorithm. `embedFileContent` reads processed content from the `file_content` table (already linearized/truncated). File watcher calls it after `upsertFileContent`; rebuild embeds files after notes.

**Query path:** `fileContentVectorSearch` runs KNN over `file_content_vectors` with the same pre-computed query embedding. `hybridSearch` includes file content vector hits conditionally (same skip as file content FTS when note-specific filters are active). FTS-only fallback fires only when both note and file content vector sources are empty. Reranker cascades through all chunk text sources.

**Cleanup:** `removeFileContent` deletes file content vectors and chunks. Rebuild cleans up vectors for deleted files.

## Test plan

- [x] 7 new unit tests: embed roundtrip, content-hash gating, re-embed on change, no-op cases (missing file, no embedder), cleanup on remove, stale chunk cleanup
- [x] Existing hybrid search test updated for refactored `embedQuery` warning message
- [x] All 2869 tests pass
- [x] Build clean (both server and CLI configs)
- [x] Lint: 0 errors
- [ ] Test deploy: verify file content vectors participate in live hybrid search

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hybrid search support for PDF and text file content, combining keyword and vector-based results.
  * File content is now automatically embedded and indexed when file tools and vector search are enabled.
  * Search results support folder filtering, metadata display, reranking, and file-content matches.

* **Bug Fixes**
  * Improved fallback to keyword search when vector embedding fails.
  * Prevented stale file-content vectors and chunks from remaining after files change or are removed.

* **Documentation**
  * Updated architecture documentation to describe file-content indexing and hybrid search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->