### PR TITLE
docs: add v0.38.1 security section to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@
 
 - Update CHANGELOG.md for v0.38.0
 
+### Security
+
+- This release fixes GHSA-wm5v-9236-597m (High, CVSS 7.5): spoofed `Forwarded`/`X-Forwarded-For` headers could bypass the per-client OAuth rate limit. All deployments `<= 0.38.0` should upgrade. Details: https://github.com/aliasunder/vault-cortex/security/advisories/GHSA-wm5v-9236-597m
+
 ## [0.38.0] — 2026-08-20
 
 ### Features


### PR DESCRIPTION
Adds the Security section for v0.38.1 to CHANGELOG.md, matching the section appended to the [v0.38.1 release notes](https://github.com/aliasunder/vault-cortex/releases/tag/v0.38.1) after the release script generated the file — GHSA-wm5v-9236-597m reference, severity, and upgrade guidance. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)