### PR TITLE
fix(search): apply folder filters in SQL before the candidate window on every hybrid-search leg

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -354,6 +354,8 @@ Both models lazy-load on first use (~1–2s cold start each, cached after). Tota
 6. Build merged results: FTS results keep their metadata and snippet (score replaced with RRF score); vector-only results get metadata from their respective tables and a snippet from their best-matching chunk text
 7. Apply user filters (folder, tags, type, related, properties, created, modified) to vector-only note results — FTS results are already filtered via SQL
 
+A `folder` filter is applied inside SQL on all four legs — a `LIKE 'folder/%'` predicate on the FTS queries and a `chunk_id IN (…)` pre-filter on the KNN queries — so each leg's candidate window is drawn from the folder itself rather than filtered down from a vault-wide top-k. Folder matching is case-insensitive on every leg.
+
 ### Cross-encoder reranking
 
 After RRF fusion, the cross-encoder model from the component table above rescores the top candidates by evaluating each (query, document) pair jointly — unlike the bi-encoder, it captures query-document interaction and distinguishes intent ("how I feel about") from topic ("uses of"). Results are reordered via position-aware score blending (inspired by [qmd](https://github.com/tobi/qmd)):

--- a/src/vault-mcp/search/__tests__/hybrid-search.test.ts
+++ b/src/vault-mcp/search/__tests__/hybrid-search.test.ts
@@ -1421,4 +1421,24 @@ describe("hybridSearch — file content FTS folder filter", () => {
 
     expect(results.map((result) => result.path)).toEqual(["Docs/inside.txt"])
   })
+
+  it("treats LIKE wildcards in the folder name as literal characters", async () => {
+    const fileIndex = createSearchIndex(":memory:", undefined, undefined, {
+      fileToolsEnabled: true,
+    })
+
+    seedTextFile(fileIndex, "Pro_ects/inside.txt", "deployment notes")
+    // Without escaping, LIKE 'Pro_ects/%' would also match this file — the
+    // "_" wildcard matches the "j" in "Projects".
+    seedTextFile(fileIndex, "Projects/outside.txt", "deployment notes")
+
+    const { results } = await fileIndex.hybridSearch(
+      { query: "deployment", filters: { folder: "Pro_ects" } },
+      logger,
+    )
+
+    expect(results.map((result) => result.path)).toEqual([
+      "Pro_ects/inside.txt",
+    ])
+  })
 })

--- a/src/vault-mcp/search/__tests__/hybrid-search.test.ts
+++ b/src/vault-mcp/search/__tests__/hybrid-search.test.ts
@@ -376,9 +376,23 @@ Content about deployment costs and infrastructure.
         { notePath: "Work/inside.md", rawContent: noteInFolder },
         logger,
       )
+      // An equally close note outside the folder proves the filter is
+      // applied at all, not merely that the inside note survives
+      hybridIndex.upsertNote(
+        {
+          filePath: "Personal/outside.md",
+          rawContent: noteInFolder,
+          fileStat: testStat(1000),
+        },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "Personal/outside.md", rawContent: noteInFolder },
+        logger,
+      )
 
-      // No lexical overlap — the note can only surface through the vector
-      // leg, so the TypeScript folder mirror is the check under test
+      // No lexical overlap — the notes can only surface through the vector
+      // leg, so the folder-scoped KNN window is the check under test
       const { results, search_mode } = await hybridIndex.hybridSearch(
         { query: "quarterly budget forecast", filters: { folder: "work" } },
         logger,
@@ -1360,6 +1374,22 @@ describe("hybridSearch — file content vector search", () => {
       logger,
     )
     await fileIndex.embedFileContent({ filePath: "Docs/inside.txt" }, logger)
+
+    // An equally close file outside the folder proves the filter is applied
+    // at all — without it, "folder ignored" and "folder matched" look alike
+    fileIndex.upsertNonMdFile("Archive/outside.txt", 100)
+    fileIndex.upsertFileContent(
+      {
+        filePath: "Archive/outside.txt",
+        rawContent: "Weekly operations checklist for the deployment crew.",
+        fileStat: testStat(1000, 100),
+      },
+      logger,
+    )
+    await fileIndex.embedFileContent(
+      { filePath: "Archive/outside.txt" },
+      logger,
+    )
 
     // Vector-only hit (no lexical overlap) + a folder filter that differs
     // only by case — must pass, as it would on the SQL LIKE leg

--- a/src/vault-mcp/search/__tests__/hybrid-search.test.ts
+++ b/src/vault-mcp/search/__tests__/hybrid-search.test.ts
@@ -1357,3 +1357,68 @@ describe("hybridSearch — file content vector search", () => {
     expect(results.map((result) => result.path)).toEqual(["notes/tagged.md"])
   })
 })
+
+// ── hybridSearch — file content FTS folder filter ─────────────
+
+describe("hybridSearch — file content FTS folder filter", () => {
+  /** Seeds one indexed text file with the given content. */
+  const seedTextFile = (
+    fileIndex: ReturnType<typeof createSearchIndex>,
+    filePath: string,
+    rawContent: string,
+  ): void => {
+    fileIndex.upsertNonMdFile(filePath, rawContent.length)
+    fileIndex.upsertFileContent(
+      { filePath, rawContent, fileStat: testStat(1000, rawContent.length) },
+      logger,
+    )
+  }
+
+  it("returns in-folder files that rank below the vault-wide candidate window", async () => {
+    const fileIndex = createSearchIndex(":memory:", undefined, undefined, {
+      fileToolsEnabled: true,
+    })
+
+    // limit 1 → candidateLimit 3. Ten short out-of-folder matches outrank the
+    // one in-folder match (bm25 favors short documents), so a folder filter
+    // applied after the SQL LIMIT would never see the in-folder file.
+    for (const fileNumber of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
+      seedTextFile(
+        fileIndex,
+        `Archive/outside-${fileNumber}.txt`,
+        "deployment notes",
+      )
+    }
+    seedTextFile(
+      fileIndex,
+      "Docs/inside.txt",
+      "A much longer runbook that mentions the deployment exactly once among many other unrelated operational words about logging, backups, rotation, and alerts.",
+    )
+
+    const { results, search_mode } = await fileIndex.hybridSearch(
+      { query: "deployment", filters: { folder: "Docs", limit: 1 } },
+      logger,
+    )
+
+    expect(search_mode).toBe("fts")
+    expect(results.map((result) => result.path)).toEqual(["Docs/inside.txt"])
+  })
+
+  it("applies the folder filter to file-content FTS hits at segment boundaries", async () => {
+    const fileIndex = createSearchIndex(":memory:", undefined, undefined, {
+      fileToolsEnabled: true,
+    })
+
+    seedTextFile(fileIndex, "Docs/inside.txt", "deployment notes")
+    // "Docs2" starts with "Docs" as a bare string — only a segment-boundary
+    // pattern ("Docs/%") keeps it out of a "Docs" filter
+    seedTextFile(fileIndex, "Docs2/outside.txt", "deployment notes")
+
+    const { results } = await fileIndex.hybridSearch(
+      { query: "deployment", filters: { folder: "Docs" } },
+      logger,
+    )
+
+    expect(results.map((result) => result.path)).toEqual(["Docs/inside.txt"])
+  })
+})

--- a/src/vault-mcp/search/__tests__/hybrid-search.test.ts
+++ b/src/vault-mcp/search/__tests__/hybrid-search.test.ts
@@ -1502,3 +1502,109 @@ describe("hybridSearch — file content FTS folder filter", () => {
     ])
   })
 })
+
+// ── hybridSearch — folder-scoped vector candidate window ──────
+
+describe("hybridSearch — folder-scoped vector candidate window", () => {
+  const EMBEDDING_DIMENSIONS = 384
+
+  /** Content-keyed embeddings: text mentioning "inside" lands on one axis,
+   *  everything else (including the query) on another — so every out-of-
+   *  folder item sits at distance 0 from the query and the in-folder item
+   *  is the furthest candidate. */
+  const createContentKeyedEmbedder = () => {
+    const axisFor = (text: string): Float32Array => {
+      const embedding = new Float32Array(EMBEDDING_DIMENSIONS).fill(0)
+      embedding[text.includes("inside") ? 1 : 0] = 1.0
+      return embedding
+    }
+    return {
+      embedText: vi
+        .fn()
+        .mockImplementation((text: string) => Promise.resolve(axisFor(text))),
+      embedBatch: vi
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(axisFor)),
+        ),
+    }
+  }
+
+  it("returns an in-folder note that ranks below the vault-wide KNN window", async () => {
+    const mockEmbedder = createContentKeyedEmbedder()
+    const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+    // limit 1 → candidateLimit 3. Ten out-of-folder notes at distance 0 fill
+    // a vault-wide top-3 many times over; the only Work/ note is the furthest.
+    for (const noteNumber of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
+      const notePath = `Archive/outside-${noteNumber}.md`
+      const rawContent = `# Outside ${noteNumber}\n\nUnrelated archive material.\n`
+      hybridIndex.upsertNote(
+        { filePath: notePath, rawContent, fileStat: testStat(1000) },
+        logger,
+      )
+      await hybridIndex.embedNote({ notePath, rawContent }, logger)
+    }
+    const insideContent = "# Inside\n\nThe one note that lives inside Work.\n"
+    hybridIndex.upsertNote(
+      {
+        filePath: "Work/inside.md",
+        rawContent: insideContent,
+        fileStat: testStat(1000),
+      },
+      logger,
+    )
+    await hybridIndex.embedNote(
+      { notePath: "Work/inside.md", rawContent: insideContent },
+      logger,
+    )
+
+    // No lexical overlap with anything seeded — vector legs only
+    const { results, search_mode } = await hybridIndex.hybridSearch(
+      { query: "zzqq", filters: { folder: "Work", limit: 1 } },
+      logger,
+    )
+
+    expect(search_mode).toBe("hybrid")
+    expect(results.map((result) => result.path)).toEqual(["Work/inside.md"])
+  })
+
+  it("returns an in-folder file that ranks below the vault-wide KNN window", async () => {
+    const mockEmbedder = createContentKeyedEmbedder()
+    const fileIndex = createSearchIndex(":memory:", mockEmbedder, undefined, {
+      fileToolsEnabled: true,
+    })
+
+    for (const fileNumber of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
+      const filePath = `Archive/outside-${fileNumber}.txt`
+      fileIndex.upsertNonMdFile(filePath, 100)
+      fileIndex.upsertFileContent(
+        {
+          filePath,
+          rawContent: "Unrelated archive material.",
+          fileStat: testStat(1000, 100),
+        },
+        logger,
+      )
+      await fileIndex.embedFileContent({ filePath }, logger)
+    }
+    fileIndex.upsertNonMdFile("Docs/inside.txt", 100)
+    fileIndex.upsertFileContent(
+      {
+        filePath: "Docs/inside.txt",
+        rawContent: "The one file that lives inside Docs.",
+        fileStat: testStat(1000, 100),
+      },
+      logger,
+    )
+    await fileIndex.embedFileContent({ filePath: "Docs/inside.txt" }, logger)
+
+    const { results, search_mode } = await fileIndex.hybridSearch(
+      { query: "zzqq", filters: { folder: "Docs", limit: 1 } },
+      logger,
+    )
+
+    expect(search_mode).toBe("hybrid")
+    expect(results.map((result) => result.path)).toEqual(["Docs/inside.txt"])
+  })
+})

--- a/src/vault-mcp/search/__tests__/hybrid-search.test.ts
+++ b/src/vault-mcp/search/__tests__/hybrid-search.test.ts
@@ -355,6 +355,39 @@ Content about deployment costs and infrastructure.
       expect(paths).not.toContain("Personal/outside.md")
     })
 
+    it("matches the folder filter case-insensitively for vector-only results, like the FTS leg", async () => {
+      const mockEmbedder = createHybridMockEmbedder()
+      const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
+
+      const noteInFolder = `---
+title: Inside Folder
+---
+Content about deployment costs and infrastructure.
+`
+      hybridIndex.upsertNote(
+        {
+          filePath: "Work/inside.md",
+          rawContent: noteInFolder,
+          fileStat: testStat(1000),
+        },
+        logger,
+      )
+      await hybridIndex.embedNote(
+        { notePath: "Work/inside.md", rawContent: noteInFolder },
+        logger,
+      )
+
+      // No lexical overlap — the note can only surface through the vector
+      // leg, so the TypeScript folder mirror is the check under test
+      const { results, search_mode } = await hybridIndex.hybridSearch(
+        { query: "quarterly budget forecast", filters: { folder: "work" } },
+        logger,
+      )
+
+      expect(search_mode).toBe("hybrid")
+      expect(results.map((result) => result.path)).toEqual(["Work/inside.md"])
+    })
+
     it("applies tag filter to vector-only results", async () => {
       const mockEmbedder = createHybridMockEmbedder()
       const hybridIndex = createSearchIndex(":memory:", mockEmbedder)
@@ -1305,6 +1338,33 @@ describe("hybridSearch — file content vector search", () => {
     // folder filter on vector-only hits is the behavior under test
     const { results } = await fileIndex.hybridSearch(
       { query: "quarterly budget forecast", filters: { folder: "Docs" } },
+      logger,
+    )
+
+    expect(results.map((result) => result.path)).toEqual(["Docs/inside.txt"])
+  })
+
+  it("matches the folder filter case-insensitively for file-content vector-only hits", async () => {
+    const mockEmbedder = createHybridMockEmbedder()
+    const fileIndex = createSearchIndex(":memory:", mockEmbedder, undefined, {
+      fileToolsEnabled: true,
+    })
+
+    fileIndex.upsertNonMdFile("Docs/inside.txt", 100)
+    fileIndex.upsertFileContent(
+      {
+        filePath: "Docs/inside.txt",
+        rawContent: "Weekly operations checklist for the deployment crew.",
+        fileStat: testStat(1000, 100),
+      },
+      logger,
+    )
+    await fileIndex.embedFileContent({ filePath: "Docs/inside.txt" }, logger)
+
+    // Vector-only hit (no lexical overlap) + a folder filter that differs
+    // only by case — must pass, as it would on the SQL LIKE leg
+    const { results } = await fileIndex.hybridSearch(
+      { query: "quarterly budget forecast", filters: { folder: "docs" } },
       logger,
     )
 

--- a/src/vault-mcp/search/__tests__/search-helpers.test.ts
+++ b/src/vault-mcp/search/__tests__/search-helpers.test.ts
@@ -795,9 +795,14 @@ describe("pathIsInFolder", () => {
     expect(pathIsInFolder("Docs/sub/deep.txt", "Docs")).toBe(true)
   })
 
-  it("ignores case, mirroring SQLite LIKE on the FTS legs", () => {
+  it("ignores ASCII case, mirroring SQLite LIKE on the SQL legs", () => {
     expect(pathIsInFolder("Projects/plan.md", "projects")).toBe(true)
     expect(pathIsInFolder("projects/plan.md", "PROJECTS")).toBe(true)
+  })
+
+  it("does not fold non-ASCII case, exactly like SQLite LIKE", () => {
+    expect(pathIsInFolder("Équipe/plan.md", "équipe")).toBe(false)
+    expect(pathIsInFolder("Équipe/plan.md", "Équipe")).toBe(true)
   })
 
   it("requires a segment boundary so a folder prefix is not enough", () => {

--- a/src/vault-mcp/search/__tests__/search-helpers.test.ts
+++ b/src/vault-mcp/search/__tests__/search-helpers.test.ts
@@ -13,6 +13,7 @@ import {
   buildSnippetFromChunkText,
   escapeLikeWildcards,
   stripTrailingSlashes,
+  pathIsInFolder,
   dayToEpochMsRange,
 } from "../search-helpers.js"
 import type { NoteRow, TaskRow } from "../search-index.js"
@@ -784,6 +785,35 @@ describe("escapeLikeWildcards", () => {
 })
 
 // ── stripTrailingSlashes ──────────────────────────────────────
+
+describe("pathIsInFolder", () => {
+  it("matches a path directly inside the folder", () => {
+    expect(pathIsInFolder("Docs/inside.txt", "Docs")).toBe(true)
+  })
+
+  it("matches a path nested below the folder", () => {
+    expect(pathIsInFolder("Docs/sub/deep.txt", "Docs")).toBe(true)
+  })
+
+  it("ignores case, mirroring SQLite LIKE on the FTS legs", () => {
+    expect(pathIsInFolder("Projects/plan.md", "projects")).toBe(true)
+    expect(pathIsInFolder("projects/plan.md", "PROJECTS")).toBe(true)
+  })
+
+  it("requires a segment boundary so a folder prefix is not enough", () => {
+    expect(pathIsInFolder("Docs2/outside.txt", "Docs")).toBe(false)
+    expect(pathIsInFolder("Documents/outside.txt", "Docs")).toBe(false)
+  })
+
+  it("ignores trailing slashes on the folder filter", () => {
+    expect(pathIsInFolder("Docs/inside.txt", "Docs//")).toBe(true)
+  })
+
+  it("does not match the folder's own path or a root-level file", () => {
+    expect(pathIsInFolder("Docs", "Docs")).toBe(false)
+    expect(pathIsInFolder("inside.txt", "Docs")).toBe(false)
+  })
+})
 
 describe("stripTrailingSlashes", () => {
   it("strips a single trailing slash", () => {

--- a/src/vault-mcp/search/__tests__/search-helpers.test.ts
+++ b/src/vault-mcp/search/__tests__/search-helpers.test.ts
@@ -788,35 +788,53 @@ describe("escapeLikeWildcards", () => {
 
 describe("pathIsInFolder", () => {
   it("matches a path directly inside the folder", () => {
-    expect(pathIsInFolder("Docs/inside.txt", "Docs")).toBe(true)
+    expect(pathIsInFolder({ path: "Docs/inside.txt", folder: "Docs" })).toBe(
+      true,
+    )
   })
 
   it("matches a path nested below the folder", () => {
-    expect(pathIsInFolder("Docs/sub/deep.txt", "Docs")).toBe(true)
+    expect(pathIsInFolder({ path: "Docs/sub/deep.txt", folder: "Docs" })).toBe(
+      true,
+    )
   })
 
   it("ignores ASCII case, mirroring SQLite LIKE on the SQL legs", () => {
-    expect(pathIsInFolder("Projects/plan.md", "projects")).toBe(true)
-    expect(pathIsInFolder("projects/plan.md", "PROJECTS")).toBe(true)
+    expect(
+      pathIsInFolder({ path: "Projects/plan.md", folder: "projects" }),
+    ).toBe(true)
+    expect(
+      pathIsInFolder({ path: "projects/plan.md", folder: "PROJECTS" }),
+    ).toBe(true)
   })
 
   it("does not fold non-ASCII case, exactly like SQLite LIKE", () => {
-    expect(pathIsInFolder("Équipe/plan.md", "équipe")).toBe(false)
-    expect(pathIsInFolder("Équipe/plan.md", "Équipe")).toBe(true)
+    expect(pathIsInFolder({ path: "Équipe/plan.md", folder: "équipe" })).toBe(
+      false,
+    )
+    expect(pathIsInFolder({ path: "Équipe/plan.md", folder: "Équipe" })).toBe(
+      true,
+    )
   })
 
   it("requires a segment boundary so a folder prefix is not enough", () => {
-    expect(pathIsInFolder("Docs2/outside.txt", "Docs")).toBe(false)
-    expect(pathIsInFolder("Documents/outside.txt", "Docs")).toBe(false)
+    expect(pathIsInFolder({ path: "Docs2/outside.txt", folder: "Docs" })).toBe(
+      false,
+    )
+    expect(
+      pathIsInFolder({ path: "Documents/outside.txt", folder: "Docs" }),
+    ).toBe(false)
   })
 
   it("ignores trailing slashes on the folder filter", () => {
-    expect(pathIsInFolder("Docs/inside.txt", "Docs//")).toBe(true)
+    expect(pathIsInFolder({ path: "Docs/inside.txt", folder: "Docs//" })).toBe(
+      true,
+    )
   })
 
   it("does not match the folder's own path or a root-level file", () => {
-    expect(pathIsInFolder("Docs", "Docs")).toBe(false)
-    expect(pathIsInFolder("inside.txt", "Docs")).toBe(false)
+    expect(pathIsInFolder({ path: "Docs", folder: "Docs" })).toBe(false)
+    expect(pathIsInFolder({ path: "inside.txt", folder: "Docs" })).toBe(false)
   })
 })
 

--- a/src/vault-mcp/search/hybrid-search.ts
+++ b/src/vault-mcp/search/hybrid-search.ts
@@ -13,6 +13,7 @@ import {
   noteMatchesSearchFilters,
   buildSnippetFromChunkText,
   escapeLikeWildcards,
+  pathIsInFolder,
   stripTrailingSlashes,
 } from "./search-helpers.js"
 import type { FileContentFtsRow } from "./search-helpers.js"
@@ -443,14 +444,12 @@ export const hybridSearch = async (
       if (!fileMetadata) continue
 
       // Apply folder filter — file content FTS applies it via SQL, but
-      // vector-only results bypass FTS and need the check here. Uses a
-      // segment boundary (folder + "/") so "Docs" doesn't match "Documents".
-      if (params.filters?.folder) {
-        const folderPrefix = stripTrailingSlashes(params.filters.folder) + "/"
-        const folderMatch =
-          fileMetadata.folder === stripTrailingSlashes(params.filters.folder) ||
-          (fileMetadata.folder + "/").startsWith(folderPrefix)
-        if (!folderMatch) continue
+      // vector-only results bypass FTS and need the same check here.
+      if (
+        params.filters?.folder &&
+        !pathIsInFolder(path, params.filters.folder)
+      ) {
+        continue
       }
 
       mergedResults.push(

--- a/src/vault-mcp/search/hybrid-search.ts
+++ b/src/vault-mcp/search/hybrid-search.ts
@@ -12,9 +12,7 @@ import {
   fileContentRowToSearchResult,
   noteMatchesSearchFilters,
   buildSnippetFromChunkText,
-  escapeLikeWildcards,
-  pathIsInFolder,
-  stripTrailingSlashes,
+  folderLikePattern,
 } from "./search-helpers.js"
 import type { FileContentFtsRow } from "./search-helpers.js"
 import type {
@@ -56,19 +54,30 @@ const embedQuery = async (
   }
 }
 
+/** KNN over note vectors — the best-matching chunk per note. With a folder
+ *  pattern the k-window is taken over in-folder chunks only, so a folder
+ *  filter can never be starved by closer matches elsewhere in the vault. */
 const vectorSearch = (
   context: SearchQueryContext,
-  params: { query: string; queryEmbeddingBuffer: Buffer; limit: number },
+  params: {
+    query: string
+    queryEmbeddingBuffer: Buffer
+    limit: number
+    folderPathPattern: string | undefined
+  },
   logger: Logger,
 ): VectorHit[] => {
-  const { knnSearchStmt } = context.vector
-  if (!knnSearchStmt) return []
+  const { knnSearchStmt, knnSearchInFolderStmt } = context.vector
+  if (!knnSearchStmt || !knnSearchInFolderStmt) return []
 
   try {
-    const noteKnnRows = knnSearchStmt.all(
-      params.queryEmbeddingBuffer,
-      params.limit,
-    )
+    const noteKnnRows = params.folderPathPattern
+      ? knnSearchInFolderStmt.all(
+          params.queryEmbeddingBuffer,
+          params.limit,
+          params.folderPathPattern,
+        )
+      : knnSearchStmt.all(params.queryEmbeddingBuffer, params.limit)
 
     // Deduplicate to best chunk per note — rows are ordered by distance
     // ascending, so the first occurrence of each path is the closest match.
@@ -102,17 +111,25 @@ const vectorSearch = (
  *  disabled or the KNN query fails. */
 const fileContentVectorSearch = (
   context: SearchQueryContext,
-  params: { query: string; queryEmbeddingBuffer: Buffer; limit: number },
+  params: {
+    query: string
+    queryEmbeddingBuffer: Buffer
+    limit: number
+    folderPathPattern: string | undefined
+  },
   logger: Logger,
 ): VectorHit[] => {
-  const knnSearchStmt = context.fileContentVector?.knnSearchStmt
-  if (!knnSearchStmt) return []
+  if (!context.fileContentVector) return []
+  const { knnSearchStmt, knnSearchInFolderStmt } = context.fileContentVector
 
   try {
-    const fileKnnRows = knnSearchStmt.all(
-      params.queryEmbeddingBuffer,
-      params.limit,
-    )
+    const fileKnnRows = params.folderPathPattern
+      ? knnSearchInFolderStmt.all(
+          params.queryEmbeddingBuffer,
+          params.limit,
+          params.folderPathPattern,
+        )
+      : knnSearchStmt.all(params.queryEmbeddingBuffer, params.limit)
 
     const bestChunkPerFile = new Map<string, VectorHit>()
     for (const knnRow of fileKnnRows) {
@@ -150,7 +167,7 @@ const runFileContentFts = (
     query: string
     snippetTokens: number
     limit: number
-    folder?: string | undefined
+    folderPathPattern: string | undefined
   },
 ): FileContentFtsRow[] => {
   if (!context.fileContentFts) return []
@@ -158,13 +175,10 @@ const runFileContentFts = (
   if (!sanitizedQuery) return []
   // "%" matches every path when no folder filter applies — the statement
   // keeps a fixed arity instead of needing a second, predicate-free variant.
-  const folderPathPattern = params.folder
-    ? `${escapeLikeWildcards(stripTrailingSlashes(params.folder))}/%`
-    : "%"
   return context.fileContentFts.searchStmt.all(
     params.snippetTokens,
     sanitizedQuery,
-    folderPathPattern,
+    params.folderPathPattern ?? "%",
     params.limit,
   )
 }
@@ -271,6 +285,12 @@ export const hybridSearch = async (
   const snippetTokens = params.filters?.snippet_tokens ?? 30
   const includeLeadingCallout = params.filters?.include_leading_callout ?? false
   const candidateLimit = Math.min(Math.max(1, userLimit * 3), 100)
+  // One LIKE pattern shared by every leg that scopes to a folder in SQL —
+  // the file-content FTS leg and both KNN legs (fullTextSearch builds its own
+  // from the same helper), so no leg can drift from the others.
+  const folderPathPattern = params.filters?.folder
+    ? folderLikePattern(params.filters.folder)
+    : undefined
 
   // Run FTS with inflated limit to give RRF enough candidates
   const ftsResults = fullTextSearch(
@@ -300,7 +320,7 @@ export const hybridSearch = async (
         query: params.query,
         snippetTokens,
         limit: candidateLimit,
-        folder: params.filters?.folder,
+        folderPathPattern,
       })
 
   // Embed the query once — shared by note and file content vector searches
@@ -310,7 +330,12 @@ export const hybridSearch = async (
   const vectorHits = queryEmbeddingBuffer
     ? vectorSearch(
         context,
-        { query: params.query, queryEmbeddingBuffer, limit: candidateLimit },
+        {
+          query: params.query,
+          queryEmbeddingBuffer,
+          limit: candidateLimit,
+          folderPathPattern,
+        },
         logger,
       )
     : []
@@ -321,7 +346,12 @@ export const hybridSearch = async (
       ? []
       : fileContentVectorSearch(
           context,
-          { query: params.query, queryEmbeddingBuffer, limit: candidateLimit },
+          {
+            query: params.query,
+            queryEmbeddingBuffer,
+            limit: candidateLimit,
+            folderPathPattern,
+          },
           logger,
         )
 
@@ -443,15 +473,9 @@ export const hybridSearch = async (
       const fileMetadata = context.selectFileContentMetadataStmt.get(path)
       if (!fileMetadata) continue
 
-      // Apply folder filter — file content FTS applies it via SQL, but
-      // vector-only results bypass FTS and need the same check here.
-      if (
-        params.filters?.folder &&
-        !pathIsInFolder(path, params.filters.folder)
-      ) {
-        continue
-      }
-
+      // No folder check here: every file-content leg (FTS and KNN) already
+      // scoped to the folder in SQL, so a file-only hit is in-folder by
+      // construction.
       mergedResults.push(
         fileContentRowToSearchResult(
           {

--- a/src/vault-mcp/search/hybrid-search.ts
+++ b/src/vault-mcp/search/hybrid-search.ts
@@ -106,9 +106,9 @@ const vectorSearch = (
   }
 }
 
-/** KNN over file content vectors — returns the best-matching chunk per file
- *  for a pre-computed query embedding. Empty when file content vectors are
- *  disabled or the KNN query fails. */
+/** KNN over file content vectors — the best-matching chunk per file. With a
+ *  folder pattern the k-window is taken over in-folder chunks only, mirroring
+ *  vectorSearch. Empty when file content vectors are disabled or the query fails. */
 const fileContentVectorSearch = (
   context: SearchQueryContext,
   params: {

--- a/src/vault-mcp/search/hybrid-search.ts
+++ b/src/vault-mcp/search/hybrid-search.ts
@@ -173,8 +173,9 @@ const runFileContentFts = (
   if (!context.fileContentFts) return []
   const sanitizedQuery = sanitizeFtsQuery(params.query)
   if (!sanitizedQuery) return []
-  // "%" matches every path when no folder filter applies — the statement
-  // keeps a fixed arity instead of needing a second, predicate-free variant.
+  // With no folder filter, bind "%" so the LIKE predicate matches every path —
+  // one prepared statement covers both cases instead of needing a second,
+  // filter-free one.
   return context.fileContentFts.searchStmt.all(
     params.snippetTokens,
     sanitizedQuery,

--- a/src/vault-mcp/search/hybrid-search.ts
+++ b/src/vault-mcp/search/hybrid-search.ts
@@ -145,24 +145,26 @@ const fileContentVectorSearch = (
  *  [] when the feature is disabled. */
 const runFileContentFts = (
   context: SearchQueryContext,
-  query: string,
-  snippetTokens: number,
-  limit: number,
-  folder?: string,
+  params: {
+    query: string
+    snippetTokens: number
+    limit: number
+    folder?: string | undefined
+  },
 ): FileContentFtsRow[] => {
   if (!context.fileContentFts) return []
-  const sanitizedQuery = sanitizeFtsQuery(query)
+  const sanitizedQuery = sanitizeFtsQuery(params.query)
   if (!sanitizedQuery) return []
   // "%" matches every path when no folder filter applies — the statement
   // keeps a fixed arity instead of needing a second, predicate-free variant.
-  const folderPathPattern = folder
-    ? `${escapeLikeWildcards(stripTrailingSlashes(folder))}/%`
+  const folderPathPattern = params.folder
+    ? `${escapeLikeWildcards(stripTrailingSlashes(params.folder))}/%`
     : "%"
   return context.fileContentFts.searchStmt.all(
-    snippetTokens,
+    params.snippetTokens,
     sanitizedQuery,
     folderPathPattern,
-    limit,
+    params.limit,
   )
 }
 
@@ -293,13 +295,12 @@ export const hybridSearch = async (
   )
   const fileContentResults = hasNoteSpecificFilters
     ? []
-    : runFileContentFts(
-        context,
-        params.query,
+    : runFileContentFts(context, {
+        query: params.query,
         snippetTokens,
-        candidateLimit,
-        params.filters?.folder,
-      )
+        limit: candidateLimit,
+        folder: params.filters?.folder,
+      })
 
   // Embed the query once — shared by note and file content vector searches
   const queryEmbeddingBuffer = await embedQuery(context, params.query, logger)

--- a/src/vault-mcp/search/hybrid-search.ts
+++ b/src/vault-mcp/search/hybrid-search.ts
@@ -12,6 +12,7 @@ import {
   fileContentRowToSearchResult,
   noteMatchesSearchFilters,
   buildSnippetFromChunkText,
+  escapeLikeWildcards,
   stripTrailingSlashes,
 } from "./search-helpers.js"
 import type { FileContentFtsRow } from "./search-helpers.js"
@@ -139,8 +140,9 @@ const fileContentVectorSearch = (
 
 // ── File content FTS (internal) ────────────────────────────────
 
-/** Runs the file_content_fts query (canvas content, etc.) and applies the
- *  folder filter in TypeScript — returns [] when the feature is disabled. */
+/** Runs the file_content_fts query (canvas content, etc.) with the folder
+ *  filter applied in SQL before the limit, mirroring fullTextSearch — returns
+ *  [] when the feature is disabled. */
 const runFileContentFts = (
   context: SearchQueryContext,
   query: string,
@@ -151,14 +153,17 @@ const runFileContentFts = (
   if (!context.fileContentFts) return []
   const sanitizedQuery = sanitizeFtsQuery(query)
   if (!sanitizedQuery) return []
-  const results = context.fileContentFts.searchStmt.all(
+  // "%" matches every path when no folder filter applies — the statement
+  // keeps a fixed arity instead of needing a second, predicate-free variant.
+  const folderPathPattern = folder
+    ? `${escapeLikeWildcards(stripTrailingSlashes(folder))}/%`
+    : "%"
+  return context.fileContentFts.searchStmt.all(
     snippetTokens,
     sanitizedQuery,
+    folderPathPattern,
     limit,
   )
-  if (!folder) return results
-  const normalizedFolder = stripTrailingSlashes(folder) + "/"
-  return results.filter((row) => row.path.startsWith(normalizedFolder))
 }
 
 // ── Reranking helper ──────────────────────────────────────────

--- a/src/vault-mcp/search/search-helpers.ts
+++ b/src/vault-mcp/search/search-helpers.ts
@@ -80,7 +80,13 @@ const foldAsciiCase = (value: string): string =>
 /** TypeScript mirror of the `path LIKE 'folder/%'` predicate the SQL legs
  *  apply — segment-boundary (so "Docs" never matches "Docs2/") and
  *  ASCII-case-insensitive, matching SQLite LIKE's folding exactly. */
-export const pathIsInFolder = (path: string, folder: string): boolean =>
+export const pathIsInFolder = ({
+  path,
+  folder,
+}: {
+  path: string
+  folder: string
+}): boolean =>
   foldAsciiCase(path).startsWith(
     `${foldAsciiCase(stripTrailingSlashes(folder))}/`,
   )
@@ -282,7 +288,11 @@ export const noteMatchesSearchFilters = (
   note: NoteRow,
   filters: SearchFilters,
 ): boolean => {
-  if (filters.folder && !pathIsInFolder(note.path, filters.folder)) return false
+  if (
+    filters.folder &&
+    !pathIsInFolder({ path: note.path, folder: filters.folder })
+  )
+    return false
 
   if (filters.tags) {
     const noteTags = parseStringArray(note.tags)

--- a/src/vault-mcp/search/search-helpers.ts
+++ b/src/vault-mcp/search/search-helpers.ts
@@ -73,8 +73,8 @@ export const stripTrailingSlashes = (folder: string): string =>
 
 /** TypeScript mirror of the `path LIKE 'folder/%'` predicate the FTS legs
  *  apply in SQL — segment-boundary (so "Docs" never matches "Docs2/") and
- *  case-insensitive, because SQLite's LIKE is case-insensitive and a
- *  vector-only hit must pass the same folder filter its FTS twin would. */
+ *  case-insensitive (full Unicode via toLowerCase — a superset of LIKE's
+ *  ASCII-only folding, so no false exclusions for non-ASCII folder names). */
 export const pathIsInFolder = (path: string, folder: string): boolean =>
   path
     .toLowerCase()
@@ -84,6 +84,13 @@ export const pathIsInFolder = (path: string, folder: string): boolean =>
  *  matched literally in a `LIKE ... ESCAPE '\'` clause. */
 export const escapeLikeWildcards = (value: string): string =>
   value.replace(/[\\%_]/g, (character) => `\\${character}`)
+
+/** The `LIKE ... ESCAPE '\'` pattern that selects every path inside a folder
+ *  — segment-boundary (`Docs/%`, so "Docs" never matches "Docs2/") with the
+ *  folder's own wildcard characters escaped. One definition keeps every
+ *  search leg's folder predicate identical. */
+export const folderLikePattern = (folder: string): string =>
+  `${escapeLikeWildcards(stripTrailingSlashes(folder))}/%`
 
 // ── FTS metadata builder ───────────────────────────────────────
 

--- a/src/vault-mcp/search/search-helpers.ts
+++ b/src/vault-mcp/search/search-helpers.ts
@@ -71,14 +71,19 @@ const parseLeadingCalloutJson = (json: string): LeadingCallout => {
 export const stripTrailingSlashes = (folder: string): string =>
   folder.replace(/\/+$/, "")
 
-/** TypeScript mirror of the `path LIKE 'folder/%'` predicate the FTS legs
- *  apply in SQL — segment-boundary (so "Docs" never matches "Docs2/") and
- *  case-insensitive (full Unicode via toLowerCase — a superset of LIKE's
- *  ASCII-only folding, so no false exclusions for non-ASCII folder names). */
+/** Folds only A–Z, exactly as SQLite's default LIKE does — so the TypeScript
+ *  mirror below can never disagree with the SQL predicate on a non-ASCII
+ *  folder name. */
+const foldAsciiCase = (value: string): string =>
+  value.replace(/[A-Z]/g, (character) => character.toLowerCase())
+
+/** TypeScript mirror of the `path LIKE 'folder/%'` predicate the SQL legs
+ *  apply — segment-boundary (so "Docs" never matches "Docs2/") and
+ *  ASCII-case-insensitive, matching SQLite LIKE's folding exactly. */
 export const pathIsInFolder = (path: string, folder: string): boolean =>
-  path
-    .toLowerCase()
-    .startsWith(`${stripTrailingSlashes(folder).toLowerCase()}/`)
+  foldAsciiCase(path).startsWith(
+    `${foldAsciiCase(stripTrailingSlashes(folder))}/`,
+  )
 
 /** Escapes LIKE-wildcard characters (`\`, `%`, `_`) in a value so it is
  *  matched literally in a `LIKE ... ESCAPE '\'` clause. */

--- a/src/vault-mcp/search/search-helpers.ts
+++ b/src/vault-mcp/search/search-helpers.ts
@@ -71,6 +71,15 @@ const parseLeadingCalloutJson = (json: string): LeadingCallout => {
 export const stripTrailingSlashes = (folder: string): string =>
   folder.replace(/\/+$/, "")
 
+/** TypeScript mirror of the `path LIKE 'folder/%'` predicate the FTS legs
+ *  apply in SQL — segment-boundary (so "Docs" never matches "Docs2/") and
+ *  case-insensitive, because SQLite's LIKE is case-insensitive and a
+ *  vector-only hit must pass the same folder filter its FTS twin would. */
+export const pathIsInFolder = (path: string, folder: string): boolean =>
+  path
+    .toLowerCase()
+    .startsWith(`${stripTrailingSlashes(folder).toLowerCase()}/`)
+
 /** Escapes LIKE-wildcard characters (`\`, `%`, `_`) in a value so it is
  *  matched literally in a `LIKE ... ESCAPE '\'` clause. */
 export const escapeLikeWildcards = (value: string): string =>
@@ -261,11 +270,7 @@ export const noteMatchesSearchFilters = (
   note: NoteRow,
   filters: SearchFilters,
 ): boolean => {
-  if (
-    filters.folder &&
-    !note.path.startsWith(stripTrailingSlashes(filters.folder) + "/")
-  )
-    return false
+  if (filters.folder && !pathIsInFolder(note.path, filters.folder)) return false
 
   if (filters.tags) {
     const noteTags = parseStringArray(note.tags)

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -917,6 +917,28 @@ export const createSearchIndex = (
       )
     : null
 
+  // Folder-scoped KNN: the chunk_id IN (...) constraint narrows the vector
+  // search to in-folder chunks BEFORE the k-window is taken, so a folder
+  // filter sees the folder's own nearest neighbours rather than whatever
+  // survives a vault-wide top-k. sqlite-vec honours rowid IN constraints
+  // inside KNN queries; chunk_id is the vec0 rowid alias.
+  const knnSearchInFolderStmt = embedder
+    ? db.prepare<
+        unknown[],
+        { note_path: string; chunk_text: string; distance: number }
+      >(
+        `SELECT nc.note_path, nc.chunk_text, nv.distance
+         FROM note_vectors nv
+         JOIN note_chunks nc ON nc.id = nv.chunk_id
+         WHERE nv.embedding MATCH ?
+           AND nv.k = ?
+           AND nv.chunk_id IN (
+             SELECT id FROM note_chunks WHERE note_path LIKE ? ESCAPE '\\'
+           )
+         ORDER BY nv.distance`,
+      )
+    : null
+
   /** First chunk text for a note — used by the reranker to score FTS-only
    *  results that have no vector hit. Chunk 0 contains the title + intro. */
   const selectFirstChunkStmt = embedder
@@ -936,6 +958,24 @@ export const createSearchIndex = (
          JOIN file_content_chunks fc ON fc.id = fv.chunk_id
          WHERE fv.embedding MATCH ?
            AND fv.k = ?
+         ORDER BY fv.distance`,
+      )
+    : null
+
+  // Folder-scoped variant — same pre-window narrowing as knnSearchInFolderStmt.
+  const fileContentKnnSearchInFolderStmt = fileContentVectorEnabled
+    ? db.prepare<
+        unknown[],
+        { file_path: string; chunk_text: string; distance: number }
+      >(
+        `SELECT fc.file_path, fc.chunk_text, fv.distance
+         FROM file_content_vectors fv
+         JOIN file_content_chunks fc ON fc.id = fv.chunk_id
+         WHERE fv.embedding MATCH ?
+           AND fv.k = ?
+           AND fv.chunk_id IN (
+             SELECT id FROM file_content_chunks WHERE file_path LIKE ? ESCAPE '\\'
+           )
          ORDER BY fv.distance`,
       )
     : null
@@ -2314,6 +2354,7 @@ export const createSearchIndex = (
     vector: {
       embedder,
       knnSearchStmt,
+      knnSearchInFolderStmt,
       selectNoteMetadataStmt,
     },
     reranker,
@@ -2333,12 +2374,14 @@ export const createSearchIndex = (
     fileContentFts: searchFileContentFtsStmt
       ? { searchStmt: searchFileContentFtsStmt }
       : null,
-    fileContentVector: fileContentKnnSearchStmt
-      ? {
-          knnSearchStmt: fileContentKnnSearchStmt,
-          selectFirstFileChunkStmt,
-        }
-      : null,
+    fileContentVector:
+      fileContentKnnSearchStmt && fileContentKnnSearchInFolderStmt
+        ? {
+            knnSearchStmt: fileContentKnnSearchStmt,
+            knnSearchInFolderStmt: fileContentKnnSearchInFolderStmt,
+            selectFirstFileChunkStmt,
+          }
+        : null,
     selectFileContentMetadataStmt,
   }
 

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -677,9 +677,12 @@ export const createSearchIndex = (
         `INSERT INTO file_content_fts (path, title, content) VALUES (?, ?, ?)`,
       )
     : null
+  // The folder predicate runs before ORDER BY/LIMIT so a folder-scoped search
+  // sees every in-folder match, not just those that rank inside the candidate
+  // window vault-wide; callers bind "%" when no folder filter applies.
   const searchFileContentFtsStmt = fileToolsEnabled
     ? db.prepare<
-        [number, string, number],
+        [number, string, string, number],
         {
           path: string
           title: string
@@ -694,6 +697,7 @@ export const createSearchIndex = (
          FROM file_content_fts
          JOIN file_content fc ON fc.path = file_content_fts.path
          WHERE file_content_fts MATCH ?
+           AND fc.path LIKE ? ESCAPE '\\'
          ORDER BY rank LIMIT ?`,
       )
     : null

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -64,6 +64,13 @@ export type MemoryEntryRow = {
 /** A memory-entry KNN hit: the full row plus its cosine distance. */
 export type MemoryEntryVectorHitRow = MemoryEntryRow & { distance: number }
 
+/** Everything a read-side query needs from the search index, handed to it
+ *  as its first argument: the open database, the prepared statements the
+ *  index compiled once at startup, and the optional ML models (embedder,
+ *  reranker). `createSearchIndex` builds one of these in its closure and
+ *  binds it into every exported query function, so the query modules stay
+ *  plain functions with no state of their own. Each optional group is
+ *  `null` when its feature is off, and each query degrades accordingly. */
 export type SearchQueryContext = {
   readonly db: Database.Database
   readonly vector: {

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -90,7 +90,7 @@ export type SearchQueryContext = {
    *  content FTS leg. */
   readonly fileContentFts: {
     readonly searchStmt: Database.Statement<
-      [number, string, number],
+      [number, string, string, number],
       FileContentFtsRow
     >
   } | null

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -14,6 +14,7 @@ import {
   rowToTaskEntry,
   noteRowToSearchResult,
   escapeLikeWildcards,
+  folderLikePattern,
   stripTrailingSlashes,
   dayToEpochMsRange,
 } from "./search-helpers.js"
@@ -68,6 +69,12 @@ export type SearchQueryContext = {
   readonly vector: {
     readonly embedder: Embedder | undefined
     readonly knnSearchStmt: Database.Statement<unknown[], VectorHitRow> | null
+    /** Same KNN narrowed to chunks whose note path matches a folder LIKE
+     *  pattern before the k-window — used whenever a folder filter is set. */
+    readonly knnSearchInFolderStmt: Database.Statement<
+      unknown[],
+      VectorHitRow
+    > | null
     readonly selectNoteMetadataStmt: Database.Statement<[string], NoteRow>
   }
   readonly reranker: Reranker | undefined
@@ -98,6 +105,11 @@ export type SearchQueryContext = {
    *  the file content vector leg. */
   readonly fileContentVector: {
     readonly knnSearchStmt: Database.Statement<
+      unknown[],
+      FileContentVectorHitRow
+    >
+    /** Folder-scoped variant — see vector.knnSearchInFolderStmt. */
+    readonly knnSearchInFolderStmt: Database.Statement<
       unknown[],
       FileContentVectorHitRow
     >
@@ -149,9 +161,7 @@ export const fullTextSearch = (
 
   if (params.filters?.folder) {
     conditions.push("n.path LIKE ? ESCAPE '\\'")
-    queryParams.push(
-      `${escapeLikeWildcards(stripTrailingSlashes(params.filters.folder))}/%`,
-    )
+    queryParams.push(folderLikePattern(params.filters.folder))
   }
 
   if (params.filters?.tags) {


### PR DESCRIPTION
## Summary

A `folder` filter on `vault_search` was being applied *after* each leg had already taken its candidate window, and inconsistently across legs. This PR makes the folder filter part of every leg's SQL, before any limit, with one case convention.

Surfaced by umm-actually on #470 (file-content FTS leg), then widened during this PR's review to the two KNN legs and to case handling.

## Three defects, one cause

| Leg | Before | After |
| --- | --- | --- |
| File-content FTS (`runFileContentFts`) | top `candidateLimit` rows by rank, then folder `.filter()` in TypeScript → in-folder files below the cutoff silently dropped | `AND fc.path LIKE ? ESCAPE '\'` before `ORDER BY rank LIMIT ?`, mirroring `fullTextSearch` |
| Note KNN + file-content KNN | top-k vault-wide, then folder check on the merged results → same drop for vector-only matches | folder-scoped statement variants: `AND chunk_id IN (SELECT id FROM <chunks> WHERE <path> LIKE ? ESCAPE '\')` before the k-window |
| Case handling | SQL legs case-insensitive (SQLite `LIKE`), TypeScript mirrors case-sensitive (`startsWith`) → `folder: "projects"` kept FTS hits from `Projects/` and dropped vector-only ones | ASCII-case-insensitive on every leg — folds only A–Z, exactly like SQLite's default `LIKE`, so the remaining TypeScript mirror (`noteMatchesSearchFilters` via `pathIsInFolder`) can never disagree with the SQL predicate on a non-ASCII folder name |

Why case-insensitive: the note FTS leg and `searchByFolder` have always matched via `LIKE`, and Obsidian resolves paths case-insensitively.

## Change

- `search-index.ts` — `file_content_fts` statement gains the folder predicate; two new prepared statements `knnSearchInFolderStmt` / `fileContentKnnSearchInFolderStmt` (the unscoped KNN statements are unchanged for the no-folder path). sqlite-vec honours rowid `IN` constraints inside KNN queries and `chunk_id` is the vec0 rowid alias — verified empirically before building on it.
- `search-helpers.ts` — `folderLikePattern(folder)` (the one `LIKE` pattern every SQL-scoped leg binds; `fullTextSearch` now uses it too) and `pathIsInFolder({ path, folder })` (segment-boundary, ASCII-case-insensitive TypeScript mirror).
- `hybrid-search.ts` — `hybridSearch` computes the pattern once and passes it to all three legs; `vectorSearch` / `fileContentVectorSearch` pick the scoped statement when a folder filter is set; the post-merge folder check on file-content vector-only hits is removed (every file-content leg now scopes in SQL); `runFileContentFts` takes a named-params object.
- `search-queries.ts` — `SearchQueryContext` carries the new statements and the FTS statement's arity.
- `ARCHITECTURE.md` — Query fusion: folder filters are applied in SQL on all four legs, case-insensitively.

No tool-surface changes.

## Tests

`hybrid-search.test.ts`:

- `describe("hybridSearch — file content FTS folder filter")` — limit-window regression (`limit: 1` → `candidateLimit` 3; ten short out-of-folder matches outrank one long in-folder match; expects exactly `["Docs/inside.txt"]`), segment boundary (`Docs/` vs `Docs2/`), LIKE-wildcard escaping (`Pro_ects` vs `Projects`).
- `describe("hybridSearch — folder-scoped vector candidate window")` — content-keyed mock embedder puts ten out-of-folder items at distance 0 and the one in-folder item on another axis; with `limit: 1` the in-folder note / file is returned. Mutation-verified by forcing the unscoped statement (both fail, plus the two file-vector folder tests that now rely on SQL).
- Case-insensitive folder filter on vector-only note and file hits, each seeded with an equally close out-of-folder control so "folder ignored" can't pass as "folder matched".

`search-helpers.test.ts`: `pathIsInFolder` unit tests (direct child, nested, ASCII case folded, non-ASCII case not folded, segment boundary, trailing slashes, non-matches). Mutation-verified: making it case-sensitive fails exactly the case tests.

`npm test` 78 files / 2,914 passing; `npm run lint` warning count unchanged (355, pre-existing); `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


