### PR TITLE
chore: bump umm-actually to v0.3.10

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -77,7 +77,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@d110bf4c0e9c50aab5cd2e74da7c9bcf03707465 # v0.3.9
+      - uses: aliasunder/umm-actually@e7adc5454e87774534d796f688ddb3f12b6344ab # v0.3.10
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}
@@ -127,5 +127,9 @@ jobs:
           # (those are excluded from its bucket)
           max_related_files: ${{ vars.UMM_MAX_RELATED_FILES || '8' }}
           max_related_docs: ${{ vars.UMM_MAX_RELATED_DOCS || '4' }}
+          # Comma-separated folder prefixes excluded from the workspace
+          # scan — invisible to import-tracing and doc-mention matching.
+          # Changed files and priority_docs are never excluded.
+          exclude_paths: ${{ vars.UMM_EXCLUDE_PATHS }}
           # true | false — per-run cost report in the workflow step summary
           cost_summary: ${{ vars.UMM_COST_SUMMARY || 'true' }}


### PR DESCRIPTION
## Summary

- Bump `aliasunder/umm-actually` SHA pin from `d110bf4` (v0.3.9) to `e7adc54` (v0.3.10)
- Wire the new `exclude_paths` input from `UMM_EXCLUDE_PATHS` repo variable — comma-separated folder prefixes excluded from the workspace scan (invisible to import-tracing and doc-mention matching)

## What changed in v0.3.10

- New `exclude_paths` input for pruning folders from the BFS workspace scan
- Input normalization for leading slashes/`./` prefixes on both `exclude_paths` and `priority_docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)