### PR TITLE
chore: bump umm-actually to v0.3.11

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -77,7 +77,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@e7adc5454e87774534d796f688ddb3f12b6344ab # v0.3.10
+      - uses: aliasunder/umm-actually@04223833a3d8b82a10482440c2aee4118fc5f9e8 # v0.3.11
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}

--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # Non-trigger comments still create a (guard-skipped) run — isolate them in a
 # per-run group so they can't cancel an in-flight review. Every comment the
@@ -33,6 +34,8 @@ jobs:
       )
     permissions:
       contents: read
+      # The comment-trigger step below reads the PR via the REST API
+      pull-requests: read
     steps:
       # issue_comment events check out the default branch unless overridden —
       # the action reads workspace files for context, so it needs the PR head.


### PR DESCRIPTION
Pins `umm_review.yml` to umm-actually v0.3.11 (`0422383`). Every posted finding comment now ends with an `umm-actually · <model>` byline naming the model that produced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)