### PR TITLE
fix(remote): read the Sync client's file record in the deletion-storm guard; boot the remote image in CI on both architectures

### DIFF
--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -2,18 +2,18 @@ name: Arch Smoke
 
 # Builds and boots the Docker image on both production architectures on
 # every PR — native runners, no QEMU. This is the only PR-time check that
-# executes an arm64 artifact (trivy-pr builds amd64 only), so it is what
-# catches a native prebuild whose glibc requirement the base image no
-# longer meets. Each leg:
+# executes an arm64 artifact (trivy-pr builds amd64 only), so it catches
+# cases where a native prebuild requires a newer glibc than the base image
+# provides. Each leg:
 #   1. build --target local — natively executes the Dockerfile deps-stage
 #      native-binding assertion for its arch
 #   2. boot smoke — run the image against a small fixture vault; /healthz
 #      returning 200 proves better-sqlite3 + sqlite-vec loaded and the
 #      FTS index built (server.ts exits 1 on any startup failure), then
 #      an authenticated MCP initialize round-trip is asserted
-#   3. build --target remote, then the remote-boot vitest tier boots it
-#      with the Sync CLI stubbed (src/__tests__/docker/fixtures/ob), so
-#      the s6 init chain runs end-to-end without Sync credentials
+#   3. build --target remote, then the remote-boot vitest suite boots
+#      the image with the Sync CLI stubbed (src/__tests__/docker/fixtures/ob),
+#      so the s6 init chain runs end-to-end without Sync credentials
 #
 # EMBEDDING_ENABLED=false at runtime is fine: onnxruntime-node's dynamic
 # import is never reached, but the deps-stage assertion already executed
@@ -85,10 +85,10 @@ jobs:
             type=gha
           cache-to: type=gha,mode=max,scope=arch-smoke-${{ matrix.arch }}-local
 
-      # Loaded on both legs so the remote-boot tier below can run it by
-      # tag. Reads the local scope too — both targets share the
-      # base/deps/build stages — and the amd64 remote scope is seeded by
-      # the main push like the others.
+      # Loaded on both legs so the remote-boot test suite below can run
+      # it by tag. Both targets share the base/deps/build stages, so this
+      # step reads the local cache scope too. The amd64 remote scope is
+      # seeded by the main-branch push like the others.
       - name: Build image from branch (remote target)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -181,9 +181,9 @@ jobs:
           fi
           echo "MCP initialize ok"
 
-      # The remote-boot tier is a vitest suite, so it needs the repo's Node
-      # toolchain. It runs after the local smoke on purpose: a native-binding
-      # regression still fails fast, before the install.
+      # The remote-boot tests are a vitest suite, so they need the repo's
+      # Node toolchain. They run after the local smoke on purpose: a
+      # native-binding regression still fails fast, before the install.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
@@ -200,8 +200,9 @@ jobs:
       # Fires on any prior step's failure (build included, so the list may
       # be empty) so a red run is diagnosable from the Actions log alone.
       # Two name filters OR together: the boot smoke's fixed `smoke` name
-      # and the remote-boot tier's remote-boot-* containers, which the
-      # tier removes itself — anything still present is a failure artifact.
+      # and the remote-boot-* containers the test suite creates. The suite
+      # removes its own containers on success; anything still present is a
+      # failure artifact.
       - name: Dump container diagnostics
         if: failure()
         run: |

--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -11,7 +11,7 @@ name: Arch Smoke
 #      returning 200 proves better-sqlite3 + sqlite-vec loaded and the
 #      FTS index built (server.ts exits 1 on any startup failure), then
 #      an authenticated MCP initialize round-trip is asserted
-#   3. build --target remote, then `npm run test:remote-boot` boots it with
+#   3. build --target remote, then the remote-boot vitest tier boots it with
 #      the obsidian-headless CLI stubbed (src/__tests__/docker/fixtures/ob)
 #      — the s6 init chain runs end-to-end without Sync credentials:
 #      env derivation, ownership record, login → sync-setup → first-sync
@@ -193,8 +193,10 @@ jobs:
           cache: npm
       - run: npm ci
 
+      # Runs the vitest config directly: `npm run test:remote-boot` would
+      # rebuild the image, and the buildx step above already built it.
       - name: Remote image boot tests (stubbed Sync client)
-        run: npm run test:remote-boot
+        run: npx vitest run --config vitest.remote-boot.config.ts
         env:
           REMOTE_IMAGE: vault-cortex:remote-ci
 

--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -11,9 +11,14 @@ name: Arch Smoke
 #      returning 200 proves better-sqlite3 + sqlite-vec loaded and the
 #      FTS index built (server.ts exits 1 on any startup failure), then
 #      an authenticated MCP initialize round-trip is asserted
-#   3. arm64 only: build --target remote as a compile check (build-only —
-#      trivy-pr already builds remote on amd64, and booting remote would
-#      need obsidian-sync credentials)
+#   3. build --target remote, then `npm run test:remote-boot` boots it with
+#      the obsidian-headless CLI stubbed (src/__tests__/docker/fixtures/ob)
+#      — the s6 init chain runs end-to-end without Sync credentials:
+#      env derivation, ownership record, login → sync-setup → first-sync
+#      ordering, sentinel, index location, STORAGE_ROOT single-volume
+#      layout, restart reuse, and the guards that stop the container.
+#      The chain was validated by hand against real Sync before it
+#      shipped; this is the per-PR regression net.
 #
 # EMBEDDING_ENABLED=false at runtime is fine: onnxruntime-node's dynamic
 # import is never reached, but the deps-stage assertion already executed
@@ -85,17 +90,17 @@ jobs:
             type=gha
           cache-to: type=gha,mode=max,scope=arch-smoke-${{ matrix.arch }}-local
 
-      # Compile check only: nothing had ever built the remote target for
-      # arm64 before merge. No load/tags — the image is never run, and
-      # amd64 remote coverage is trivy-pr's job (building it here too
-      # would be pure redundancy in the same PR run). Reads the local
-      # scope too — both targets share the base/deps/build stages.
-      - name: Build image from branch (remote target, arm64 compile check)
-        if: matrix.arch == 'arm64'
+      # Loaded on both legs so the remote-boot tier below can run it by
+      # tag. Reads the local scope too — both targets share the
+      # base/deps/build stages — and the amd64 remote scope is seeded by
+      # the main push like the others.
+      - name: Build image from branch (remote target)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           target: remote
+          load: true
+          tags: vault-cortex:remote-ci
           build-args: APT_UPGRADE_DATE=${{ steps.date.outputs.date }}
           cache-from: |
             type=gha,scope=arch-smoke-${{ matrix.arch }}-remote
@@ -181,9 +186,25 @@ jobs:
           fi
           echo "MCP initialize ok"
 
+      # The remote-boot tier is a vitest suite, so it needs the repo's Node
+      # toolchain. It runs after the local smoke on purpose: a native-binding
+      # regression still fails fast, before the install.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+
+      - name: Remote image boot tests (stubbed Sync client)
+        run: npm run test:remote-boot
+        env:
+          REMOTE_IMAGE: vault-cortex:remote-ci
+
       # Fires on any prior step's failure (build included — hence the
-      # container-existence guard) so a red run is diagnosable from the
-      # Actions log alone.
+      # container-existence guards) so a red run is diagnosable from the
+      # Actions log alone. The tier names its containers remote-boot-*
+      # and removes them itself; anything still present is a failure
+      # artifact worth dumping.
       - name: Dump container diagnostics
         if: failure()
         run: |
@@ -192,10 +213,16 @@ jobs:
             docker inspect -f '{{json .State}}' smoke
             docker logs smoke
           fi
+          for container in $(docker ps -aq --filter name=remote-boot-); do
+            docker inspect -f '{{.Name}} {{json .State}}' "$container"
+            docker logs "$container"
+          done
 
-      - name: Remove smoke container
+      - name: Remove smoke containers
         if: always()
         run: |
           if docker inspect smoke > /dev/null 2>&1; then
             docker rm -f smoke
           fi
+          docker ps -aq --filter name=remote-boot- | xargs -r docker rm -f -v
+          docker volume ls -q --filter name=remote-boot- | xargs -r docker volume rm

--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -197,20 +197,16 @@ jobs:
         env:
           REMOTE_IMAGE: vault-cortex:remote-ci
 
-      # Fires on any prior step's failure (build included — hence the
-      # container-existence guards) so a red run is diagnosable from the
-      # Actions log alone. The tier names its containers remote-boot-*
-      # and removes them itself; anything still present is a failure
-      # artifact worth dumping.
+      # Fires on any prior step's failure (build included, so the list may
+      # be empty) so a red run is diagnosable from the Actions log alone.
+      # Two name filters OR together: the boot smoke's fixed `smoke` name
+      # and the remote-boot tier's remote-boot-* containers, which the
+      # tier removes itself — anything still present is a failure artifact.
       - name: Dump container diagnostics
         if: failure()
         run: |
           docker ps -a
-          if docker inspect smoke > /dev/null 2>&1; then
-            docker inspect -f '{{json .State}}' smoke
-            docker logs smoke
-          fi
-          for container in $(docker ps -aq --filter name=remote-boot-); do
+          for container in $(docker ps -aq --filter name=smoke --filter name=remote-boot-); do
             docker inspect -f '{{.Name}} {{json .State}}' "$container"
             docker logs "$container"
           done
@@ -218,8 +214,5 @@ jobs:
       - name: Remove smoke containers
         if: always()
         run: |
-          if docker inspect smoke > /dev/null 2>&1; then
-            docker rm -f smoke
-          fi
-          docker ps -aq --filter name=remote-boot- | xargs -r docker rm -f -v
+          docker ps -aq --filter name=smoke --filter name=remote-boot- | xargs -r docker rm -f -v
           docker volume ls -q --filter name=remote-boot- | xargs -r docker volume rm

--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -17,8 +17,6 @@ name: Arch Smoke
 #      env derivation, ownership record, login → sync-setup → first-sync
 #      ordering, sentinel, index location, STORAGE_ROOT single-volume
 #      layout, restart reuse, and the guards that stop the container.
-#      The chain was validated by hand against real Sync before it
-#      shipped; this is the per-PR regression net.
 #
 # EMBEDDING_ENABLED=false at runtime is fine: onnxruntime-node's dynamic
 # import is never reached, but the deps-stage assertion already executed

--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -42,7 +42,7 @@ jobs:
   arch-smoke:
     name: arch-smoke (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       # Arch failures are independent signals — never cancel the other leg.
       fail-fast: false

--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -1,22 +1,19 @@
 name: Arch Smoke
 
 # Builds and boots the Docker image on both production architectures on
-# every PR — native runners, no QEMU. Motivated by v0.33.0–v0.33.4: the
-# arm64 image crash-looped (better-sqlite3 v13's linux-arm64 prebuild
-# needs glibc >= 2.38, the base had 2.36) and nothing at PR time ever
-# executed an arm64 artifact — trivy-pr builds amd64 only. Each leg:
+# every PR — native runners, no QEMU. This is the only PR-time check that
+# executes an arm64 artifact (trivy-pr builds amd64 only), so it is what
+# catches a native prebuild whose glibc requirement the base image no
+# longer meets. Each leg:
 #   1. build --target local — natively executes the Dockerfile deps-stage
 #      native-binding assertion for its arch
 #   2. boot smoke — run the image against a small fixture vault; /healthz
 #      returning 200 proves better-sqlite3 + sqlite-vec loaded and the
 #      FTS index built (server.ts exits 1 on any startup failure), then
 #      an authenticated MCP initialize round-trip is asserted
-#   3. build --target remote, then the remote-boot vitest tier boots it with
-#      the obsidian-headless CLI stubbed (src/__tests__/docker/fixtures/ob)
-#      — the s6 init chain runs end-to-end without Sync credentials:
-#      env derivation, ownership record, login → sync-setup → first-sync
-#      ordering, sentinel, index location, STORAGE_ROOT single-volume
-#      layout, restart reuse, and the guards that stop the container.
+#   3. build --target remote, then the remote-boot vitest tier boots it
+#      with the Sync CLI stubbed (src/__tests__/docker/fixtures/ob), so
+#      the s6 init chain runs end-to-end without Sync credentials
 #
 # EMBEDDING_ENABLED=false at runtime is fine: onnxruntime-node's dynamic
 # import is never reached, but the deps-stage assertion already executed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1082,8 +1082,9 @@ re-verify each contract against the new source before merging:
 - Verbs and flags the scripts call: `login`, `sync-config`, `sync`,
   `sync --continuous`, and `sync-setup --vault --device-name`.
 - `ob sync` creates `<vault>/.obsidian/` and a `.obsidian/.sync.lock`
-  directory before transferring anything — `vault_has_content` in
-  `init-first-sync` excludes exactly those two.
+  directory before transferring anything, so their presence does not mean
+  files arrived — `vault_has_content` in `init-first-sync` ignores both
+  when deciding whether the vault holds content.
 - The device's file record, which the deletion-storm guard reads:
   `obsidian-headless/sync/<vaultId>/state.db` under `$XDG_CONFIG_HOME`,
   table `local_files`, loaded at engine startup and diffed against disk.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1029,34 +1029,30 @@ from `npm test`).
 ### Remote image boot tests — when to add
 
 Remote image boot tests (`src/__tests__/docker/`) boot the built
-`:remote` image with the Sync CLI replaced by the `fixtures/ob` stub,
-so the s6 init chain runs end-to-end without credentials or network.
+`:remote` image with the Sync CLI replaced by the `fixtures/ob` stub.
 They catch what the per-script `sh` specs structurally can't — oneshot
-ordering, published env, volume layout, and whether a guard really
-stops the container. Run via `npm run test:remote-boot` after
+ordering, published env, volume layout, guards that must stop the
+container. Run via `npm run test:remote-boot` after
 `docker build --target remote -t vault-cortex:remote-ci .` (separate
-vitest config, excluded from `npm test`); `arch_smoke.yml` runs it on
-both architectures. One boot per `describe` — add assertions to an
-existing boot before adding a new one; only the guards block boots per
-scenario.
+vitest config, excluded from `npm test`; `arch_smoke.yml` runs it on
+both architectures). One boot per `describe`; only the guards block
+boots per scenario.
 
 **Always add:**
 
 - New init oneshot or ordering change → extend the expected `ob` call
-  sequence or add a published-file assertion.
-- New derived variable → assert its `container_environment` file
-  (exact bytes, no trailing newline).
-- New guard that stops the container → a guards-block scenario
-  asserting the exact ERROR line and the failing service.
+  sequence.
+- New derived variable → assert its `container_environment` file.
+- New guard → a guards-block scenario asserting the ERROR line and the
+  failing service.
 - New Sync failure mode → a stub switch (like `OB_STUB_SYNC_FAIL=1`)
-  plus a scenario asserting the chain's response.
+  plus a scenario.
 
 **Never add:**
 
-- Branch logic inside one script — the `sh` specs in
-  `src/vault-mcp/__tests__/` cover it without a boot.
-- Server tool behaviour — the integration tier covers it without Docker.
-- Anything that needs real Obsidian Sync — that stays a Test Deploy.
+- Branch logic inside one script — the `sh` specs cover it.
+- Server tool behaviour — the integration tier covers it.
+- Anything needing real Obsidian Sync — that stays a Test Deploy.
 
 ## SST conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1088,10 +1088,13 @@ re-verify each contract against the new source before merging:
   table `local_files`, loaded at engine startup and diffed against disk.
 
 The remote-boot stub (`src/__tests__/docker/fixtures/ob`) mirrors these
-contracts, so a change in the CLI does not fail the tier by itself:
-update the stub to the new behaviour, run the tier and the `sh` specs,
-then boot the new image once against real Obsidian Sync and confirm the
-first sync, the guard's file count, and continuous sync in the logs.
+contracts, so a change in the CLI does not fail the tier by itself.
+After updating the pinned version:
+
+1. Update the stub to match the new behaviour.
+2. Run the remote-boot tier and the `sh` specs.
+3. Boot the new image once against real Obsidian Sync and confirm the
+   first sync, the guard's file count, and continuous sync in the logs.
 
 ## Operational docs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1028,42 +1028,34 @@ from `npm test`).
 
 ### Remote image boot tests — when to add
 
-Remote image boot tests (`src/__tests__/docker/`) run the built
-`:remote` image with the obsidian-headless CLI replaced by the
-`fixtures/ob` stub (bind-mounted over the real `cli.js`), so the s6
-init chain runs end-to-end without Sync credentials or network. They
-catch what the per-script `sh` specs structurally can't — oneshot
-ordering, what `init-derive-env` actually publishes to
-`/run/s6/container_environment/`, where the sentinel, ownership record
-and index land on each volume layout, and whether a guard really stops
-the container. Run via `npm run test:remote-boot` against a prior
+Remote image boot tests (`src/__tests__/docker/`) boot the built
+`:remote` image with the Sync CLI replaced by the `fixtures/ob` stub,
+so the s6 init chain runs end-to-end without credentials or network.
+They catch what the per-script `sh` specs structurally can't — oneshot
+ordering, published env, volume layout, and whether a guard really
+stops the container. Run via `npm run test:remote-boot` after
 `docker build --target remote -t vault-cortex:remote-ci .` (separate
 vitest config, excluded from `npm test`); `arch_smoke.yml` runs it on
-both architectures on every PR. One container boot per `describe` —
-group assertions under an existing boot before adding a new one. The
-guards block is the exception: each guard needs its own env or volume
-state, so it boots one container per scenario.
+both architectures. One boot per `describe` — add assertions to an
+existing boot before adding a new one; only the guards block boots per
+scenario.
 
 **Always add:**
 
-- New init oneshot, or a change to oneshot ordering → extend the
-  expected `ob` call sequence or add a published-file assertion.
-- New variable derived by `print-derived-env` → assert its
-  `container_environment` file (exact bytes, no trailing newline).
-- New guard that stops the container → a scenario in the guards block
-  asserting the exact ERROR line and the failing service's name.
-- New failure mode of a Sync call → a switch on the stub (env var, like
-  `OB_STUB_SYNC_FAIL=1`) plus a scenario asserting the chain's response.
-- Change to where the sentinel, `.applied-ids`, or index lives → update
-  the layout assertions for both volume layouts.
+- New init oneshot or ordering change → extend the expected `ob` call
+  sequence or add a published-file assertion.
+- New derived variable → assert its `container_environment` file
+  (exact bytes, no trailing newline).
+- New guard that stops the container → a guards-block scenario
+  asserting the exact ERROR line and the failing service.
+- New Sync failure mode → a stub switch (like `OB_STUB_SYNC_FAIL=1`)
+  plus a scenario asserting the chain's response.
 
 **Never add:**
 
-- Branch logic inside one script (input normalization, message
-  wording) — the `sh` specs in `src/vault-mcp/__tests__/` cover it
-  without a boot.
-- Server tool behaviour — the integration tier
-  (`src/__tests__/integration/`) covers it without Docker.
+- Branch logic inside one script — the `sh` specs in
+  `src/vault-mcp/__tests__/` cover it without a boot.
+- Server tool behaviour — the integration tier covers it without Docker.
 - Anything that needs real Obsidian Sync — that stays a Test Deploy.
 
 ## SST conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1086,6 +1086,9 @@ re-verify each contract against the new source before merging:
 - The device's file record, which the deletion-storm guard reads:
   `obsidian-headless/sync/<vaultId>/state.db` under `$XDG_CONFIG_HOME`,
   table `local_files`, loaded at engine startup and diffed against disk.
+- Files delivered by `sync --continuous` land in that same table: the
+  server-push handler feeds the download path, which writes each file's
+  row on completion. The stub's `sync-record` verb mirrors this.
 
 The remote-boot stub (`src/__tests__/docker/fixtures/ob`) mirrors these
 contracts, so a change in the CLI does not fail the tier by itself.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1039,7 +1039,9 @@ the container. Run via `npm run test:remote-boot` against a prior
 `docker build --target remote -t vault-cortex:remote-ci .` (separate
 vitest config, excluded from `npm test`); `arch_smoke.yml` runs it on
 both architectures on every PR. One container boot per `describe` —
-group assertions under an existing boot before adding a new one.
+group assertions under an existing boot before adding a new one. The
+guards block is the exception: each guard needs its own env or volume
+state, so it boots one container per scenario.
 
 **Always add:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1033,9 +1033,10 @@ Remote image boot tests (`src/__tests__/docker/`) boot the built
 They catch what the per-script `sh` specs structurally can't — oneshot
 ordering, published env, volume layout, guards. Run via
 `npm run test:remote-boot` (builds the image, then runs a separate
-vitest config excluded from `npm test`). One boot per `describe`; the
-guards and failing-sync blocks boot per scenario because each needs
-different env or outcome.
+vitest config excluded from `npm test`). Tests in a `describe` block share
+one booted container. The guard and failing-sync blocks are the exception:
+every scenario there boots its own container, since each one sets
+different env or expects a different outcome.
 
 **Always add:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1082,9 +1082,9 @@ re-verify each contract against the new source before merging:
 - Verbs and flags the scripts call: `login`, `sync-config`, `sync`,
   `sync --continuous`, and `sync-setup --vault --device-name`.
 - `ob sync` creates `<vault>/.obsidian/` and a `.obsidian/.sync.lock`
-  directory before transferring anything, so their presence does not mean
-  files arrived — `vault_has_content` in `init-first-sync` ignores both
-  when deciding whether the vault holds content.
+  directory before transferring anything. `vault_has_content` in
+  `init-first-sync` therefore treats an `.obsidian/` folder that holds
+  nothing but `.sync.lock` as an empty vault.
 - The device's file record, which the deletion-storm guard reads:
   `obsidian-headless/sync/<vaultId>/state.db` under `$XDG_CONFIG_HOME`,
   table `local_files`, loaded at engine startup and diffed against disk.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -909,17 +909,17 @@ createTestIndex()` at the top of each test. `beforeEach` is only
   under `rootfs/etc/s6-overlay/scripts/` are the `vault-mcp` server's
   boot chain for the `:remote` target, not TypeScript modules, and
   vitest's include paths (`src/`, `cli/src/`, `scripts/`) don't reach
-  `rootfs/`. Their specs live in
+  `rootfs/`. Their tests live in
   `src/vault-mcp/__tests__/` (`init-first-sync.test.ts`,
   `init-setup-user.test.ts`, `init-setup-vault.test.ts`,
-  `print-derived-env.test.ts`), run the real
+  `print-derived-env.test.ts`). These script tests run the real
   script under `sh` with stub binaries on `PATH`, and name the script
   they cover — don't move them under `rootfs/` or widen vitest's
   include for them. Whole-image behaviour — the chain's ordering, the
   `container_environment` files it publishes, the volume layout, and
   the guards that stop the container — is the remote-boot tier's job
   (`src/__tests__/docker/`, see "Remote image boot tests — when to
-  add"); per-script branch coverage stays in the `sh` specs.
+  add"); the branches inside one script stay in that script's test file.
 - Separate `it()` blocks over callback-pattern `it.each` when
   assertions are structurally different — `it.each` is for genuinely
   identical assertion shapes (input → expected).
@@ -1030,7 +1030,7 @@ from `npm test`).
 
 Remote image boot tests (`src/__tests__/docker/`) boot the built
 `:remote` image with the Sync CLI replaced by the `fixtures/ob` stub.
-They catch what the per-script `sh` specs structurally can't — oneshot
+They catch what a single script's test file cannot — oneshot
 ordering, published env, volume layout, guards. Run via
 `npm run test:remote-boot` (builds the image, then runs a separate
 vitest config excluded from `npm test`). Tests in a `describe` block share
@@ -1048,7 +1048,7 @@ different env or expects a different outcome.
 
 **Never add:**
 
-- Branch logic inside one script — the `sh` specs cover it.
+- Branch logic inside one script — that script's test file covers it.
 - Server tool behaviour — the integration tier covers it.
 - Anything needing real Obsidian Sync — that stays a Test Deploy.
 
@@ -1100,7 +1100,7 @@ because the stub still behaves the old way. After updating the pinned
 version:
 
 1. Update the stub to match the new behaviour.
-2. Run the remote-boot tier and the `sh` specs.
+2. Run the remote-boot tests and the init-script tests.
 3. Boot the new image once against real Obsidian Sync and confirm the
    first sync, the guard's file count, and continuous sync in the logs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ src/
       server-integration.test.ts       #   Every tool + prompt exercised per config (default, READONLY, DISABLED_TOOLS, etc.)
       server-error-contracts.test.ts   #   Documented error paths verified over real HTTP
       fixtures/vault/                  #   Fixture vault copied to tempdir per server boot
-    docker/                            # Remote image boot tier (npm run test:remote-boot; excluded from npm test)
+    docker/                            # Remote image boot tests (npm run test:remote-boot; excluded from npm test)
       docker-harness.ts                #   docker run/exec/logs/healthz helpers + MCP client factory
       remote-image-boot.test.ts        #   s6 init chain end-to-end against the built :remote image, ob stubbed
       fixtures/ob                      #   POSIX stub for the obsidian-headless CLI, bind-mounted over its cli.js
@@ -915,11 +915,12 @@ createTestIndex()` at the top of each test. `beforeEach` is only
   `print-derived-env.test.ts`). These script tests run the real
   script under `sh` with stub binaries on `PATH`, and name the script
   they cover — don't move them under `rootfs/` or widen vitest's
-  include for them. Whole-image behaviour — the chain's ordering, the
-  `container_environment` files it publishes, the volume layout, and
-  the guards that stop the container — is the remote-boot tier's job
-  (`src/__tests__/docker/`, see "Remote image boot tests — when to
-  add"); the branches inside one script stay in that script's test file.
+  include for them. Whole-image behaviour (the init chain's ordering,
+  the `container_environment` files the chain publishes, the volume
+  layout, and the checks that stop the container) belongs in the
+  remote-boot test suite (`src/__tests__/docker/`, see "Remote image
+  boot tests — when to add"); the branches inside one script stay in
+  that script's test file.
 - Separate `it()` blocks over callback-pattern `it.each` when
   assertions are structurally different — `it.each` is for genuinely
   identical assertion shapes (input → expected).
@@ -1030,27 +1031,34 @@ from `npm test`).
 
 Remote image boot tests (`src/__tests__/docker/`) boot the built
 `:remote` image with the Sync CLI replaced by the `fixtures/ob` stub.
-They catch what a single script's test file cannot — oneshot
-ordering, published env, volume layout, guards. Run via
-`npm run test:remote-boot` (builds the image, then runs a separate
-vitest config excluded from `npm test`). Tests in a `describe` block share
-one booted container. The guard and failing-sync blocks are the exception:
-every scenario there boots its own container, since each one sets a
-different env or expects a different outcome.
+They catch what a single script's test file cannot: the ordering of
+init scripts, the `container_environment` files the init chain
+writes, the volume layout, and the checks that stop the container
+on bad state. Run via `npm run test:remote-boot` (builds the image,
+then runs a separate vitest config excluded from `npm test`).
+
+Tests in a `describe` block share one booted container. The
+guard-scenario and failing-sync `describe` blocks are the exception:
+every test there boots its own container, since each sets a different
+environment or expects a different exit outcome.
 
 **Always add:**
 
-- New init oneshot or ordering change → extend the expected `ob` call
+- New init script or ordering change → extend the expected `ob` call
   sequence.
-- New derived variable → assert its `container_environment` file.
-- New guard → a guards-block scenario asserting the ERROR line.
-- New Sync failure mode → a stub switch (like `OB_STUB_SYNC_FAIL=1`).
+- New variable that `init-derive-env` writes → assert its
+  `container_environment` file.
+- New safety check that stops the container → a guard-scenario test
+  asserting the ERROR line.
+- New Sync failure mode → a new stub switch (like
+  `OB_STUB_SYNC_FAIL=1`).
 
 **Never add:**
 
 - Branch logic inside one script — that script's test file covers it.
-- Server tool behaviour — the integration tier covers it.
-- Anything needing real Obsidian Sync — that stays a Test Deploy.
+- Server tool behaviour — the integration test suite covers it.
+- Anything needing real Obsidian Sync — that stays a manual test
+  deploy.
 
 ## SST conventions
 
@@ -1076,7 +1084,7 @@ If you add or rename a secret in `sst.config.ts`, re-run `sst deploy`
 
 The Sync CLI's [documentation](https://obsidian.md/help/sync/headless)
 covers usage, not internals, so the `:remote` init chain depends on
-behaviour read out of the pinned `cli.js`. Treat every bump
+behaviour observed in the pinned `cli.js`. Treat every bump
 of `obsidian-headless/package.json` as a potential regression and
 re-verify each contract against the new source before merging:
 
@@ -1086,12 +1094,13 @@ re-verify each contract against the new source before merging:
   directory before transferring anything. `vault_has_content` in
   `init-first-sync` therefore treats an `.obsidian/` folder that holds
   nothing but `.sync.lock` as an empty vault.
-- The device's file record, which the deletion-storm guard reads:
+- The device's file record is
   `obsidian-headless/sync/<vaultId>/state.db` under `$XDG_CONFIG_HOME`,
-  table `local_files`, loaded at engine startup and diffed against disk.
-- Files delivered by `sync --continuous` land in that same table: the
-  server-push handler feeds the download path, which writes each file's
-  row on completion. The stub's `sync-record` verb mirrors this.
+  table `local_files`. The deletion-storm guard reads this table. The
+  engine loads it at startup and compares it against the files on disk.
+- Files delivered by `sync --continuous` are recorded in that same
+  table as they arrive. The stub's `sync-record` verb mirrors this
+  recording.
 
 The remote-boot tests never run the real CLI — they run the stub
 (`src/__tests__/docker/fixtures/ob`), which imitates the behaviour listed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1031,22 +1031,18 @@ from `npm test`).
 Remote image boot tests (`src/__tests__/docker/`) boot the built
 `:remote` image with the Sync CLI replaced by the `fixtures/ob` stub.
 They catch what the per-script `sh` specs structurally can't — oneshot
-ordering, published env, volume layout, guards that must stop the
-container. Run via `npm run test:remote-boot` after
-`docker build --target remote -t vault-cortex:remote-ci .` (separate
-vitest config, excluded from `npm test`; `arch_smoke.yml` runs it on
-both architectures). One boot per `describe`; only the guards block
-boots per scenario.
+ordering, published env, volume layout, guards. Run via
+`npm run test:remote-boot` (builds the image, then runs a separate
+vitest config excluded from `npm test`). One boot per `describe`; only
+the guards block boots per scenario.
 
 **Always add:**
 
 - New init oneshot or ordering change → extend the expected `ob` call
   sequence.
 - New derived variable → assert its `container_environment` file.
-- New guard → a guards-block scenario asserting the ERROR line and the
-  failing service.
-- New Sync failure mode → a stub switch (like `OB_STUB_SYNC_FAIL=1`)
-  plus a scenario.
+- New guard → a guards-block scenario asserting the ERROR line.
+- New Sync failure mode → a stub switch (like `OB_STUB_SYNC_FAIL=1`).
 
 **Never add:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1073,8 +1073,9 @@ If you add or rename a secret in `sst.config.ts`, re-run `sst deploy`
 
 ## Upgrading obsidian-headless
 
-The Sync CLI has no public documentation, so the `:remote` init chain
-depends on behaviour read out of the pinned `cli.js`. Treat every bump
+The Sync CLI's [documentation](https://obsidian.md/help/sync/headless)
+covers usage, not internals, so the `:remote` init chain depends on
+behaviour read out of the pinned `cli.js`. Treat every bump
 of `obsidian-headless/package.json` as a potential regression and
 re-verify each contract against the new source before merging:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1093,9 +1093,11 @@ re-verify each contract against the new source before merging:
   server-push handler feeds the download path, which writes each file's
   row on completion. The stub's `sync-record` verb mirrors this.
 
-The remote-boot stub (`src/__tests__/docker/fixtures/ob`) mirrors these
-contracts, so a change in the CLI does not fail the tier by itself.
-After updating the pinned version:
+The remote-boot tests never run the real CLI — they run the stub
+(`src/__tests__/docker/fixtures/ob`), which imitates the behaviour listed
+above. So if a new CLI version behaves differently, the tests still pass,
+because the stub still behaves the old way. After updating the pinned
+version:
 
 1. Update the stub to match the new behaviour.
 2. Run the remote-boot tier and the `sh` specs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,10 @@ src/
       server-integration.test.ts       #   Every tool + prompt exercised per config (default, READONLY, DISABLED_TOOLS, etc.)
       server-error-contracts.test.ts   #   Documented error paths verified over real HTTP
       fixtures/vault/                  #   Fixture vault copied to tempdir per server boot
+    docker/                            # Remote image boot tier (npm run test:remote-boot; excluded from npm test)
+      docker-harness.ts                #   docker run/exec/logs/healthz helpers + MCP client factory
+      remote-image-boot.test.ts        #   s6 init chain end-to-end against the built :remote image, ob stubbed
+      fixtures/ob                      #   POSIX stub for the obsidian-headless CLI, bind-mounted over its cli.js
   functions/
     authorizer.ts                      # Lambda: path-aware auth (OAuth pass-through, JWT + static)
   vault-mcp/
@@ -910,7 +914,11 @@ createTestIndex()` at the top of each test. `beforeEach` is only
   `init-setup-user.test.ts`, `print-derived-env.test.ts`), run the real
   script under `sh` with stub binaries on `PATH`, and name the script
   they cover — don't move them under `rootfs/` or widen vitest's
-  include for them.
+  include for them. Whole-image behaviour — the chain's ordering, the
+  `container_environment` files it publishes, the volume layout, and
+  the guards that stop the container — is the remote-boot tier's job
+  (`src/__tests__/docker/`, see "Remote image boot tests — when to
+  add"); per-script branch coverage stays in the `sh` specs.
 - Separate `it()` blocks over callback-pattern `it.each` when
   assertions are structurally different — `it.each` is for genuinely
   identical assertion shapes (input → expected).
@@ -1016,6 +1024,41 @@ from `npm test`).
 - Flag parsing — `program.test.ts` covers Commander.
 - Prompt branching logic — unit tests cover via scripted answers.
 - Docker interaction — unit tests inject `DockerRunner` stubs.
+
+### Remote image boot tests — when to add
+
+Remote image boot tests (`src/__tests__/docker/`) run the built
+`:remote` image with the obsidian-headless CLI replaced by the
+`fixtures/ob` stub (bind-mounted over the real `cli.js`), so the s6
+init chain runs end-to-end without Sync credentials or network. They
+catch what the per-script `sh` specs structurally can't — oneshot
+ordering, what `init-derive-env` actually publishes to
+`/run/s6/container_environment/`, where the sentinel, ownership record
+and index land on each volume layout, and whether a guard really stops
+the container. Run via `npm run test:remote-boot` against a prior
+`docker build --target remote -t vault-cortex:remote-ci .` (separate
+vitest config, excluded from `npm test`); `arch_smoke.yml` runs it on
+both architectures on every PR. One container boot per `describe` —
+group assertions under an existing boot before adding a new one.
+
+**Always add:**
+
+- New init oneshot, or a change to oneshot ordering → extend the
+  expected `ob` call sequence or add a published-file assertion.
+- New variable derived by `print-derived-env` → assert its
+  `container_environment` file (exact bytes, no trailing newline).
+- New guard that stops the container → a scenario in the guards block
+  asserting the exact ERROR line and the failing service's name.
+- Change to where the sentinel, `.applied-ids`, or index lives → update
+  the layout assertions for both volume layouts.
+
+**Never add:**
+
+- Branch logic inside one script (retry counts, warning text) — the
+  `sh` specs in `src/vault-mcp/__tests__/` cover it without a boot.
+- Server tool behaviour — the integration tier
+  (`src/__tests__/integration/`) covers it without Docker.
+- Anything that needs real Obsidian Sync — that stays a Test Deploy.
 
 ## SST conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1049,13 +1049,16 @@ group assertions under an existing boot before adding a new one.
   `container_environment` file (exact bytes, no trailing newline).
 - New guard that stops the container → a scenario in the guards block
   asserting the exact ERROR line and the failing service's name.
+- New failure mode of a Sync call → a switch on the stub (env var, like
+  `OB_STUB_SYNC_FAIL=1`) plus a scenario asserting the chain's response.
 - Change to where the sentinel, `.applied-ids`, or index lives → update
   the layout assertions for both volume layouts.
 
 **Never add:**
 
-- Branch logic inside one script (retry counts, warning text) — the
-  `sh` specs in `src/vault-mcp/__tests__/` cover it without a boot.
+- Branch logic inside one script (input normalization, message
+  wording) — the `sh` specs in `src/vault-mcp/__tests__/` cover it
+  without a boot.
 - Server tool behaviour — the integration tier
   (`src/__tests__/integration/`) covers it without Docker.
 - Anything that needs real Obsidian Sync — that stays a Test Deploy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1037,10 +1037,11 @@ writes, the volume layout, and the checks that stop the container
 on bad state. Run via `npm run test:remote-boot` (builds the image,
 then runs a separate vitest config excluded from `npm test`).
 
-Tests in a `describe` block share one booted container. The
-guard-scenario and failing-sync `describe` blocks are the exception:
-every test there boots its own container, since each sets a different
-environment or expects a different exit outcome.
+Tests in a `describe` block share one booted container. Two places boot
+more often, because each scenario sets a different environment or
+expects a different exit outcome: every guard scenario boots inside its
+own `it()`, and the failing-sync block boots once per sub-`describe`
+(memory on, memory off).
 
 **Always add:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1070,6 +1070,28 @@ you've run `npx sst deploy` (or `sst dev`) once for your stage.
 If you add or rename a secret in `sst.config.ts`, re-run `sst deploy`
 (or `sst dev`) to regenerate `sst-env.d.ts`.
 
+## Upgrading obsidian-headless
+
+The Sync CLI has no public documentation, so the `:remote` init chain
+depends on behaviour read out of the pinned `cli.js`. Treat every bump
+of `obsidian-headless/package.json` as a potential regression and
+re-verify each contract against the new source before merging:
+
+- Verbs and flags the scripts call: `login`, `sync-config`, `sync`,
+  `sync --continuous`, and `sync-setup --vault --device-name`.
+- `ob sync` creates `<vault>/.obsidian/` and a `.obsidian/.sync.lock`
+  directory before transferring anything — `vault_has_content` in
+  `init-first-sync` excludes exactly those two.
+- The device's file record, which the deletion-storm guard reads:
+  `obsidian-headless/sync/<vaultId>/state.db` under `$XDG_CONFIG_HOME`,
+  table `local_files`, loaded at engine startup and diffed against disk.
+
+The remote-boot stub (`src/__tests__/docker/fixtures/ob`) mirrors these
+contracts, so a change in the CLI does not fail the tier by itself:
+update the stub to the new behaviour, run the tier and the `sh` specs,
+then boot the new image once against real Obsidian Sync and confirm the
+first sync, the guard's file count, and continuous sync in the logs.
+
 ## Operational docs
 
 The README is the front door — humans land there first. The full AWS/SST

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1035,7 +1035,7 @@ ordering, published env, volume layout, guards. Run via
 `npm run test:remote-boot` (builds the image, then runs a separate
 vitest config excluded from `npm test`). Tests in a `describe` block share
 one booted container. The guard and failing-sync blocks are the exception:
-every scenario there boots its own container, since each one sets
+every scenario there boots its own container, since each one sets a
 different env or expects a different outcome.
 
 **Always add:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1033,8 +1033,9 @@ Remote image boot tests (`src/__tests__/docker/`) boot the built
 They catch what the per-script `sh` specs structurally can't — oneshot
 ordering, published env, volume layout, guards. Run via
 `npm run test:remote-boot` (builds the image, then runs a separate
-vitest config excluded from `npm test`). One boot per `describe`; only
-the guards block boots per scenario.
+vitest config excluded from `npm test`). One boot per `describe`; the
+guards and failing-sync blocks boot per scenario because each needs
+different env or outcome.
 
 **Always add:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1099,8 +1099,8 @@ re-verify each contract against the new source before merging:
   table `local_files`. The deletion-storm guard reads this table. The
   engine loads it at startup and compares it against the files on disk.
 - Files delivered by `sync --continuous` are recorded in that same
-  table as they arrive. The stub's `sync-record` verb mirrors this
-  recording.
+  table as they arrive, and a file deleted locally has its row removed.
+  The stub's `sync-record` and `sync-forget` verbs mirror the two.
 
 The remote-boot tests never run the real CLI — they run the stub
 (`src/__tests__/docker/fixtures/ob`), which imitates the behaviour listed

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -723,16 +723,17 @@ process has spawned. Two mechanisms with distinct jobs:
   sync health, and a later sync crash restarts just that service, not the
   MCP server.
 - **`init-first-sync` gates vault state.** Three outcomes, checked in order:
-  1. **Deletion-storm guard** (before sync runs): the Sync client keeps a
-     per-device record of the files it holds locally
-     (`obsidian-headless/sync/<vaultId>/state.db` on the config volume) and,
-     at startup, pushes every recorded file missing from disk as a deletion.
-     If that record lists files but the vault has no content, the container
-     refuses to start. Content is any visible entry or anything inside
-     `.obsidian/` (synced settings) except the Sync client's own
-     `.sync.lock`; other dotfiles are not synced and do not count. A record
-     that exists but cannot be read also stops the container. No record
-     means a fresh device, which downloads without deleting.
+  1. **Deletion-storm guard** (before sync runs): the container refuses to
+     start when the Sync client's file record lists files but the vault has
+     no content.
+     - The record is `obsidian-headless/sync/<vaultId>/state.db` on the
+       config volume — at startup the client pushes every recorded file
+       missing from disk as a deletion.
+     - Content is any visible entry, or anything inside `.obsidian/` except
+       the client's own `.sync.lock`. Other dotfiles are not synced and do
+       not count.
+     - A record that exists but cannot be read also stops the container.
+     - No record means a fresh device, which downloads without deleting.
   2. **Sync succeeds**: the first sync runs to completion before any service
      starts.
   3. **Sync fails**: FATAL when the memory bootstrap could still overwrite

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -724,12 +724,14 @@ process has spawned. Two mechanisms with distinct jobs:
   MCP server.
 - **`init-first-sync` gates vault state.** Three outcomes, checked in order:
   1. **Deletion-storm guard** (before sync runs): a sentinel on the config
-     volume records that a prior sync delivered files. If the sentinel exists
-     but the vault is empty (no visible files — dotfiles like `.obsidian/`
-     excluded), the container refuses to start.
+     volume records that a prior sync delivered content. If the sentinel
+     exists but the vault has no content, the container refuses to start.
+     Content is any visible entry or anything inside `.obsidian/` (synced
+     settings) except the Sync client's own `.sync.lock`; other dotfiles are
+     not synced and do not count.
   2. **Sync succeeds**: the first sync runs to completion before any service
-     starts. The sentinel is written only if the vault now has visible files
-     — an empty remote vault has nothing a wipe could delete, and a sentinel
+     starts. The sentinel is written only if the vault now has content — an
+     empty remote vault has nothing a wipe could delete, and a sentinel
      beside it would stop every later boot.
   3. **Sync fails**: FATAL when the memory bootstrap could still overwrite
      real files (memory layer enabled, memory folder absent). Warn-and-continue

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -723,16 +723,18 @@ process has spawned. Two mechanisms with distinct jobs:
   sync health, and a later sync crash restarts just that service, not the
   MCP server.
 - **`init-first-sync` gates vault state.** Three outcomes, checked in order:
-  1. **Deletion-storm guard** (before sync runs): a sentinel on the config
-     volume records that a prior sync delivered content. If the sentinel
-     exists but the vault has no content, the container refuses to start.
-     Content is any visible entry or anything inside `.obsidian/` (synced
-     settings) except the Sync client's own `.sync.lock`; other dotfiles are
-     not synced and do not count.
+  1. **Deletion-storm guard** (before sync runs): the Sync client keeps a
+     per-device record of the files it holds locally
+     (`obsidian-headless/sync/<vaultId>/state.db` on the config volume) and,
+     at startup, pushes every recorded file missing from disk as a deletion.
+     If that record lists files but the vault has no content, the container
+     refuses to start. Content is any visible entry or anything inside
+     `.obsidian/` (synced settings) except the Sync client's own
+     `.sync.lock`; other dotfiles are not synced and do not count. A record
+     that exists but cannot be read also stops the container. No record
+     means a fresh device, which downloads without deleting.
   2. **Sync succeeds**: the first sync runs to completion before any service
-     starts. The sentinel is written only if the vault now has content — an
-     empty remote vault has nothing a wipe could delete, and a sentinel
-     beside it would stop every later boot.
+     starts.
   3. **Sync fails**: FATAL when the memory bootstrap could still overwrite
      real files (memory layer enabled, memory folder absent). Warn-and-continue
      when the memory folder is present or memory is disabled — the server
@@ -760,8 +762,8 @@ layout spans three mounts. Setting `STORAGE_ROOT=<dir>` makes
   variable for per-user config, `~/.config` when unset; obsidian-headless
   keeps its Sync login and device registration under
   `$XDG_CONFIG_HOME/obsidian-headless/`, and `init-setup-user` /
-  `init-first-sync` keep the `.applied-ids` record and the deletion-storm
-  sentinel beside it
+  `init-first-sync` read the `.applied-ids` record and the Sync client's
+  own state there
 
 Derivation never overrides a variable that is already set to a non-empty
 value. `LOG_DIR=none` turns log files off; the sentinel exists because every

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -727,8 +727,8 @@ process has spawned. Two mechanisms with distinct jobs:
      start when the Sync client's file record lists files but the vault has
      no content.
      - The record is `obsidian-headless/sync/<vaultId>/state.db` on the
-       config volume — at startup the client pushes every recorded file
-       missing from disk as a deletion.
+       config volume. At startup, the client pushes every recorded file
+       that is missing from disk as a deletion.
      - Content is any visible entry, or anything inside `.obsidian/` except
        the client's own `.sync.lock`. Other dotfiles are not synced and do
        not count.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -729,9 +729,12 @@ process has spawned. Two mechanisms with distinct jobs:
      - The record is `obsidian-headless/sync/<vaultId>/state.db` on the
        config volume. At startup, the client pushes every recorded file
        that is missing from disk as a deletion.
-     - Content is any visible entry, or anything inside `.obsidian/` except
-       the client's own `.sync.lock`. Other dotfiles are not synced and do
-       not count.
+     - Content is a regular file: any file at any depth with no dot-named
+       path component, or any file inside `.obsidian/` except under the
+       client's own `.sync.lock/`.
+     - Empty folders do not count, so a wipe that deletes files but keeps
+       the folder tree still reads as empty. Dotfiles outside `.obsidian/`
+       are not synced and do not count either.
      - A record that exists but cannot be read also stops the container.
      - No record means a fresh device, which downloads without deleting.
   2. **Sync succeeds**: the first sync runs to completion before any service

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -724,11 +724,13 @@ process has spawned. Two mechanisms with distinct jobs:
   MCP server.
 - **`init-first-sync` gates vault state.** Three outcomes, checked in order:
   1. **Deletion-storm guard** (before sync runs): a sentinel on the config
-     volume records that a prior sync completed. If the sentinel exists but
-     the vault is empty (no visible files — dotfiles like `.obsidian/`
+     volume records that a prior sync delivered files. If the sentinel exists
+     but the vault is empty (no visible files — dotfiles like `.obsidian/`
      excluded), the container refuses to start.
   2. **Sync succeeds**: the first sync runs to completion before any service
-     starts. The sentinel is written for subsequent boots.
+     starts. The sentinel is written only if the vault now has visible files
+     — an empty remote vault has nothing a wipe could delete, and a sentinel
+     beside it would stop every later boot.
   3. **Sync fails**: FATAL when the memory bootstrap could still overwrite
      real files (memory layer enabled, memory folder absent). Warn-and-continue
      when the memory folder is present or memory is disabled — the server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,17 +128,16 @@ truth. Key points:
    npm run prettier:check && npm run lint && npm test && npm run build
    ```
 4. **Fill out the PR template** — the checklist mirrors CI
-5. **Required checks must pass** — the `CI` workflow runs prettier, lint,
-   test, and build on every PR. The `Arch Smoke` workflow builds the Docker
-   image and boots it on native amd64 and arm64 runners (`arch-smoke (amd64)`
-   and `arch-smoke (arm64)` checks), and on both architectures also boots the
-   remote image with a stubbed Sync client to run its init chain end-to-end
-   (`npm run test:remote-boot`) — a native-binding, startup, or init-chain
-   failure on either architecture blocks the merge. Two security scans also gate merges:
-   **Gitleaks** (secret detection) and **Trivy** (vulnerability scan of the
-   Docker image built from your branch — a fixable CRITICAL/HIGH CVE fails
-   the `trivy-pr` check and blocks the merge; the finding details are in the
-   job log)
+5. **Required checks must pass** — every check below blocks the merge;
+   the finding details are in each job's log:
+   - `CI` — prettier, lint, test, and build
+   - `arch-smoke (amd64)` / `arch-smoke (arm64)` — builds the Docker image
+     and boots it on a native runner for each architecture, then boots the
+     remote image with a stubbed Sync client to run its init chain
+     end-to-end (`npm run test:remote-boot`)
+   - `gitleaks` — secret detection
+   - `trivy-pr` — vulnerability scan of the Docker image built from your
+     branch; a fixable CRITICAL/HIGH CVE fails it
 
 ## Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,8 +131,9 @@ truth. Key points:
 5. **Required checks must pass** — the `CI` workflow runs prettier, lint,
    test, and build on every PR. The `Arch Smoke` workflow builds the Docker
    image and boots it on native amd64 and arm64 runners (`arch-smoke (amd64)`
-   and `arch-smoke (arm64)` checks), with the arm64 check also build-verifying
-   the remote image target — a native-binding, startup, or remote-build
+   and `arch-smoke (arm64)` checks), and on both architectures also boots the
+   remote image with a stubbed Sync client to run its init chain end-to-end
+   (`npm run test:remote-boot`) — a native-binding, startup, or init-chain
    failure on either architecture blocks the merge. Two security scans also gate merges:
    **Gitleaks** (secret detection) and **Trivy** (vulnerability scan of the
    Docker image built from your branch — a fixable CRITICAL/HIGH CVE fails

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -129,8 +129,8 @@ mechanism-level detail.
   completion before the server starts, so memory bootstrap can never race
   an incoming sync
 - Sync-state vault guard (remote image): a sentinel on the config volume
-  tracks prior sync completion — if the vault volume is empty but a prior
-  sync completed, the container refuses to start before any sync attempt,
+  records that a prior sync delivered files — if the vault volume is empty
+  but that sentinel exists, the container refuses to start before any sync attempt,
   preventing the sync engine from interpreting the empty vault as mass
   local deletions
 - Memory shrink guard: refuses writes that would remove >50% of a file's

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -129,8 +129,9 @@ mechanism-level detail.
   completion before the server starts, so memory bootstrap can never race
   an incoming sync
 - Sync-state vault guard (remote image): a sentinel on the config volume
-  records that a prior sync delivered files — if the vault volume is empty
-  but that sentinel exists, the container refuses to start before any sync attempt,
+  records that a prior sync delivered content (notes or synced `.obsidian/`
+  settings) — if the vault volume has none but that sentinel exists, the
+  container refuses to start before any sync attempt,
   preventing the sync engine from interpreting the empty vault as mass
   local deletions
 - Memory shrink guard: refuses writes that would remove >50% of a file's

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -128,12 +128,11 @@ mechanism-level detail.
 - First-sync gate (remote image): the init chain runs Obsidian Sync to
   completion before the server starts, so memory bootstrap can never race
   an incoming sync
-- Sync-state vault guard (remote image): a sentinel on the config volume
-  records that a prior sync delivered content (notes or synced `.obsidian/`
-  settings) — if the vault volume has none but that sentinel exists, the
-  container refuses to start before any sync attempt,
-  preventing the sync engine from interpreting the empty vault as mass
-  local deletions
+- Sync-state vault guard (remote image): the Sync client's own device
+  record of locally held files is read before any sync attempt — if it
+  lists files but the vault volume has no content (notes or synced
+  `.obsidian/` settings), the container refuses to start, preventing the
+  sync engine from interpreting the empty vault as mass local deletions
 - Memory shrink guard: refuses writes that would remove >50% of a file's
   bytes — defense-in-depth against bugs that would silently erase most of
   a memory file

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -129,10 +129,11 @@ mechanism-level detail.
   completion before the server starts, so memory bootstrap can never race
   an incoming sync
 - Sync-state vault guard (remote image): the Sync client's own device
-  record of locally held files is read before any sync attempt — if it
-  lists files but the vault volume has no content (notes or synced
-  `.obsidian/` settings), the container refuses to start, preventing the
-  sync engine from interpreting the empty vault as mass local deletions
+  record of locally held files is read before any sync attempt. If the
+  record lists files but the vault volume has no content (notes or
+  synced `.obsidian/` settings), the container refuses to start,
+  preventing the sync engine from interpreting the empty vault as mass
+  local deletions
 - Memory shrink guard: refuses writes that would remove >50% of a file's
   bytes — defense-in-depth against bugs that would silently erase most of
   a memory file

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "vitest": "4.1.11"
   },
   "allowScripts": {
-    "puppeteer@25.7.0": true,
+    "puppeteer@25.8.0": true,
     "node-pty@1.1.0": true
   },
   "puppeteer": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:cli-pty": "vitest run --config vitest.cli-pty.config.ts",
+    "test:remote-boot": "vitest run --config vitest.remote-boot.config.ts",
     "prepare": "husky",
     "render:social-preview": "puppeteer browsers install chrome && tsx scripts/render-social-preview.ts"
   },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:cli-pty": "vitest run --config vitest.cli-pty.config.ts",
-    "test:remote-boot": "vitest run --config vitest.remote-boot.config.ts",
+    "build:remote-image": "docker build --target remote -t vault-cortex:remote-ci .",
+    "test:remote-boot": "npm run build:remote-image && vitest run --config vitest.remote-boot.config.ts",
     "prepare": "husky",
     "render:social-preview": "puppeteer browsers install chrome && tsx scripts/render-social-preview.ts"
   },

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -62,6 +62,7 @@ if [ -f "$SYNC_SENTINEL" ] && ! vault_has_content; then
   echo "[obsidian-sync] every previously-synced file as a local deletion, pushing mass" >&2
   echo "[obsidian-sync] deletions to all connected devices." >&2
   echo "[obsidian-sync] To restore the vault: re-attach the vault volume or restore from backup." >&2
+  echo "[obsidian-sync] If you emptied the vault on purpose, this stop is expected — re-register the device as below; a fresh device downloads the empty vault without deleting anything." >&2
   echo "[obsidian-sync] To start fresh: remove the Obsidian config directory (${XDG_CONFIG_HOME:-$HOME/.config} — the obsidian_config volume under Compose, or the config directory under STORAGE_ROOT) to re-register the device." >&2
   exit 1
 fi

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -61,18 +61,22 @@ known_sync_files() {
   ' "$@"
 }
 
-# "Content" is anything sync could have delivered: a visible entry, or an
-# entry inside .obsidian/ (synced settings and plugin data). Other dotfiles
-# are not synced. `ob sync` itself creates .obsidian/ and a .sync.lock
-# directory in it before transferring anything (obsidian-headless cli.js),
-# so those two alone do not count.
+# "Content" is a regular file that sync could have delivered: a file at
+# any depth whose path has no dot-named component, or any file under
+# .obsidian/ (synced settings and plugin data). Dotfiles elsewhere are not
+# synced and do not count. `ob sync` itself creates .obsidian/ and a
+# .sync.lock directory in it before transferring anything
+# (obsidian-headless cli.js), so that directory is skipped.
+#
+# Directories alone are not content: a wipe that deletes files but leaves
+# the folder tree in place (`find -type f -delete`, a restore that kept
+# empty directories) must still read as an empty vault, or the guard would
+# let the engine push every recorded file as a deletion.
 vault_has_content() {
-  for entry in "$VAULT_PATH"/* "$VAULT_PATH"/.obsidian/* "$VAULT_PATH"/.obsidian/.[!.]*; do
-    [ -e "$entry" ] || continue
-    [ "$entry" = "$VAULT_PATH/.obsidian/.sync.lock" ] && continue
-    return 0
-  done
-  return 1
+  find "$VAULT_PATH" -mindepth 1 \
+    \( -path "$VAULT_PATH/.obsidian/.sync.lock" -prune \) -o \
+    \( -name '.*' ! -path "$VAULT_PATH/.obsidian" ! -path "$VAULT_PATH/.obsidian/*" -prune \) -o \
+    -type f -print | grep -q .
 }
 
 if ! KNOWN_SYNC_FILES=$(known_sync_files); then

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -38,18 +38,21 @@ SYNC_STATE_ROOT="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-headless/sync"
 # 0 when no store exists yet (fresh device). A store that exists but
 # cannot be read is a non-zero exit — the caller treats that as fatal
 # rather than assuming the device is fresh.
+# stdout is the return value: the caller captures it with $(...) and
+# compares it as an integer, so the only output is the bare number.
 known_sync_files() {
   set -- "$SYNC_STATE_ROOT"/*/state.db
   [ -e "$1" ] || { echo 0; return 0; }
   node --no-warnings -e '
     const { DatabaseSync } = require("node:sqlite")
-    const counts = process.argv.slice(1).map((file) => {
+    const storeCounts = process.argv.slice(1).map((file) => {
       const db = new DatabaseSync(file, { readOnly: true })
-      const { n } = db.prepare("SELECT COUNT(*) AS n FROM local_files").get()
+      const { count } = db.prepare("SELECT COUNT(*) AS count FROM local_files").get()
       db.close()
-      return n
+      return count
     })
-    console.log(counts.reduce((total, n) => total + n, 0))
+    const knownFiles = storeCounts.reduce((total, count) => total + count, 0)
+    console.log(knownFiles)
   ' "$@"
 }
 

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -4,11 +4,14 @@
 # against a still-empty vault, bootstraps default About Me/ templates, and
 # bidirectional sync pushes them over the user's real memory files (#440).
 #
-# Pre-sync guard: if a prior sync completed (sentinel on the config volume)
-# but the vault is empty, the sync engine would interpret every previously-
-# synced file as a local deletion and push mass deletions upstream (#440
-# incident 2026-08-15). FATAL in this case — the user must restore the vault
-# volume or wipe the config volume to re-register as a fresh device.
+# Pre-sync guard: if a prior sync delivered content (sentinel on the config
+# volume) but the vault is empty, the sync engine would interpret every
+# previously-synced file as a local deletion and push mass deletions
+# upstream (#440 incident 2026-08-15). FATAL in this case — the user must
+# restore the vault volume or wipe the config volume to re-register as a
+# fresh device. The sentinel is only written when the completed sync left
+# visible files behind: a vault that is empty on the remote too has nothing
+# a wipe could delete, and a sentinel there would stop every later boot.
 #
 # Failure policy once attempts are exhausted, keyed on whether that clobber
 # is possible — bootstrap writes templates only when the memory layer is
@@ -28,9 +31,9 @@ if ! cd "$VAULT_PATH"; then
 fi
 
 # Sentinel in the Obsidian config directory (the obsidian_config volume under
-# Compose, $STORAGE_ROOT/config in single-volume mode): written after the
-# first successful sync, gone when that directory is wiped (fresh device =
-# no sentinel = safe). In single-volume mode the sentinel and the vault share
+# Compose, $STORAGE_ROOT/config in single-volume mode): written after a
+# successful sync that delivered files, gone when that directory is wiped
+# (fresh device = no sentinel = safe). In single-volume mode the sentinel and the vault share
 # one mount, so the guard below still fires if only the vault directory is
 # emptied.
 SYNC_SENTINEL="${XDG_CONFIG_HOME:-$HOME/.config}/.vault-synced"
@@ -72,7 +75,11 @@ ATTEMPT=1
 while :; do
   echo "[obsidian-sync] First sync (attempt ${ATTEMPT}/${MAX_ATTEMPTS}) — waiting for completion before starting services..."
   if s6-setuidgid obsidian ob sync; then
-    touch "$SYNC_SENTINEL"
+    # Only a vault with content needs the wipe guard on later boots; an
+    # empty remote vault (memory disabled, no notes yet) must stay bootable.
+    if vault_has_visible_files; then
+      touch "$SYNC_SENTINEL"
+    fi
     echo "[obsidian-sync] First sync complete."
     exit 0
   fi

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -10,8 +10,8 @@
 # upstream (#440 incident 2026-08-15). FATAL in this case — the user must
 # restore the vault volume or wipe the config volume to re-register as a
 # fresh device. The sentinel is only written when the completed sync left
-# visible files behind: a vault that is empty on the remote too has nothing
-# a wipe could delete, and a sentinel there would stop every later boot.
+# content behind: a vault that is empty on the remote too has nothing a
+# wipe could delete, and a sentinel there would stop every later boot.
 #
 # Failure policy once attempts are exhausted, keyed on whether that clobber
 # is possible — bootstrap writes templates only when the memory layer is
@@ -38,18 +38,25 @@ fi
 # emptied.
 SYNC_SENTINEL="${XDG_CONFIG_HOME:-$HOME/.config}/.vault-synced"
 
-# Pre-sync guard: an empty vault with a prior-sync sentinel means the vault
-# volume was wiped while the config volume (device state) was kept — syncing
-# would push mass deletions. The glob excludes dotfiles, so .obsidian/ alone
-# counts as empty.
-vault_has_visible_files() {
-  for entry in "$VAULT_PATH"/*; do
-    [ -e "$entry" ] && return 0
+# "Content" is anything sync could have delivered: a visible entry, or an
+# entry inside .obsidian/ (synced settings and plugin data). Other dotfiles
+# are not synced. `ob sync` itself creates .obsidian/ and a .sync.lock
+# directory in it before transferring anything (obsidian-headless cli.js),
+# so those two alone do not count — otherwise every empty vault would look
+# like it had content after its first sync.
+vault_has_content() {
+  for entry in "$VAULT_PATH"/* "$VAULT_PATH"/.obsidian/* "$VAULT_PATH"/.obsidian/.[!.]*; do
+    [ -e "$entry" ] || continue
+    [ "$entry" = "$VAULT_PATH/.obsidian/.sync.lock" ] && continue
+    return 0
   done
   return 1
 }
 
-if [ -f "$SYNC_SENTINEL" ] && ! vault_has_visible_files; then
+# Pre-sync guard: a vault without content but with a prior-sync sentinel
+# means the vault volume was wiped while the config volume (device state)
+# was kept — syncing would push mass deletions.
+if [ -f "$SYNC_SENTINEL" ] && ! vault_has_content; then
   echo "[obsidian-sync] ERROR: The vault is empty but this device has previously synced." >&2
   echo "[obsidian-sync] Starting sync in this state would cause the sync engine to interpret" >&2
   echo "[obsidian-sync] every previously-synced file as a local deletion, pushing mass" >&2
@@ -77,7 +84,7 @@ while :; do
   if s6-setuidgid obsidian ob sync; then
     # Only a vault with content needs the wipe guard on later boots; an
     # empty remote vault (memory disabled, no notes yet) must stay bootable.
-    if vault_has_visible_files; then
+    if vault_has_content; then
       touch "$SYNC_SENTINEL"
     fi
     echo "[obsidian-sync] First sync complete."

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -4,14 +4,10 @@
 # against a still-empty vault, bootstraps default About Me/ templates, and
 # bidirectional sync pushes them over the user's real memory files (#440).
 #
-# Pre-sync guard: if a prior sync delivered content (sentinel on the config
-# volume) but the vault is empty, the sync engine would interpret every
-# previously-synced file as a local deletion and push mass deletions
-# upstream (#440 incident 2026-08-15). FATAL in this case — the user must
-# restore the vault volume or wipe the config volume to re-register as a
-# fresh device. The sentinel is only written when the completed sync left
-# content behind: a vault that is empty on the remote too has nothing a
-# wipe could delete, and a sentinel there would stop every later boot.
+# Pre-sync guard: a sentinel from a prior sync beside a vault with no
+# content means the vault volume was wiped while device state was kept —
+# the sync engine would push every previously-synced file as a deletion.
+# FATAL before any sync runs.
 #
 # Failure policy once attempts are exhausted, keyed on whether that clobber
 # is possible — bootstrap writes templates only when the memory layer is
@@ -31,11 +27,11 @@ if ! cd "$VAULT_PATH"; then
 fi
 
 # Sentinel in the Obsidian config directory (the obsidian_config volume under
-# Compose, $STORAGE_ROOT/config in single-volume mode): written after a
-# successful sync that delivered files, gone when that directory is wiped
-# (fresh device = no sentinel = safe). In single-volume mode the sentinel and the vault share
-# one mount, so the guard below still fires if only the vault directory is
-# emptied.
+# Compose, $STORAGE_ROOT/config in single-volume mode): written only after
+# a sync that delivered content, so an empty remote vault never carries one
+# and stays bootable. Gone when that directory is wiped (fresh device = no
+# sentinel = safe). In single-volume mode the sentinel and the vault share
+# one mount, so the guard still fires if only the vault directory is emptied.
 SYNC_SENTINEL="${XDG_CONFIG_HOME:-$HOME/.config}/.vault-synced"
 
 # "Content" is anything sync could have delivered: a visible entry, or an
@@ -53,9 +49,6 @@ vault_has_content() {
   return 1
 }
 
-# Pre-sync guard: a vault without content but with a prior-sync sentinel
-# means the vault volume was wiped while the config volume (device state)
-# was kept — syncing would push mass deletions.
 if [ -f "$SYNC_SENTINEL" ] && ! vault_has_content; then
   echo "[obsidian-sync] ERROR: The vault is empty but this device has previously synced." >&2
   echo "[obsidian-sync] Starting sync in this state would cause the sync engine to interpret" >&2

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -4,10 +4,11 @@
 # against a still-empty vault, bootstraps default About Me/ templates, and
 # bidirectional sync pushes them over the user's real memory files (#440).
 #
-# Pre-sync guard: a sentinel from a prior sync beside a vault with no
-# content means the vault volume was wiped while device state was kept —
-# the sync engine would push every previously-synced file as a deletion.
-# FATAL before any sync runs.
+# Pre-sync guard: the sync engine keeps a per-device record of the files
+# it holds locally and, at startup, pushes every recorded file missing from
+# disk as a deletion. A non-empty record beside a vault with no content
+# means the vault volume was wiped while device state was kept. FATAL
+# before any sync runs.
 #
 # Failure policy once attempts are exhausted, keyed on whether that clobber
 # is possible — bootstrap writes templates only when the memory layer is
@@ -26,20 +27,38 @@ if ! cd "$VAULT_PATH"; then
   exit 1
 fi
 
-# Sentinel in the Obsidian config directory (the obsidian_config volume under
-# Compose, $STORAGE_ROOT/config in single-volume mode): written only after
-# a sync that delivered content, so an empty remote vault never carries one
-# and stays bootable. Gone when that directory is wiped (fresh device = no
-# sentinel = safe). In single-volume mode the sentinel and the vault share
-# one mount, so the guard still fires if only the vault directory is emptied.
-SYNC_SENTINEL="${XDG_CONFIG_HOME:-$HOME/.config}/.vault-synced"
+# obsidian-headless keeps one SQLite store per configured vault under its
+# config directory ($XDG_CONFIG_HOME/obsidian-headless/sync/<vaultId>/ —
+# the obsidian_config volume under Compose, $STORAGE_ROOT/config in
+# single-volume mode). Its local_files table is what the engine diffs
+# against disk. Counting across every store is deliberately conservative:
+# the image serves one vault, so any record of local files belongs to it.
+SYNC_STATE_ROOT="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-headless/sync"
+
+# Prints the number of files the sync state records as present locally;
+# 0 when no store exists yet (fresh device). A store that exists but
+# cannot be read is a non-zero exit — the caller treats that as fatal
+# rather than assuming the device is fresh.
+known_sync_files() {
+  set -- "$SYNC_STATE_ROOT"/*/state.db
+  [ -e "$1" ] || { echo 0; return 0; }
+  node --no-warnings -e '
+    const { DatabaseSync } = require("node:sqlite")
+    const counts = process.argv.slice(1).map((file) => {
+      const db = new DatabaseSync(file, { readOnly: true })
+      const { n } = db.prepare("SELECT COUNT(*) AS n FROM local_files").get()
+      db.close()
+      return n
+    })
+    console.log(counts.reduce((total, n) => total + n, 0))
+  ' "$@"
+}
 
 # "Content" is anything sync could have delivered: a visible entry, or an
 # entry inside .obsidian/ (synced settings and plugin data). Other dotfiles
 # are not synced. `ob sync` itself creates .obsidian/ and a .sync.lock
 # directory in it before transferring anything (obsidian-headless cli.js),
-# so those two alone do not count — otherwise every empty vault would look
-# like it had content after its first sync.
+# so those two alone do not count.
 vault_has_content() {
   for entry in "$VAULT_PATH"/* "$VAULT_PATH"/.obsidian/* "$VAULT_PATH"/.obsidian/.[!.]*; do
     [ -e "$entry" ] || continue
@@ -49,7 +68,13 @@ vault_has_content() {
   return 1
 }
 
-if [ -f "$SYNC_SENTINEL" ] && ! vault_has_content; then
+if ! KNOWN_SYNC_FILES=$(known_sync_files); then
+  echo "[obsidian-sync] ERROR: Could not read this device's sync state under ${SYNC_STATE_ROOT}." >&2
+  echo "[obsidian-sync] Refusing to sync without knowing which files this device has already synced." >&2
+  exit 1
+fi
+
+if [ "$KNOWN_SYNC_FILES" -gt 0 ] && ! vault_has_content; then
   echo "[obsidian-sync] ERROR: The vault is empty but this device has previously synced." >&2
   echo "[obsidian-sync] Starting sync in this state would cause the sync engine to interpret" >&2
   echo "[obsidian-sync] every previously-synced file as a local deletion, pushing mass" >&2
@@ -76,11 +101,6 @@ ATTEMPT=1
 while :; do
   echo "[obsidian-sync] First sync (attempt ${ATTEMPT}/${MAX_ATTEMPTS}) — waiting for completion before starting services..."
   if s6-setuidgid obsidian ob sync; then
-    # Only a vault with content needs the wipe guard on later boots; an
-    # empty remote vault (memory disabled, no notes yet) must stay bootable.
-    if vault_has_content; then
-      touch "$SYNC_SENTINEL"
-    fi
     echo "[obsidian-sync] First sync complete."
     exit 0
   fi

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -28,11 +28,10 @@ if ! cd "$VAULT_PATH"; then
 fi
 
 # obsidian-headless keeps one SQLite store per configured vault under its
-# config directory ($XDG_CONFIG_HOME/obsidian-headless/sync/<vaultId>/ —
-# the obsidian_config volume under Compose, $STORAGE_ROOT/config in
-# single-volume mode). Its local_files table is what the engine diffs
-# against disk. Counting across every store is deliberately conservative:
-# the image serves one vault, so any record of local files belongs to it.
+# config directory: $XDG_CONFIG_HOME/obsidian-headless/sync/<vaultId>/state.db.
+# Its local_files table is the record the engine diffs against disk.
+# The guard sums that table across every store rather than resolving
+# <vaultId>: the image serves one vault, so any record belongs to it.
 SYNC_STATE_ROOT="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-headless/sync"
 
 # Prints the number of files the sync state records as present locally;

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -45,6 +45,12 @@ SYNC_STATE_ROOT="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-headless/sync"
 # rather than assuming the device is fresh.
 # stdout is the return value: the caller captures it with $(...) and
 # compares it as an integer, so the only output is the bare number.
+#
+# local_files holds folders as well as files; each row's data JSON carries
+# "folder": true or false. Only file rows count: folder rows survive a
+# vault emptied of notes while the folders stay, and a deleted folder is
+# not what the guard protects against. A row whose data does not say
+# either way is counted, so an unexpected shape errs toward stopping.
 known_sync_files() {
   set -- "$SYNC_STATE_ROOT"/*/state.db
   [ -e "$1" ] || { echo 0; return 0; }
@@ -52,7 +58,9 @@ known_sync_files() {
     const { DatabaseSync } = require("node:sqlite")
     const storeCounts = process.argv.slice(1).map((file) => {
       const db = new DatabaseSync(file, { readOnly: true })
-      const { count } = db.prepare("SELECT COUNT(*) AS count FROM local_files").get()
+      const { count } = db
+        .prepare("SELECT COUNT(*) AS count FROM local_files WHERE COALESCE(json_extract(data, ?), 0) = 0")
+        .get("$.folder")
       db.close()
       return count
     })

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -5,10 +5,10 @@
 # bidirectional sync pushes them over the user's real memory files (#440).
 #
 # Pre-sync guard: the sync engine keeps a per-device record of the files
-# it holds locally and, at startup, pushes every recorded file missing from
-# disk as a deletion. A non-empty record beside a vault with no content
-# means the vault volume was wiped while device state was kept. FATAL
-# before any sync runs.
+# it holds locally and, at startup, pushes every recorded file that is
+# missing from disk as a deletion. A non-empty record alongside a vault
+# with no content means the vault volume was wiped while the device state
+# was kept. The guard exits FATAL before any sync runs.
 #
 # Failure policy once attempts are exhausted, keyed on whether that clobber
 # is possible — bootstrap writes templates only when the memory layer is
@@ -27,14 +27,15 @@ if ! cd "$VAULT_PATH"; then
   exit 1
 fi
 
-# obsidian-headless keeps one SQLite store per configured vault under its
-# config directory: $XDG_CONFIG_HOME/obsidian-headless/sync/<vaultId>/state.db.
-# Its local_files table is the record the engine diffs against disk.
-# The guard sums that table across every store rather than resolving
+# obsidian-headless keeps one SQLite store per configured vault:
+# $XDG_CONFIG_HOME/obsidian-headless/sync/<vaultId>/state.db. Its
+# local_files table is the record the engine compares against disk.
+#
+# The guard sums local_files across every store instead of resolving
 # <vaultId>. The image serves one vault, so a second store exists only
-# after this device was registered against a different remote vault
-# (one deleted and re-created, or a manual sync-setup); counting its
-# rows too keeps the guard conservative, at the cost of stopping the
+# after the device was registered against a different remote vault
+# (one deleted and re-created, or a manual sync-setup). Counting that
+# store too keeps the guard conservative; the cost is a stopped
 # container until the device is re-registered.
 SYNC_STATE_ROOT="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-headless/sync"
 
@@ -86,7 +87,8 @@ if [ "$KNOWN_SYNC_FILES" -gt 0 ] && ! vault_has_content; then
   echo "[obsidian-sync] every previously-synced file as a local deletion, pushing mass" >&2
   echo "[obsidian-sync] deletions to all connected devices." >&2
   echo "[obsidian-sync] To restore the vault: re-attach the vault volume or restore from backup." >&2
-  echo "[obsidian-sync] If you emptied the vault on purpose, this stop is expected — re-register the device as below; a fresh device downloads the empty vault without deleting anything." >&2
+  echo "[obsidian-sync] If you emptied the vault on purpose, this stop is expected." >&2
+  echo "[obsidian-sync] Re-register the device as below. A fresh device downloads the empty vault without deleting anything." >&2
   echo "[obsidian-sync] To start fresh: remove the Obsidian config directory (${XDG_CONFIG_HOME:-$HOME/.config} — the obsidian_config volume under Compose, or the config directory under STORAGE_ROOT) to re-register the device." >&2
   exit 1
 fi

--- a/rootfs/etc/s6-overlay/scripts/init-first-sync
+++ b/rootfs/etc/s6-overlay/scripts/init-first-sync
@@ -31,7 +31,11 @@ fi
 # config directory: $XDG_CONFIG_HOME/obsidian-headless/sync/<vaultId>/state.db.
 # Its local_files table is the record the engine diffs against disk.
 # The guard sums that table across every store rather than resolving
-# <vaultId>: the image serves one vault, so any record belongs to it.
+# <vaultId>. The image serves one vault, so a second store exists only
+# after this device was registered against a different remote vault
+# (one deleted and re-created, or a manual sync-setup); counting its
+# rows too keeps the guard conservative, at the cost of stopping the
+# container until the device is re-registered.
 SYNC_STATE_ROOT="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-headless/sync"
 
 # Prints the number of files the sync state records as present locally;

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -1,0 +1,292 @@
+/** Remote-boot tier harness — drives the built `:remote` image through the
+ *  Docker CLI and connects an MCP SDK Client to the published port.
+ *
+ *  Every Docker call goes through `execFile` with an argv array, never a
+ *  shell string, so container names, env values, and mount paths are passed
+ *  verbatim. */
+
+import { execFile } from "node:child_process"
+import { resolve } from "node:path"
+import { promisify } from "node:util"
+import { setTimeout as sleep } from "node:timers/promises"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+
+const execFileAsync = promisify(execFile)
+
+/** Path of the real obsidian-headless CLI inside the image — the target of
+ *  the `.bin/ob` symlink on PATH. Mounting the stub here (not over the
+ *  symlink) keeps the override explicit about which file it replaces. */
+const OB_CLI_PATH_IN_IMAGE =
+  "/opt/obsidian-headless/node_modules/obsidian-headless/cli.js"
+
+const OB_STUB_PATH = resolve(import.meta.dirname, "fixtures/ob")
+
+/** Port the MCP server listens on inside the container (Dockerfile `PORT`). */
+const CONTAINER_PORT = 8000
+
+type CommandResult = {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+/** Run `docker <argv>` and capture the outcome without throwing on a non-zero
+ *  exit — callers decide whether a failure is an error or the expected
+ *  result (e.g. `test -e` returning 1). */
+export const docker = async (argv: string[]): Promise<CommandResult> => {
+  try {
+    const { stdout, stderr } = await execFileAsync("docker", argv, {
+      maxBuffer: 64 * 1024 * 1024,
+    })
+    return { code: 0, stdout, stderr }
+  } catch (error) {
+    if (!isExecFileError(error)) throw error
+    return { code: error.code, stdout: error.stdout, stderr: error.stderr }
+  }
+}
+
+type ExecFileError = Error & { code: number; stdout: string; stderr: string }
+
+const isExecFileError = (error: unknown): error is ExecFileError =>
+  error instanceof Error &&
+  typeof Reflect.get(error, "code") === "number" &&
+  typeof Reflect.get(error, "stdout") === "string" &&
+  typeof Reflect.get(error, "stderr") === "string"
+
+/** Run `docker <argv>` and throw with the captured stderr when it fails. */
+const dockerOrThrow = async (argv: string[]): Promise<string> => {
+  const result = await docker(argv)
+  if (result.code !== 0) {
+    throw new Error(
+      `docker ${argv.join(" ")} exited ${result.code}: ${result.stderr.trim()}`,
+    )
+  }
+  return result.stdout
+}
+
+/** Fail fast with a build hint when the image under test is missing —
+ *  without this, every container start would fail with Docker's own
+ *  "No such image" message buried in a timeout. */
+export const assertImagePresent = async (image: string): Promise<void> => {
+  const result = await docker(["image", "inspect", image])
+  if (result.code !== 0) {
+    throw new Error(
+      `Remote image "${image}" not found — build it first: docker build --target remote -t ${image} .`,
+    )
+  }
+}
+
+type RunContainerOptions = {
+  name: string
+  image: string
+  env: Record<string, string>
+  /** `host-path-or-volume:container-path[:ro]` mount specs. */
+  volumes: string[]
+  /** Publish the MCP port on an OS-assigned loopback port. */
+  publishPort: boolean
+}
+
+export type ContainerHandle = {
+  name: string
+  /** Remove the container and every volume it created. */
+  cleanup: () => Promise<void>
+}
+
+/** Start a detached container from the image under test with the `ob` stub
+ *  mounted over the real CLI. The returned cleanup removes the container
+ *  together with its anonymous volumes (`rm -v`); named volumes passed in
+ *  `volumes` are removed explicitly, since `rm -v` leaves those alone. */
+export const runContainer = async ({
+  name,
+  image,
+  env,
+  volumes,
+  publishPort,
+}: RunContainerOptions): Promise<ContainerHandle> => {
+  const envArgs = Object.entries(env).flatMap(([key, value]) => [
+    "-e",
+    `${key}=${value}`,
+  ])
+  const volumeArgs = volumes.flatMap((spec) => ["-v", spec])
+  const publishArgs = publishPort ? ["-p", `127.0.0.1::${CONTAINER_PORT}`] : []
+
+  await dockerOrThrow([
+    "run",
+    "-d",
+    "--pull=never",
+    "--name",
+    name,
+    "-v",
+    `${OB_STUB_PATH}:${OB_CLI_PATH_IN_IMAGE}:ro`,
+    ...envArgs,
+    ...volumeArgs,
+    ...publishArgs,
+    image,
+  ])
+
+  const namedVolumes = volumes.map(namedVolumeOf).filter((volume) => volume)
+
+  const cleanup = async (): Promise<void> => {
+    await docker(["rm", "-f", "-v", name])
+    if (namedVolumes.length > 0) {
+      await docker(["volume", "rm", "-f", ...namedVolumes])
+    }
+  }
+
+  return { name, cleanup }
+}
+
+/** The named-volume half of a `name:/path` mount spec, or "" for a bind
+ *  mount (absolute host path) — Docker treats a source without a leading
+ *  slash as a volume name. */
+const namedVolumeOf = (spec: string): string => {
+  const source = spec.split(":")[0] ?? ""
+  return source.startsWith("/") ? "" : source
+}
+
+/** The loopback port Docker assigned to the container's MCP port. */
+export const publishedPort = async (name: string): Promise<number> => {
+  const mapping = await dockerOrThrow(["port", name, `${CONTAINER_PORT}/tcp`])
+  // `docker port` prints one `host:port` line per address family; the
+  // loopback publish yields `127.0.0.1:NNNNN`.
+  const firstLine = mapping.split("\n")[0] ?? ""
+  const port = Number(firstLine.split(":").at(-1))
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error(`could not parse published port from "${mapping.trim()}"`)
+  }
+  return port
+}
+
+const isRunning = async (name: string): Promise<boolean> => {
+  const state = await dockerOrThrow([
+    "inspect",
+    "-f",
+    "{{.State.Running}}",
+    name,
+  ])
+  return state.trim() === "true"
+}
+
+/** Combined stdout + stderr of the container (s6 writes oneshot output to
+ *  both streams). `since` narrows to lines after a Docker timestamp, which
+ *  is how the restart scenario ignores the first boot's output. */
+export const containerLogs = async (
+  name: string,
+  since?: string,
+): Promise<string> => {
+  const sinceArgs = since ? ["--since", since] : []
+  const result = await docker(["logs", ...sinceArgs, name])
+  return `${result.stdout}${result.stderr}`
+}
+
+/** Poll `/healthz` until it answers 200, failing early — with the container
+ *  logs attached — if the container stops first, so an init-chain failure
+ *  reads as the script's ERROR line rather than a bare timeout. */
+export const waitForHealthz = async ({
+  name,
+  port,
+  deadlineMs,
+}: {
+  name: string
+  port: number
+  deadlineMs: number
+}): Promise<void> => {
+  const deadline = Date.now() + deadlineMs
+  while (Date.now() < deadline) {
+    if (!(await isRunning(name))) {
+      throw new Error(
+        `container ${name} stopped before /healthz answered:\n${await containerLogs(name)}`,
+      )
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/healthz`)
+      if (response.ok) return
+    } catch {
+      // Connection refused while the server is still booting — keep polling.
+    }
+    await sleep(500)
+  }
+  throw new Error(
+    `container ${name} did not answer /healthz within ${deadlineMs}ms:\n${await containerLogs(name)}`,
+  )
+}
+
+/** Wait for the container to stop on its own (an init oneshot failed and
+ *  S6_BEHAVIOUR_IF_STAGE2_FAILS=2 halted it). Kills the container at the
+ *  deadline so a guard that failed to fire can't hang the suite. */
+export const waitForStopped = async ({
+  name,
+  deadlineMs,
+}: {
+  name: string
+  deadlineMs: number
+}): Promise<void> => {
+  const deadline = Date.now() + deadlineMs
+  while (Date.now() < deadline) {
+    if (!(await isRunning(name))) return
+    await sleep(500)
+  }
+  await docker(["kill", name])
+  throw new Error(
+    `container ${name} was still running after ${deadlineMs}ms:\n${await containerLogs(name)}`,
+  )
+}
+
+/** Run a command inside the container and report its outcome — non-zero
+ *  exits are data here (`test -e` on an absent path), not errors. */
+export const execInContainer = (
+  name: string,
+  argv: string[],
+): Promise<CommandResult> => docker(["exec", name, ...argv])
+
+/** Raw bytes of a file inside the container — no trimming, so a stray
+ *  trailing newline in a published env value fails an exact assertion. */
+export const readContainerFile = (
+  name: string,
+  path: string,
+): Promise<string> => dockerOrThrow(["exec", name, "cat", path])
+
+/** Whether a path exists inside the container, via `test -e`'s exit code
+ *  rather than a failed `cat` (which could also mean a permissions error). */
+export const pathExistsInContainer = async (
+  name: string,
+  path: string,
+): Promise<boolean> => {
+  const result = await execInContainer(name, ["test", "-e", path])
+  return result.code === 0
+}
+
+/** Sorted regular-file paths under a directory inside the container. */
+export const listFilesInContainer = async (
+  name: string,
+  directory: string,
+): Promise<string[]> => {
+  const listing = await dockerOrThrow([
+    "exec",
+    name,
+    "find",
+    directory,
+    "-type",
+    "f",
+  ])
+  return listing.split("\n").filter(Boolean).sort()
+}
+
+/** Connect an MCP SDK Client to the container's published port. */
+export const createClient = async (
+  port: number,
+  token: string,
+): Promise<Client> => {
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://127.0.0.1:${port}/mcp`),
+    { requestInit: { headers: { Authorization: `Bearer ${token}` } } },
+  )
+  const client = new Client({ name: "remote-boot-test", version: "1.0.0" })
+  // SDK's StreamableHTTPClientTransport.sessionId is `string | undefined` but
+  // the Transport interface declares `sessionId?: string` — incompatible under
+  // exactOptionalPropertyTypes. Self-cleans when the SDK fixes the type.
+  // @ts-expect-error — SDK type misalignment (sessionId optionality)
+  await client.connect(transport)
+  return client
+}

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -55,7 +55,7 @@ const isExecFileError = (error: unknown): error is ExecFileError =>
   typeof Reflect.get(error, "stderr") === "string"
 
 /** Run `docker <argv>` and throw with the captured stderr when it fails. */
-const dockerOrThrow = async (argv: string[]): Promise<string> => {
+export const dockerOrThrow = async (argv: string[]): Promise<string> => {
   const result = await docker(argv)
   if (result.code !== 0) {
     throw new Error(
@@ -141,34 +141,90 @@ export const runContainer = async ({
   return { name, cleanup }
 }
 
-/** Create an empty file inside a named volume before any container mounts
- *  it — how a scenario fakes state left by a previous boot (a first-sync
- *  sentinel, for instance). Runs `touch` from the image under test with its
+/** Node one-liner that prints how many files the sync state under a config
+ *  directory records as present locally — the same query init-first-sync
+ *  runs. Prints 0 when no store exists. Takes the config directory as its
+ *  argument. */
+const COUNT_SYNC_STATE_FILES_SCRIPT = `
+  const { readdirSync, existsSync } = require("node:fs")
+  const { join } = require("node:path")
+  const { DatabaseSync } = require("node:sqlite")
+  const syncRoot = join(process.argv[1], "obsidian-headless", "sync")
+  const stores = existsSync(syncRoot)
+    ? readdirSync(syncRoot).map((vaultId) => join(syncRoot, vaultId, "state.db")).filter(existsSync)
+    : []
+  const counts = stores.map((file) => {
+    const db = new DatabaseSync(file, { readOnly: true })
+    const { n } = db.prepare("SELECT COUNT(*) AS n FROM local_files").get()
+    db.close()
+    return n
+  })
+  console.log(counts.reduce((total, n) => total + n, 0))
+`
+
+/** How many files the device's sync state (under `configDir` inside the
+ *  container) records as present locally. */
+export const countSyncStateFiles = async ({
+  name,
+  configDir,
+}: {
+  name: string
+  configDir: string
+}): Promise<number> => {
+  const output = await dockerOrThrow([
+    "exec",
+    name,
+    "node",
+    "--no-warnings",
+    "-e",
+    COUNT_SYNC_STATE_FILES_SCRIPT,
+    configDir,
+  ])
+  return Number(output.trim())
+}
+
+/** Seed a named config volume with sync state recording `knownFiles` local
+ *  files before any container mounts it — how a scenario fakes a device
+ *  that has synced before. Runs `node` from the image under test with its
  *  entrypoint bypassed, so the s6 init chain never starts and no other image
  *  has to be pulled. */
-export const seedVolumeFile = async ({
+export const seedSyncState = async ({
   image,
   volume,
   mountPath,
-  file,
+  knownFiles,
 }: {
   image: string
   volume: string
   /** Where the volume is mounted for the seeding run. */
   mountPath: string
-  /** Path of the file to create, relative to `mountPath`. */
-  file: string
+  knownFiles: number
 }): Promise<void> => {
   await dockerOrThrow([
     "run",
     "--rm",
     "--pull=never",
     "--entrypoint",
-    "touch",
+    "node",
     "-v",
     `${volume}:${mountPath}`,
     image,
-    `${mountPath}/${file}`,
+    "--no-warnings",
+    "-e",
+    `
+      const { mkdirSync } = require("node:fs")
+      const { join } = require("node:path")
+      const { DatabaseSync } = require("node:sqlite")
+      const stateDir = join(process.argv[1], "obsidian-headless", "sync", "seeded-vault-id")
+      mkdirSync(stateDir, { recursive: true })
+      const db = new DatabaseSync(join(stateDir, "state.db"))
+      db.exec("CREATE TABLE local_files (path TEXT PRIMARY KEY, data TEXT NOT NULL)")
+      const insert = db.prepare("INSERT INTO local_files VALUES (?, ?)")
+      for (let i = 0; i < Number(process.argv[2]); i += 1) insert.run("note-" + i + ".md", "{}")
+      db.close()
+    `,
+    mountPath,
+    String(knownFiles),
   ])
 }
 

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -93,12 +93,17 @@ export type ContainerHandle = {
   cleanup: () => Promise<void>
 }
 
-/** Start a detached container from the image under test with the `ob` stub
- *  mounted over the real CLI. The returned cleanup removes the container
- *  together with its anonymous volumes (`rm -v`); named volumes passed in
- *  `volumes` are removed explicitly, since `rm -v` leaves those alone. A
- *  removal that fails throws, naming the container or volume, so a leak
- *  fails the hook instead of accumulating silently across local runs. */
+/** Start a detached container from the image under test with exactly one
+ *  file swapped: the `ob` stub is bind-mounted read-only over the real Sync
+ *  client's `cli.js`, so every `ob` call the init chain makes hits the stub
+ *  while the s6 chain, `init-first-sync`, and the volumes stay real. That
+ *  single mount is what lets the tier run without Sync credentials.
+ *
+ *  The returned cleanup removes the container together with its anonymous
+ *  volumes (`rm -v`); named volumes passed in `volumes` are removed
+ *  explicitly, since `rm -v` leaves those alone. A removal that fails
+ *  throws, naming the container or volume, so a leak fails the hook
+ *  instead of accumulating silently across local runs. */
 export const runContainer = async ({
   name,
   image,
@@ -111,8 +116,13 @@ export const runContainer = async ({
     `${key}=${value}`,
   ])
   const volumeArgs = volumes.flatMap((spec) => ["-v", spec])
+  // `127.0.0.1::<port>` leaves the host port to Docker; `publishedPort` reads
+  // it back, so parallel runs never collide on a fixed port.
   const publishArgs = publishPort ? ["-p", `127.0.0.1::${CONTAINER_PORT}`] : []
 
+  // `--pull=never`: only the image this run just built may boot. Without it,
+  // a missing local tag would pull the published `:remote` and the tier would
+  // silently test the released image instead of the branch.
   await dockerOrThrow([
     "run",
     "-d",

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -137,6 +137,37 @@ export const runContainer = async ({
   return { name, cleanup }
 }
 
+/** Create an empty file inside a named volume before any container mounts
+ *  it — how a scenario fakes state left by a previous boot (a first-sync
+ *  sentinel, for instance). Runs `touch` from the image under test with its
+ *  entrypoint bypassed, so the s6 init chain never starts and no other image
+ *  has to be pulled. */
+export const seedVolumeFile = async ({
+  image,
+  volume,
+  mountPath,
+  file,
+}: {
+  image: string
+  volume: string
+  /** Where the volume is mounted for the seeding run. */
+  mountPath: string
+  /** Path of the file to create, relative to `mountPath`. */
+  file: string
+}): Promise<void> => {
+  await dockerOrThrow([
+    "run",
+    "--rm",
+    "--pull=never",
+    "--entrypoint",
+    "touch",
+    "-v",
+    `${volume}:${mountPath}`,
+    image,
+    `${mountPath}/${file}`,
+  ])
+}
+
 /** The named-volume half of a `name:/path` mount spec, or "" for a bind
  *  mount (absolute host path) — Docker treats a source without a leading
  *  slash as a volume name. */

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -220,6 +220,8 @@ export const containerLogs = async (
   return stdout
 }
 
+const HEALTHZ_ATTEMPT_TIMEOUT_MS = 5_000
+
 /** Poll `/healthz` until it answers 200, failing early — with the container
  *  logs attached — if the container stops first, so an init-chain failure
  *  reads as the script's ERROR line rather than a bare timeout. */
@@ -239,11 +241,22 @@ export const waitForHealthz = async ({
         `container ${name} stopped before /healthz answered:\n${await containerLogs(name)}`,
       )
     }
+    // Each attempt is capped at the shorter of 5 s and the remaining budget:
+    // a server that accepts the connection but never answers would otherwise
+    // hold `fetch` open past the deadline and the failure would surface as a
+    // bare hook timeout with no logs attached.
+    const attemptTimeoutMs = Math.min(
+      HEALTHZ_ATTEMPT_TIMEOUT_MS,
+      deadline - Date.now(),
+    )
     try {
-      const response = await fetch(`http://127.0.0.1:${port}/healthz`)
+      const response = await fetch(`http://127.0.0.1:${port}/healthz`, {
+        signal: AbortSignal.timeout(attemptTimeoutMs),
+      })
       if (response.ok) return
     } catch {
-      // Connection refused while the server is still booting — keep polling.
+      // Connection refused while the server is still booting, or an attempt
+      // that timed out — keep polling.
     }
     await sleep(500)
   }

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -168,16 +168,25 @@ const isRunning = async (name: string): Promise<boolean> => {
   return state.trim() === "true"
 }
 
-/** Combined stdout + stderr of the container (s6 writes oneshot output to
- *  both streams). `since` narrows to lines after a Docker timestamp, which
- *  is how the restart scenario ignores the first boot's output. */
+/** The container's stdout and stderr merged in emission order (init scripts
+ *  log progress on stdout and retries/errors on stderr, and tests assert the
+ *  interleaving). Merging has to happen at the source — two pipes read back
+ *  separately can't be re-interleaved — so this is the one Docker call that
+ *  goes through `sh`, with the name passed as a positional argument rather
+ *  than spliced into the command string. `since` narrows to lines after a
+ *  Docker timestamp, which is how the restart scenario ignores the first
+ *  boot's output. */
 export const containerLogs = async (
   name: string,
   since?: string,
 ): Promise<string> => {
   const sinceArgs = since ? ["--since", since] : []
-  const result = await docker(["logs", ...sinceArgs, name])
-  return `${result.stdout}${result.stderr}`
+  const { stdout } = await execFileAsync(
+    "sh",
+    ["-c", 'docker logs "$@" 2>&1', "sh", ...sinceArgs, name],
+    { maxBuffer: 64 * 1024 * 1024 },
+  )
+  return stdout
 }
 
 /** Poll `/healthz` until it answers 200, failing early — with the container

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -72,7 +72,7 @@ export const assertImagePresent = async (image: string): Promise<void> => {
   const result = await docker(["image", "inspect", image])
   if (result.code !== 0) {
     throw new Error(
-      `Remote image "${image}" not found — build it first: docker build --target remote -t ${image} .`,
+      `Remote image "${image}" not found — build it first: npm run build:remote-image (tags vault-cortex:remote-ci; set REMOTE_IMAGE to test another tag)`,
     )
   }
 }

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -251,26 +251,35 @@ export const execInContainer = (
 
 /** Raw bytes of a file inside the container — no trimming, so a stray
  *  trailing newline in a published env value fails an exact assertion. */
-export const readContainerFile = (
-  name: string,
-  path: string,
-): Promise<string> => dockerOrThrow(["exec", name, "cat", path])
+export const readContainerFile = ({
+  name,
+  path,
+}: {
+  name: string
+  path: string
+}): Promise<string> => dockerOrThrow(["exec", name, "cat", path])
 
 /** Whether a path exists inside the container, via `test -e`'s exit code
  *  rather than a failed `cat` (which could also mean a permissions error). */
-export const pathExistsInContainer = async (
-  name: string,
-  path: string,
-): Promise<boolean> => {
+export const pathExistsInContainer = async ({
+  name,
+  path,
+}: {
+  name: string
+  path: string
+}): Promise<boolean> => {
   const result = await execInContainer(name, ["test", "-e", path])
   return result.code === 0
 }
 
 /** Sorted regular-file paths under a directory inside the container. */
-export const listFilesInContainer = async (
-  name: string,
-  directory: string,
-): Promise<string[]> => {
+export const listFilesInContainer = async ({
+  name,
+  directory,
+}: {
+  name: string
+  directory: string
+}): Promise<string[]> => {
   const listing = await dockerOrThrow([
     "exec",
     name,

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -245,9 +245,9 @@ export const waitForHealthz = async ({
     // a server that accepts the connection but never answers would otherwise
     // hold `fetch` open past the deadline and the failure would surface as a
     // bare hook timeout with no logs attached.
-    const attemptTimeoutMs = Math.min(
-      HEALTHZ_ATTEMPT_TIMEOUT_MS,
-      deadline - Date.now(),
+    const attemptTimeoutMs = Math.max(
+      0,
+      Math.min(HEALTHZ_ATTEMPT_TIMEOUT_MS, deadline - Date.now()),
     )
     try {
       const response = await fetch(`http://127.0.0.1:${port}/healthz`, {

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -96,7 +96,9 @@ export type ContainerHandle = {
 /** Start a detached container from the image under test with the `ob` stub
  *  mounted over the real CLI. The returned cleanup removes the container
  *  together with its anonymous volumes (`rm -v`); named volumes passed in
- *  `volumes` are removed explicitly, since `rm -v` leaves those alone. */
+ *  `volumes` are removed explicitly, since `rm -v` leaves those alone. A
+ *  removal that fails throws, naming the container or volume, so a leak
+ *  fails the hook instead of accumulating silently across local runs. */
 export const runContainer = async ({
   name,
   image,
@@ -128,9 +130,11 @@ export const runContainer = async ({
   const namedVolumes = volumes.map(namedVolumeOf).filter((volume) => volume)
 
   const cleanup = async (): Promise<void> => {
-    await docker(["rm", "-f", "-v", name])
+    // Sequential on purpose: a named volume is still in use until the
+    // container is gone, so its removal only runs once `rm` succeeded.
+    await dockerOrThrow(["rm", "-f", "-v", name])
     if (namedVolumes.length > 0) {
-      await docker(["volume", "rm", "-f", ...namedVolumes])
+      await dockerOrThrow(["volume", "rm", "-f", ...namedVolumes])
     }
   }
 

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -1,4 +1,4 @@
-/** Remote-boot tier harness — drives the built `:remote` image through the
+/** Remote-boot test harness — drives the built `:remote` image through the
  *  Docker CLI and connects an MCP SDK Client to the published port.
  *
  *  Every Docker call goes through `execFile` with an argv array, never a
@@ -95,9 +95,9 @@ export type ContainerHandle = {
 
 /** Start a detached container from the image under test with exactly one
  *  file swapped: the `ob` stub is bind-mounted read-only over the real Sync
- *  client's `cli.js`, so every `ob` call the init chain makes hits the stub
- *  while the s6 chain, `init-first-sync`, and the volumes stay real. That
- *  single mount is what lets the tier run without Sync credentials.
+ *  client's `cli.js`, so every `ob` call that the init chain makes hits the
+ *  stub while the s6 chain, `init-first-sync`, and the volumes stay real.
+ *  That single mount is what lets the tests run without Sync credentials.
  *
  *  The returned cleanup removes the container together with its anonymous
  *  volumes (`rm -v`); named volumes passed in `volumes` are removed
@@ -121,8 +121,8 @@ export const runContainer = async ({
   const publishArgs = publishPort ? ["-p", `127.0.0.1::${CONTAINER_PORT}`] : []
 
   // `--pull=never`: only the image this run just built may boot. Without it,
-  // a missing local tag would pull the published `:remote` and the tier would
-  // silently test the released image instead of the branch.
+  // a missing local tag would pull the published `:remote` and the tests
+  // would silently run against the released image instead of the branch.
   await dockerOrThrow([
     "run",
     "-d",
@@ -270,14 +270,14 @@ const isRunning = async (name: string): Promise<boolean> => {
   return state.trim() === "true"
 }
 
-/** The container's stdout and stderr merged in emission order (init scripts
+/** The container's stdout and stderr merged in emission order. Init scripts
  *  log progress on stdout and retries/errors on stderr, and tests assert the
- *  interleaving). Merging has to happen at the source — two pipes read back
- *  separately can't be re-interleaved — so this is the one Docker call that
- *  goes through `sh`, with the name passed as a positional argument rather
- *  than spliced into the command string. `since` narrows to lines after a
- *  Docker timestamp, which is how the restart scenario ignores the first
- *  boot's output. */
+ *  interleaving. Two pipes read back separately cannot be re-interleaved, so
+ *  this is the one Docker call that goes through `sh`, with the name passed
+ *  as a positional argument rather than spliced into the command string.
+ *
+ *  `since` narrows to lines after a Docker timestamp, which is how the
+ *  restart scenarios ignore the first boot's output. */
 export const containerLogs = async (
   name: string,
   since?: string,
@@ -336,9 +336,10 @@ export const waitForHealthz = async ({
   )
 }
 
-/** Wait for the container to stop on its own (an init oneshot failed and
- *  S6_BEHAVIOUR_IF_STAGE2_FAILS=2 halted it). Kills the container at the
- *  deadline so a guard that failed to fire can't hang the suite. */
+/** Wait for the container to stop on its own (a one-shot init script failed
+ *  and S6_BEHAVIOUR_IF_STAGE2_FAILS=2 halted the container). Kills the
+ *  container at the deadline so a check that failed to fire cannot hang the
+ *  suite. */
 export const waitForStopped = async ({
   name,
   deadlineMs,
@@ -365,7 +366,8 @@ export const execInContainer = (
 ): Promise<CommandResult> => docker(["exec", name, ...argv])
 
 /** Raw bytes of a file inside the container — no trimming, so a stray
- *  trailing newline in a published env value fails an exact assertion. */
+ *  trailing newline in a `container_environment` value fails an exact
+ *  assertion. */
 export const readContainerFile = ({
   name,
   path,

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -153,13 +153,14 @@ const COUNT_SYNC_STATE_FILES_SCRIPT = `
   const stores = existsSync(syncRoot)
     ? readdirSync(syncRoot).map((vaultId) => join(syncRoot, vaultId, "state.db")).filter(existsSync)
     : []
-  const counts = stores.map((file) => {
+  const storeCounts = stores.map((file) => {
     const db = new DatabaseSync(file, { readOnly: true })
-    const { n } = db.prepare("SELECT COUNT(*) AS n FROM local_files").get()
+    const { count } = db.prepare("SELECT COUNT(*) AS count FROM local_files").get()
     db.close()
-    return n
+    return count
   })
-  console.log(counts.reduce((total, n) => total + n, 0))
+  const knownFiles = storeCounts.reduce((total, count) => total + count, 0)
+  console.log(knownFiles)
 `
 
 /** How many files the device's sync state (under `configDir` inside the

--- a/src/__tests__/docker/docker-harness.ts
+++ b/src/__tests__/docker/docker-harness.ts
@@ -165,7 +165,7 @@ const COUNT_SYNC_STATE_FILES_SCRIPT = `
     : []
   const storeCounts = stores.map((file) => {
     const db = new DatabaseSync(file, { readOnly: true })
-    const { count } = db.prepare("SELECT COUNT(*) AS count FROM local_files").get()
+    const { count } = db.prepare("SELECT COUNT(*) AS count FROM local_files WHERE COALESCE(json_extract(data, ?), 0) = 0").get("$.folder")
     db.close()
     return count
   })

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -17,8 +17,10 @@
 # set, but none of the CI scenarios set it.)
 #
 # Behaviour switches (container env, reaches the stub via with-contenv):
-#   OB_STUB_SYNC_FAIL=1 — one-shot `sync` exits 1 without writing notes, so
-#                         init-first-sync walks its retry and failure paths
+#   OB_STUB_SYNC_FAIL=1  — one-shot `sync` exits 1 without writing notes, so
+#                          init-first-sync walks its retry and failure paths
+#   OB_STUB_SYNC_EMPTY=1 — one-shot `sync` succeeds without writing notes:
+#                          a remote vault that has nothing in it yet
 set -eu
 
 CALL_LOG="${XDG_CONFIG_HOME:-$HOME/.config}/ob-calls.log"
@@ -38,6 +40,9 @@ case "${1:-}" in
     if [ "${OB_STUB_SYNC_FAIL:-}" = "1" ]; then
       echo "ob stub: sync failing on request (OB_STUB_SYNC_FAIL=1)" >&2
       exit 1
+    fi
+    if [ "${OB_STUB_SYNC_EMPTY:-}" = "1" ]; then
+      exit 0
     fi
     # One-shot first sync (init-first-sync cd's into $VAULT_PATH first):
     # "deliver" the remote vault by writing the fixture notes into the

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -13,8 +13,8 @@
 #
 # Logging "$*" cannot leak the Sync token: the real CLI reads
 # OBSIDIAN_AUTH_TOKEN from the environment and never receives it as an
-# argument, and the init scripts pass none of the secret-bearing env vars
-# on the command line.
+# argument. (VAULT_PASSWORD is a CLI argument to `ob sync-setup` when
+# set, but none of the CI scenarios set it.)
 #
 # Behaviour switches (container env, reaches the stub via with-contenv):
 #   OB_STUB_SYNC_FAIL=1 — one-shot `sync` exits 1 without writing notes, so

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -1,22 +1,26 @@
 #!/bin/sh
-# Stand-in for the obsidian-headless CLI (`ob`) used by the remote-boot tier.
+# Stand-in for the obsidian-headless CLI (`ob`) used by the remote-boot
+# tests.
 #
-# The tier bind-mounts this file over
+# The test harness bind-mounts this file over
 # /opt/obsidian-headless/node_modules/obsidian-headless/cli.js — the target of
 # the `.bin/ob` symlink the image puts on PATH — so the real s6 init chain runs
 # unchanged while every Sync call lands here instead of on Obsidian's servers.
 #
-# Every invocation runs as the `obsidian` user under with-contenv, after
-# init-setup-user has created and chowned the config dir, so the call log
-# below lives beside .applied-ids and the sync state and survives a
-# `docker restart` — the test asserts the cumulative sequence across boots.
+# Every invocation runs as the `obsidian` user (s6's `with-contenv`
+# injects the container environment). init-setup-user has already created
+# and chowned the config directory by this point, so the call log lives
+# beside .applied-ids and the sync state. The log survives a
+# `docker restart`, which lets the test assert the cumulative call
+# sequence across boots.
 #
 # Logging "$*" cannot leak the Sync token: the real CLI reads
 # OBSIDIAN_AUTH_TOKEN from the environment and never receives it as an
 # argument. (VAULT_PASSWORD is a CLI argument to `ob sync-setup` when
 # set, but none of the CI scenarios set it.)
 #
-# Behaviour switches (container env, reaches the stub via with-contenv):
+# Behaviour switches (set as container env vars; s6's with-contenv makes
+# them visible to the stub):
 #   OB_STUB_SYNC_FAIL=1  — one-shot `sync` exits 1 without writing notes, so
 #                          init-first-sync walks its retry and failure paths
 #   OB_STUB_SYNC_EMPTY=1 — one-shot `sync` succeeds without writing notes:
@@ -69,12 +73,12 @@ case "${1:-}" in
       echo "ob stub: sync failing on request (OB_STUB_SYNC_FAIL=1)" >&2
       exit 1
     fi
-    # The real client creates .obsidian/ and takes a .obsidian/.sync.lock
+    # The real client creates .obsidian/ and a .obsidian/.sync.lock
     # directory before transferring anything, so every one-shot sync
-    # leaves these behind — init-first-sync must not read them as content.
+    # leaves these behind — init-first-sync must not count them as content.
     mkdir -p .obsidian/.sync.lock
     # A remote vault with nothing in it: the sync state records no files,
-    # so a restart must be read as a fresh device, not a wiped one.
+    # so on restart the guard must treat the device as fresh, not wiped.
     if [ "${OB_STUB_SYNC_EMPTY:-}" = "1" ]; then
       record_local_files
       exit 0

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -73,10 +73,14 @@ case "${1:-}" in
     # directory before transferring anything, so every one-shot sync
     # leaves these behind — init-first-sync must not read them as content.
     mkdir -p .obsidian/.sync.lock
+    # A remote vault with nothing in it: the sync state records no files,
+    # so a restart must be read as a fresh device, not a wiped one.
     if [ "${OB_STUB_SYNC_EMPTY:-}" = "1" ]; then
       record_local_files
       exit 0
     fi
+    # A remote vault holding only Obsidian settings: the one recorded file
+    # lives under .obsidian/, which init-first-sync must count as content.
     if [ "${OB_STUB_SYNC_CONFIG_ONLY:-}" = "1" ]; then
       printf '{"theme":"obsidian"}\n' > .obsidian/appearance.json
       record_local_files ".obsidian/appearance.json"

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -32,8 +32,8 @@ printf '%s\n' "$*" >> "$CALL_LOG"
 # The real client records every file it holds locally in
 # obsidian-headless/sync/<vaultId>/state.db (table local_files) — the
 # record init-first-sync reads to decide whether an empty vault was wiped.
-# Each one-shot sync records what it delivered, vault-relative paths as
-# arguments.
+# Each one-shot sync records what it delivered; the vault-relative paths
+# arrive as the arguments.
 record_local_files() {
   state_dir="$CONFIG_HOME/obsidian-headless/sync/ci-vault-id"
   mkdir -p "$state_dir"

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -21,6 +21,8 @@
 #                          init-first-sync walks its retry and failure paths
 #   OB_STUB_SYNC_EMPTY=1 — one-shot `sync` succeeds without writing notes:
 #                          a remote vault that has nothing in it yet
+#   OB_STUB_SYNC_CONFIG_ONLY=1 — one-shot `sync` delivers only .obsidian/
+#                          settings, no notes
 set -eu
 
 CALL_LOG="${XDG_CONFIG_HOME:-$HOME/.config}/ob-calls.log"
@@ -41,7 +43,15 @@ case "${1:-}" in
       echo "ob stub: sync failing on request (OB_STUB_SYNC_FAIL=1)" >&2
       exit 1
     fi
+    # The real client creates .obsidian/ and takes a .obsidian/.sync.lock
+    # directory before transferring anything, so every one-shot sync
+    # leaves these behind — init-first-sync must not read them as content.
+    mkdir -p .obsidian/.sync.lock
     if [ "${OB_STUB_SYNC_EMPTY:-}" = "1" ]; then
+      exit 0
+    fi
+    if [ "${OB_STUB_SYNC_CONFIG_ONLY:-}" = "1" ]; then
+      printf '{"theme":"obsidian"}\n' > .obsidian/appearance.json
       exit 0
     fi
     # One-shot first sync (init-first-sync cd's into $VAULT_PATH first):

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -41,8 +41,10 @@ case "${1:-}" in
     fi
     # One-shot first sync (init-first-sync cd's into $VAULT_PATH first):
     # "deliver" the remote vault by writing the fixture notes into the
-    # current directory. Visible files here are also what keeps the
-    # empty-vault guard from firing on the next boot.
+    # current directory. These visible files are also what keeps the
+    # sentinel-plus-empty-vault guard quiet on the next boot: the sentinel
+    # is written after this sync, and an empty vault beside it reads as a
+    # wiped vault.
     mkdir -p Projects
     cat > "Projects/Remote Boot.md" << 'EOF'
 ---

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -8,7 +8,7 @@
 #
 # Every invocation runs as the `obsidian` user under with-contenv, after
 # init-setup-user has created and chowned the config dir, so the call log
-# below lives beside .vault-synced and .applied-ids and survives a
+# below lives beside .applied-ids and the sync state and survives a
 # `docker restart` — the test asserts the cumulative sequence across boots.
 #
 # Logging "$*" cannot leak the Sync token: the real CLI reads
@@ -25,11 +25,37 @@
 #                          settings, no notes
 set -eu
 
-CALL_LOG="${XDG_CONFIG_HOME:-$HOME/.config}/ob-calls.log"
+CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+CALL_LOG="$CONFIG_HOME/ob-calls.log"
 printf '%s\n' "$*" >> "$CALL_LOG"
+
+# The real client records every file it holds locally in
+# obsidian-headless/sync/<vaultId>/state.db (table local_files) — the
+# record init-first-sync reads to decide whether an empty vault was wiped.
+# Each one-shot sync records what it delivered, vault-relative paths as
+# arguments.
+record_local_files() {
+  state_dir="$CONFIG_HOME/obsidian-headless/sync/ci-vault-id"
+  mkdir -p "$state_dir"
+  node --no-warnings -e '
+    const { DatabaseSync } = require("node:sqlite")
+    const db = new DatabaseSync(process.argv[1])
+    db.exec("CREATE TABLE IF NOT EXISTS local_files (path TEXT PRIMARY KEY, data TEXT NOT NULL)")
+    const insert = db.prepare("INSERT OR REPLACE INTO local_files VALUES (?, ?)")
+    for (const path of process.argv.slice(2)) insert.run(path, "{}")
+    db.close()
+  ' "$state_dir/state.db" "$@"
+}
 
 case "${1:-}" in
   login | sync-setup | sync-config)
+    exit 0
+    ;;
+  sync-record)
+    # Test-only verb: record files that "arrived" through continuous sync
+    # (which the stub otherwise just sleeps through). Not a real ob command.
+    shift
+    record_local_files "$@"
     exit 0
     ;;
   sync)
@@ -48,18 +74,18 @@ case "${1:-}" in
     # leaves these behind — init-first-sync must not read them as content.
     mkdir -p .obsidian/.sync.lock
     if [ "${OB_STUB_SYNC_EMPTY:-}" = "1" ]; then
+      record_local_files
       exit 0
     fi
     if [ "${OB_STUB_SYNC_CONFIG_ONLY:-}" = "1" ]; then
       printf '{"theme":"obsidian"}\n' > .obsidian/appearance.json
+      record_local_files ".obsidian/appearance.json"
       exit 0
     fi
     # One-shot first sync (init-first-sync cd's into $VAULT_PATH first):
     # "deliver" the remote vault by writing the fixture notes into the
-    # current directory. These visible files are also what keeps the
-    # sentinel-plus-empty-vault guard quiet on the next boot: the sentinel
-    # is written after this sync, and an empty vault beside it reads as a
-    # wiped vault.
+    # current directory and recording them in the sync state.
+    record_local_files "Projects/Remote Boot.md" "Sync Log.md"
     mkdir -p Projects
     cat > "Projects/Remote Boot.md" << 'EOF'
 ---

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Stand-in for the obsidian-headless CLI (`ob`) used by the remote-boot tier.
+#
+# The tier bind-mounts this file over
+# /opt/obsidian-headless/node_modules/obsidian-headless/cli.js — the target of
+# the `.bin/ob` symlink the image puts on PATH — so the real s6 init chain runs
+# unchanged while every Sync call lands here instead of on Obsidian's servers.
+#
+# Every invocation runs as the `obsidian` user under with-contenv, after
+# init-setup-user has created and chowned the config dir, so the call log
+# below lives beside .vault-synced and .applied-ids and survives a
+# `docker restart` — the test asserts the cumulative sequence across boots.
+#
+# Logging "$*" cannot leak the Sync token: the real CLI reads
+# OBSIDIAN_AUTH_TOKEN from the environment and never receives it as an
+# argument, and the init scripts pass none of the secret-bearing env vars
+# on the command line.
+set -eu
+
+CALL_LOG="${XDG_CONFIG_HOME:-$HOME/.config}/ob-calls.log"
+printf '%s\n' "$*" >> "$CALL_LOG"
+
+case "${1:-}" in
+  login | sync-setup | sync-config)
+    exit 0
+    ;;
+  sync)
+    if [ "${2:-}" = "--continuous" ]; then
+      # svc-obsidian-sync execs `ob sync --continuous` and s6 supervises the
+      # resulting process; blocking forever keeps the service "up" instead
+      # of restart-looping, which is what a healthy sync daemon looks like.
+      exec sleep infinity
+    fi
+    # One-shot first sync (init-first-sync cd's into $VAULT_PATH first):
+    # "deliver" the remote vault by writing the fixture notes into the
+    # current directory. Visible files here are also what keeps the
+    # empty-vault guard from firing on the next boot.
+    mkdir -p Projects
+    cat > "Projects/Remote Boot.md" << 'EOF'
+---
+tags: [ci, remote-boot]
+---
+
+# Remote Boot
+
+Delivered by the stubbed first sync. Links to [[Sync Log]].
+EOF
+    cat > "Sync Log.md" << 'EOF'
+# Sync Log
+
+Second fixture note; links back to [[Remote Boot]].
+EOF
+    exit 0
+    ;;
+  *)
+    echo "ob stub: unexpected invocation: $*" >&2
+    exit 64
+    ;;
+esac

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -98,6 +98,11 @@ case "${1:-}" in
       echo "ob stub: sync failing on request (OB_STUB_SYNC_FAIL=1)" >&2
       exit 1
     fi
+    # What the vault held before this one-shot sync delivered anything,
+    # one top-level entry per line (.obsidian excluded). A test reads it to
+    # prove the server's memory bootstrap ran after the first sync, not
+    # before: an "About Me" line here means the templates landed first.
+    find . -mindepth 1 -maxdepth 1 ! -name '.obsidian' | sort >> "$CONFIG_HOME/pre-sync-entries.log"
     # The real client creates .obsidian/ and a .obsidian/.sync.lock
     # directory before transferring anything, so every one-shot sync
     # leaves these behind — init-first-sync must not count them as content.

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -15,6 +15,10 @@
 # OBSIDIAN_AUTH_TOKEN from the environment and never receives it as an
 # argument, and the init scripts pass none of the secret-bearing env vars
 # on the command line.
+#
+# Behaviour switches (container env, reaches the stub via with-contenv):
+#   OB_STUB_SYNC_FAIL=1 — one-shot `sync` exits 1 without writing notes, so
+#                         init-first-sync walks its retry and failure paths
 set -eu
 
 CALL_LOG="${XDG_CONFIG_HOME:-$HOME/.config}/ob-calls.log"
@@ -30,6 +34,10 @@ case "${1:-}" in
       # resulting process; blocking forever keeps the service "up" instead
       # of restart-looping, which is what a healthy sync daemon looks like.
       exec sleep infinity
+    fi
+    if [ "${OB_STUB_SYNC_FAIL:-}" = "1" ]; then
+      echo "ob stub: sync failing on request (OB_STUB_SYNC_FAIL=1)" >&2
+      exit 1
     fi
     # One-shot first sync (init-first-sync cd's into $VAULT_PATH first):
     # "deliver" the remote vault by writing the fixture notes into the

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -51,7 +51,7 @@ record_local_files() {
     const db = new DatabaseSync(process.argv[1])
     db.exec("CREATE TABLE IF NOT EXISTS local_files (path TEXT PRIMARY KEY, data TEXT NOT NULL)")
     const insert = db.prepare("INSERT OR REPLACE INTO local_files VALUES (?, ?)")
-    for (const path of process.argv.slice(2)) insert.run(path, "{}")
+    for (const path of process.argv.slice(2)) insert.run(path, JSON.stringify({ folder: false }))
     db.close()
   ' "$state_dir/state.db" "$@"
 }

--- a/src/__tests__/docker/fixtures/ob
+++ b/src/__tests__/docker/fixtures/ob
@@ -27,6 +27,11 @@
 #                          a remote vault that has nothing in it yet
 #   OB_STUB_SYNC_CONFIG_ONLY=1 — one-shot `sync` delivers only .obsidian/
 #                          settings, no notes
+#
+# Test-only verbs (not real ob commands) that stand in for what continuous
+# sync does to the record while the container runs:
+#   ob sync-record <paths>  — files arrived: add their rows
+#   ob sync-forget <paths>  — files were deleted locally: drop their rows
 set -eu
 
 CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -51,6 +56,19 @@ record_local_files() {
   ' "$state_dir/state.db" "$@"
 }
 
+# The real client drops a file's row when the file is deleted locally, so
+# a vault emptied by hand while the device runs leaves an empty record.
+forget_local_files() {
+  state_dir="$CONFIG_HOME/obsidian-headless/sync/ci-vault-id"
+  node --no-warnings -e '
+    const { DatabaseSync } = require("node:sqlite")
+    const db = new DatabaseSync(process.argv[1])
+    const remove = db.prepare("DELETE FROM local_files WHERE path = ?")
+    for (const path of process.argv.slice(2)) remove.run(path)
+    db.close()
+  ' "$state_dir/state.db" "$@"
+}
+
 case "${1:-}" in
   login | sync-setup | sync-config)
     exit 0
@@ -60,6 +78,13 @@ case "${1:-}" in
     # (which the stub otherwise just sleeps through). Not a real ob command.
     shift
     record_local_files "$@"
+    exit 0
+    ;;
+  sync-forget)
+    # Test-only verb: drop the rows for files deleted locally while the
+    # stub's continuous sync was "running". Not a real ob command.
+    shift
+    forget_local_files "$@"
     exit 0
     ;;
   sync)

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -441,6 +441,14 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
       memoryDirExit: 0,
       syncedNotePresent: true,
     })
+    // Existence alone holds in either order. The stub lists the vault's
+    // top-level entries just before its one-shot sync delivers anything;
+    // an empty listing proves the memory folder was not there yet.
+    const entriesBeforeFirstSync = await readContainerFile({
+      name,
+      path: "/persist/config/pre-sync-entries.log",
+    })
+    expect(entriesBeforeFirstSync).toBe("")
   })
 
   it("writes nothing into the legacy /vault, /data and /home/obsidian/.config paths", async () => {

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -27,15 +27,17 @@ import { callTool, textContent } from "../integration/test-harness.js"
 import {
   assertImagePresent,
   containerLogs,
+  countSyncStateFiles,
   createClient,
   docker,
+  dockerOrThrow,
   execInContainer,
   listFilesInContainer,
   pathExistsInContainer,
   publishedPort,
   readContainerFile,
   runContainer,
-  seedVolumeFile,
+  seedSyncState,
   waitForHealthz,
   waitForStopped,
 } from "./docker-harness.js"
@@ -220,13 +222,10 @@ describe("remote image boot — three-volume layout (anonymous /vault, /data, /h
     expect(callLog).toBe(callLogOf(1))
   })
 
-  it("writes the first-sync sentinel to /home/obsidian/.config/.vault-synced", async () => {
+  it("records the two synced notes in the sync state under /home/obsidian/.config", async () => {
     expect(
-      await pathExistsInContainer({
-        name,
-        path: "/home/obsidian/.config/.vault-synced",
-      }),
-    ).toBe(true)
+      await countSyncStateFiles({ name, configDir: "/home/obsidian/.config" }),
+    ).toBe(2)
   })
 
   it("creates the search index at /data/index.db", async () => {
@@ -392,18 +391,18 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
     })
   })
 
-  it("writes the ownership record and first-sync sentinel under /persist/config", async () => {
+  it("writes the ownership record and the sync state under /persist/config", async () => {
     const appliedIds = await readContainerFile({
       name,
       path: "/persist/config/.applied-ids",
     })
-    const sentinelPresent = await pathExistsInContainer({
+    const knownSyncFiles = await countSyncStateFiles({
       name,
-      path: "/persist/config/.vault-synced",
+      configDir: "/persist/config",
     })
-    expect({ appliedIds, sentinelPresent }).toEqual({
+    expect({ appliedIds, knownSyncFiles }).toEqual({
       appliedIds: "1000:1000\n",
-      sentinelPresent: true,
+      knownSyncFiles: 2,
     })
   })
 
@@ -490,16 +489,16 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
       ).toBe(callLogOf(2))
     })
 
-    it("keeps the first-sync sentinel and the synced notes", async () => {
-      const sentinelPresent = await pathExistsInContainer({
+    it("keeps the sync state and the synced notes", async () => {
+      const knownSyncFiles = await countSyncStateFiles({
         name,
-        path: "/persist/config/.vault-synced",
+        configDir: "/persist/config",
       })
       const syncedNotes = (
         await listFilesInContainer({ name, directory: "/persist/vault" })
       ).filter((path) => !path.startsWith("/persist/vault/About Me/"))
-      expect({ sentinelPresent, syncedNotes }).toEqual({
-        sentinelPresent: true,
+      expect({ knownSyncFiles, syncedNotes }).toEqual({
+        knownSyncFiles: 2,
         syncedNotes: [
           "/persist/vault/Projects/Remote Boot.md",
           "/persist/vault/Sync Log.md",
@@ -605,13 +604,13 @@ describe("remote image boot — first sync keeps failing (OB_STUB_SYNC_FAIL=1)",
       )
     })
 
-    it("does not write the first-sync sentinel", async () => {
+    it("records no synced files", async () => {
       expect(
-        await pathExistsInContainer({
+        await countSyncStateFiles({
           name,
-          path: "/home/obsidian/.config/.vault-synced",
+          configDir: "/home/obsidian/.config",
         }),
-      ).toBe(false)
+      ).toBe(0)
     })
 
     it("serves an empty vault over MCP rather than refusing requests", async () => {
@@ -633,8 +632,8 @@ describe("remote image boot — first sync keeps failing (OB_STUB_SYNC_FAIL=1)",
 describe("remote image boot — empty remote vault with the memory layer disabled", () => {
   // Nothing ever lands in the vault: the stub delivers no notes and memory
   // is off, so no About Me/ templates are bootstrapped either. The device
-  // must stay bootable across restarts — the wipe guard keys on a sentinel
-  // that only a content-delivering sync may write.
+  // must stay bootable across restarts — its sync state records no files,
+  // so an empty vault is not a wiped one.
   const name = uniqueName("empty-vault")
   const env = {
     ...BASE_ENV,
@@ -661,7 +660,7 @@ describe("remote image boot — empty remote vault with the memory layer disable
     await handle?.cleanup()
   })
 
-  it("completes the first sync with an empty vault and writes no sentinel", async () => {
+  it("completes the first sync with an empty vault and records no files", async () => {
     expect(await containerLogs(name)).toContain(
       "[obsidian-sync] First sync complete.",
     )
@@ -669,11 +668,8 @@ describe("remote image boot — empty remote vault with the memory layer disable
       [],
     )
     expect(
-      await pathExistsInContainer({
-        name,
-        path: "/home/obsidian/.config/.vault-synced",
-      }),
-    ).toBe(false)
+      await countSyncStateFiles({ name, configDir: "/home/obsidian/.config" }),
+    ).toBe(0)
   })
 
   describe("after docker restart", () => {
@@ -700,11 +696,68 @@ describe("remote image boot — empty remote vault with the memory layer disable
   })
 })
 
+describe("remote image boot — vault wiped after files arrived while the container ran", () => {
+  // The device started with an empty vault, received files through
+  // continuous sync (no restart involved), and then had its vault volume
+  // emptied. The sync state still records those files, so the next boot
+  // must stop before the engine can push them as deletions.
+  const name = uniqueName("wiped-while-running")
+  const env = {
+    ...BASE_ENV,
+    MEMORY_ENABLED: "false",
+    PUBLIC_URL: "http://localhost:8000",
+    OB_STUB_SYNC_EMPTY: "1",
+  }
+  let handle: ContainerHandle | undefined
+
+  beforeAll(async () => {
+    handle = await runContainer({
+      name,
+      image: IMAGE,
+      env,
+      volumes: [],
+      publishPort: true,
+    })
+    const port = await publishedPort(name)
+    await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
+    // What continuous sync would do: deliver a note and record it in the
+    // sync state, as the obsidian user the stub normally runs as.
+    await dockerOrThrow([
+      "exec",
+      "--user",
+      "obsidian",
+      "--env",
+      "HOME=/home/obsidian",
+      name,
+      "sh",
+      "-c",
+      'printf "# Arrived later\n" > "/vault/Arrived Later.md" && ob sync-record "Arrived Later.md"',
+    ])
+    // The wipe: the vault volume emptied while device state is kept.
+    await execInContainer(name, ["rm", "-f", "/vault/Arrived Later.md"])
+    await docker(["restart", name])
+    await waitForStopped({ name, deadlineMs: STOP_DEADLINE_MS })
+  })
+
+  afterAll(async () => {
+    await handle?.cleanup()
+  })
+
+  it("stops on the next boot instead of syncing the wiped vault", async () => {
+    const logs = await containerLogs(name)
+    expect(logs).toContain(
+      "[obsidian-sync] ERROR: The vault is empty but this device has previously synced.",
+    )
+    expect(logs).toContain(
+      "s6-rc: warning: unable to start service init-first-sync: command exited 1",
+    )
+  })
+})
+
 describe("remote image boot — remote vault holding only synced .obsidian/ settings", () => {
   // Settings are synced but there are no notes and memory is off. The
-  // settings are content a wipe could delete, so the sentinel must be
-  // written — and on restart the guard must read them as content too, or
-  // the device locks itself out.
+  // settings are recorded in the sync state, so on restart the guard must
+  // read them as content too, or the device locks itself out.
   const name = uniqueName("config-only")
   const env = {
     ...BASE_ENV,
@@ -731,16 +784,13 @@ describe("remote image boot — remote vault holding only synced .obsidian/ sett
     await handle?.cleanup()
   })
 
-  it("writes the sentinel for a vault whose only content is .obsidian/ settings", async () => {
+  it("records the synced settings file in the sync state", async () => {
     expect(await listFilesInContainer({ name, directory: "/vault" })).toEqual([
       "/vault/.obsidian/appearance.json",
     ])
     expect(
-      await pathExistsInContainer({
-        name,
-        path: "/home/obsidian/.config/.vault-synced",
-      }),
-    ).toBe(true)
+      await countSyncStateFiles({ name, configDir: "/home/obsidian/.config" }),
+    ).toBe(1)
   })
 
   describe("after docker restart", () => {
@@ -853,17 +903,17 @@ describe("remote image boot — init-chain guards stop the container", () => {
     expect(logs).not.toContain("[obsidian-sync] Authenticated.")
   })
 
-  it("refuses to sync an empty vault when a previous sync's sentinel is present", async () => {
-    // The #440 data-loss guard: a kept config volume (device state + sentinel)
-    // with a wiped vault volume would have the sync engine push every
-    // previously-synced file as a deletion. Seed the sentinel the way a prior
-    // boot would leave it, then boot against an empty anonymous /vault.
+  it("refuses to sync an empty vault when the device's sync state records files", async () => {
+    // A kept config volume (sync state recording files) with a wiped vault
+    // volume would have the sync engine push every recorded file as a
+    // deletion. Seed the state the way a synced device carries it, then
+    // boot against an empty anonymous /vault.
     const configVolume = `${uniqueName("synced-config")}-volume`
-    await seedVolumeFile({
+    await seedSyncState({
       image: IMAGE,
       volume: configVolume,
       mountPath: "/home/obsidian/.config",
-      file: ".vault-synced",
+      knownFiles: 3,
     })
     const logs = await logsAfterGuardStops({
       scenario: "empty-vault-after-sync",

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -768,6 +768,79 @@ describe("remote image boot — vault wiped after files arrived while the contai
   })
 })
 
+describe("remote image boot — notes deleted by hand while the container ran", () => {
+  // The engine drops a file's row from the sync state when the file is
+  // deleted locally, so a vault emptied on purpose while the device runs
+  // leaves an empty record. The next boot must read that as "nothing to
+  // push" and start normally, not as a wipe.
+  const name = uniqueName("emptied-by-hand")
+  const env = {
+    ...BASE_ENV,
+    MEMORY_ENABLED: "false",
+    PUBLIC_URL: "http://localhost:8000",
+    OB_STUB_SYNC_EMPTY: "1",
+  }
+  let handle: ContainerHandle | undefined
+  let restartedAt = ""
+
+  beforeAll(async () => {
+    handle = await runContainer({
+      name,
+      image: IMAGE,
+      env,
+      volumes: [],
+      publishPort: true,
+    })
+    const port = await publishedPort(name)
+    await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
+    // A note arrives through continuous sync, then the user deletes it;
+    // the engine records the arrival and then forgets the row.
+    await dockerOrThrow([
+      "exec",
+      "--user",
+      "obsidian",
+      "--env",
+      "HOME=/home/obsidian",
+      name,
+      "sh",
+      "-c",
+      'printf "# Arrived later\n" > "/vault/Arrived Later.md" && ob sync-record "Arrived Later.md" && rm "/vault/Arrived Later.md" && ob sync-forget "Arrived Later.md"',
+    ])
+    const beforeRestart = await bootedStartedAt(name)
+    await docker(["restart", name])
+    restartedAt = await bootedStartedAt(name)
+    if (restartedAt === beforeRestart) {
+      throw new Error("docker restart did not produce a new StartedAt")
+    }
+    const restartedPort = await publishedPort(name)
+    await waitForHealthz({
+      name,
+      port: restartedPort,
+      deadlineMs: BOOT_DEADLINE_MS,
+    })
+  })
+
+  afterAll(async () => {
+    await handle?.cleanup()
+  })
+
+  it("boots again after the restart without the deletion-storm guard firing", async () => {
+    const logsSinceRestart = await containerLogs(name, restartedAt)
+    expect(logsSinceRestart).toContain("[obsidian-sync] First sync complete.")
+    expect(logsSinceRestart).not.toContain(
+      "The vault is empty but this device has previously synced.",
+    )
+  })
+
+  it("records no files once the deleted note's row is gone", async () => {
+    const knownFiles = await countSyncStateFiles({
+      name,
+      configDir: "/home/obsidian/.config",
+    })
+    expect(knownFiles).toBe(0)
+  })
+})
+
 describe("remote image boot — remote vault holding only synced .obsidian/ settings", () => {
   // Settings are synced but there are no notes and memory is off. The
   // settings are recorded in the sync state, so on restart the guard must

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -711,6 +711,7 @@ describe("remote image boot — vault wiped after files arrived while the contai
     OB_STUB_SYNC_EMPTY: "1",
   }
   let handle: ContainerHandle | undefined
+  let restartedAt = ""
 
   beforeAll(async () => {
     handle = await runContainer({
@@ -737,7 +738,12 @@ describe("remote image boot — vault wiped after files arrived while the contai
     ])
     // The wipe: the vault volume emptied while device state is kept.
     await execInContainer(name, ["rm", "-f", "/vault/Arrived Later.md"])
+    const beforeRestart = await bootedStartedAt(name)
     await docker(["restart", name])
+    restartedAt = await bootedStartedAt(name)
+    if (restartedAt === beforeRestart) {
+      throw new Error("docker restart did not produce a new StartedAt")
+    }
     await waitForStopped({ name, deadlineMs: STOP_DEADLINE_MS })
   })
 
@@ -745,14 +751,18 @@ describe("remote image boot — vault wiped after files arrived while the contai
     await handle?.cleanup()
   })
 
-  it("stops on the next boot instead of syncing the wiped vault", async () => {
-    const logs = await containerLogs(name)
-    expect(logs).toContain(
+  it("stops on the next boot before any sync attempt", async () => {
+    // Scoped to the restarted boot: the first boot's logs legitimately
+    // contain a sync attempt, so a guard that had slipped behind the first
+    // `ob sync` would still pass an assertion over the full two-boot log.
+    const logsSinceRestart = await containerLogs(name, restartedAt)
+    expect(logsSinceRestart).toContain(
       "[obsidian-sync] ERROR: The vault is empty but this device has previously synced.",
     )
-    expect(logs).toContain(
+    expect(logsSinceRestart).toContain(
       "s6-rc: warning: unable to start service init-first-sync: command exited 1",
     )
+    expect(logsSinceRestart).not.toContain("First sync (attempt")
   })
 })
 

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -275,10 +275,39 @@ describe("remote image boot — three-volume layout (anonymous /vault, /data, /h
         args: { query: "stubbed first sync" },
       })
       const searchResponse: unknown = JSON.parse(textContent(result))
-      expect(searchResponse).toMatchObject({
+      // `modified` is the boot-time mtime and `score` an RRF float — every
+      // other field of the response is fixed by the fixture, so pin those.
+      const isSearchResponse = (
+        value: unknown,
+      ): value is { results: Record<string, unknown>[] } =>
+        typeof value === "object" &&
+        value !== null &&
+        Array.isArray(Reflect.get(value, "results"))
+      if (!isSearchResponse(searchResponse)) {
+        throw new Error(
+          `unexpected vault_search response: ${textContent(result)}`,
+        )
+      }
+      const deterministicResults = searchResponse.results.map(
+        ({ modified: _modified, score: _score, ...fixedFields }) => fixedFields,
+      )
+      expect({ ...searchResponse, results: deterministicResults }).toEqual({
         total: 1,
         search_mode: "fts",
-        results: [{ path: "Projects/Remote Boot.md", title: "Remote Boot" }],
+        reranked: false,
+        results: [
+          {
+            path: "Projects/Remote Boot.md",
+            title: "Remote Boot",
+            folder: "Projects",
+            kind: "note",
+            type: null,
+            tags: ["ci", "remote-boot"],
+            bytes: 108,
+            snippet:
+              "\n# Remote Boot\n\nDelivered by the stubbed first sync. Links to [[Sync Log]].\n",
+          },
+        ],
       })
     } finally {
       await client.close()
@@ -355,9 +384,11 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
       `http://127.0.0.1:${port}/.well-known/oauth-protected-resource/mcp`,
     )
     const metadata: unknown = await response.json()
-    expect(metadata).toMatchObject({
+    expect(metadata).toEqual({
       resource: "https://ci.example.test/mcp",
       authorization_servers: ["https://ci.example.test/"],
+      scopes_supported: ["vault"],
+      resource_documentation: "https://github.com/aliasunder/vault-cortex",
     })
   })
 

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -36,6 +36,7 @@ import {
   publishedPort,
   readContainerFile,
   runContainer,
+  seedVolumeFile,
   waitForHealthz,
   waitForStopped,
 } from "./docker-harness.js"
@@ -634,16 +635,21 @@ describe("remote image boot — init-chain guards stop the container", () => {
   /** Boot with the given env, register cleanup for the current test before
    *  anything can throw, and return the logs once the container has stopped
    *  on its own. */
-  const logsAfterGuardStops = async (
-    scenario: string,
-    env: Record<string, string>,
-  ): Promise<string> => {
+  const logsAfterGuardStops = async ({
+    scenario,
+    env,
+    volumes = [],
+  }: {
+    scenario: string
+    env: Record<string, string>
+    volumes?: string[]
+  }): Promise<string> => {
     const name = uniqueName(scenario)
     const handle = await runContainer({
       name,
       image: IMAGE,
       env,
-      volumes: [],
+      volumes,
       publishPort: false,
     })
     onTestFinished(handle.cleanup)
@@ -652,9 +658,9 @@ describe("remote image boot — init-chain guards stop the container", () => {
   }
 
   it("refuses STORAGE_ROOT=/ with the init-derive-env error", async () => {
-    const logs = await logsAfterGuardStops("storage-root-slash", {
-      ...BASE_ENV,
-      STORAGE_ROOT: "/",
+    const logs = await logsAfterGuardStops({
+      scenario: "storage-root-slash",
+      env: { ...BASE_ENV, STORAGE_ROOT: "/" },
     })
     expect(logs).toContain(
       "[vault-cortex] ERROR: STORAGE_ROOT must be an absolute path to a directory inside a persistent mount (e.g. /persist), not '/'.",
@@ -665,9 +671,9 @@ describe("remote image boot — init-chain guards stop the container", () => {
   })
 
   it("refuses a relative INDEX_DB_PATH with the init-setup-user error", async () => {
-    const logs = await logsAfterGuardStops("relative-index-db", {
-      ...BASE_ENV,
-      INDEX_DB_PATH: "relative/index.db",
+    const logs = await logsAfterGuardStops({
+      scenario: "relative-index-db",
+      env: { ...BASE_ENV, INDEX_DB_PATH: "relative/index.db" },
     })
     expect(logs).toContain(
       "[obsidian-sync] ERROR: INDEX_DB_PATH must be an absolute path with at least one directory component (got 'relative/index.db').",
@@ -679,7 +685,10 @@ describe("remote image boot — init-chain guards stop the container", () => {
 
   it("refuses to start without OBSIDIAN_AUTH_TOKEN before ever calling the Sync client", async () => {
     const { OBSIDIAN_AUTH_TOKEN: _omitted, ...envWithoutToken } = BASE_ENV
-    const logs = await logsAfterGuardStops("missing-token", envWithoutToken)
+    const logs = await logsAfterGuardStops({
+      scenario: "missing-token",
+      env: envWithoutToken,
+    })
     expect(logs).toContain(
       "[obsidian-sync] ERROR: OBSIDIAN_AUTH_TOKEN is empty or unset.",
     )
@@ -690,5 +699,34 @@ describe("remote image boot — init-chain guards stop the container", () => {
     // init-obsidian-login logs "Authenticated." only after `ob login`
     // returns, so its absence proves the gate fired before the stub ran.
     expect(logs).not.toContain("[obsidian-sync] Authenticated.")
+  })
+
+  it("refuses to sync an empty vault when a previous sync's sentinel is present", async () => {
+    // The #440 data-loss guard: a kept config volume (device state + sentinel)
+    // with a wiped vault volume would have the sync engine push every
+    // previously-synced file as a deletion. Seed the sentinel the way a prior
+    // boot would leave it, then boot against an empty anonymous /vault.
+    const configVolume = `${uniqueName("synced-config")}-volume`
+    await seedVolumeFile({
+      image: IMAGE,
+      volume: configVolume,
+      mountPath: "/home/obsidian/.config",
+      file: ".vault-synced",
+    })
+    const logs = await logsAfterGuardStops({
+      scenario: "empty-vault-after-sync",
+      env: BASE_ENV,
+      volumes: [`${configVolume}:/home/obsidian/.config`],
+    })
+    expect(logs).toContain(
+      "[obsidian-sync] ERROR: The vault is empty but this device has previously synced.",
+    )
+    expect(logs).toContain(
+      "s6-rc: warning: unable to start service init-first-sync: command exited 1",
+    )
+    // The guard sits before the first `ob sync`; the stub logs nothing
+    // itself, but init-first-sync announces each attempt, so no attempt
+    // line proves no sync was ever started.
+    expect(logs).not.toContain("First sync (attempt")
   })
 })

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -1,11 +1,10 @@
 /** Remote image boot tier — runs the built `:remote` image end-to-end with the
  *  obsidian-headless CLI replaced by `fixtures/ob`.
  *
- *  The s6 init chain (derive-env → setup-user → check-auth → login →
- *  setup-vault → first-sync → sync → mcp) was validated by hand against real
- *  Obsidian Sync before it shipped; this tier is the per-PR regression net
- *  for the assembled chain — ordering, published env, volume layout, guards —
- *  that the per-script `sh` specs in `src/vault-mcp/__tests__/` cannot see.
+ *  Covers the assembled s6 init chain (derive-env → setup-user → check-auth →
+ *  login → setup-vault → first-sync → sync → mcp) — ordering, published env,
+ *  volume layout, guards — which the per-script `sh` specs in
+ *  `src/vault-mcp/__tests__/` cannot see.
  *
  *  Needs Docker and a prior `docker build --target remote -t
  *  vault-cortex:remote-ci .`; run with `npm run test:remote-boot`

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -1,0 +1,515 @@
+/** Remote image boot tier — runs the built `:remote` image end-to-end with the
+ *  obsidian-headless CLI replaced by `fixtures/ob`.
+ *
+ *  The s6 init chain (derive-env → setup-user → check-auth → login →
+ *  setup-vault → first-sync → sync → mcp) was validated by hand against real
+ *  Obsidian Sync before it shipped; this tier is the per-PR regression net
+ *  for the assembled chain — ordering, published env, volume layout, guards —
+ *  that the per-script `sh` specs in `src/vault-mcp/__tests__/` cannot see.
+ *
+ *  Needs Docker and a prior `docker build --target remote -t
+ *  vault-cortex:remote-ci .`; run with `npm run test:remote-boot`
+ *  (REMOTE_IMAGE overrides the tag).
+ *
+ *  One container per describe block: a boot is the expensive resource that
+ *  justifies `beforeAll` over const-per-test. Each test then reads its own
+ *  state from the container — nothing is mutated between tests, and the
+ *  restart block re-derives its handle from the boot it nests under. */
+
+import { randomBytes } from "node:crypto"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { callTool, textContent } from "../integration/test-harness.js"
+import {
+  assertImagePresent,
+  containerLogs,
+  createClient,
+  docker,
+  execInContainer,
+  listFilesInContainer,
+  pathExistsInContainer,
+  publishedPort,
+  readContainerFile,
+  runContainer,
+  waitForHealthz,
+  waitForStopped,
+} from "./docker-harness.js"
+import type { ContainerHandle } from "./docker-harness.js"
+
+const IMAGE = process.env.REMOTE_IMAGE ?? "vault-cortex:remote-ci"
+
+/** Deliberately low-entropy fixtures so secret scanners never flag them. The
+ *  Sync token only has to be non-empty (init-check-auth) — the stub ignores
+ *  it; the MCP token is what the test client authenticates with. */
+const FAKE_SYNC_TOKEN = "fake-obsidian-sync-token-for-ci"
+const FAKE_MCP_TOKEN = "fake-mcp-token-for-ci"
+
+const BOOT_DEADLINE_MS = 120_000
+const STOP_DEADLINE_MS = 60_000
+
+/** Env every scenario shares. Embeddings stay off so the boot doesn't
+ *  download a model; the chain under test doesn't touch search ranking. */
+const BASE_ENV = {
+  OBSIDIAN_AUTH_TOKEN: FAKE_SYNC_TOKEN,
+  VAULT_NAME: "ci-vault",
+  DEVICE_NAME: "ci-device",
+  MCP_AUTH_TOKEN: FAKE_MCP_TOKEN,
+  EMBEDDING_ENABLED: "false",
+}
+
+/** Every `ob` call one boot makes, in order, for BASE_ENV (only the
+ *  sync-config flags whose env var is set are applied; SYNC_CONFIGS has a
+ *  baked-in default). The stub appends "$*" per call. */
+const EXPECTED_BOOT_SEQUENCE = [
+  "login",
+  "sync-setup --vault ci-vault --device-name ci-device",
+  "sync-config --device-name ci-device",
+  "sync-config --configs core-plugin-data,community-plugin-data",
+  "sync",
+  "sync --continuous",
+]
+
+const callLogOf = (boots: number): string =>
+  Array.from({ length: boots }, () => EXPECTED_BOOT_SEQUENCE)
+    .flat()
+    .map((call) => `${call}\n`)
+    .join("")
+
+/** Test-owned copy of what the stub's one-shot sync writes. */
+const REMOTE_BOOT_NOTE = `---
+tags: [ci, remote-boot]
+---
+
+# Remote Boot
+
+Delivered by the stubbed first sync. Links to [[Sync Log]].
+`
+
+const OWNERSHIP_LINE = "Ownership IDs changed"
+
+const uniqueName = (scenario: string): string =>
+  `remote-boot-${scenario}-${randomBytes(4).toString("hex")}`
+
+const bootedStartedAt = async (name: string): Promise<string> => {
+  const result = await docker(["inspect", "-f", "{{.State.StartedAt}}", name])
+  return result.stdout.trim()
+}
+
+const readSyncedNoteOverMcp = async (port: number): Promise<string> => {
+  const client = await createClient(port, FAKE_MCP_TOKEN)
+  try {
+    const result = await callTool({
+      client,
+      name: "vault_read_note",
+      args: { path: "Projects/Remote Boot.md" },
+    })
+    return textContent(result)
+  } finally {
+    await client.close()
+  }
+}
+
+beforeAll(async () => {
+  await assertImagePresent(IMAGE)
+})
+
+describe("remote image boot — three-volume layout (anonymous /vault, /data, /home/obsidian/.config)", () => {
+  const name = uniqueName("three-volume")
+  // Memory off keeps the vault listing exact: with it on, the server would
+  // also bootstrap the About Me/ templates. The single-volume scenario
+  // covers the bootstrap path.
+  const env = {
+    ...BASE_ENV,
+    MEMORY_ENABLED: "false",
+    PUBLIC_URL: "http://localhost:8000",
+  }
+
+  // Assigned once the container is up — the beforeAll boot is the one place
+  // these are written; every test only reads them.
+  let handle: ContainerHandle | undefined
+  let port = 0
+
+  beforeAll(async () => {
+    handle = await runContainer({
+      name,
+      image: IMAGE,
+      env,
+      volumes: [],
+      publishPort: true,
+    })
+    port = await publishedPort(name)
+    await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
+  })
+
+  afterAll(async () => {
+    await handle?.cleanup()
+  })
+
+  it("publishes VAULT_PATH and INDEX_DB_PATH to container_environment without a trailing newline", async () => {
+    const vaultPath = await readContainerFile(
+      name,
+      "/run/s6/container_environment/VAULT_PATH",
+    )
+    const indexDbPath = await readContainerFile(
+      name,
+      "/run/s6/container_environment/INDEX_DB_PATH",
+    )
+    expect({ vaultPath, indexDbPath }).toEqual({
+      vaultPath: "/vault",
+      indexDbPath: "/data/index.db",
+    })
+  })
+
+  it("does not publish LOG_DIR or XDG_CONFIG_HOME when STORAGE_ROOT is unset", async () => {
+    const logDirPublished = await pathExistsInContainer(
+      name,
+      "/run/s6/container_environment/LOG_DIR",
+    )
+    const xdgPublished = await pathExistsInContainer(
+      name,
+      "/run/s6/container_environment/XDG_CONFIG_HOME",
+    )
+    expect({ logDirPublished, xdgPublished }).toEqual({
+      logDirPublished: false,
+      xdgPublished: false,
+    })
+  })
+
+  it("records the applied ownership IDs as 1000:1000 in the default config dir", async () => {
+    const appliedIds = await readContainerFile(
+      name,
+      "/home/obsidian/.config/.applied-ids",
+    )
+    expect(appliedIds).toBe("1000:1000\n")
+  })
+
+  it("invokes the Sync client in the documented order: login, sync-setup, sync-config ×2, sync, sync --continuous", async () => {
+    const callLog = await readContainerFile(
+      name,
+      "/home/obsidian/.config/ob-calls.log",
+    )
+    expect(callLog).toBe(callLogOf(1))
+  })
+
+  it("writes the first-sync sentinel to /home/obsidian/.config/.vault-synced", async () => {
+    expect(
+      await pathExistsInContainer(name, "/home/obsidian/.config/.vault-synced"),
+    ).toBe(true)
+  })
+
+  it("creates the search index at /data/index.db", async () => {
+    expect(await pathExistsInContainer(name, "/data/index.db")).toBe(true)
+  })
+
+  it("keeps `ob sync --continuous` supervised as svc-obsidian-sync", async () => {
+    const status = await execInContainer(name, [
+      "/command/s6-svstat",
+      "-o",
+      "up",
+      "/run/service/svc-obsidian-sync",
+    ])
+    expect(status.stdout.trim()).toBe("true")
+  })
+
+  it("runs the MCP server as the obsidian user (UID 1000)", async () => {
+    const pidResult = await execInContainer(name, [
+      "/command/s6-svstat",
+      "-o",
+      "pid",
+      "/run/service/svc-vault-mcp",
+    ])
+    const pid = pidResult.stdout.trim()
+    const owner = await execInContainer(name, [
+      "stat",
+      "-c",
+      "%u",
+      `/proc/${pid}`,
+    ])
+    expect(owner.stdout.trim()).toBe("1000")
+  })
+
+  it("serves a note delivered by the first sync over MCP", async () => {
+    expect(await readSyncedNoteOverMcp(port)).toBe(REMOTE_BOOT_NOTE)
+  })
+
+  it("indexes the first-sync notes before reporting healthy", async () => {
+    const client = await createClient(port, FAKE_MCP_TOKEN)
+    try {
+      const result = await callTool({
+        client,
+        name: "vault_search",
+        args: { query: "stubbed first sync" },
+      })
+      const searchResponse: unknown = JSON.parse(textContent(result))
+      expect(searchResponse).toMatchObject({
+        total: 1,
+        search_mode: "fts",
+        results: [{ path: "Projects/Remote Boot.md", title: "Remote Boot" }],
+      })
+    } finally {
+      await client.close()
+    }
+  })
+
+  it("leaves the vault containing exactly the first-sync notes when memory is disabled", async () => {
+    expect(await listFilesInContainer(name, "/vault")).toEqual([
+      "/vault/Projects/Remote Boot.md",
+      "/vault/Sync Log.md",
+    ])
+  })
+})
+
+describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", () => {
+  const name = uniqueName("single-volume")
+  const volume = `${name}-persist`
+  const env = {
+    ...BASE_ENV,
+    STORAGE_ROOT: "/persist",
+    RAILWAY_PUBLIC_DOMAIN: "ci.example.test",
+  }
+
+  // Assigned once the container is up — the beforeAll boot is the one place
+  // these are written; every test only reads them.
+  let handle: ContainerHandle | undefined
+  let port = 0
+
+  beforeAll(async () => {
+    handle = await runContainer({
+      name,
+      image: IMAGE,
+      env,
+      volumes: [`${volume}:/persist`],
+      publishPort: true,
+    })
+    port = await publishedPort(name)
+    await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
+  })
+
+  afterAll(async () => {
+    await handle?.cleanup()
+  })
+
+  it("derives VAULT_PATH, INDEX_DB_PATH, LOG_DIR, XDG_CONFIG_HOME and PUBLIC_URL under /persist", async () => {
+    const published = Object.fromEntries(
+      await Promise.all(
+        [
+          "VAULT_PATH",
+          "INDEX_DB_PATH",
+          "LOG_DIR",
+          "XDG_CONFIG_HOME",
+          "PUBLIC_URL",
+        ].map(async (variable) => [
+          variable,
+          await readContainerFile(
+            name,
+            `/run/s6/container_environment/${variable}`,
+          ),
+        ]),
+      ),
+    )
+    expect(published).toEqual({
+      VAULT_PATH: "/persist/vault",
+      INDEX_DB_PATH: "/persist/data/index.db",
+      LOG_DIR: "/persist/data/logs",
+      XDG_CONFIG_HOME: "/persist/config",
+      PUBLIC_URL: "https://ci.example.test",
+    })
+  })
+
+  it("advertises the PUBLIC_URL derived from RAILWAY_PUBLIC_DOMAIN to MCP clients", async () => {
+    const response = await fetch(
+      `http://127.0.0.1:${port}/.well-known/oauth-protected-resource/mcp`,
+    )
+    const metadata: unknown = await response.json()
+    expect(metadata).toMatchObject({
+      resource: "https://ci.example.test/mcp",
+      authorization_servers: ["https://ci.example.test/"],
+    })
+  })
+
+  it("writes the ownership record and first-sync sentinel under /persist/config", async () => {
+    const appliedIds = await readContainerFile(
+      name,
+      "/persist/config/.applied-ids",
+    )
+    const sentinelPresent = await pathExistsInContainer(
+      name,
+      "/persist/config/.vault-synced",
+    )
+    expect({ appliedIds, sentinelPresent }).toEqual({
+      appliedIds: "1000:1000\n",
+      sentinelPresent: true,
+    })
+  })
+
+  it("creates the search index and log directory under /persist/data", async () => {
+    const indexPresent = await pathExistsInContainer(
+      name,
+      "/persist/data/index.db",
+    )
+    const logsDir = await execInContainer(name, [
+      "test",
+      "-d",
+      "/persist/data/logs",
+    ])
+    expect({ indexPresent, logsDirExit: logsDir.code }).toEqual({
+      indexPresent: true,
+      logsDirExit: 0,
+    })
+  })
+
+  it("bootstraps the memory folder into the derived vault path after the first sync", async () => {
+    const memoryDir = await execInContainer(name, [
+      "test",
+      "-d",
+      "/persist/vault/About Me",
+    ])
+    const syncedNotePresent = await pathExistsInContainer(
+      name,
+      "/persist/vault/Projects/Remote Boot.md",
+    )
+    expect({ memoryDirExit: memoryDir.code, syncedNotePresent }).toEqual({
+      memoryDirExit: 0,
+      syncedNotePresent: true,
+    })
+  })
+
+  it("writes nothing into the legacy /vault, /data and /home/obsidian/.config paths", async () => {
+    const legacyEntries = await execInContainer(name, [
+      "find",
+      "/vault",
+      "/data",
+      "/home/obsidian/.config",
+      "-mindepth",
+      "1",
+    ])
+    expect(legacyEntries.stdout).toBe("")
+  })
+
+  describe("after docker restart", () => {
+    let restartedAt = ""
+
+    beforeAll(async () => {
+      const beforeRestart = await bootedStartedAt(name)
+      await docker(["restart", name])
+      restartedAt = await bootedStartedAt(name)
+      if (restartedAt === beforeRestart) {
+        throw new Error("docker restart did not produce a new StartedAt")
+      }
+      port = await publishedPort(name)
+      await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
+    })
+
+    it("becomes healthy again without re-fixing ownership", async () => {
+      const logsSinceRestart = await containerLogs(name, restartedAt)
+      expect(logsSinceRestart).toContain("[obsidian-sync] First sync complete.")
+      expect(logsSinceRestart).not.toContain(OWNERSHIP_LINE)
+    })
+
+    it("keeps the ownership record unchanged", async () => {
+      expect(
+        await readContainerFile(name, "/persist/config/.applied-ids"),
+      ).toBe("1000:1000\n")
+    })
+
+    it("runs the full Sync sequence again, appending to the first boot's log", async () => {
+      expect(
+        await readContainerFile(name, "/persist/config/ob-calls.log"),
+      ).toBe(callLogOf(2))
+    })
+
+    it("keeps the first-sync sentinel and the synced notes", async () => {
+      const sentinelPresent = await pathExistsInContainer(
+        name,
+        "/persist/config/.vault-synced",
+      )
+      const syncedNotes = (
+        await listFilesInContainer(name, "/persist/vault")
+      ).filter((path) => !path.startsWith("/persist/vault/About Me/"))
+      expect({ sentinelPresent, syncedNotes }).toEqual({
+        sentinelPresent: true,
+        syncedNotes: [
+          "/persist/vault/Projects/Remote Boot.md",
+          "/persist/vault/Sync Log.md",
+        ],
+      })
+    })
+
+    it("still serves the synced note over MCP", async () => {
+      expect(await readSyncedNoteOverMcp(port)).toBe(REMOTE_BOOT_NOTE)
+    })
+  })
+})
+
+describe("remote image boot — init-chain guards stop the container", () => {
+  const bootExpectingStop = async (
+    scenario: string,
+    env: Record<string, string>,
+  ): Promise<{ name: string; logs: string; cleanup: () => Promise<void> }> => {
+    const name = uniqueName(scenario)
+    const handle = await runContainer({
+      name,
+      image: IMAGE,
+      env,
+      volumes: [],
+      publishPort: false,
+    })
+    await waitForStopped({ name, deadlineMs: STOP_DEADLINE_MS })
+    return { name, logs: await containerLogs(name), cleanup: handle.cleanup }
+  }
+
+  it("refuses STORAGE_ROOT=/ with the init-derive-env error", async () => {
+    const { logs, cleanup } = await bootExpectingStop("storage-root-slash", {
+      ...BASE_ENV,
+      STORAGE_ROOT: "/",
+    })
+    try {
+      expect(logs).toContain(
+        "[vault-cortex] ERROR: STORAGE_ROOT must be an absolute path to a directory inside a persistent mount (e.g. /persist), not '/'.",
+      )
+      expect(logs).toContain(
+        "s6-rc: warning: unable to start service init-derive-env: command exited 1",
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("refuses a relative INDEX_DB_PATH with the init-setup-user error", async () => {
+    const { logs, cleanup } = await bootExpectingStop("relative-index-db", {
+      ...BASE_ENV,
+      INDEX_DB_PATH: "relative/index.db",
+    })
+    try {
+      expect(logs).toContain(
+        "[obsidian-sync] ERROR: INDEX_DB_PATH must be an absolute path with at least one directory component (got 'relative/index.db').",
+      )
+      expect(logs).toContain(
+        "s6-rc: warning: unable to start service init-setup-user: command exited 1",
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it("refuses to start without OBSIDIAN_AUTH_TOKEN before ever calling the Sync client", async () => {
+    const { OBSIDIAN_AUTH_TOKEN: _omitted, ...envWithoutToken } = BASE_ENV
+    const { logs, cleanup } = await bootExpectingStop(
+      "missing-token",
+      envWithoutToken,
+    )
+    try {
+      expect(logs).toContain(
+        "[obsidian-sync] ERROR: OBSIDIAN_AUTH_TOKEN is empty or unset.",
+      )
+      expect(logs).toContain(
+        "s6-rc: warning: unable to start service init-check-auth: command exited 1",
+      )
+      // A stopped container can't `exec`, so the call log is out of reach;
+      // init-obsidian-login logs "Authenticated." only after `ob login`
+      // returns, so its absence proves the gate fired before the stub ran.
+      expect(logs).not.toContain("[obsidian-sync] Authenticated.")
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -6,9 +6,8 @@
  *  volume layout, guards — which the per-script `sh` specs in
  *  `src/vault-mcp/__tests__/` cannot see.
  *
- *  Needs Docker and a prior `docker build --target remote -t
- *  vault-cortex:remote-ci .`; run with `npm run test:remote-boot`
- *  (REMOTE_IMAGE overrides the tag).
+ *  Needs Docker; `npm run test:remote-boot` builds the image and runs the
+ *  tier (REMOTE_IMAGE points the tests at a different image tag).
  *
  *  One container per describe block: a boot is the expensive resource that
  *  justifies `beforeAll` over const-per-test. Each test then reads its own

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -11,8 +11,10 @@
  *
  *  One container per describe block: a boot is the expensive resource that
  *  justifies `beforeAll` over const-per-test. Each test then reads its own
- *  state from the container — nothing is mutated between tests, and the
- *  restart block re-derives its handle from the boot it nests under. */
+ *  state from the container; nothing is mutated between tests. A nested
+ *  "after docker restart" block does not boot a second container — it
+ *  restarts the one its parent booted (same name, same volumes) and
+ *  re-reads the published port, which Docker may reassign. */
 
 import { randomBytes } from "node:crypto"
 import {

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -55,6 +55,27 @@ const BOOT_DEADLINE_MS = 120_000
  *  timeout. A real guard failure halts the container within seconds. */
 const STOP_DEADLINE_MS = 20_000
 
+/** A first sync that keeps failing takes three attempts with two 10 s
+ *  sleeps between them (init-first-sync's MAX_ATTEMPTS=3 when VAULT_NAME is
+ *  set), so those scenarios get their own, longer budgets. */
+const FAILING_SYNC_TEST_TIMEOUT_MS = 120_000
+const FAILING_SYNC_STOP_DEADLINE_MS = 90_000
+
+/** init-first-sync's progress, retry, and outcome lines all name the step —
+ *  "First sync (attempt …)", "First sync failed …", "First sync did not
+ *  complete …" — which is what lets a test read the whole run back in
+ *  order from the merged container logs. */
+const isFirstSyncLine = (line: string): boolean => line.includes("First sync")
+
+/** Log lines init-first-sync emits across a fully failing run. */
+const FIRST_SYNC_ATTEMPT_LINES = [
+  "[obsidian-sync] First sync (attempt 1/3) — waiting for completion before starting services...",
+  "[obsidian-sync] First sync failed — retrying in 10s...",
+  "[obsidian-sync] First sync (attempt 2/3) — waiting for completion before starting services...",
+  "[obsidian-sync] First sync failed — retrying in 10s...",
+  "[obsidian-sync] First sync (attempt 3/3) — waiting for completion before starting services...",
+]
+
 /** Env every scenario shares. Embeddings stay off so the boot doesn't
  *  download a model; the chain under test doesn't touch search ranking. */
 const BASE_ENV = {
@@ -445,6 +466,123 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
 
     it("still serves the synced note over MCP", async () => {
       expect(await readSyncedNoteOverMcp(port)).toBe(REMOTE_BOOT_NOTE)
+    })
+  })
+})
+
+describe("remote image boot — first sync keeps failing (OB_STUB_SYNC_FAIL=1)", () => {
+  describe("with the memory layer enabled and no memory folder synced", () => {
+    it(
+      "retries three times, then refuses to start so the server cannot bootstrap templates over unsynced notes",
+      async () => {
+        const name = uniqueName("failing-sync-memory-on")
+        const handle = await runContainer({
+          name,
+          image: IMAGE,
+          env: { ...BASE_ENV, OB_STUB_SYNC_FAIL: "1" },
+          volumes: [],
+          publishPort: false,
+        })
+        onTestFinished(handle.cleanup)
+        await waitForStopped({
+          name,
+          deadlineMs: FAILING_SYNC_STOP_DEADLINE_MS,
+        })
+        const logs = await containerLogs(name)
+        const attemptLines = logs.split("\n").filter(isFirstSyncLine)
+        expect(attemptLines).toEqual([
+          ...FIRST_SYNC_ATTEMPT_LINES,
+          "[obsidian-sync] ERROR: First sync failed and the memory folder ('About Me') has not synced yet.",
+        ])
+        expect(logs).toContain(
+          "s6-rc: warning: unable to start service init-first-sync: command exited 1",
+        )
+      },
+      FAILING_SYNC_TEST_TIMEOUT_MS,
+    )
+  })
+
+  describe("with the memory layer disabled", () => {
+    const name = uniqueName("failing-sync-memory-off")
+    const env = {
+      ...BASE_ENV,
+      OB_STUB_SYNC_FAIL: "1",
+      MEMORY_ENABLED: "false",
+      PUBLIC_URL: "http://localhost:8000",
+    }
+
+    // Assigned once the container is up — the beforeAll boot is the one place
+    // these are written; every test only reads them.
+    let handle: ContainerHandle | undefined
+    let port = 0
+
+    beforeAll(async () => {
+      handle = await runContainer({
+        name,
+        image: IMAGE,
+        env,
+        volumes: [],
+        publishPort: true,
+      })
+      port = await publishedPort(name)
+      await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
+    })
+
+    afterAll(async () => {
+      await handle?.cleanup()
+    })
+
+    it("retries three times, warns, and starts the services anyway", async () => {
+      const logs = await containerLogs(name)
+      const attemptLines = logs.split("\n").filter(isFirstSyncLine)
+      expect(attemptLines).toEqual([
+        ...FIRST_SYNC_ATTEMPT_LINES,
+        "[obsidian-sync] WARNING: First sync did not complete — starting services anyway.",
+      ])
+    })
+
+    it("calls `ob sync` once per attempt before handing over to continuous sync", async () => {
+      const callLog = await readContainerFile(
+        name,
+        "/home/obsidian/.config/ob-calls.log",
+      )
+      expect(callLog).toBe(
+        [
+          "login",
+          "sync-setup --vault ci-vault --device-name ci-device",
+          "sync-config --device-name ci-device",
+          "sync-config --configs core-plugin-data,community-plugin-data",
+          "sync",
+          "sync",
+          "sync",
+          "sync --continuous",
+        ]
+          .map((call) => `${call}\n`)
+          .join(""),
+      )
+    })
+
+    it("does not write the first-sync sentinel", async () => {
+      expect(
+        await pathExistsInContainer(
+          name,
+          "/home/obsidian/.config/.vault-synced",
+        ),
+      ).toBe(false)
+    })
+
+    it("serves an empty vault over MCP rather than refusing requests", async () => {
+      const client = await createClient(port, FAKE_MCP_TOKEN)
+      try {
+        const result = await callTool({
+          client,
+          name: "vault_list_notes",
+          args: {},
+        })
+        expect(JSON.parse(textContent(result))).toEqual([])
+      } finally {
+        await client.close()
+      }
     })
   })
 })

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -56,8 +56,8 @@ const BOOT_DEADLINE_MS = 120_000
 const STOP_DEADLINE_MS = 20_000
 
 /** A first sync that keeps failing takes three attempts with two 10 s
- *  sleeps between them (init-first-sync's MAX_ATTEMPTS=3 when VAULT_NAME is
- *  set), so those scenarios get their own, longer budgets. */
+ *  sleeps between them (init-first-sync's MAX_ATTEMPTS=3), so those
+ *  scenarios get their own, longer budgets. */
 const FAILING_SYNC_TEST_TIMEOUT_MS = 120_000
 const FAILING_SYNC_STOP_DEADLINE_MS = 90_000
 
@@ -691,6 +691,73 @@ describe("remote image boot — empty remote vault with the memory layer disable
     })
 
     it("syncs again instead of stopping on the empty-vault guard", async () => {
+      const logsSinceRestart = await containerLogs(name, restartedAt)
+      expect(logsSinceRestart).toContain("[obsidian-sync] First sync complete.")
+      expect(logsSinceRestart).not.toContain(
+        "The vault is empty but this device has previously synced.",
+      )
+    })
+  })
+})
+
+describe("remote image boot — remote vault holding only synced .obsidian/ settings", () => {
+  // Settings are synced but there are no notes and memory is off. The
+  // settings are content a wipe could delete, so the sentinel must be
+  // written — and on restart the guard must read them as content too, or
+  // the device locks itself out.
+  const name = uniqueName("config-only")
+  const env = {
+    ...BASE_ENV,
+    MEMORY_ENABLED: "false",
+    PUBLIC_URL: "http://localhost:8000",
+    OB_STUB_SYNC_CONFIG_ONLY: "1",
+  }
+  let handle: ContainerHandle | undefined
+  let port = 0
+
+  beforeAll(async () => {
+    handle = await runContainer({
+      name,
+      image: IMAGE,
+      env,
+      volumes: [],
+      publishPort: true,
+    })
+    port = await publishedPort(name)
+    await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
+  })
+
+  afterAll(async () => {
+    await handle?.cleanup()
+  })
+
+  it("writes the sentinel for a vault whose only content is .obsidian/ settings", async () => {
+    expect(await listFilesInContainer({ name, directory: "/vault" })).toEqual([
+      "/vault/.obsidian/appearance.json",
+    ])
+    expect(
+      await pathExistsInContainer({
+        name,
+        path: "/home/obsidian/.config/.vault-synced",
+      }),
+    ).toBe(true)
+  })
+
+  describe("after docker restart", () => {
+    let restartedAt = ""
+
+    beforeAll(async () => {
+      const beforeRestart = await bootedStartedAt(name)
+      await docker(["restart", name])
+      restartedAt = await bootedStartedAt(name)
+      if (restartedAt === beforeRestart) {
+        throw new Error("docker restart did not produce a new StartedAt")
+      }
+      port = await publishedPort(name)
+      await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
+    })
+
+    it("reads the synced settings as content and syncs again", async () => {
       const logsSinceRestart = await containerLogs(name, restartedAt)
       expect(logsSinceRestart).toContain("[obsidian-sync] First sync complete.")
       expect(logsSinceRestart).not.toContain(

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -17,7 +17,14 @@
  *  restart block re-derives its handle from the boot it nests under. */
 
 import { randomBytes } from "node:crypto"
-import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+} from "vitest"
 import { callTool, textContent } from "../integration/test-harness.js"
 import {
   assertImagePresent,
@@ -44,7 +51,10 @@ const FAKE_SYNC_TOKEN = "fake-obsidian-sync-token-for-ci"
 const FAKE_MCP_TOKEN = "fake-mcp-token-for-ci"
 
 const BOOT_DEADLINE_MS = 120_000
-const STOP_DEADLINE_MS = 60_000
+/** Under the 30 s test timeout, so a guard that fails to stop the container
+ *  fails on waitForStopped's own message (with logs) rather than a bare
+ *  timeout. A real guard failure halts the container within seconds. */
+const STOP_DEADLINE_MS = 20_000
 
 /** Env every scenario shares. Embeddings stay off so the boot doesn't
  *  download a model; the chain under test doesn't touch search ranking. */
@@ -441,10 +451,13 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
 })
 
 describe("remote image boot — init-chain guards stop the container", () => {
-  const bootExpectingStop = async (
+  /** Boot with the given env, register cleanup for the current test before
+   *  anything can throw, and return the logs once the container has stopped
+   *  on its own. */
+  const logsAfterGuardStops = async (
     scenario: string,
     env: Record<string, string>,
-  ): Promise<{ name: string; logs: string; cleanup: () => Promise<void> }> => {
+  ): Promise<string> => {
     const name = uniqueName(scenario)
     const handle = await runContainer({
       name,
@@ -453,63 +466,49 @@ describe("remote image boot — init-chain guards stop the container", () => {
       volumes: [],
       publishPort: false,
     })
+    onTestFinished(handle.cleanup)
     await waitForStopped({ name, deadlineMs: STOP_DEADLINE_MS })
-    return { name, logs: await containerLogs(name), cleanup: handle.cleanup }
+    return containerLogs(name)
   }
 
   it("refuses STORAGE_ROOT=/ with the init-derive-env error", async () => {
-    const { logs, cleanup } = await bootExpectingStop("storage-root-slash", {
+    const logs = await logsAfterGuardStops("storage-root-slash", {
       ...BASE_ENV,
       STORAGE_ROOT: "/",
     })
-    try {
-      expect(logs).toContain(
-        "[vault-cortex] ERROR: STORAGE_ROOT must be an absolute path to a directory inside a persistent mount (e.g. /persist), not '/'.",
-      )
-      expect(logs).toContain(
-        "s6-rc: warning: unable to start service init-derive-env: command exited 1",
-      )
-    } finally {
-      await cleanup()
-    }
+    expect(logs).toContain(
+      "[vault-cortex] ERROR: STORAGE_ROOT must be an absolute path to a directory inside a persistent mount (e.g. /persist), not '/'.",
+    )
+    expect(logs).toContain(
+      "s6-rc: warning: unable to start service init-derive-env: command exited 1",
+    )
   })
 
   it("refuses a relative INDEX_DB_PATH with the init-setup-user error", async () => {
-    const { logs, cleanup } = await bootExpectingStop("relative-index-db", {
+    const logs = await logsAfterGuardStops("relative-index-db", {
       ...BASE_ENV,
       INDEX_DB_PATH: "relative/index.db",
     })
-    try {
-      expect(logs).toContain(
-        "[obsidian-sync] ERROR: INDEX_DB_PATH must be an absolute path with at least one directory component (got 'relative/index.db').",
-      )
-      expect(logs).toContain(
-        "s6-rc: warning: unable to start service init-setup-user: command exited 1",
-      )
-    } finally {
-      await cleanup()
-    }
+    expect(logs).toContain(
+      "[obsidian-sync] ERROR: INDEX_DB_PATH must be an absolute path with at least one directory component (got 'relative/index.db').",
+    )
+    expect(logs).toContain(
+      "s6-rc: warning: unable to start service init-setup-user: command exited 1",
+    )
   })
 
   it("refuses to start without OBSIDIAN_AUTH_TOKEN before ever calling the Sync client", async () => {
     const { OBSIDIAN_AUTH_TOKEN: _omitted, ...envWithoutToken } = BASE_ENV
-    const { logs, cleanup } = await bootExpectingStop(
-      "missing-token",
-      envWithoutToken,
+    const logs = await logsAfterGuardStops("missing-token", envWithoutToken)
+    expect(logs).toContain(
+      "[obsidian-sync] ERROR: OBSIDIAN_AUTH_TOKEN is empty or unset.",
     )
-    try {
-      expect(logs).toContain(
-        "[obsidian-sync] ERROR: OBSIDIAN_AUTH_TOKEN is empty or unset.",
-      )
-      expect(logs).toContain(
-        "s6-rc: warning: unable to start service init-check-auth: command exited 1",
-      )
-      // A stopped container can't `exec`, so the call log is out of reach;
-      // init-obsidian-login logs "Authenticated." only after `ob login`
-      // returns, so its absence proves the gate fired before the stub ran.
-      expect(logs).not.toContain("[obsidian-sync] Authenticated.")
-    } finally {
-      await cleanup()
-    }
+    expect(logs).toContain(
+      "s6-rc: warning: unable to start service init-check-auth: command exited 1",
+    )
+    // A stopped container can't `exec`, so the call log is out of reach;
+    // init-obsidian-login logs "Authenticated." only after `ob login`
+    // returns, so its absence proves the gate fired before the stub ran.
+    expect(logs).not.toContain("[obsidian-sync] Authenticated.")
   })
 })

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -175,14 +175,14 @@ describe("remote image boot — three-volume layout (anonymous /vault, /data, /h
   })
 
   it("publishes VAULT_PATH and INDEX_DB_PATH to container_environment without a trailing newline", async () => {
-    const vaultPath = await readContainerFile(
+    const vaultPath = await readContainerFile({
       name,
-      "/run/s6/container_environment/VAULT_PATH",
-    )
-    const indexDbPath = await readContainerFile(
+      path: "/run/s6/container_environment/VAULT_PATH",
+    })
+    const indexDbPath = await readContainerFile({
       name,
-      "/run/s6/container_environment/INDEX_DB_PATH",
-    )
+      path: "/run/s6/container_environment/INDEX_DB_PATH",
+    })
     expect({ vaultPath, indexDbPath }).toEqual({
       vaultPath: "/vault",
       indexDbPath: "/data/index.db",
@@ -190,14 +190,14 @@ describe("remote image boot — three-volume layout (anonymous /vault, /data, /h
   })
 
   it("does not publish LOG_DIR or XDG_CONFIG_HOME when STORAGE_ROOT is unset", async () => {
-    const logDirPublished = await pathExistsInContainer(
+    const logDirPublished = await pathExistsInContainer({
       name,
-      "/run/s6/container_environment/LOG_DIR",
-    )
-    const xdgPublished = await pathExistsInContainer(
+      path: "/run/s6/container_environment/LOG_DIR",
+    })
+    const xdgPublished = await pathExistsInContainer({
       name,
-      "/run/s6/container_environment/XDG_CONFIG_HOME",
-    )
+      path: "/run/s6/container_environment/XDG_CONFIG_HOME",
+    })
     expect({ logDirPublished, xdgPublished }).toEqual({
       logDirPublished: false,
       xdgPublished: false,
@@ -205,29 +205,34 @@ describe("remote image boot — three-volume layout (anonymous /vault, /data, /h
   })
 
   it("records the applied ownership IDs as 1000:1000 in the default config dir", async () => {
-    const appliedIds = await readContainerFile(
+    const appliedIds = await readContainerFile({
       name,
-      "/home/obsidian/.config/.applied-ids",
-    )
+      path: "/home/obsidian/.config/.applied-ids",
+    })
     expect(appliedIds).toBe("1000:1000\n")
   })
 
   it("invokes the Sync client in the documented order: login, sync-setup, sync-config ×2, sync, sync --continuous", async () => {
-    const callLog = await readContainerFile(
+    const callLog = await readContainerFile({
       name,
-      "/home/obsidian/.config/ob-calls.log",
-    )
+      path: "/home/obsidian/.config/ob-calls.log",
+    })
     expect(callLog).toBe(callLogOf(1))
   })
 
   it("writes the first-sync sentinel to /home/obsidian/.config/.vault-synced", async () => {
     expect(
-      await pathExistsInContainer(name, "/home/obsidian/.config/.vault-synced"),
+      await pathExistsInContainer({
+        name,
+        path: "/home/obsidian/.config/.vault-synced",
+      }),
     ).toBe(true)
   })
 
   it("creates the search index at /data/index.db", async () => {
-    expect(await pathExistsInContainer(name, "/data/index.db")).toBe(true)
+    expect(await pathExistsInContainer({ name, path: "/data/index.db" })).toBe(
+      true,
+    )
   })
 
   it("keeps `ob sync --continuous` supervised as svc-obsidian-sync", async () => {
@@ -281,7 +286,7 @@ describe("remote image boot — three-volume layout (anonymous /vault, /data, /h
   })
 
   it("leaves the vault containing exactly the first-sync notes when memory is disabled", async () => {
-    expect(await listFilesInContainer(name, "/vault")).toEqual([
+    expect(await listFilesInContainer({ name, directory: "/vault" })).toEqual([
       "/vault/Projects/Remote Boot.md",
       "/vault/Sync Log.md",
     ])
@@ -329,10 +334,10 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
           "PUBLIC_URL",
         ].map(async (variable) => [
           variable,
-          await readContainerFile(
+          await readContainerFile({
             name,
-            `/run/s6/container_environment/${variable}`,
-          ),
+            path: `/run/s6/container_environment/${variable}`,
+          }),
         ]),
       ),
     )
@@ -357,14 +362,14 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
   })
 
   it("writes the ownership record and first-sync sentinel under /persist/config", async () => {
-    const appliedIds = await readContainerFile(
+    const appliedIds = await readContainerFile({
       name,
-      "/persist/config/.applied-ids",
-    )
-    const sentinelPresent = await pathExistsInContainer(
+      path: "/persist/config/.applied-ids",
+    })
+    const sentinelPresent = await pathExistsInContainer({
       name,
-      "/persist/config/.vault-synced",
-    )
+      path: "/persist/config/.vault-synced",
+    })
     expect({ appliedIds, sentinelPresent }).toEqual({
       appliedIds: "1000:1000\n",
       sentinelPresent: true,
@@ -372,10 +377,10 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
   })
 
   it("creates the search index and log directory under /persist/data", async () => {
-    const indexPresent = await pathExistsInContainer(
+    const indexPresent = await pathExistsInContainer({
       name,
-      "/persist/data/index.db",
-    )
+      path: "/persist/data/index.db",
+    })
     const logsDir = await execInContainer(name, [
       "test",
       "-d",
@@ -393,10 +398,10 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
       "-d",
       "/persist/vault/About Me",
     ])
-    const syncedNotePresent = await pathExistsInContainer(
+    const syncedNotePresent = await pathExistsInContainer({
       name,
-      "/persist/vault/Projects/Remote Boot.md",
-    )
+      path: "/persist/vault/Projects/Remote Boot.md",
+    })
     expect({ memoryDirExit: memoryDir.code, syncedNotePresent }).toEqual({
       memoryDirExit: 0,
       syncedNotePresent: true,
@@ -437,23 +442,23 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
 
     it("keeps the ownership record unchanged", async () => {
       expect(
-        await readContainerFile(name, "/persist/config/.applied-ids"),
+        await readContainerFile({ name, path: "/persist/config/.applied-ids" }),
       ).toBe("1000:1000\n")
     })
 
     it("runs the full Sync sequence again, appending to the first boot's log", async () => {
       expect(
-        await readContainerFile(name, "/persist/config/ob-calls.log"),
+        await readContainerFile({ name, path: "/persist/config/ob-calls.log" }),
       ).toBe(callLogOf(2))
     })
 
     it("keeps the first-sync sentinel and the synced notes", async () => {
-      const sentinelPresent = await pathExistsInContainer(
+      const sentinelPresent = await pathExistsInContainer({
         name,
-        "/persist/config/.vault-synced",
-      )
+        path: "/persist/config/.vault-synced",
+      })
       const syncedNotes = (
-        await listFilesInContainer(name, "/persist/vault")
+        await listFilesInContainer({ name, directory: "/persist/vault" })
       ).filter((path) => !path.startsWith("/persist/vault/About Me/"))
       expect({ sentinelPresent, syncedNotes }).toEqual({
         sentinelPresent: true,
@@ -542,10 +547,10 @@ describe("remote image boot — first sync keeps failing (OB_STUB_SYNC_FAIL=1)",
     })
 
     it("calls `ob sync` once per attempt before handing over to continuous sync", async () => {
-      const callLog = await readContainerFile(
+      const callLog = await readContainerFile({
         name,
-        "/home/obsidian/.config/ob-calls.log",
-      )
+        path: "/home/obsidian/.config/ob-calls.log",
+      })
       expect(callLog).toBe(
         [
           "login",
@@ -564,10 +569,10 @@ describe("remote image boot — first sync keeps failing (OB_STUB_SYNC_FAIL=1)",
 
     it("does not write the first-sync sentinel", async () => {
       expect(
-        await pathExistsInContainer(
+        await pathExistsInContainer({
           name,
-          "/home/obsidian/.config/.vault-synced",
-        ),
+          path: "/home/obsidian/.config/.vault-synced",
+        }),
       ).toBe(false)
     })
 

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -276,7 +276,7 @@ describe("remote image boot — three-volume layout (anonymous /vault, /data, /h
         args: { query: "stubbed first sync" },
       })
       const searchResponse: unknown = JSON.parse(textContent(result))
-      // `modified` is the boot-time mtime and `score` an RRF float — every
+      // `modified` is the boot-time mtime and `score` is an RRF float — every
       // other field of the response is fixed by the fixture, so pin those.
       const isSearchResponse = (
         value: unknown,

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -752,9 +752,8 @@ describe("remote image boot — vault wiped after files arrived while the contai
   })
 
   it("stops on the next boot before any sync attempt", async () => {
-    // Scoped to the restarted boot: the first boot's logs legitimately
-    // contain a sync attempt, so a guard that had slipped behind the first
-    // `ob sync` would still pass an assertion over the full two-boot log.
+    // Only the restarted boot's logs: the first boot ran a sync on purpose,
+    // so "no sync attempt" can only be asserted after the restart.
     const logsSinceRestart = await containerLogs(name, restartedAt)
     expect(logsSinceRestart).toContain(
       "[obsidian-sync] ERROR: The vault is empty but this device has previously synced.",

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -417,7 +417,14 @@ describe("remote image boot — single-volume layout (STORAGE_ROOT=/persist)", (
       "-mindepth",
       "1",
     ])
-    expect(legacyEntries.stdout).toBe("")
+    // Assert both exit code and stdout: code 0 proves all three
+    // directories exist (find errors on a missing path), stdout ""
+    // proves they're empty. Without the code check, a missing directory
+    // would coincidentally pass (find errors to stderr, stdout stays "").
+    expect({ code: legacyEntries.code, stdout: legacyEntries.stdout }).toEqual({
+      code: 0,
+      stdout: "",
+    })
   })
 
   describe("after docker restart", () => {

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -630,6 +630,76 @@ describe("remote image boot — first sync keeps failing (OB_STUB_SYNC_FAIL=1)",
   })
 })
 
+describe("remote image boot — empty remote vault with the memory layer disabled", () => {
+  // Nothing ever lands in the vault: the stub delivers no notes and memory
+  // is off, so no About Me/ templates are bootstrapped either. The device
+  // must stay bootable across restarts — the wipe guard keys on a sentinel
+  // that only a content-delivering sync may write.
+  const name = uniqueName("empty-vault")
+  const env = {
+    ...BASE_ENV,
+    MEMORY_ENABLED: "false",
+    PUBLIC_URL: "http://localhost:8000",
+    OB_STUB_SYNC_EMPTY: "1",
+  }
+  let handle: ContainerHandle | undefined
+  let port = 0
+
+  beforeAll(async () => {
+    handle = await runContainer({
+      name,
+      image: IMAGE,
+      env,
+      volumes: [],
+      publishPort: true,
+    })
+    port = await publishedPort(name)
+    await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
+  })
+
+  afterAll(async () => {
+    await handle?.cleanup()
+  })
+
+  it("completes the first sync with an empty vault and writes no sentinel", async () => {
+    expect(await containerLogs(name)).toContain(
+      "[obsidian-sync] First sync complete.",
+    )
+    expect(await listFilesInContainer({ name, directory: "/vault" })).toEqual(
+      [],
+    )
+    expect(
+      await pathExistsInContainer({
+        name,
+        path: "/home/obsidian/.config/.vault-synced",
+      }),
+    ).toBe(false)
+  })
+
+  describe("after docker restart", () => {
+    let restartedAt = ""
+
+    beforeAll(async () => {
+      const beforeRestart = await bootedStartedAt(name)
+      await docker(["restart", name])
+      restartedAt = await bootedStartedAt(name)
+      if (restartedAt === beforeRestart) {
+        throw new Error("docker restart did not produce a new StartedAt")
+      }
+      port = await publishedPort(name)
+      await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
+    })
+
+    it("syncs again instead of stopping on the empty-vault guard", async () => {
+      const logsSinceRestart = await containerLogs(name, restartedAt)
+      expect(logsSinceRestart).toContain("[obsidian-sync] First sync complete.")
+      expect(logsSinceRestart).not.toContain(
+        "The vault is empty but this device has previously synced.",
+      )
+    })
+  })
+})
+
 describe("remote image boot — init-chain guards stop the container", () => {
   /** Boot with the given env, register cleanup for the current test before
    *  anything can throw, and return the logs once the container has stopped
@@ -680,6 +750,22 @@ describe("remote image boot — init-chain guards stop the container", () => {
     expect(logs).toContain(
       "s6-rc: warning: unable to start service init-setup-user: command exited 1",
     )
+  })
+
+  it("refuses to start without VAULT_NAME before registering the vault", async () => {
+    const { VAULT_NAME: _omitted, ...envWithoutVaultName } = BASE_ENV
+    const logs = await logsAfterGuardStops({
+      scenario: "missing-vault-name",
+      env: envWithoutVaultName,
+    })
+    expect(logs).toContain("[obsidian-sync] ERROR: VAULT_NAME is not set.")
+    expect(logs).toContain(
+      "s6-rc: warning: unable to start service init-setup-vault: command exited 1",
+    )
+    // init-setup-vault runs after login, so the guard fires with the
+    // device authenticated but never registered against a vault.
+    expect(logs).toContain("[obsidian-sync] Authenticated.")
+    expect(logs).not.toContain("First sync (attempt")
   })
 
   it("refuses to start without OBSIDIAN_AUTH_TOKEN before ever calling the Sync client", async () => {

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -1,13 +1,14 @@
-/** Remote image boot tier — runs the built `:remote` image end-to-end with the
- *  obsidian-headless CLI replaced by `fixtures/ob`.
+/** Remote image boot tests — runs the built `:remote` image end-to-end with
+ *  the obsidian-headless CLI replaced by `fixtures/ob`.
  *
  *  Covers the assembled s6 init chain (derive-env → setup-user → check-auth →
- *  login → setup-vault → first-sync → sync → mcp) — ordering, published env,
- *  volume layout, guards — which the per-script `sh` specs in
- *  `src/vault-mcp/__tests__/` cannot see.
+ *  login → setup-vault → first-sync → sync → mcp): script ordering, the
+ *  `container_environment` files each script writes, the volume layout, and
+ *  the safety checks that stop the container. The per-script tests in
+ *  `src/vault-mcp/__tests__/` cannot see these cross-script interactions.
  *
  *  Needs Docker; `npm run test:remote-boot` builds the image and runs the
- *  tier (REMOTE_IMAGE points the tests at a different image tag).
+ *  suite (REMOTE_IMAGE points the tests at a different image tag).
  *
  *  One container per describe block: a boot is the expensive resource that
  *  justifies `beforeAll` over const-per-test. Each test then reads its own
@@ -54,14 +55,15 @@ const FAKE_SYNC_TOKEN = "fake-obsidian-sync-token-for-ci"
 const FAKE_MCP_TOKEN = "fake-mcp-token-for-ci"
 
 const BOOT_DEADLINE_MS = 120_000
-/** Under the 30 s test timeout, so a guard that fails to stop the container
- *  fails on waitForStopped's own message (with logs) rather than a bare
- *  timeout. A real guard failure halts the container within seconds. */
+/** Set below the 30 s test timeout so that a safety check that fails to
+ *  stop the container reports via waitForStopped's message (with logs)
+ *  rather than a bare timeout. In practice the container halts within
+ *  seconds. */
 const STOP_DEADLINE_MS = 20_000
 
 /** A first sync that keeps failing takes three attempts with two 10 s
- *  sleeps between them (init-first-sync's MAX_ATTEMPTS=3), so those
- *  scenarios get their own, longer budgets. */
+ *  sleeps between them (init-first-sync's MAX_ATTEMPTS=3), so the
+ *  failing-sync scenarios get their own, longer budgets. */
 const FAILING_SYNC_TEST_TIMEOUT_MS = 120_000
 const FAILING_SYNC_STOP_DEADLINE_MS = 90_000
 
@@ -80,8 +82,9 @@ const FIRST_SYNC_ATTEMPT_LINES = [
   "[obsidian-sync] First sync (attempt 3/3) — waiting for completion before starting services...",
 ]
 
-/** Env every scenario shares. Embeddings stay off so the boot doesn't
- *  download a model; the chain under test doesn't touch search ranking. */
+/** Environment variables every scenario shares. Embeddings stay off so the
+ *  boot doesn't download a model; the init chain under test doesn't touch
+ *  search ranking. */
 const BASE_ENV = {
   OBSIDIAN_AUTH_TOKEN: FAKE_SYNC_TOKEN,
   VAULT_NAME: "ci-vault",
@@ -90,9 +93,9 @@ const BASE_ENV = {
   EMBEDDING_ENABLED: "false",
 }
 
-/** Every `ob` call one boot makes, in order, for BASE_ENV (only the
- *  sync-config flags whose env var is set are applied; SYNC_CONFIGS has a
- *  baked-in default). The stub appends "$*" per call. */
+/** Every `ob` call that a single boot makes, in order, for BASE_ENV.
+ *  Only the sync-config flags whose env var is set are applied;
+ *  SYNC_CONFIGS has a baked-in default. The stub appends "$*" per call. */
 const EXPECTED_BOOT_SEQUENCE = [
   "login",
   "sync-setup --vault ci-vault --device-name ci-device",
@@ -148,9 +151,9 @@ beforeAll(async () => {
 
 describe("remote image boot — three-volume layout (anonymous /vault, /data, /home/obsidian/.config)", () => {
   const name = uniqueName("three-volume")
-  // Memory off keeps the vault listing exact: with it on, the server would
-  // also bootstrap the About Me/ templates. The single-volume scenario
-  // covers the bootstrap path.
+  // Memory off keeps the vault listing exact: with memory enabled, the
+  // server would also bootstrap the About Me/ templates. The single-volume
+  // scenario covers the bootstrap path.
   const env = {
     ...BASE_ENV,
     MEMORY_ENABLED: "false",
@@ -699,10 +702,9 @@ describe("remote image boot — empty remote vault with the memory layer disable
 })
 
 describe("remote image boot — vault wiped after files arrived while the container ran", () => {
-  // The device started with an empty vault, received files through
-  // continuous sync (no restart involved), and then had its vault volume
-  // emptied. The sync state still records those files, so the next boot
-  // must stop before the engine can push them as deletions.
+  // The sync state records files that arrived while the container ran, so
+  // if the vault volume is emptied afterward, the next boot must stop
+  // before the engine can push those files as deletions.
   const name = uniqueName("wiped-while-running")
   const env = {
     ...BASE_ENV,
@@ -724,7 +726,8 @@ describe("remote image boot — vault wiped after files arrived while the contai
     const port = await publishedPort(name)
     await waitForHealthz({ name, port, deadlineMs: BOOT_DEADLINE_MS })
     // What continuous sync would do: deliver a note and record it in the
-    // sync state, as the obsidian user the stub normally runs as.
+    // sync state. The exec runs as the `obsidian` user, which is the user
+    // the stub normally runs as.
     await dockerOrThrow([
       "exec",
       "--user",
@@ -828,7 +831,7 @@ describe("remote image boot — remote vault holding only synced .obsidian/ sett
   })
 })
 
-describe("remote image boot — init-chain guards stop the container", () => {
+describe("remote image boot — safety checks in the init chain stop the container", () => {
   /** Boot with the given env, register cleanup for the current test before
    *  anything can throw, and return the logs once the container has stopped
    *  on its own. */

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -8,7 +8,7 @@ import {
   rmSync,
 } from "node:fs"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 
 import { describe, expect, it, onTestFinished } from "vitest"
 
@@ -71,6 +71,8 @@ type GateRunOptions = {
   memoryEnabled?: string
   /** Vault-relative directories to create before running. */
   vaultDirs?: string[]
+  /** Vault-relative empty files to create before running (parents created). */
+  vaultFiles?: string[]
   /** When false, VAULT_PATH points at a directory that doesn't exist. */
   vaultExists?: boolean
   /** When true, pre-creates the .vault-synced sentinel (simulates a prior sync). */
@@ -99,6 +101,10 @@ const runGateScript = (options: GateRunOptions): GateRun => {
   }
   for (const vaultDir of options.vaultDirs ?? []) {
     mkdirSync(join(vaultPath, vaultDir), { recursive: true })
+  }
+  for (const vaultFile of options.vaultFiles ?? []) {
+    mkdirSync(dirname(join(vaultPath, vaultFile)), { recursive: true })
+    writeFileSync(join(vaultPath, vaultFile), "")
   }
   if (options.sentinel) {
     writeFileSync(sentinelPath, "")
@@ -352,12 +358,12 @@ describe("init-first-sync gate script", () => {
     )
   })
 
-  it("refuses when the vault has only hidden entries and a prior sync completed", () => {
+  it("refuses when the vault holds only the Sync client's own .obsidian/.sync.lock and a prior sync completed", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
       sentinel: true,
-      vaultDirs: [".obsidian"],
+      vaultDirs: [".obsidian/.sync.lock"],
     })
 
     expect(run.status).toBe(1)
@@ -365,6 +371,34 @@ describe("init-first-sync gate script", () => {
     expect(run.stderr).toContain(
       "ERROR: The vault is empty but this device has previously synced.",
     )
+  })
+
+  it("refuses when the vault has only a non-Obsidian dotfile and a prior sync completed", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      sentinel: true,
+      vaultFiles: [".trash"],
+    })
+
+    expect(run.status).toBe(1)
+    expect(run.syncCalls).toBe(0)
+    expect(run.stderr).toContain(
+      "ERROR: The vault is empty but this device has previously synced.",
+    )
+  })
+
+  it("allows sync when the vault holds only synced Obsidian config and a prior sync completed", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      sentinel: true,
+      vaultFiles: [".obsidian/app.json"],
+    })
+
+    expect(run.status).toBe(0)
+    expect(run.syncCalls).toBe(1)
+    expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
   })
 
   it("allows sync when the vault has visible files and a prior sync completed", () => {
@@ -407,6 +441,28 @@ describe("init-first-sync gate script", () => {
     expect(run.syncCalls).toBe(1)
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
     expect(existsSync(run.sentinelPath)).toBe(false)
+  })
+
+  it("does not write the sentinel when the sync left only its own .obsidian/.sync.lock", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      vaultDirs: [".obsidian/.sync.lock"],
+    })
+
+    expect(run.status).toBe(0)
+    expect(existsSync(run.sentinelPath)).toBe(false)
+  })
+
+  it("writes the sentinel when the sync delivered only Obsidian config", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      vaultFiles: [".obsidian/app.json"],
+    })
+
+    expect(run.status).toBe(0)
+    expect(existsSync(run.sentinelPath)).toBe(true)
   })
 
   // -- XDG_CONFIG_HOME relocation (single-volume mode) ---------------------

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -388,17 +388,35 @@ describe("init-first-sync gate script", () => {
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
   })
 
-  it("writes the sentinel file after a successful sync", () => {
+  it("writes the sentinel file after a successful sync that delivered files", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      vaultDirs: ["Notes"],
+    })
+
+    expect(run.status).toBe(0)
+    expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
+    expect(existsSync(run.sentinelPath)).toBe(true)
+  })
+
+  it("does not write the sentinel when the completed sync left the vault empty", () => {
     const run = runGateScript({ syncOutcomes: [0], vaultName: "Test" })
 
     expect(run.status).toBe(0)
-    expect(existsSync(run.sentinelPath)).toBe(true)
+    expect(run.syncCalls).toBe(1)
+    expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
+    expect(existsSync(run.sentinelPath)).toBe(false)
   })
 
   // -- XDG_CONFIG_HOME relocation (single-volume mode) ---------------------
 
   it("writes the sentinel under $HOME/.config when XDG_CONFIG_HOME is unset", () => {
-    const run = runGateScript({ syncOutcomes: [0], vaultName: "Test" })
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      vaultDirs: ["Notes"],
+    })
 
     expect(run.status).toBe(0)
     expect(run.sentinelPath).toBe(run.legacySentinelPath)
@@ -409,6 +427,7 @@ describe("init-first-sync gate script", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
+      vaultDirs: ["Notes"],
       xdgConfigHome: true,
     })
 

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from "node:child_process"
 import {
-  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -9,6 +8,7 @@ import {
 } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
+import { DatabaseSync } from "node:sqlite"
 
 import { describe, expect, it, onTestFinished } from "vitest"
 
@@ -55,12 +55,8 @@ type GateRun = {
   stdout: string
   stderr: string
   syncCalls: number
-  /** Obsidian config directory the script resolved (sentinel's parent). */
+  /** Obsidian config directory the script resolved. */
   configDir: string
-  /** Path to the sentinel file for post-run assertions. */
-  sentinelPath: string
-  /** Where the sentinel lands with XDG_CONFIG_HOME unset ($HOME/.config). */
-  legacySentinelPath: string
 }
 
 type GateRunOptions = {
@@ -75,11 +71,28 @@ type GateRunOptions = {
   vaultFiles?: string[]
   /** When false, VAULT_PATH points at a directory that doesn't exist. */
   vaultExists?: boolean
-  /** When true, pre-creates the .vault-synced sentinel (simulates a prior sync). */
-  sentinel?: boolean
+  /** Number of files to record in the device's sync state
+   *  (`obsidian-headless/sync/<vaultId>/state.db`, `local_files` table) —
+   *  what a prior sync would have left behind. Omit for a fresh device. */
+  knownSyncFiles?: number
+  /** When true, writes a state.db that is not a SQLite database. */
+  corruptSyncState?: boolean
   /** When true, runs with XDG_CONFIG_HOME pointing at a directory outside
-   *  $HOME (single-volume mode) — the sentinel must follow it. */
+   *  $HOME (single-volume mode) — the sync state must be read from there. */
   xdgConfigHome?: boolean
+}
+
+/** Mirror of the sync engine's local_files table, with one row per file. */
+const writeSyncState = (stateDbPath: string, knownFiles: number): void => {
+  const db = new DatabaseSync(stateDbPath)
+  db.exec(
+    "CREATE TABLE local_files (path TEXT PRIMARY KEY, data TEXT NOT NULL)",
+  )
+  const insert = db.prepare("INSERT INTO local_files VALUES (?, ?)")
+  for (let fileIndex = 0; fileIndex < knownFiles; fileIndex += 1) {
+    insert.run(`note-${fileIndex}.md`, "{}")
+  }
+  db.close()
 }
 
 const runGateScript = (options: GateRunOptions): GateRun => {
@@ -91,8 +104,7 @@ const runGateScript = (options: GateRunOptions): GateRun => {
   const legacyConfigDir = join(homeDir, ".config")
   const xdgConfigDir = join(tempDir, "persist", "config")
   const configDir = options.xdgConfigHome ? xdgConfigDir : legacyConfigDir
-  const sentinelPath = join(configDir, ".vault-synced")
-  const legacySentinelPath = join(legacyConfigDir, ".vault-synced")
+  const syncStateDir = join(configDir, "obsidian-headless", "sync", "vault-id")
   mkdirSync(stubBinDir)
   mkdirSync(legacyConfigDir, { recursive: true })
   mkdirSync(xdgConfigDir, { recursive: true })
@@ -106,8 +118,13 @@ const runGateScript = (options: GateRunOptions): GateRun => {
     mkdirSync(dirname(join(vaultPath, vaultFile)), { recursive: true })
     writeFileSync(join(vaultPath, vaultFile), "")
   }
-  if (options.sentinel) {
-    writeFileSync(sentinelPath, "")
+  if (options.knownSyncFiles !== undefined) {
+    mkdirSync(syncStateDir, { recursive: true })
+    writeSyncState(join(syncStateDir, "state.db"), options.knownSyncFiles)
+  }
+  if (options.corruptSyncState) {
+    mkdirSync(syncStateDir, { recursive: true })
+    writeFileSync(join(syncStateDir, "state.db"), "not a database")
   }
 
   writeFileSync(join(stubBinDir, "ob"), OB_STUB, { mode: 0o755 })
@@ -152,8 +169,6 @@ const runGateScript = (options: GateRunOptions): GateRun => {
     stderr: result.stderr,
     syncCalls,
     configDir,
-    sentinelPath,
-    legacySentinelPath,
   }
 }
 
@@ -336,13 +351,13 @@ describe("init-first-sync gate script", () => {
     )
   })
 
-  // -- Sync-state vault guard (empty vault + prior-sync sentinel) ----------
+  // -- Sync-state vault guard (recorded local files + vault without content) --
 
-  it("refuses to sync when the vault is empty but a prior sync completed", () => {
+  it("refuses to sync when the vault is empty but the device recorded synced files", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
-      sentinel: true,
+      knownSyncFiles: 3,
     })
 
     expect(run.status).toBe(1)
@@ -365,7 +380,7 @@ describe("init-first-sync gate script", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
-      sentinel: true,
+      knownSyncFiles: 3,
       vaultDirs: [".obsidian/.sync.lock"],
     })
 
@@ -380,7 +395,7 @@ describe("init-first-sync gate script", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
-      sentinel: true,
+      knownSyncFiles: 3,
       vaultFiles: [".trash"],
     })
 
@@ -395,7 +410,7 @@ describe("init-first-sync gate script", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
-      sentinel: true,
+      knownSyncFiles: 3,
       vaultFiles: [".obsidian/app.json"],
     })
 
@@ -408,7 +423,7 @@ describe("init-first-sync gate script", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
-      sentinel: true,
+      knownSyncFiles: 3,
       vaultDirs: ["About Me"],
     })
 
@@ -417,7 +432,7 @@ describe("init-first-sync gate script", () => {
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
   })
 
-  it("allows sync on a fresh device with an empty vault (no sentinel)", () => {
+  it("allows sync on a fresh device with an empty vault (no sync state)", () => {
     const run = runGateScript({ syncOutcomes: [0], vaultName: "Test" })
 
     expect(run.status).toBe(0)
@@ -425,82 +440,39 @@ describe("init-first-sync gate script", () => {
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
   })
 
-  it("writes the sentinel file after a successful sync that delivered files", () => {
+  it("allows sync on a device whose sync state records zero files and an empty vault", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
-      vaultDirs: ["Notes"],
+      knownSyncFiles: 0,
     })
-
-    expect(run.status).toBe(0)
-    expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
-    expect(existsSync(run.sentinelPath)).toBe(true)
-  })
-
-  it("does not write the sentinel when the completed sync left the vault empty", () => {
-    const run = runGateScript({ syncOutcomes: [0], vaultName: "Test" })
 
     expect(run.status).toBe(0)
     expect(run.syncCalls).toBe(1)
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
-    expect(existsSync(run.sentinelPath)).toBe(false)
   })
 
-  it("does not write the sentinel when the sync left only its own .obsidian/.sync.lock", () => {
+  it("refuses to sync when the sync state exists but cannot be read", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
-      vaultDirs: [".obsidian/.sync.lock"],
+      corruptSyncState: true,
     })
 
-    expect(run.status).toBe(0)
-    expect(existsSync(run.sentinelPath)).toBe(false)
-  })
-
-  it("writes the sentinel when the sync delivered only Obsidian config", () => {
-    const run = runGateScript({
-      syncOutcomes: [0],
-      vaultName: "Test",
-      vaultFiles: [".obsidian/app.json"],
-    })
-
-    expect(run.status).toBe(0)
-    expect(existsSync(run.sentinelPath)).toBe(true)
+    expect(run.status).toBe(1)
+    expect(run.syncCalls).toBe(0)
+    expect(run.stderr).toContain(
+      `ERROR: Could not read this device's sync state under ${join(run.configDir, "obsidian-headless", "sync")}.`,
+    )
   })
 
   // -- XDG_CONFIG_HOME relocation (single-volume mode) ---------------------
 
-  it("writes the sentinel under $HOME/.config when XDG_CONFIG_HOME is unset", () => {
+  it("stops when the vault is empty and the sync state sits under XDG_CONFIG_HOME", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
-      vaultDirs: ["Notes"],
-    })
-
-    expect(run.status).toBe(0)
-    expect(run.sentinelPath).toBe(run.legacySentinelPath)
-    expect(existsSync(run.legacySentinelPath)).toBe(true)
-  })
-
-  it("writes the sentinel under XDG_CONFIG_HOME when set, not under $HOME", () => {
-    const run = runGateScript({
-      syncOutcomes: [0],
-      vaultName: "Test",
-      vaultDirs: ["Notes"],
-      xdgConfigHome: true,
-    })
-
-    expect(run.status).toBe(0)
-    expect(run.syncCalls).toBe(1)
-    expect(existsSync(run.sentinelPath)).toBe(true)
-    expect(existsSync(run.legacySentinelPath)).toBe(false)
-  })
-
-  it("stops when the vault is empty and the sentinel sits under XDG_CONFIG_HOME", () => {
-    const run = runGateScript({
-      syncOutcomes: [0],
-      vaultName: "Test",
-      sentinel: true,
+      knownSyncFiles: 3,
       xdgConfigHome: true,
     })
 
@@ -514,26 +486,8 @@ describe("init-first-sync gate script", () => {
     )
   })
 
-  it("does not write the sentinel file when sync fails fatally", () => {
-    const run = runGateScript({ syncOutcomes: [1], vaultName: "Test" })
-
-    expect(run.status).toBe(1)
-    expect(existsSync(run.sentinelPath)).toBe(false)
-  })
-
-  it("does not write the sentinel file when sync fails but services start", () => {
-    const run = runGateScript({
-      syncOutcomes: [1],
-      vaultName: "Test",
-      vaultDirs: ["About Me"],
-    })
-
-    expect(run.status).toBe(0)
-    expect(existsSync(run.sentinelPath)).toBe(false)
-  })
-
   it("fires the guard regardless of VAULT_NAME", () => {
-    const run = runGateScript({ syncOutcomes: [0], sentinel: true })
+    const run = runGateScript({ syncOutcomes: [0], knownSyncFiles: 3 })
 
     expect(run.status).toBe(1)
     expect(run.syncCalls).toBe(0)

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -127,9 +127,9 @@ const runGateScript = (options: GateRunOptions): GateRun => {
     writeSyncState(join(syncStateDir, "state.db"), options.knownSyncFiles)
   }
   if (options.secondStoreSyncFiles !== undefined) {
-    // Glob order is not what the name suggests: "vault-id-second/state.db"
-    // sorts before "vault-id/state.db" ("-" < "/"), so this store is the
-    // first one the script sees. The two-store specs cover both positions.
+    // Despite the "second" in its name, the glob lists this store first:
+    // "vault-id-second/state.db" sorts before "vault-id/state.db" because
+    // "-" < "/". The two-store specs cover both positions.
     const secondStoreDir = join(dirname(syncStateDir), "vault-id-second")
     mkdirSync(secondStoreDir, { recursive: true })
     writeSyncState(

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -418,7 +418,7 @@ describe("init-first-sync gate script", () => {
     expect(existsSync(run.legacySentinelPath)).toBe(false)
   })
 
-  it("fires the empty-vault guard from a sentinel under XDG_CONFIG_HOME", () => {
+  it("stops when the vault is empty and the sentinel sits under XDG_CONFIG_HOME", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -127,7 +127,9 @@ const runGateScript = (options: GateRunOptions): GateRun => {
     writeSyncState(join(syncStateDir, "state.db"), options.knownSyncFiles)
   }
   if (options.secondStoreSyncFiles !== undefined) {
-    // Sorts after "vault-id" so the glob hands it to the script last.
+    // Glob order is not what the name suggests: "vault-id-second/state.db"
+    // sorts before "vault-id/state.db" ("-" < "/"), so this store is the
+    // first one the script sees. The two-store specs cover both positions.
     const secondStoreDir = join(dirname(syncStateDir), "vault-id-second")
     mkdirSync(secondStoreDir, { recursive: true })
     writeSyncState(

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -75,6 +75,10 @@ type GateRunOptions = {
    *  (`obsidian-headless/sync/<vaultId>/state.db`, `local_files` table) —
    *  what a prior sync would have left behind. Omit for a fresh device. */
   knownSyncFiles?: number
+  /** Number of files to record in a second store
+   *  (`obsidian-headless/sync/<otherVaultId>/state.db`) — a device whose
+   *  sync root holds more than one vault's state. Omit for one store. */
+  secondStoreSyncFiles?: number
   /** When true, writes a state.db that is not a SQLite database. */
   corruptSyncState?: boolean
   /** When true, runs with XDG_CONFIG_HOME pointing at a directory outside
@@ -121,6 +125,14 @@ const runGateScript = (options: GateRunOptions): GateRun => {
   if (options.knownSyncFiles !== undefined) {
     mkdirSync(syncStateDir, { recursive: true })
     writeSyncState(join(syncStateDir, "state.db"), options.knownSyncFiles)
+  }
+  if (options.secondStoreSyncFiles !== undefined) {
+    const secondStoreDir = join(dirname(syncStateDir), "other-vault-id")
+    mkdirSync(secondStoreDir, { recursive: true })
+    writeSyncState(
+      join(secondStoreDir, "state.db"),
+      options.secondStoreSyncFiles,
+    )
   }
   if (options.corruptSyncState) {
     mkdirSync(syncStateDir, { recursive: true })
@@ -458,6 +470,37 @@ describe("init-first-sync gate script", () => {
       syncOutcomes: [0],
       vaultName: "Test",
       knownSyncFiles: 0,
+    })
+
+    expect(run.status).toBe(0)
+    expect(run.syncCalls).toBe(1)
+    expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
+  })
+
+  it("refuses to sync when only a second store records files and the vault is empty", () => {
+    // The guard reads every store under the sync root, not just the first
+    // match — a device that has registered more than one vault keeps a
+    // store per vault, and rows in any of them mean files were delivered.
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      knownSyncFiles: 0,
+      secondStoreSyncFiles: 2,
+    })
+
+    expect(run.status).toBe(1)
+    expect(run.syncCalls).toBe(0)
+    expect(run.stderr).toContain(
+      "ERROR: The vault is empty but this device has previously synced.",
+    )
+  })
+
+  it("allows sync when two stores both record zero files and the vault is empty", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      knownSyncFiles: 0,
+      secondStoreSyncFiles: 0,
     })
 
     expect(run.status).toBe(0)

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -381,7 +381,10 @@ describe("init-first-sync gate script", () => {
       "ERROR: The vault is empty but this device has previously synced.",
     )
     expect(run.stderr).toContain(
-      "If you emptied the vault on purpose, this stop is expected — re-register the device as below; a fresh device downloads the empty vault without deleting anything.",
+      "If you emptied the vault on purpose, this stop is expected.",
+    )
+    expect(run.stderr).toContain(
+      "Re-register the device as below. A fresh device downloads the empty vault without deleting anything.",
     )
     expect(run.stderr).toContain(
       "To start fresh: remove the Obsidian config directory (",
@@ -468,7 +471,7 @@ describe("init-first-sync gate script", () => {
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
   })
 
-  it("allows sync on a device whose sync state records zero files and an empty vault", () => {
+  it("allows sync on a device whose sync state records zero files when the vault is empty", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -419,6 +419,19 @@ describe("init-first-sync gate script", () => {
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
   })
 
+  it("allows sync when the vault holds a hidden non-lock entry under .obsidian/ and a prior sync completed", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      knownSyncFiles: 3,
+      vaultFiles: [".obsidian/.hidden-plugin-data"],
+    })
+
+    expect(run.status).toBe(0)
+    expect(run.syncCalls).toBe(1)
+    expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
+  })
+
   it("allows sync when the vault has visible files and a prior sync completed", () => {
     const run = runGateScript({
       syncOutcomes: [0],

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -75,6 +75,9 @@ type GateRunOptions = {
    *  (`obsidian-headless/sync/<vaultId>/state.db`, `local_files` table) —
    *  what a prior sync would have left behind. Omit for a fresh device. */
   knownSyncFiles?: number
+  /** Number of folder rows to record alongside the files — the engine keeps
+   *  a row per folder too, marked `"folder": true`. These must not count. */
+  knownSyncFolders?: number
   /** Number of files to record in a second store
    *  (`obsidian-headless/sync/<otherVaultId>/state.db`) — a device whose
    *  sync root holds more than one vault's state. Omit for one store. */
@@ -86,15 +89,27 @@ type GateRunOptions = {
   xdgConfigHome?: boolean
 }
 
-/** Mirror of the sync engine's local_files table, with one row per file. */
-const writeSyncState = (stateDbPath: string, knownFiles: number): void => {
+/** Mirror of the sync engine's local_files table: one row per file and one
+ *  per folder, each row's data carrying the engine's `folder` flag. */
+const writeSyncState = ({
+  stateDbPath,
+  knownFiles,
+  knownFolders = 0,
+}: {
+  stateDbPath: string
+  knownFiles: number
+  knownFolders?: number
+}): void => {
   const db = new DatabaseSync(stateDbPath)
   db.exec(
     "CREATE TABLE local_files (path TEXT PRIMARY KEY, data TEXT NOT NULL)",
   )
   const insert = db.prepare("INSERT INTO local_files VALUES (?, ?)")
   for (let fileIndex = 0; fileIndex < knownFiles; fileIndex += 1) {
-    insert.run(`note-${fileIndex}.md`, "{}")
+    insert.run(`note-${fileIndex}.md`, JSON.stringify({ folder: false }))
+  }
+  for (let folderIndex = 0; folderIndex < knownFolders; folderIndex += 1) {
+    insert.run(`folder-${folderIndex}`, JSON.stringify({ folder: true }))
   }
   db.close()
 }
@@ -124,7 +139,13 @@ const runGateScript = (options: GateRunOptions): GateRun => {
   }
   if (options.knownSyncFiles !== undefined) {
     mkdirSync(syncStateDir, { recursive: true })
-    writeSyncState(join(syncStateDir, "state.db"), options.knownSyncFiles)
+    writeSyncState({
+      stateDbPath: join(syncStateDir, "state.db"),
+      knownFiles: options.knownSyncFiles,
+      ...(options.knownSyncFolders === undefined
+        ? {}
+        : { knownFolders: options.knownSyncFolders }),
+    })
   }
   if (options.secondStoreSyncFiles !== undefined) {
     // Despite the "second" in its name, the glob lists this store first:
@@ -132,10 +153,10 @@ const runGateScript = (options: GateRunOptions): GateRun => {
     // "-" < "/". The two-store specs cover both positions.
     const secondStoreDir = join(dirname(syncStateDir), "vault-id-second")
     mkdirSync(secondStoreDir, { recursive: true })
-    writeSyncState(
-      join(secondStoreDir, "state.db"),
-      options.secondStoreSyncFiles,
-    )
+    writeSyncState({
+      stateDbPath: join(secondStoreDir, "state.db"),
+      knownFiles: options.secondStoreSyncFiles,
+    })
   }
   if (options.corruptSyncState) {
     mkdirSync(syncStateDir, { recursive: true })
@@ -564,6 +585,37 @@ describe("init-first-sync gate script", () => {
     expect(run.status).toBe(0)
     expect(run.syncCalls).toBe(1)
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
+  })
+
+  it("allows sync when the record holds only folder rows and the vault is empty", () => {
+    // Notes deleted by hand while the container ran: the engine dropped
+    // their rows, but the rows for the (now empty) folders stay. Those
+    // are not files the engine would push as deletions.
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      knownSyncFiles: 0,
+      knownSyncFolders: 4,
+    })
+
+    expect(run.status).toBe(0)
+    expect(run.syncCalls).toBe(1)
+    expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
+  })
+
+  it("refuses to sync when file rows sit beside folder rows and the vault is empty", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      knownSyncFiles: 2,
+      knownSyncFolders: 4,
+    })
+
+    expect(run.status).toBe(1)
+    expect(run.syncCalls).toBe(0)
+    expect(run.stderr).toContain(
+      "ERROR: The vault is empty but this device has previously synced.",
+    )
   })
 
   it("refuses to sync when the sync state exists but cannot be read", () => {

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -127,7 +127,8 @@ const runGateScript = (options: GateRunOptions): GateRun => {
     writeSyncState(join(syncStateDir, "state.db"), options.knownSyncFiles)
   }
   if (options.secondStoreSyncFiles !== undefined) {
-    const secondStoreDir = join(dirname(syncStateDir), "other-vault-id")
+    // Sorts after "vault-id" so the glob hands it to the script last.
+    const secondStoreDir = join(dirname(syncStateDir), "vault-id-second")
     mkdirSync(secondStoreDir, { recursive: true })
     writeSyncState(
       join(secondStoreDir, "state.db"),
@@ -477,15 +478,30 @@ describe("init-first-sync gate script", () => {
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
   })
 
-  it("refuses to sync when only a second store records files and the vault is empty", () => {
-    // The guard reads every store under the sync root, not just the first
-    // match — a device that has registered more than one vault keeps a
-    // store per vault, and rows in any of them mean files were delivered.
+  // The guard reads every store under the sync root, not just the first or
+  // last match — a device that has registered more than one vault keeps a
+  // store per vault, and rows in any of them mean files were delivered.
+  it("refuses to sync when only the last of two stores records files and the vault is empty", () => {
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
       knownSyncFiles: 0,
       secondStoreSyncFiles: 2,
+    })
+
+    expect(run.status).toBe(1)
+    expect(run.syncCalls).toBe(0)
+    expect(run.stderr).toContain(
+      "ERROR: The vault is empty but this device has previously synced.",
+    )
+  })
+
+  it("refuses to sync when only the first of two stores records files and the vault is empty", () => {
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      knownSyncFiles: 2,
+      secondStoreSyncFiles: 0,
     })
 
     expect(run.status).toBe(1)

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -450,17 +450,54 @@ describe("init-first-sync gate script", () => {
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
   })
 
-  it("allows sync when the vault has visible files and a prior sync completed", () => {
+  it("allows sync when the vault has a note inside a folder and a prior sync completed", () => {
+    // The note sits in a subfolder with nothing at the vault root — a
+    // common layout, so the content check must look below the top level.
     const run = runGateScript({
       syncOutcomes: [0],
       vaultName: "Test",
       knownSyncFiles: 3,
-      vaultDirs: ["About Me"],
+      vaultFiles: ["About Me/Principles.md"],
     })
 
     expect(run.status).toBe(0)
     expect(run.syncCalls).toBe(1)
     expect(run.stdout).toContain("[obsidian-sync] First sync complete.")
+  })
+
+  it("refuses when only empty folders remain and a prior sync completed", () => {
+    // A wipe that deleted the files but kept the folder tree must still
+    // read as an empty vault — directories alone are not content.
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      knownSyncFiles: 3,
+      vaultDirs: ["Projects", "About Me"],
+    })
+
+    expect(run.status).toBe(1)
+    expect(run.syncCalls).toBe(0)
+    expect(run.stderr).toContain(
+      "ERROR: The vault is empty but this device has previously synced.",
+    )
+  })
+
+  it("refuses when a dotfile inside a folder is the only file and a prior sync completed", () => {
+    // Sync never delivers dotfiles outside .obsidian/, so a leftover
+    // Projects/.hidden-note.md is not evidence that the vault's files
+    // are still here.
+    const run = runGateScript({
+      syncOutcomes: [0],
+      vaultName: "Test",
+      knownSyncFiles: 3,
+      vaultFiles: ["Projects/.hidden-note.md"],
+    })
+
+    expect(run.status).toBe(1)
+    expect(run.syncCalls).toBe(0)
+    expect(run.stderr).toContain(
+      "ERROR: The vault is empty but this device has previously synced.",
+    )
   })
 
   it("allows sync on a fresh device with an empty vault (no sync state)", () => {

--- a/src/vault-mcp/__tests__/init-first-sync.test.ts
+++ b/src/vault-mcp/__tests__/init-first-sync.test.ts
@@ -351,6 +351,9 @@ describe("init-first-sync gate script", () => {
       "ERROR: The vault is empty but this device has previously synced.",
     )
     expect(run.stderr).toContain(
+      "If you emptied the vault on purpose, this stop is expected — re-register the device as below; a fresh device downloads the empty vault without deleting anything.",
+    )
+    expect(run.stderr).toContain(
       "To start fresh: remove the Obsidian config directory (",
     )
     expect(run.stderr).toContain(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
       "cli/src/**/*.test.ts",
       "scripts/**/*.test.ts",
     ],
-    exclude: ["node_modules/**", "cli/src/__tests__/integration/**"],
+    exclude: [
+      "node_modules/**",
+      "cli/src/__tests__/integration/**",
+      "src/__tests__/docker/**",
+    ],
   },
 })

--- a/vitest.remote-boot.config.ts
+++ b/vitest.remote-boot.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from "vitest/config"
 
 // Remote-boot tier: boots the built `:remote` Docker image with a stubbed
-// Sync client. Excluded from `npm test` (needs Docker + a prior image build);
-// run via `npm run test:remote-boot` — locally and from arch_smoke.yml.
+// Sync client. Excluded from `npm test` (needs Docker). Locally
+// `npm run test:remote-boot` builds the image then runs this config;
+// arch_smoke.yml builds via buildx and runs the config directly.
 export default defineConfig({
   test: {
     globals: false,

--- a/vitest.remote-boot.config.ts
+++ b/vitest.remote-boot.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config"
+
+// Remote-boot tier: boots the built `:remote` Docker image with a stubbed
+// Sync client. Excluded from `npm test` (needs Docker + a prior image build);
+// run via `npm run test:remote-boot` — locally and from arch_smoke.yml.
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: "node",
+    testTimeout: 30_000,
+    // Container boots (and the restart) live in beforeAll hooks.
+    hookTimeout: 180_000,
+    fileParallelism: false,
+    include: ["src/__tests__/docker/**/*.test.ts"],
+  },
+})


### PR DESCRIPTION
## Summary

Two changes to the `:remote` image's boot path:

1. **Fix: the deletion-storm guard reads the Sync client's own file record instead of a sentinel.** `init-first-sync` used a `.vault-synced` sentinel written after the first sync as a proxy for "this device holds synced files". That proxy was wrong in both directions: a vault with no visible files (memory layer disabled, no notes yet) got a sentinel and then tripped the guard on every later boot, and a device that started empty and received files through continuous sync never got one, so a later vault wipe would sail through. The guard now reads the record the sync engine itself diffs against disk.
2. **Remote image boot test tier** — `npm run test:remote-boot` — run from `arch_smoke.yml` on amd64 and arm64 on every PR. The s6 init chain (`init-derive-env` → `init-setup-user` → `init-check-auth` → `init-obsidian-login` → `init-setup-vault` → `init-first-sync` → `svc-obsidian-sync` → `svc-vault-mcp`) was validated by hand against real Obsidian Sync and each script has its own `sh` spec, but nothing ran the *assembled* chain per PR because it needs `ob login`. This tier boots the real image with the obsidian-headless CLI replaced by a stub, so the chain runs end-to-end with no credentials or network. The fix in (1) is one of the things it proves.

## The fix

`rootfs/etc/s6-overlay/scripts/init-first-sync`: the sentinel is gone. Before any sync attempt the script counts rows in the `local_files` table of every `obsidian-headless/sync/<vaultId>/state.db` under the config directory, using Node 24's built-in `node:sqlite` read-only (no new dependency). Verified in the pinned obsidian-headless v0.0.14 `cli.js`: the engine loads `local_files` at startup and pushes every recorded path that is missing from disk as a deletion, and a fresh device (no store) skips deletions entirely.

- Files recorded and the vault has no content → stop, with the existing ERROR text.
- No store → fresh device → proceed.
- A store that exists but cannot be read → stop with a distinct ERROR (fail closed, never "assume fresh").

"Content" is a regular file: any file at any depth with no dot-named path component, or any file inside `.obsidian/` except under `.sync.lock/`. The engine runs `mkdir -p <vault>/.obsidian` and creates that lock directory before transferring anything, so those two are left behind by every sync and must not count. Empty folders do not count either, so a wipe that deletes the files but keeps the folder tree still reads as empty. Dotfiles outside `.obsidian/` are not synced and do not count.

| Situation | Before | After |
| --- | --- | --- |
| Empty remote vault, memory disabled, container restarted | Stops on the guard; never boots again | Boots |
| Vault holding only synced `.obsidian/` settings, restarted | Stops; never boots again | Boots |
| Started empty, files arrived through continuous sync, vault wiped, restarted | **Syncs — mass deletions pushed** | Stops (guard) |
| Synced vault wiped, config volume kept | Stops (guard) | Stops (guard) |
| Synced vault wiped with `find -type f -delete` (folder tree kept), config volume kept | **Syncs — mass deletions pushed** | Stops (guard) |
| Vault holding only synced settings, wiped with config volume kept | Stops (guard) | Stops (guard) |
| All notes deleted by hand inside a live vault, restarted | Stops; never boots again | Boots — the engine removed those rows as the files went, so the record is empty |
| Fresh device, empty vault | Boots | Boots |

Existing deployments need nothing: their `state.db` already exists and already records their files. A leftover `.vault-synced` is inert.

## How the tier works

Each scenario is one `docker run` of the locally built `remote` image with a single file swapped: the harness bind-mounts the `ob` stub read-only over the real Sync client's `cli.js` — the file the `.bin/ob` symlink on `PATH` points at — so every `ob login` / `sync-setup` / `sync` the init chain issues hits the stub. Everything else is the real image: the real s6 init chain, the real `init-first-sync`, real named volumes. Around that one mount:

- `--pull=never` — only the image this branch just built; never a silent fallback to the published `:remote`.
- `-e KEY=VALUE` per scenario — `VAULT_NAME`, `STORAGE_ROOT`, the `OB_STUB_*` switches.
- `-v` specs per scenario — three named volumes for the Compose layout, one for `STORAGE_ROOT` mode.
- `-p 127.0.0.1::8000` only when the scenario talks HTTP — Docker picks a free loopback port, the harness reads it back for `/healthz` and the MCP client.
- Argument arrays through `execFile`, never a shell string.

That is what lets the tier run in CI with no Sync credentials.

- `src/__tests__/docker/fixtures/ob` — POSIX `sh` stub bind-mounted read-only over `/opt/obsidian-headless/node_modules/obsidian-headless/cli.js` (the target of the `.bin/ob` symlink on `PATH`). `login` / `sync-setup` / `sync-config` exit 0; one-shot `sync` writes two fixture notes into `$PWD` and records them in a real `state.db` (`local_files`), exactly where the engine keeps it; `sync --continuous` blocks so s6 sees a healthy service. Every one-shot sync creates `.obsidian/.sync.lock` like the real client. Every call is appended to `$XDG_CONFIG_HOME/ob-calls.log` so the sequence can be asserted across `docker restart`. Switches: `OB_STUB_SYNC_FAIL=1` (sync exits 1), `OB_STUB_SYNC_EMPTY=1` (succeeds, records nothing), `OB_STUB_SYNC_CONFIG_ONLY=1` (delivers and records only `.obsidian/appearance.json`). A test-only `ob sync-record <paths>` verb stands in for continuous sync delivering files while the container runs.
- `src/__tests__/docker/docker-harness.ts` — `execFile`-based Docker helpers: run with an OS-assigned loopback port, healthz poll with a per-attempt timeout that fails early with logs if the container stops, `docker exec` reads, stop-wait with a kill deadline, `seedSyncState` for pre-seeding a named config volume with a `state.db` recording N files, `countSyncStateFiles` for reading that record back, and an MCP SDK client factory.
- `src/__tests__/docker/remote-image-boot.test.ts` — 39 tests:
  - **three-volume layout**: exact `container_environment` bytes, `.applied-ids`, sentinel + index locations, the `ob` call sequence, `svc-obsidian-sync` up, server as UID 1000, a synced note served and indexed over MCP, vault holds exactly the synced files.
  - **single-volume layout** (`STORAGE_ROOT=/persist`): the five derived values, `PUBLIC_URL` in the OAuth metadata, everything under `/persist`, `About Me/` bootstrapped after the first sync (the stub records the vault listing just before delivering; it must be empty), legacy paths untouched — then `docker restart`: healthy with no re-chown, call log doubled, sentinel + notes intact.
  - **empty remote vault, memory disabled** (`OB_STUB_SYNC_EMPTY=1`): first sync completes, vault empty, record empty — then `docker restart`: syncs again, guard line absent.
  - **vault wiped after files arrived while running**: boots empty, `ob sync-record` delivers and records a note as continuous sync would, the note is deleted, `docker restart` — the container stops on the guard's ERROR line.
  - **notes deleted by hand while running**: boots empty, `ob sync-record` records an arrived note, the note is deleted and `ob sync-forget` drops its row as the engine does, `docker restart` — boots again with no guard ERROR and a record of 0 files.
  - **config-only remote vault** (`OB_STUB_SYNC_CONFIG_ONLY=1`): vault holds exactly `.obsidian/appearance.json`, record has one row — then `docker restart`: syncs again, guard line absent.
  - **first sync keeps failing** (`OB_STUB_SYNC_FAIL=1`): three attempts then FATAL (memory on, folder absent) or WARNING + services start (memory off).
  - **guards** (one boot per scenario): `STORAGE_ROOT=/`, relative `INDEX_DB_PATH`, missing `OBSIDIAN_AUTH_TOKEN`, missing `VAULT_NAME` (the #476 check), and a seeded `state.db` recording files + empty vault (`seedSyncState`) each stop the container with the exact ERROR line and s6's `unable to start service <oneshot>`.
- `package.json`: `build:remote-image` (the docker build) and `test:remote-boot` (build, then the tier); excluded from `npm test` like `test:cli-pty`.
- `arch_smoke.yml`: the remote target is built with `load` on both legs, then `npm ci` and the vitest config run directly (the buildx step already built the image). Diagnostics and cleanup enumerate the `smoke` and `remote-boot-*` containers with one OR'd name filter. Job timeout 20 → 30 min for cold caches.
- Docs: ARCHITECTURE.md and SECURITY.md guard wording; AGENTS.md structure tree, rootfs-spec exception, and a "Remote image boot tests — when to add" section; CONTRIBUTING.md lists every check the `main` ruleset requires.

## Tests

- `src/vault-mcp/__tests__/init-first-sync.test.ts`: 33 `sh` specs — guard cases seed a real `state.db` via `node:sqlite` (`knownSyncFiles: N`); new cases for a record of zero files (boots), a corrupt store (stops with the read-failure ERROR), `.obsidian/.sync.lock` only (guard fires), a non-Obsidian dotfile only (guard fires), `.obsidian/app.json` only (guard passes), a hidden non-lock entry `.obsidian/.hidden-plugin-data` only (guard passes), and two sync stores with rows in only the first or only the last (guard fires either way; both empty → boots). Content-rule cases: empty folders only (guard fires), a note inside a folder with nothing at the root (guard passes), a nested dotfile as the only file (guard fires). Mutation: dropping `-type f` from `vault_has_content` fails three specs. Folder-row cases: folder rows only (boots), file rows beside folder rows (guard fires); dropping the `folder` filter fails the folder-only spec. Mutations, each killed by exactly the named tests: guard blind to the store (6 tests); `-gt 0` → `-ge 0` (10); fail-open on read error (1).
- `npm run test:remote-boot` locally on Apple Silicon: 39/39 in ~80 s. Mutation (guard blind to the store, image rebuilt): the wiped-while-running and seeded-state scenarios fail on `waitForStopped` — the container keeps running.
- Earlier tier mutations (each failed only the named tests, passed after revert): `printf '%s'` → `'%s\n'` (trailing-newline tests), sentinel `touch` removed (sentinel tests), `STORAGE_ROOT=/` guard without `exit 1`, `.applied-ids` as `1000/1000`, `init-first-sync` dependency moved, `MAX_ATTEMPTS` 3 → 1, seeded sentinel removed (deletion-storm scenario keeps running → `waitForStopped` fails).
- Workflow shell under `bash -e`: the OR'd filter matches both container families; the empty list exits 0.
- Delta ship-check (pr-review, code-quality, test-audit, bug-check) on the commits after the first review round: 3 findings, all fixed (stale comment, negative `AbortSignal.timeout`, `allowScripts` puppeteer key).
- `npm run prettier:check`, `npm run lint`, `npm run build` (both tsconfigs); all CI checks green on both arches.

## Live validation

Local `remote` build of this branch (arm64), real Obsidian Sync credentials, a throwaway device name, `SYNC_MODE=pull-only`, three named volumes:

1. Fresh volumes → first sync completed, server started. The real client's `state.db` has tables `meta, local_files, server_files, pending_files`; `local_files(path, data)` held 2,242 rows — 2,101 file rows (equal to the 2,101 files on disk) plus 141 folder rows. The script's own `known_sync_files` returned 2242 (before the file-row filter; it would return 2101 now).
2. `docker restart` → guard read the record, vault had content, first sync completed, server started.
3. Vault volume emptied with the config volume kept → guard stopped the container before any sync (`ERROR: The vault is empty but this device has previously synced.` → `rc.init: fatal`, exit 1).

No `Deleting` line appeared in any boot. The record includes folder rows (`"folder": true` in each row's data). The guard now counts only file rows (`73c7a0e`), so a vault emptied of notes while its folders remain boots normally; at validation time the sum was 2,242 because the filter had not been added yet.

## Not exercised here

Real Obsidian Sync in CI — the stub replaces it there; Test Deploy remains the check for the built image against a live account.




