### PR TITLE
ci: cosign keyless signing for GitHub releases

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -165,4 +165,4 @@ jobs:
         if: ${{ needs.deploy.outputs.digest-local != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$GITHUB_REF_NAME" digests.txt digests.txt.sigstore.json
+        run: gh release upload --clobber "$GITHUB_REF_NAME" digests.txt digests.txt.sigstore.json

--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -118,11 +118,17 @@ jobs:
           git commit -m "docs: update CHANGELOG.md for $GITHUB_REF_NAME"
           git push origin main
 
+      # Idempotent: skip creation if the release already exists so a
+      # re-run after a signing failure proceeds to the cosign steps.
       - name: Create GitHub release
         timeout-minutes: 2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if gh release view "$GITHUB_REF_NAME" --json tagName > /dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists, skipping creation"
+            exit 0
+          fi
           for i in 1 2 3; do
             if gh release create "$GITHUB_REF_NAME" \
                  --title "$GITHUB_REF_NAME" \

--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -79,6 +79,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      id-token: write # cosign keyless signing via Fulcio OIDC
     steps:
       - name: Generate App token
         id: app-token
@@ -133,3 +134,29 @@ jobs:
           done
           echo "Failed to create release after 3 attempts"
           exit 1
+
+      - name: Install cosign
+        if: ${{ needs.deploy.outputs.digest-local != '' }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Create digest file
+        if: ${{ needs.deploy.outputs.digest-local != '' }}
+        env:
+          IMAGE: ghcr.io/${{ vars.GHCR_USER }}/vault-cortex
+          VERSION: ${{ needs.validate.outputs.version }}
+          DIGEST_LOCAL: ${{ needs.deploy.outputs.digest-local }}
+          DIGEST_REMOTE: ${{ needs.deploy.outputs.digest-remote }}
+        run: |
+          printf '%s %s\n' "$DIGEST_LOCAL" "$IMAGE:v$VERSION" > digests.txt
+          printf '%s %s\n' "$DIGEST_REMOTE" "$IMAGE:v$VERSION-remote" >> digests.txt
+          cat digests.txt
+
+      - name: Sign digest file
+        if: ${{ needs.deploy.outputs.digest-local != '' }}
+        run: cosign sign-blob --yes --bundle digests.txt.sigstore.json digests.txt
+
+      - name: Upload signed digests to release
+        if: ${{ needs.deploy.outputs.digest-local != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" digests.txt digests.txt.sigstore.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,13 @@ on:
         required: false
         default: false
         type: boolean
+    outputs:
+      digest-local:
+        description: Manifest digest of the local target (empty when skip_build is true)
+        value: ${{ jobs.deploy.outputs.digest-local }}
+      digest-remote:
+        description: Manifest digest of the remote target (empty when skip_build is true)
+        value: ${{ jobs.deploy.outputs.digest-remote }}
 
 # Top-level token is read-only; the job declares its writes. Callers'
 # job-level grants are the ceiling — they must cover the same set.
@@ -34,6 +41,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    outputs:
+      digest-local: ${{ steps.build-local.outputs.digest }}
+      digest-remote: ${{ steps.build-remote.outputs.digest }}
     permissions:
       id-token: write # AWS OIDC role assumption
       contents: read
@@ -160,6 +170,7 @@ jobs:
       # server.json / the base Dockerfile LABEL.
       - name: Build and push image (remote target)
         if: ${{ !inputs.skip_build }}
+        id: build-remote
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -188,6 +199,7 @@ jobs:
 
       - name: Build and push image (local target)
         if: ${{ !inputs.skip_build }}
+        id: build-local
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -136,6 +136,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      id-token: write # cosign keyless signing via Fulcio OIDC
     steps:
       - name: Generate App token
         id: app-token
@@ -197,3 +198,30 @@ jobs:
           done
           echo "Failed to create release after 3 attempts"
           exit 1
+
+      - name: Install cosign
+        if: ${{ needs.deploy.outputs.digest-local != '' }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Create digest file
+        if: ${{ needs.deploy.outputs.digest-local != '' }}
+        env:
+          IMAGE: ghcr.io/${{ vars.GHCR_USER }}/vault-cortex
+          VERSION: ${{ needs.bump-and-tag.outputs.version }}
+          DIGEST_LOCAL: ${{ needs.deploy.outputs.digest-local }}
+          DIGEST_REMOTE: ${{ needs.deploy.outputs.digest-remote }}
+        run: |
+          printf '%s %s\n' "$DIGEST_LOCAL" "$IMAGE:v$VERSION" > digests.txt
+          printf '%s %s\n' "$DIGEST_REMOTE" "$IMAGE:v$VERSION-remote" >> digests.txt
+          cat digests.txt
+
+      - name: Sign digest file
+        if: ${{ needs.deploy.outputs.digest-local != '' }}
+        run: cosign sign-blob --yes --bundle digests.txt.sigstore.json digests.txt
+
+      - name: Upload signed digests to release
+        if: ${{ needs.deploy.outputs.digest-local != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.bump-and-tag.outputs.tag }}
+        run: gh release upload "$TAG" digests.txt digests.txt.sigstore.json

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -230,4 +230,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.bump-and-tag.outputs.tag }}
-        run: gh release upload "$TAG" digests.txt digests.txt.sigstore.json
+        run: gh release upload --clobber "$TAG" digests.txt digests.txt.sigstore.json

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -181,12 +181,18 @@ jobs:
           git commit -m "docs: update CHANGELOG.md for $TAG"
           git push origin main
 
+      # Idempotent: skip creation if the release already exists so a
+      # re-run after a signing failure proceeds to the cosign steps.
       - name: Create GitHub release
         timeout-minutes: 2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.bump-and-tag.outputs.tag }}
         run: |
+          if gh release view "$TAG" --json tagName > /dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping creation"
+            exit 0
+          fi
           for i in 1 2 3; do
             if gh release create "$TAG" \
                  --title "$TAG" \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -231,7 +231,7 @@ gh release download v0.38.0 --pattern 'digests.txt*'
 
 cosign verify-blob \
   --bundle digests.txt.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/aliasunder/vault-cortex/' \
+  --certificate-identity-regexp '^https://github\.com/aliasunder/vault-cortex/\.github/workflows/(auto_release|manual_release)\.yml@.*$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   digests.txt
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -215,9 +215,10 @@ you've found a Vault Cortex–specific exploit path for one.
 
 ## Release Signing
 
-Every GitHub Release includes a signed digest file (`digests.txt` +
-`digests.txt.sigstore.json`) containing the GHCR image manifest digests for
-both the local and remote Docker targets. Signatures use
+Every server release (`v*` tags) includes a signed digest file (`digests.txt`
+\+ `digests.txt.sigstore.json`) containing the GHCR image manifest digests for
+both the local and remote Docker targets. CLI releases (`cli-v*` tags) are npm
+packages and do not include container digests. Signatures use
 [Sigstore cosign](https://docs.sigstore.dev/) keyless signing — no long-lived
 keys; the signing identity is the GitHub Actions OIDC token, and each signature
 is recorded in Sigstore's public transparency log

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -238,7 +238,7 @@ cosign verify-blob \
 Then confirm the image you pulled matches a signed digest:
 
 ```bash
-docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/aliasunder/vault-cortex:latest
+docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/aliasunder/vault-cortex:v0.38.0
 # Compare the sha256:... with the corresponding line in digests.txt
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -213,6 +213,35 @@ Base-image CVEs surfaced by Trivy are typically already tracked in the
 Security tab and handled through image updates. A report is still welcome if
 you've found a Vault Cortex–specific exploit path for one.
 
+## Release Signing
+
+Every GitHub Release includes a signed digest file (`digests.txt` +
+`digests.txt.sigstore.json`) containing the GHCR image manifest digests for
+both the local and remote Docker targets. Signatures use
+[Sigstore cosign](https://docs.sigstore.dev/) keyless signing — no long-lived
+keys; the signing identity is the GitHub Actions OIDC token, and each signature
+is recorded in Sigstore's public transparency log
+([Rekor](https://docs.sigstore.dev/logging/overview/)).
+
+To verify a release's digest file:
+
+```bash
+gh release download v0.38.0 --pattern 'digests.txt*'
+
+cosign verify-blob \
+  --bundle digests.txt.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/aliasunder/vault-cortex/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  digests.txt
+```
+
+Then confirm the image you pulled matches a signed digest:
+
+```bash
+docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/aliasunder/vault-cortex:latest
+# Compare the sha256:... with the corresponding line in digests.txt
+```
+
 ## Reporting a Vulnerability
 
 If you discover a security issue, please report it through


### PR DESCRIPTION
## Summary

- Sign release digest files with [Sigstore cosign](https://docs.sigstore.dev/) (keyless via GitHub Actions OIDC) and attach them to GitHub Releases — satisfies the OpenSSF Scorecard [Signed-Releases](https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases) check (8/10)
- Each release gets `digests.txt` (GHCR manifest digests for both local and remote targets) + `digests.txt.sigstore.json` (Sigstore bundle with signature, certificate, and Rekor transparency log entry)
- No long-lived keys — signing uses the GitHub Actions OIDC token via Fulcio CA; signatures are publicly verifiable via `cosign verify-blob`
- Release creation is idempotent so a re-run after a signing failure retries the cosign steps instead of failing at release creation

## Test plan

- [x] `actionlint` passes on all three modified workflows
- [ ] First release after merge: verify `digests.txt` + `digests.txt.sigstore.json` appear as release assets
- [ ] Run `cosign verify-blob` locally against downloaded assets
- [ ] Dispatch `scorecard.yml` and verify Signed-Releases check improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)