### PR TITLE
feat(oauth)!: bind refresh tokens to MCP_AUTH_TOKEN and their client so rotation revokes every session

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -602,25 +602,33 @@ sequenceDiagram
 Signed with HMAC-SHA256 using `MCP_AUTH_TOKEN` as the key. Both the Lambda
 authorizer and Express can verify independently — no shared state needed.
 
-**Token storage:** Refresh tokens and registered clients are persisted in
-SQLite (`/data/oauth.db`) — survives container restarts, no re-authentication
-needed after deploys for active clients. Each refresh token is stored under an
-HMAC of the token keyed by `MCP_AUTH_TOKEN`, never in plaintext: a row is only
-reachable under the auth token that wrote it, and a copied `oauth.db` holds no
-token a client could present. Auth codes are in-memory (short-lived, 10
-minutes). A refresh token is honoured only for the client it was issued to, and
-a refresh may narrow the granted scope but never widen it. Access tokens are
-JWTs (stateless, no storage needed). Revoked access tokens are tracked in
-SQLite; a revoked refresh token is simply deleted.
+**Token storage:** what each credential is and where it lives.
+
+- **Registered clients** — persisted in SQLite (`/data/oauth.db`), so they
+  survive container restarts and active clients don't re-authenticate after a
+  deploy.
+- **Refresh tokens** — persisted in the same database, stored under an HMAC of
+  the token keyed by `MCP_AUTH_TOKEN`, never in plaintext. A row is only
+  reachable under the auth token that wrote it, and a copied `oauth.db` holds
+  no token a client could present.
+- **Refresh grants** — a refresh token is honoured only for the client it was
+  issued to, and a refresh may narrow the granted scope but never widen it.
+- **Auth codes** — in-memory, short-lived (10 minutes).
+- **Access tokens** — JWTs; stateless, no storage.
+- **Revoked tokens** — revoked access tokens are tracked in SQLite; a revoked
+  refresh token is simply deleted.
 
 **Refresh token expiry:** 60-day sliding (inactivity) window. Each successful
 use rotates the token AND extends the window by another 60 days, so a daily
 client never sees expiry. A client dormant for >60 days is forced through the
-full OAuth flow on its next attempt. The schema column is `expires_at INTEGER
-NOT NULL`; a row past `expires_at` is deleted when its token is presented, and
-every remaining expired row is purged each time a new refresh token is issued,
-so rows left by dormant clients or by a token rotation never accumulate. This bounds the blast radius of a leaked refresh token without
-inconveniencing active sessions.
+full OAuth flow on its next attempt. This bounds the blast radius of a leaked
+refresh token without inconveniencing active sessions. Expired rows
+(`expires_at INTEGER NOT NULL`) are removed two ways:
+
+- a row past `expires_at` is deleted when its token is presented;
+- every remaining expired row is purged each time a new refresh token is
+  issued, so rows left by dormant clients or by a token rotation never
+  accumulate.
 
 **Rate limiting:** OAuth endpoints (`/token`, `/register`, `/authorize`,
 `/revoke`) are rate-limited at 5 req/min per client IP, bucketed by a
@@ -647,12 +655,15 @@ direct-to-server traffic, not reverse-proxy deployments.) A tripped limiter
 emits an `oauth_rate_limited` warn log with the client IP and endpoint path
 before returning the 429.
 
-**Rotating `MCP_AUTH_TOKEN`:** Update the SST secret AND the Lightsail `.env`, then redeploy
-both. Rotation ends every OAuth session: existing JWTs signed with the old key
-become invalid immediately, and every stored refresh token becomes unreachable
-because rows are keyed under the old token. Each client goes back through the
-consent page on its next request. Procedure:
-[`DEPLOY.md`](./DEPLOY.md#rotating-mcp_auth_token).
+**Rotating `MCP_AUTH_TOKEN`:** update the SST secret AND the Lightsail `.env`,
+then redeploy both
+([`DEPLOY.md`](./DEPLOY.md#rotating-mcp_auth_token)). Rotation ends every
+OAuth session:
+
+- existing JWTs signed with the old key become invalid immediately;
+- every stored refresh token becomes unreachable, because rows are keyed
+  under the old token;
+- each client goes back through the consent page on its next request.
 
 ### Optional hardening + customization
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -604,17 +604,21 @@ authorizer and Express can verify independently — no shared state needed.
 
 **Token storage:** Refresh tokens and registered clients are persisted in
 SQLite (`/data/oauth.db`) — survives container restarts, no re-authentication
-needed after deploys for active clients. Auth codes are in-memory (short-lived,
-10 minutes). Access tokens are JWTs (stateless, no storage needed). Revoked
-tokens are tracked in SQLite.
+needed after deploys for active clients. Each refresh token is stored under an
+HMAC of the token keyed by `MCP_AUTH_TOKEN`, never in plaintext: a row is only
+reachable under the auth token that wrote it, and a copied `oauth.db` holds no
+token a client could present. Auth codes are in-memory (short-lived, 10
+minutes). Access tokens are JWTs (stateless, no storage needed). Revoked access
+tokens are tracked in SQLite; a revoked refresh token is simply deleted.
 
 **Refresh token expiry:** 60-day sliding (inactivity) window. Each successful
 use rotates the token AND extends the window by another 60 days, so a daily
 client never sees expiry. A client dormant for >60 days is forced through the
 full OAuth flow on its next attempt. The schema column is `expires_at INTEGER
-NOT NULL`; rows past `expires_at` are deleted on read so the table self-cleans.
-This bounds the blast radius of a leaked refresh token without inconveniencing
-active sessions.
+NOT NULL`; rows past `expires_at` are purged each time a new refresh token is
+issued, so rows left by dormant clients or by a token rotation never
+accumulate. This bounds the blast radius of a leaked refresh token without
+inconveniencing active sessions.
 
 **Rate limiting:** OAuth endpoints (`/token`, `/register`, `/authorize`,
 `/revoke`) are rate-limited at 5 req/min per client IP, bucketed by a
@@ -642,9 +646,10 @@ emits an `oauth_rate_limited` warn log with the client IP and endpoint path
 before returning the 429.
 
 **Rotating `MCP_AUTH_TOKEN`:** Update the SST secret AND the Lightsail `.env`, then redeploy
-both. Existing JWTs signed with the old key become invalid immediately.
-Refresh tokens in SQLite are unaffected — clients silently get new JWTs
-signed with the new key on their next token refresh. Procedure:
+both. Rotation ends every OAuth session: existing JWTs signed with the old key
+become invalid immediately, and every stored refresh token becomes unreachable
+because rows are keyed under the old token. Each client goes back through the
+consent page on its next request. Procedure:
 [`DEPLOY.md`](./DEPLOY.md#rotating-mcp_auth_token).
 
 ### Optional hardening + customization

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -608,8 +608,10 @@ needed after deploys for active clients. Each refresh token is stored under an
 HMAC of the token keyed by `MCP_AUTH_TOKEN`, never in plaintext: a row is only
 reachable under the auth token that wrote it, and a copied `oauth.db` holds no
 token a client could present. Auth codes are in-memory (short-lived, 10
-minutes). Access tokens are JWTs (stateless, no storage needed). Revoked access
-tokens are tracked in SQLite; a revoked refresh token is simply deleted.
+minutes). A refresh token is honoured only for the client it was issued to, and
+a refresh may narrow the granted scope but never widen it. Access tokens are
+JWTs (stateless, no storage needed). Revoked access tokens are tracked in
+SQLite; a revoked refresh token is simply deleted.
 
 **Refresh token expiry:** 60-day sliding (inactivity) window. Each successful
 use rotates the token AND extends the window by another 60 days, so a daily

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -660,7 +660,8 @@ then redeploy both
 ([`DEPLOY.md`](./DEPLOY.md#rotating-mcp_auth_token)). Rotation ends every
 OAuth session:
 
-- existing JWTs signed with the old key become invalid immediately;
+- existing access JWTs, signed with the old key, fail verification
+  immediately (without a rotation they live for 24 hours);
 - every stored refresh token becomes unreachable, because rows are keyed
   under the old token;
 - each client goes back through the consent page on its next request.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -617,9 +617,9 @@ SQLite; a revoked refresh token is simply deleted.
 use rotates the token AND extends the window by another 60 days, so a daily
 client never sees expiry. A client dormant for >60 days is forced through the
 full OAuth flow on its next attempt. The schema column is `expires_at INTEGER
-NOT NULL`; rows past `expires_at` are purged each time a new refresh token is
-issued, so rows left by dormant clients or by a token rotation never
-accumulate. This bounds the blast radius of a leaked refresh token without
+NOT NULL`; a row past `expires_at` is deleted when its token is presented, and
+every remaining expired row is purged each time a new refresh token is issued,
+so rows left by dormant clients or by a token rotation never accumulate. This bounds the blast radius of a leaked refresh token without
 inconveniencing active sessions.
 
 **Rate limiting:** OAuth endpoints (`/token`, `/register`, `/authorize`,

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -404,6 +404,8 @@ ssh -i ~/.ssh/vault-cortex ubuntu@<lightsailIp> \
 
 ### Rotating `MCP_AUTH_TOKEN`
 
+Rotation ends every OAuth session — each connected client goes back through the consent page on its next request, and clients that use the token directly need the new value.
+
 The token must stay in sync across three places: the SST secret (`sst secret set McpAuthToken`), the GitHub repo secret, and the instance `.env`. CI writes the instance `.env` from the GitHub secret on every deploy, so the laptop rotation procedure becomes:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Vault Cortex writes to personal notes — the file safety layer is built to prev
 - **Injection prevention** — search queries are parameterized and FTS5-sanitized; prompt content is wrapped in XML data markers with closing-tag escaping to prevent tag-breakout injection.
 - **Container hardening** — non-root user, PID 1 init, no package managers in the runtime image, digest-pinned base, graceful shutdown.
 
-See [ARCHITECTURE.md → Data Integrity](./ARCHITECTURE.md#data-integrity) for mechanism details and [SECURITY.md → Runtime Hardening](./SECURITY.md#runtime-hardening) for the full attack-surface inventory.
+See [ARCHITECTURE.md → Data Integrity](./ARCHITECTURE.md#data-integrity) for mechanism details and [SECURITY.md → Runtime Hardening](./SECURITY.md#runtime-hardening) for how each part of the server is hardened.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Two methods:
 | **OAuth 2.1**     | Claude Desktop, Claude Code, claude.ai, any OAuth client | JWT (HS256, 24h)     |
 | **Static bearer** | Claude Code, MCP Inspector, curl                         | Raw `MCP_AUTH_TOKEN` |
 
-OAuth uses dynamic client registration — no Client ID/Secret needed. A consent page opens in your browser; enter your `MCP_AUTH_TOKEN` to approve. Refresh tokens have a 60-day sliding expiry (daily users never re-authenticate).
+OAuth uses dynamic client registration — no Client ID/Secret needed. A consent page opens in your browser; enter your `MCP_AUTH_TOKEN` to approve. Refresh tokens have a 60-day sliding expiry (daily users never re-authenticate). Rotating `MCP_AUTH_TOKEN` ends every session — each client re-authorizes through the consent page.
 
 See [ARCHITECTURE.md → Auth](./ARCHITECTURE.md#auth-oauth-21--defense-in-depth) for the full flow diagram.
 

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -240,12 +240,13 @@ downtime.
 - **`MCP_AUTH_TOKEN`** signs access JWTs and keys the lookup of stored
   refresh tokens. It's in SST secrets and gets redeployed to
   `/opt/vault-cortex/.env` on any fresh boot. If you also rotated it during
-  the outage, the rotation rules apply on top of the restore: existing
-  access JWTs are rejected on their next request (their signatures were
-  made with the old secret — unlike a restore without rotation, where they
-  stay valid until they expire), stored refresh tokens can no longer be
-  found, and you approve each client again on the consent page the next
-  time it connects.
+  the outage, the rotation rules apply on top of the restore:
+  - Existing access JWTs are rejected on their next request — their
+    signatures were made with the old secret. Without a rotation they stay
+    valid until they expire.
+  - Stored refresh tokens can no longer be found.
+  - You approve each client again on the consent page the next time it
+    connects.
 
 ## Verifying the seatbelts work
 

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -233,8 +233,9 @@ downtime.
     carry over and clients silently get new JWTs on their next refresh.
   - Snapshot from before refresh tokens were stored under their HMAC key:
     the first boot clears the raw rows and each client re-auths once.
-  - DB gone (Scenario C): every client re-auths via the consent page on its
-    next token refresh — minor inconvenience, no data loss.
+  - Fresh instance with no snapshot to restore (Scenario C): `oauth.db`
+    starts empty, so every client re-auths via the consent page on its next
+    token refresh — minor inconvenience, no data loss.
 - **`MCP_AUTH_TOKEN`** signs JWTs and keys the stored refresh tokens. It's
   in SST secrets and gets redeployed to `/opt/vault-cortex/.env` on any
   fresh boot. If you rotated it during the outage, every JWT and every

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -228,14 +228,16 @@ downtime.
 - **Existing JWTs (24h)** keep working until expiry — `/mcp` validation
   is stateless HMAC signature checking. Clients hold these silently.
 - **Refresh tokens** are in `oauth.db` on the restored disk. If the
-  snapshot is recent (Scenario B), refresh tokens carry over and clients
-  silently get new JWTs on their next refresh cycle. If the DB is gone
-  (Scenario C), every client re-auths via the consent page on its next
-  token refresh — minor inconvenience, no data loss.
-- **`MCP_AUTH_TOKEN`** is the JWT signing HMAC key. It's in SST secrets
-  and gets redeployed to `/opt/vault-cortex/.env` on any fresh boot. If
-  you rotated it during the outage, all existing JWTs die immediately
-  and every client re-auths on their next call.
+  snapshot is recent (Scenario B) and `MCP_AUTH_TOKEN` is unchanged,
+  refresh tokens carry over and clients silently get new JWTs on their
+  next refresh cycle. If the DB is gone (Scenario C), every client
+  re-auths via the consent page on its next token refresh — minor
+  inconvenience, no data loss.
+- **`MCP_AUTH_TOKEN`** is the JWT signing HMAC key and the key under which
+  refresh tokens are stored. It's in SST secrets and gets redeployed to
+  `/opt/vault-cortex/.env` on any fresh boot. If you rotated it during
+  the outage, all existing JWTs die immediately, every stored refresh
+  token becomes unreachable, and every client re-auths on its next call.
 
 ## Verifying the seatbelts work
 

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -237,11 +237,15 @@ downtime.
   - Fresh instance with no snapshot to restore (Scenario C): `oauth.db`
     starts empty, so every client re-auths via the consent page on its next
     token refresh — minor inconvenience, no data loss.
-- **`MCP_AUTH_TOKEN`** signs JWTs and keys the stored refresh tokens. It's
-  in SST secrets and gets redeployed to `/opt/vault-cortex/.env` on any
-  fresh boot. If you rotated it during the outage, every JWT and every
-  stored refresh token stops working, and every client re-auths on its
-  next call.
+- **`MCP_AUTH_TOKEN`** signs access JWTs and keys the lookup of stored
+  refresh tokens. It's in SST secrets and gets redeployed to
+  `/opt/vault-cortex/.env` on any fresh boot. If you also rotated it during
+  the outage, the rotation rules apply on top of the restore: existing
+  access JWTs are rejected on their next request (their signatures were
+  made with the old secret — unlike a restore without rotation, where they
+  stay valid until they expire), stored refresh tokens can no longer be
+  found, and you approve each client again on the consent page the next
+  time it connects.
 
 ## Verifying the seatbelts work
 

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -232,7 +232,8 @@ downtime.
   - Recent snapshot (Scenario B), `MCP_AUTH_TOKEN` unchanged: refresh tokens
     carry over and clients silently get new JWTs on their next refresh.
   - Snapshot from before refresh tokens were stored under their HMAC key:
-    the first boot clears the raw rows and each client re-auths once.
+    the first boot clears the raw rows and each client re-auths once — when
+    its access JWT expires, within 24 hours.
   - Fresh instance with no snapshot to restore (Scenario C): `oauth.db`
     starts empty, so every client re-auths via the consent page on its next
     token refresh — minor inconvenience, no data loss.

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -227,19 +227,19 @@ downtime.
 
 - **Existing JWTs (24h)** keep working until expiry — `/mcp` validation
   is stateless HMAC signature checking. Clients hold these silently.
-- **Refresh tokens** are in `oauth.db` on the restored disk. If the
-  snapshot is recent (Scenario B) and `MCP_AUTH_TOKEN` is unchanged,
-  refresh tokens carry over and clients silently get new JWTs on their
-  next refresh cycle. A snapshot taken before refresh tokens were stored
-  under their HMAC key holds raw rows, which the first boot
-  clears — each client re-auths once. If the DB is gone (Scenario C),
-  every client re-auths via the consent page on its next token refresh —
-  minor inconvenience, no data loss.
-- **`MCP_AUTH_TOKEN`** is the JWT signing HMAC key and the key under which
-  refresh tokens are stored. It's in SST secrets and gets redeployed to
-  `/opt/vault-cortex/.env` on any fresh boot. If you rotated it during
-  the outage, all existing JWTs die immediately, every stored refresh
-  token becomes unreachable, and every client re-auths on its next call.
+- **Refresh tokens** are in `oauth.db` on the restored disk. What happens
+  next depends on the snapshot:
+  - Recent snapshot (Scenario B), `MCP_AUTH_TOKEN` unchanged: refresh tokens
+    carry over and clients silently get new JWTs on their next refresh.
+  - Snapshot from before refresh tokens were stored under their HMAC key:
+    the first boot clears the raw rows and each client re-auths once.
+  - DB gone (Scenario C): every client re-auths via the consent page on its
+    next token refresh — minor inconvenience, no data loss.
+- **`MCP_AUTH_TOKEN`** signs JWTs and keys the stored refresh tokens. It's
+  in SST secrets and gets redeployed to `/opt/vault-cortex/.env` on any
+  fresh boot. If you rotated it during the outage, every JWT and every
+  stored refresh token stops working, and every client re-auths on its
+  next call.
 
 ## Verifying the seatbelts work
 

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -230,9 +230,11 @@ downtime.
 - **Refresh tokens** are in `oauth.db` on the restored disk. If the
   snapshot is recent (Scenario B) and `MCP_AUTH_TOKEN` is unchanged,
   refresh tokens carry over and clients silently get new JWTs on their
-  next refresh cycle. If the DB is gone (Scenario C), every client
-  re-auths via the consent page on its next token refresh — minor
-  inconvenience, no data loss.
+  next refresh cycle. A snapshot taken before refresh tokens were stored
+  under their HMAC key holds raw rows, which the first boot
+  clears — each client re-auths once. If the DB is gone (Scenario C),
+  every client re-auths via the consent page on its next token refresh —
+  minor inconvenience, no data loss.
 - **`MCP_AUTH_TOKEN`** is the JWT signing HMAC key and the key under which
   refresh tokens are stored. It's in SST secrets and gets redeployed to
   `/opt/vault-cortex/.env` on any fresh boot. If you rotated it during

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,12 +3,12 @@
 ## Scope
 
 Vault Cortex is a remote MCP server that exposes an Obsidian vault over HTTPS.
-The attack surface below covers the server itself — what ships in the Docker
+This section covers the server itself — what ships in the Docker
 image. Deployers bring their own TLS termination, reverse proxy, and CI/CD
 pipeline; those are outside vault-cortex's scope but the reference deployment
 notes below describe what the maintainer uses.
 
-### Server attack surface
+### What the server exposes
 
 - **Authentication and authorization** — OAuth 2.1 (Authorization Code + PKCE),
   JWT tokens (HS256), static bearer token fallback, Express middleware (defense

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,7 +70,9 @@ mechanism-level detail.
   configuration, where `SYNC_CONFIGS` syncs community plugin settings to
   the server whenever the desktop pushes them.
 - The search index and OAuth databases live outside the vault (the
-  default `/data` volume), so the file tools can't reach them.
+  default `/data` volume), so the file tools can't reach them. The OAuth
+  database stores refresh tokens keyed by an HMAC under `MCP_AUTH_TOKEN`,
+  so a copy of it holds no usable credential.
   Hidden-path blocking does not cover a database relocated into a
   _visible_ vault folder — there it is readable like any other vault
   file.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,12 +3,12 @@
 ## Scope
 
 Vault Cortex is a remote MCP server that exposes an Obsidian vault over HTTPS.
-This section covers the server itself — what ships in the Docker
+The attack surface below covers the server itself — what ships in the Docker
 image. Deployers bring their own TLS termination, reverse proxy, and CI/CD
 pipeline; those are outside vault-cortex's scope but the reference deployment
 notes below describe what the maintainer uses.
 
-### What the server exposes
+### Server attack surface
 
 - **Authentication and authorization** — OAuth 2.1 (Authorization Code + PKCE),
   JWT tokens (HS256), static bearer token fallback, Express middleware (defense

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -143,11 +143,10 @@ under **Variables**: `READONLY_MODE=true` removes every tool that writes to
 the vault, and `FILE_TOOLS_ENABLED=false` or `MEMORY_ENABLED=false` hide
 those tool groups entirely (see [Configuration](#configuration)).
 
-Rotating `MCP_AUTH_TOKEN` invalidates the access tokens issued under it;
-clients that still hold a refresh token reconnect on their own, so remove
-the server from a client you no longer trust rather than relying on
-rotation alone. The full attack-surface inventory is in
-[SECURITY.md](../../SECURITY.md).
+Rotating `MCP_AUTH_TOKEN` ends every session: access tokens issued under
+the old value stop working, stored refresh tokens become unusable, and each
+client goes back through the consent page on its next request. The full
+attack-surface inventory is in [SECURITY.md](../../SECURITY.md).
 
 ## First start
 
@@ -244,7 +243,7 @@ The template sets these; change them under the service's **Variables** tab
 | `DEVICE_NAME`                     | `vault-cortex`  | The device name that labels this container's changes in Obsidian's sync log.                                                                                                              |
 | `TRUST_PROXY_HOPS`                | `2`             | Two Railway proxies sit between a visitor and the container; this lets the server see the visitor's real address in its logs and rate limits.                                             |
 | `RAILWAY_HEALTHCHECK_TIMEOUT_SEC` | `900`           | How long Railway waits for the first health check — the first start downloads the vault and builds the index.                                                                             |
-| `MCP_AUTH_TOKEN`                  | generated       | Your MCP client's token. Change it here to rotate it.                                                                                                                                     |
+| `MCP_AUTH_TOKEN`                  | generated       | Your MCP client's token. Change it here to rotate it — every connected client re-authorizes.                                                                                              |
 | `OBSIDIAN_AUTH_TOKEN`             | yours           | Obsidian Sync login. Re-run `get-sync-token` and paste the new value if Sync ever rejects it.                                                                                             |
 | `VAULT_NAME`                      | yours           | The vault this container syncs.                                                                                                                                                           |
 | `VAULT_PASSWORD`                  | yours / empty   | End-to-end encryption password, if your vault has one.                                                                                                                                    |

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -145,8 +145,9 @@ those tool groups entirely (see [Configuration](#configuration)).
 
 Rotating `MCP_AUTH_TOKEN` ends every session: access tokens issued under
 the old value stop working, stored refresh tokens become unusable, and each
-client goes back through the consent page on its next request. The full
-attack-surface inventory is in [SECURITY.md](../../SECURITY.md).
+client goes back through the consent page on its next request.
+[SECURITY.md](../../SECURITY.md) describes what the server exposes and how
+each part is hardened.
 
 ## First start
 

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -131,11 +131,10 @@ under **Environment**: `READONLY_MODE=true` removes every tool that writes
 to the vault, and `FILE_TOOLS_ENABLED=false` or `MEMORY_ENABLED=false` hide
 those tool groups entirely (see [Configuration](#configuration)).
 
-Rotating `MCP_AUTH_TOKEN` invalidates the access tokens issued under it;
-clients that still hold a refresh token reconnect on their own, so remove
-the server from a client you no longer trust rather than relying on
-rotation alone. The full attack-surface inventory is in
-[SECURITY.md](../../SECURITY.md).
+Rotating `MCP_AUTH_TOKEN` ends every session: access tokens issued under
+the old value stop working, stored refresh tokens become unusable, and each
+client goes back through the consent page on its next request. The full
+attack-surface inventory is in [SECURITY.md](../../SECURITY.md).
 
 ## First start
 
@@ -230,7 +229,7 @@ tab (each change triggers a redeploy):
 | `PORT`                  | `8000`          | The port the image listens on. Leave as is.                                                                                                                                               |
 | `DEVICE_NAME`           | `vault-cortex`  | The device name that labels this container's changes in Obsidian's sync log.                                                                                                              |
 | `TRUST_PROXY_HOPS`      | `2`             | Render's network puts two proxies between a visitor and the container; this lets the server see the visitor's real address in its logs and rate limits.                                   |
-| `MCP_AUTH_TOKEN`        | generated       | Your MCP client's token. Change it here to rotate it.                                                                                                                                     |
+| `MCP_AUTH_TOKEN`        | generated       | Your MCP client's token. Change it here to rotate it — every connected client re-authorizes.                                                                                              |
 | `OBSIDIAN_AUTH_TOKEN`   | yours           | Obsidian Sync login. Re-run `get-sync-token` and paste the new value if Sync ever rejects it.                                                                                             |
 | `VAULT_NAME`            | yours           | The vault this container syncs.                                                                                                                                                           |
 | `VAULT_PASSWORD`        | yours / empty   | End-to-end encryption password, if your vault has one.                                                                                                                                    |

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -133,8 +133,9 @@ those tool groups entirely (see [Configuration](#configuration)).
 
 Rotating `MCP_AUTH_TOKEN` ends every session: access tokens issued under
 the old value stop working, stored refresh tokens become unusable, and each
-client goes back through the consent page on its next request. The full
-attack-surface inventory is in [SECURITY.md](../../SECURITY.md).
+client goes back through the consent page on its next request.
+[SECURITY.md](../../SECURITY.md) describes what the server exposes and how
+each part is hardened.
 
 ## First start
 

--- a/src/__tests__/integration/server-integration.test.ts
+++ b/src/__tests__/integration/server-integration.test.ts
@@ -1329,14 +1329,17 @@ describe("rotating MCP_AUTH_TOKEN", () => {
     if (!isIssuedTokens(rotatedTokens)) throw new Error("malformed refresh")
     await before.cleanup()
 
-    const after = await startServer(port, {
+    // A fresh port: the first server's socket can linger after exit, and
+    // only the data directory needs to carry over.
+    const rotatedPort = await freePort()
+    const after = await startServer(rotatedPort, {
       MCP_AUTH_TOKEN: TOKEN_B,
       INDEX_DB_PATH: indexDbPath,
     })
     onTestFinished(() => after.cleanup())
 
     const rejected = await refresh({
-      port,
+      port: rotatedPort,
       client,
       refreshToken: rotatedTokens.refresh_token,
     })
@@ -1345,14 +1348,20 @@ describe("rotating MCP_AUTH_TOKEN", () => {
       error: "invalid_grant",
       error_description: "Refresh token expired or invalid",
     })
-    expect(await mcpStatusWithBearer(port, rotatedTokens.access_token)).toBe(
-      401,
-    )
+    expect(
+      await mcpStatusWithBearer(rotatedPort, rotatedTokens.access_token),
+    ).toBe(401)
 
-    const reissued = await authorize({ port, client, authToken: TOKEN_B })
-    expect(await mcpStatusWithBearer(port, reissued.access_token)).toBe(200)
+    const reissued = await authorize({
+      port: rotatedPort,
+      client,
+      authToken: TOKEN_B,
+    })
+    expect(await mcpStatusWithBearer(rotatedPort, reissued.access_token)).toBe(
+      200,
+    )
     const refreshedAgain = await refresh({
-      port,
+      port: rotatedPort,
       client,
       refreshToken: reissued.refresh_token,
     })

--- a/src/__tests__/integration/server-integration.test.ts
+++ b/src/__tests__/integration/server-integration.test.ts
@@ -10,6 +10,10 @@ import {
   onTestFinished,
   vi,
 } from "vitest"
+import { createHash, randomBytes } from "node:crypto"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import {
   startServer,
@@ -1138,4 +1142,220 @@ describe("boot rejection", () => {
     expect(stderr).toContain('"message":"server failed to listen"')
     expect(stderr).toContain("EADDRINUSE")
   }, 30_000)
+})
+
+// ── Rotating MCP_AUTH_TOKEN ends every OAuth session ───────────
+
+describe("rotating MCP_AUTH_TOKEN", () => {
+  const REDIRECT_URI = "http://127.0.0.1/callback"
+  const TOKEN_A = "integration-token-before-rotation"
+  const TOKEN_B = "integration-token-after-rotation"
+
+  const base64Url = (buffer: Buffer): string =>
+    buffer
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "")
+
+  type RegisteredClient = { client_id: string; client_secret: string }
+  type IssuedTokens = { access_token: string; refresh_token: string }
+
+  const isRegisteredClient = (value: unknown): value is RegisteredClient =>
+    typeof value === "object" &&
+    value !== null &&
+    "client_id" in value &&
+    "client_secret" in value
+
+  const isIssuedTokens = (value: unknown): value is IssuedTokens =>
+    typeof value === "object" &&
+    value !== null &&
+    "access_token" in value &&
+    "refresh_token" in value
+
+  /** Initialize over /mcp with the transport's required Accept header, so
+   *  a valid bearer is distinguishable (200) from a rejected one (401). */
+  const mcpStatusWithBearer = async (
+    port: number,
+    bearer: string,
+  ): Promise<number> => {
+    const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: `Bearer ${bearer}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      }),
+    })
+    return response.status
+  }
+
+  const registerClient = async (port: number): Promise<RegisteredClient> => {
+    const response = await fetch(`http://127.0.0.1:${port}/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        client_name: "integration-test",
+        redirect_uris: [REDIRECT_URI],
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+      }),
+    })
+    expect(response.status).toBe(201)
+    const registered: unknown = await response.json()
+    if (!isRegisteredClient(registered)) throw new Error("malformed client")
+    return registered
+  }
+
+  /** Consent page → approve with the auth token → PKCE code exchange. */
+  const authorize = async ({
+    port,
+    client,
+    authToken,
+  }: {
+    port: number
+    client: RegisteredClient
+    authToken: string
+  }): Promise<IssuedTokens> => {
+    const verifier = base64Url(randomBytes(32))
+    const challenge = base64Url(createHash("sha256").update(verifier).digest())
+    const authorizeUrl = new URL(`http://127.0.0.1:${port}/authorize`)
+    authorizeUrl.search = new URLSearchParams({
+      response_type: "code",
+      client_id: client.client_id,
+      redirect_uri: REDIRECT_URI,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      scope: "vault",
+    }).toString()
+    const consentHtml = await (await fetch(authorizeUrl)).text()
+    const requestId = /name="request_id"\s+value="([^"]+)"/.exec(
+      consentHtml,
+    )?.[1]
+    if (!requestId) throw new Error("consent page carried no request_id")
+
+    const decision = await fetch(`http://127.0.0.1:${port}/oauth/decide`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        request_id: requestId,
+        token: authToken,
+        action: "approve",
+      }),
+      redirect: "manual",
+    })
+    const location = decision.headers.get("location")
+    const code = location ? new URL(location).searchParams.get("code") : null
+    if (!code) {
+      throw new Error(
+        `consent did not redirect with a code: ${decision.status}`,
+      )
+    }
+
+    const tokenResponse = await fetch(`http://127.0.0.1:${port}/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        code_verifier: verifier,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+        redirect_uri: REDIRECT_URI,
+      }),
+    })
+    expect(tokenResponse.status).toBe(200)
+    const issued: unknown = await tokenResponse.json()
+    if (!isIssuedTokens(issued)) throw new Error("malformed token response")
+    return issued
+  }
+
+  const refresh = ({
+    port,
+    client,
+    refreshToken,
+  }: {
+    port: number
+    client: RegisteredClient
+    refreshToken: string
+  }): Promise<Response> =>
+    fetch(`http://127.0.0.1:${port}/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      }),
+    })
+
+  it("rejects every refresh token issued under the old token and accepts a fresh consent", async () => {
+    // The OAuth database lives beside INDEX_DB_PATH, so a test-owned data
+    // directory survives the first server's cleanup and the second boot
+    // opens the same oauth.db under the new token.
+    const dataDir = await mkdtemp(join(tmpdir(), "vc-integ-rotation-"))
+    onTestFinished(async () => {
+      await rm(dataDir, { recursive: true, force: true })
+    })
+    const indexDbPath = join(dataDir, "search.db")
+    const port = await freePort()
+
+    const before = await startServer(port, {
+      MCP_AUTH_TOKEN: TOKEN_A,
+      INDEX_DB_PATH: indexDbPath,
+    })
+    const client = await registerClient(port)
+    const issued = await authorize({ port, client, authToken: TOKEN_A })
+    expect(await mcpStatusWithBearer(port, issued.access_token)).toBe(200)
+    const rotated = await refresh({
+      port,
+      client,
+      refreshToken: issued.refresh_token,
+    })
+    expect(rotated.status).toBe(200)
+    const rotatedTokens: unknown = await rotated.json()
+    if (!isIssuedTokens(rotatedTokens)) throw new Error("malformed refresh")
+    await before.cleanup()
+
+    const after = await startServer(port, {
+      MCP_AUTH_TOKEN: TOKEN_B,
+      INDEX_DB_PATH: indexDbPath,
+    })
+    onTestFinished(() => after.cleanup())
+
+    const rejected = await refresh({
+      port,
+      client,
+      refreshToken: rotatedTokens.refresh_token,
+    })
+    expect(rejected.status).toBe(400)
+    expect(await rejected.json()).toEqual({
+      error: "invalid_grant",
+      error_description: "Refresh token expired or invalid",
+    })
+    expect(await mcpStatusWithBearer(port, rotatedTokens.access_token)).toBe(
+      401,
+    )
+
+    const reissued = await authorize({ port, client, authToken: TOKEN_B })
+    expect(await mcpStatusWithBearer(port, reissued.access_token)).toBe(200)
+    const refreshedAgain = await refresh({
+      port,
+      client,
+      refreshToken: reissued.refresh_token,
+    })
+    expect(refreshedAgain.status).toBe(200)
+  }, 60_000)
 })

--- a/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
@@ -173,7 +173,7 @@ describe("OAuth refresh token sliding expiry", () => {
       DateTime.now().plus({ days: 60 }).toUnixInteger(),
     )
 
-    const tokens = await oauth.provider.exchangeRefreshToken!(
+    const tokens = await oauth.provider.exchangeRefreshToken(
       client,
       "fresh-token",
     )
@@ -194,7 +194,7 @@ describe("OAuth refresh token sliding expiry", () => {
     )
 
     await expect(
-      oauth.provider.exchangeRefreshToken!(client, "expired-token"),
+      oauth.provider.exchangeRefreshToken(client, "expired-token"),
     ).rejects.toThrow("Refresh token expired or invalid")
   })
 
@@ -208,7 +208,7 @@ describe("OAuth refresh token sliding expiry", () => {
     )
 
     await expect(
-      oauth.provider.exchangeRefreshToken!(client, "expired-token"),
+      oauth.provider.exchangeRefreshToken(client, "expired-token"),
     ).rejects.toThrow("Refresh token expired or invalid")
 
     expect(storedRefreshTokenKeys(db)).toEqual([])
@@ -225,24 +225,22 @@ describe("OAuth refresh token sliding expiry", () => {
       DateTime.now().plus({ days: 1 }).toUnixInteger(),
     )
 
-    const tokens = await oauth.provider.exchangeRefreshToken!(
-      client,
-      "first-token",
-    )
+    const tokens = await exchangeRefreshToken(oauth, client, "first-token")
     const newToken = tokens.refresh_token
-    expect(typeof newToken).toBe("string")
-    expect(newToken!.length).toBeGreaterThan(0)
+    if (!newToken) throw new Error("no refresh token issued")
 
     const row = db
-      .prepare("SELECT expires_at FROM refresh_tokens WHERE token = ?")
-      .get(refreshTokenKey(newToken!)) as { expires_at: number } | undefined
-    expect(row).not.toBeUndefined()
+      .prepare<[string], { expires_at: number }>(
+        "SELECT expires_at FROM refresh_tokens WHERE token = ?",
+      )
+      .get(refreshTokenKey(newToken))
+    if (!row) throw new Error("rotated refresh token was not stored")
 
     // The new token's expires_at should be ~60 days from "now" — i.e.
     // a fresh window, not inherited from the old token's expires_at.
     const expected = DateTime.now().plus({ days: 60 }).toUnixInteger()
-    expect(row!.expires_at).toBeGreaterThanOrEqual(expected - 5)
-    expect(row!.expires_at).toBeLessThanOrEqual(expected + 5)
+    expect(row.expires_at).toBeGreaterThanOrEqual(expected - 5)
+    expect(row.expires_at).toBeLessThanOrEqual(expected + 5)
   })
 
   it("invalidates the old token after rotation (single-use)", async () => {
@@ -254,10 +252,10 @@ describe("OAuth refresh token sliding expiry", () => {
       DateTime.now().plus({ days: 60 }).toUnixInteger(),
     )
 
-    await oauth.provider.exchangeRefreshToken!(client, "first-token")
+    await oauth.provider.exchangeRefreshToken(client, "first-token")
 
     await expect(
-      oauth.provider.exchangeRefreshToken!(client, "first-token"),
+      oauth.provider.exchangeRefreshToken(client, "first-token"),
     ).rejects.toThrow("Refresh token expired or invalid")
   })
 
@@ -265,13 +263,13 @@ describe("OAuth refresh token sliding expiry", () => {
     seedRefreshToken(db, "pre-migration-token", client.client_id, ["vault"], 0)
 
     await expect(
-      oauth.provider.exchangeRefreshToken!(client, "pre-migration-token"),
+      oauth.provider.exchangeRefreshToken(client, "pre-migration-token"),
     ).rejects.toThrow("Refresh token expired or invalid")
   })
 
   it("rejects a non-existent refresh token", async () => {
     await expect(
-      oauth.provider.exchangeRefreshToken!(client, "never-existed"),
+      oauth.provider.exchangeRefreshToken(client, "never-existed"),
     ).rejects.toThrow("Refresh token expired or invalid")
   })
 })
@@ -680,7 +678,7 @@ describe("OAuth audit logging", () => {
     )
     logs.length = 0
 
-    await oauth.provider.exchangeRefreshToken!(client, "audit-refresh")
+    await oauth.provider.exchangeRefreshToken(client, "audit-refresh")
 
     const event = logs.find((log) => log.message === "oauth_token_refreshed")
     expect(event).toBeDefined()
@@ -692,7 +690,7 @@ describe("OAuth audit logging", () => {
     const { logs, oauth, client } = await setupAuditTest()
 
     await expect(
-      oauth.provider.exchangeRefreshToken!(client, "nonexistent"),
+      oauth.provider.exchangeRefreshToken(client, "nonexistent"),
     ).rejects.toThrow("Refresh token expired or invalid")
 
     const event = logs.find(

--- a/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
@@ -9,12 +9,16 @@ import {
 import { mkdtemp, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import { createHmac } from "node:crypto"
 import Database from "better-sqlite3"
 import { DateTime } from "luxon"
 import { signJwt } from "../../../jwt.js"
 import { createOAuthProvider } from "../oauth-provider.js"
 import type { OAuthProvider } from "../oauth-provider.js"
-import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js"
+import type {
+  OAuthClientInformationFull,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js"
 import { logger, type Logger } from "../../../logger.js"
 
 type LogCall = {
@@ -38,6 +42,69 @@ const recordingLogger = (sink: LogCall[]): Logger => {
 }
 
 const AUTH_TOKEN = "test-static-token"
+const OTHER_AUTH_TOKEN = "rotated-static-token"
+
+// Mirrors the provider's storage-key derivation so tests can seed and
+// inspect rows without importing production as its own oracle.
+const refreshTokenKey = (token: string, secret = AUTH_TOKEN): string =>
+  createHmac("sha256", secret).update(`refresh-token:${token}`).digest("hex")
+
+const storedRefreshTokenKeys = (db: Database.Database): string[] =>
+  db
+    .prepare<[], { token: string }>(
+      "SELECT token FROM refresh_tokens ORDER BY token",
+    )
+    .all()
+    .map((refreshTokenRow) => refreshTokenRow.token)
+
+const storedRevokedTokens = (db: Database.Database): string[] =>
+  db
+    .prepare<[], { token: string }>(
+      "SELECT token FROM revoked_tokens ORDER BY token",
+    )
+    .all()
+    .map((revokedTokenRow) => revokedTokenRow.token)
+
+const schemaVersion = (db: Database.Database): unknown =>
+  db.pragma("user_version", { simple: true })
+
+const exchangeRefreshToken = (
+  oauth: OAuthProvider,
+  client: OAuthClientInformationFull,
+  refreshToken: string,
+): Promise<OAuthTokens> =>
+  oauth.provider.exchangeRefreshToken(client, refreshToken)
+
+// revokeToken is optional on the SDK's provider type; this provider
+// always implements it.
+const revokeToken = async (
+  oauth: OAuthProvider,
+  client: OAuthClientInformationFull,
+  token: string,
+): Promise<void> => {
+  if (!oauth.provider.revokeToken)
+    throw new Error("revokeToken not implemented")
+  await oauth.provider.revokeToken(client, { token })
+}
+
+/** Runs the real consent → code → token flow and returns the issued tokens. */
+const issueTokens = async (
+  oauth: OAuthProvider,
+  client: OAuthClientInformationFull,
+): Promise<OAuthTokens> => {
+  const requestId = await startAuthFlow(oauth, client)
+  const code = oauth.approveRequest(requestId, logger)
+  return oauth.provider.exchangeAuthorizationCode(client, code)
+}
+
+const issuedRefreshToken = async (
+  oauth: OAuthProvider,
+  client: OAuthClientInformationFull,
+): Promise<string> => {
+  const tokens = await issueTokens(oauth, client)
+  if (!tokens.refresh_token) throw new Error("no refresh token issued")
+  return tokens.refresh_token
+}
 
 const seedClient = (db: Database.Database): OAuthClientInformationFull => {
   const client = {
@@ -72,7 +139,7 @@ const seedRefreshToken = (
 ): void => {
   db.prepare(
     "INSERT INTO refresh_tokens (token, client_id, scopes, expires_at) VALUES (?, ?, ?, ?)",
-  ).run(token, clientId, scopes.join(" "), expiresAt)
+  ).run(refreshTokenKey(token), clientId, scopes.join(" "), expiresAt)
 }
 
 describe("OAuth refresh token sliding expiry", () => {
@@ -146,10 +213,7 @@ describe("OAuth refresh token sliding expiry", () => {
       oauth.provider.exchangeRefreshToken!(client, "expired-token"),
     ).rejects.toThrow("Refresh token expired or invalid")
 
-    const row = db
-      .prepare("SELECT * FROM refresh_tokens WHERE token = ?")
-      .get("expired-token")
-    expect(row).toBeUndefined()
+    expect(storedRefreshTokenKeys(db)).toEqual([])
   })
 
   it("rotates to a new token with a fresh 60-day window on use", async () => {
@@ -171,7 +235,7 @@ describe("OAuth refresh token sliding expiry", () => {
 
     const row = db
       .prepare("SELECT expires_at FROM refresh_tokens WHERE token = ?")
-      .get(newToken!) as { expires_at: number } | undefined
+      .get(refreshTokenKey(newToken!)) as { expires_at: number } | undefined
     expect(row).not.toBeUndefined()
 
     // The new token's expires_at should be ~60 days from "now" — i.e.
@@ -233,8 +297,6 @@ describe("OAuth refresh token schema migration", () => {
         client_id TEXT NOT NULL,
         scopes TEXT NOT NULL
       );
-      INSERT INTO refresh_tokens (token, client_id, scopes)
-      VALUES ('legacy-token', 'legacy-client', 'vault');
     `)
     oldDb.close()
 
@@ -245,36 +307,87 @@ describe("OAuth refresh token schema migration", () => {
     })
 
     const db = new Database(dbPath)
-    try {
-      const columns = db
-        .prepare("SELECT name FROM pragma_table_info('refresh_tokens')")
-        .all() as { name: string }[]
-      expect(columns.map((column) => column.name)).toContain("expires_at")
-
-      const row = db
-        .prepare("SELECT expires_at FROM refresh_tokens WHERE token = ?")
-        .get("legacy-token") as { expires_at: number } | undefined
-      expect(row).toBeDefined()
-      expect(row!.expires_at).toBe(0) // DEFAULT 0 — treated as expired
-    } finally {
+    onTestFinished(() => {
       db.close()
-    }
+    })
+    const columns = db
+      .prepare<[], { name: string }>(
+        "SELECT name FROM pragma_table_info('refresh_tokens')",
+      )
+      .all()
+    expect(columns.map((column) => column.name)).toEqual([
+      "token",
+      "client_id",
+      "scopes",
+      "expires_at",
+    ])
   })
 
-  it("is idempotent — re-running on a migrated DB doesn't error", () => {
+  it("clears raw refresh tokens written before keyed storage and records schema version 1", () => {
+    const oldDb = new Database(dbPath)
+    oldDb.exec(`
+      CREATE TABLE refresh_tokens (
+        token TEXT PRIMARY KEY,
+        client_id TEXT NOT NULL,
+        scopes TEXT NOT NULL,
+        expires_at INTEGER NOT NULL
+      );
+    `)
+    oldDb
+      .prepare(
+        "INSERT INTO refresh_tokens (token, client_id, scopes, expires_at) VALUES (?, ?, ?, ?)",
+      )
+      .run(
+        "legacy-token",
+        "legacy-client",
+        "vault",
+        DateTime.now().plus({ days: 60 }).toUnixInteger(),
+      )
+    oldDb.close()
+
     createOAuthProvider({
       authToken: AUTH_TOKEN,
       dbPath,
       logger,
     })
 
-    expect(() =>
-      createOAuthProvider({
-        authToken: AUTH_TOKEN,
-        dbPath,
-        logger,
-      }),
-    ).not.toThrow()
+    const db = new Database(dbPath)
+    onTestFinished(() => {
+      db.close()
+    })
+    expect(storedRefreshTokenKeys(db)).toEqual([])
+    expect(schemaVersion(db)).toBe(1)
+  })
+
+  it("keeps keyed refresh tokens when the provider is re-opened on a migrated DB", async () => {
+    createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      dbPath,
+      logger,
+    })
+    const db = new Database(dbPath)
+    onTestFinished(() => {
+      db.close()
+    })
+    const client = seedClient(db)
+    seedRefreshToken(
+      db,
+      "live-token",
+      client.client_id,
+      ["vault"],
+      DateTime.now().plus({ days: 60 }).toUnixInteger(),
+    )
+
+    const reopened = createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      dbPath,
+      logger,
+    })
+
+    expect(storedRefreshTokenKeys(db)).toEqual([refreshTokenKey("live-token")])
+    expect(schemaVersion(db)).toBe(1)
+    const tokens = await exchangeRefreshToken(reopened, client, "live-token")
+    expect(tokens.scope).toBe("vault")
   })
 })
 
@@ -611,3 +724,110 @@ const startAuthFlow = async (
   if (!match?.[1]) throw new Error("no request_id in consent HTML")
   return match[1]
 }
+
+describe("OAuth refresh token storage keyed by the auth token", () => {
+  const createKeyedStorageTest = async (): Promise<{
+    dbPath: string
+    oauth: OAuthProvider
+    db: Database.Database
+    client: OAuthClientInformationFull
+  }> => {
+    const dir = await mkdtemp(join(tmpdir(), "oauth-keyed-test-"))
+    const dbPath = join(dir, "oauth.db")
+    const oauth = createOAuthProvider({ authToken: AUTH_TOKEN, dbPath, logger })
+    const db = new Database(dbPath)
+    onTestFinished(async () => {
+      db.close()
+      await rm(dir, { recursive: true, force: true })
+    })
+    const client = seedClient(db)
+    return { dbPath, oauth, db, client }
+  }
+
+  it("stores an issued refresh token only under its HMAC key", async () => {
+    const { oauth, db, client } = await createKeyedStorageTest()
+
+    const refreshToken = await issuedRefreshToken(oauth, client)
+
+    expect(storedRefreshTokenKeys(db)).toEqual([refreshTokenKey(refreshToken)])
+  })
+
+  it("rejects a refresh token issued under a different auth token and leaves its row in place", async () => {
+    const { dbPath, oauth, db, client } = await createKeyedStorageTest()
+    const firstToken = await issuedRefreshToken(oauth, client)
+    const secondToken = await issuedRefreshToken(oauth, client)
+    const rotated = createOAuthProvider({
+      authToken: OTHER_AUTH_TOKEN,
+      dbPath,
+      logger,
+    })
+
+    await expect(
+      exchangeRefreshToken(rotated, client, firstToken),
+    ).rejects.toThrow("Refresh token expired or invalid")
+
+    expect(storedRefreshTokenKeys(db)).toEqual(
+      [refreshTokenKey(firstToken), refreshTokenKey(secondToken)].sort(),
+    )
+    const tokens = await exchangeRefreshToken(oauth, client, secondToken)
+    expect(tokens.scope).toBe("vault")
+  })
+
+  it("purges expired rows when a refresh token is issued", async () => {
+    const { oauth, db, client } = await createKeyedStorageTest()
+    seedRefreshToken(
+      db,
+      "expired-token",
+      client.client_id,
+      ["vault"],
+      DateTime.now().minus({ seconds: 1 }).toUnixInteger(),
+    )
+    seedRefreshToken(
+      db,
+      "live-token",
+      client.client_id,
+      ["vault"],
+      DateTime.now().plus({ days: 60 }).toUnixInteger(),
+    )
+
+    const issued = await issuedRefreshToken(oauth, client)
+
+    expect(storedRefreshTokenKeys(db)).toEqual(
+      [refreshTokenKey("live-token"), refreshTokenKey(issued)].sort(),
+    )
+  })
+
+  it("revoking a refresh token removes its row without recording it in revoked_tokens", async () => {
+    const { oauth, db, client } = await createKeyedStorageTest()
+    const refreshToken = await issuedRefreshToken(oauth, client)
+
+    await revokeToken(oauth, client, refreshToken)
+
+    expect(storedRefreshTokenKeys(db)).toEqual([])
+    expect(storedRevokedTokens(db)).toEqual([])
+    await expect(
+      exchangeRefreshToken(oauth, client, refreshToken),
+    ).rejects.toThrow("Refresh token expired or invalid")
+  })
+
+  it("revoking an access token records it in revoked_tokens and rejects it afterwards", async () => {
+    const { oauth, db, client } = await createKeyedStorageTest()
+    const { access_token: accessToken } = await issueTokens(oauth, client)
+
+    await revokeToken(oauth, client, accessToken)
+
+    expect(storedRevokedTokens(db)).toEqual([accessToken])
+    await expect(oauth.provider.verifyAccessToken(accessToken)).rejects.toThrow(
+      "Token has been revoked",
+    )
+  })
+
+  it("revoking an unknown string records nothing", async () => {
+    const { oauth, db, client } = await createKeyedStorageTest()
+
+    await revokeToken(oauth, client, "not-a-token")
+
+    expect(storedRevokedTokens(db)).toEqual([])
+    expect(storedRefreshTokenKeys(db)).toEqual([])
+  })
+})

--- a/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
@@ -822,6 +822,69 @@ describe("OAuth refresh token storage keyed by the auth token", () => {
     )
   })
 
+  it("rejects a refresh token presented by a client other than the one it was issued to and leaves its row in place", async () => {
+    const { oauth, db, client } = await createKeyedStorageTest()
+    const refreshToken = await issuedRefreshToken(oauth, client)
+    const otherClient: OAuthClientInformationFull = {
+      ...client,
+      client_id: "other-client",
+    }
+
+    await expect(
+      exchangeRefreshToken(oauth, otherClient, refreshToken),
+    ).rejects.toThrow("Refresh token expired or invalid")
+
+    expect(storedRefreshTokenKeys(db)).toEqual([refreshTokenKey(refreshToken)])
+    const tokens = await exchangeRefreshToken(oauth, client, refreshToken)
+    expect(tokens.scope).toBe("vault")
+  })
+
+  it("rejects a refresh that requests a scope outside the granted scope", async () => {
+    const { oauth, client } = await createKeyedStorageTest()
+    const refreshToken = await issuedRefreshToken(oauth, client)
+
+    await expect(
+      oauth.provider.exchangeRefreshToken(client, refreshToken, [
+        "vault",
+        "admin",
+      ]),
+    ).rejects.toThrow("Requested scope exceeds the granted scope")
+  })
+
+  it("issues the stored scope when a refresh requests none", async () => {
+    const { oauth, db, client } = await createKeyedStorageTest()
+    seedRefreshToken(
+      db,
+      "two-scope-token",
+      client.client_id,
+      ["vault", "extra"],
+      DateTime.now().plus({ days: 60 }).toUnixInteger(),
+    )
+
+    const tokens = await exchangeRefreshToken(oauth, client, "two-scope-token")
+
+    expect(tokens.scope).toBe("vault extra")
+  })
+
+  it("narrows the issued scope when a refresh requests a subset", async () => {
+    const { oauth, db, client } = await createKeyedStorageTest()
+    seedRefreshToken(
+      db,
+      "two-scope-token",
+      client.client_id,
+      ["vault", "extra"],
+      DateTime.now().plus({ days: 60 }).toUnixInteger(),
+    )
+
+    const tokens = await oauth.provider.exchangeRefreshToken(
+      client,
+      "two-scope-token",
+      ["vault"],
+    )
+
+    expect(tokens.scope).toBe("vault")
+  })
+
   it("revoking an unknown string records nothing", async () => {
     const { oauth, db, client } = await createKeyedStorageTest()
 

--- a/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
@@ -701,17 +701,52 @@ describe("OAuth audit logging", () => {
     expect(event!.data.reason).toBe("expired_or_invalid")
   })
 
-  it("logs oauth_token_revoked on revocation", async () => {
+  it("logs oauth_token_revoked with the client and an unknown token type when nothing matched", async () => {
     const { logs, oauth, client } = await setupAuditTest()
 
-    await oauth.provider.revokeToken!(client, {
-      token: "some-token",
-      token_type_hint: "access_token",
-    })
+    await revokeToken(oauth, client, "some-token")
+
+    expect(logs.filter((log) => log.message === "oauth_token_revoked")).toEqual(
+      [
+        {
+          level: "info",
+          message: "oauth_token_revoked",
+          data: {
+            component: "oauth",
+            clientId: client.client_id,
+            tokenType: "unknown",
+          },
+        },
+      ],
+    )
+  })
+
+  it("logs tokenType refresh_token when a stored refresh token is revoked", async () => {
+    const { logs, oauth, client } = await setupAuditTest()
+    const refreshToken = await issuedRefreshToken(oauth, client)
+
+    await revokeToken(oauth, client, refreshToken)
 
     const event = logs.find((log) => log.message === "oauth_token_revoked")
-    expect(event).toBeDefined()
-    expect(event!.level).toBe("info")
+    expect(event?.data).toEqual({
+      component: "oauth",
+      clientId: client.client_id,
+      tokenType: "refresh_token",
+    })
+  })
+
+  it("logs tokenType access_token when a valid access JWT is revoked", async () => {
+    const { logs, oauth, client } = await setupAuditTest()
+    const { access_token: accessToken } = await issueTokens(oauth, client)
+
+    await revokeToken(oauth, client, accessToken)
+
+    const event = logs.find((log) => log.message === "oauth_token_revoked")
+    expect(event?.data).toEqual({
+      component: "oauth",
+      clientId: client.client_id,
+      tokenType: "access_token",
+    })
   })
 
   it("logs oauth_token_rejected when a revoked token is verified", async () => {

--- a/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
@@ -47,6 +47,7 @@ const OTHER_AUTH_TOKEN = "rotated-static-token"
 // Mirrors the provider's storage-key derivation so tests can seed and
 // inspect rows without importing production as its own oracle.
 const refreshTokenKey = (token: string, secret = AUTH_TOKEN): string =>
+  "hmac-sha256:" +
   createHmac("sha256", secret).update(`refresh-token:${token}`).digest("hex")
 
 const storedRefreshTokenKeys = (db: Database.Database): string[] =>
@@ -64,9 +65,6 @@ const storedRevokedTokens = (db: Database.Database): string[] =>
     )
     .all()
     .map((revokedTokenRow) => revokedTokenRow.token)
-
-const schemaVersion = (db: Database.Database): unknown =>
-  db.pragma("user_version", { simple: true })
 
 const exchangeRefreshToken = (
   oauth: OAuthProvider,
@@ -217,12 +215,14 @@ describe("OAuth refresh token sliding expiry", () => {
   })
 
   it("rotates to a new token with a fresh 60-day window on use", async () => {
+    // Seeded far from a fresh window so a rotated token that inherited
+    // this expiry would miss the assertion below by ~59 days.
     seedRefreshToken(
       db,
       "first-token",
       client.client_id,
       ["vault"],
-      DateTime.now().plus({ days: 60 }).toUnixInteger(),
+      DateTime.now().plus({ days: 1 }).toUnixInteger(),
     )
 
     const tokens = await oauth.provider.exchangeRefreshToken!(
@@ -323,7 +323,7 @@ describe("OAuth refresh token schema migration", () => {
     ])
   })
 
-  it("clears raw refresh tokens written before keyed storage and records schema version 1", () => {
+  it("clears raw refresh tokens written by a version that stored them in plaintext", () => {
     const oldDb = new Database(dbPath)
     oldDb.exec(`
       CREATE TABLE refresh_tokens (
@@ -356,7 +356,40 @@ describe("OAuth refresh token schema migration", () => {
       db.close()
     })
     expect(storedRefreshTokenKeys(db)).toEqual([])
-    expect(schemaVersion(db)).toBe(1)
+  })
+
+  it("clears raw refresh tokens written after a rollback beside keyed rows it keeps", async () => {
+    createOAuthProvider({ authToken: AUTH_TOKEN, dbPath, logger })
+    const db = new Database(dbPath)
+    onTestFinished(() => {
+      db.close()
+    })
+    const client = seedClient(db)
+    seedRefreshToken(
+      db,
+      "keyed-token",
+      client.client_id,
+      ["vault"],
+      DateTime.now().plus({ days: 60 }).toUnixInteger(),
+    )
+    db.prepare(
+      "INSERT INTO refresh_tokens (token, client_id, scopes, expires_at) VALUES (?, ?, ?, ?)",
+    ).run(
+      "raw-token-from-rollback",
+      client.client_id,
+      "vault",
+      DateTime.now().plus({ days: 60 }).toUnixInteger(),
+    )
+
+    const reopened = createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      dbPath,
+      logger,
+    })
+
+    expect(storedRefreshTokenKeys(db)).toEqual([refreshTokenKey("keyed-token")])
+    const tokens = await exchangeRefreshToken(reopened, client, "keyed-token")
+    expect(tokens.scope).toBe("vault")
   })
 
   it("logs oauth_refresh_tokens_cleared when clearing raw tokens", () => {
@@ -397,14 +430,14 @@ describe("OAuth refresh token schema migration", () => {
         level: "info",
         message: "oauth_refresh_tokens_cleared",
         data: expect.objectContaining({
-          reason: "storage_key_upgrade",
+          reason: "plaintext_rows",
           rows: 1,
         }),
       }),
     )
   })
 
-  it("keeps keyed refresh tokens when the provider is re-opened on a migrated DB", async () => {
+  it("keeps keyed refresh tokens when the provider is re-opened", async () => {
     createOAuthProvider({
       authToken: AUTH_TOKEN,
       dbPath,
@@ -430,7 +463,6 @@ describe("OAuth refresh token schema migration", () => {
     })
 
     expect(storedRefreshTokenKeys(db)).toEqual([refreshTokenKey("live-token")])
-    expect(schemaVersion(db)).toBe(1)
     const tokens = await exchangeRefreshToken(reopened, client, "live-token")
     expect(tokens.scope).toBe("vault")
   })
@@ -942,6 +974,44 @@ describe("OAuth refresh token storage keyed by the auth token", () => {
       client,
       "two-scope-token",
       ["vault"],
+    )
+
+    expect(tokens.scope).toBe("vault")
+  })
+
+  it("keeps a narrowed scope on the rotated refresh token", async () => {
+    const { oauth, db, client } = await createKeyedStorageTest()
+    seedRefreshToken(
+      db,
+      "two-scope-token",
+      client.client_id,
+      ["vault", "extra"],
+      DateTime.now().plus({ days: 60 }).toUnixInteger(),
+    )
+    const narrowed = await oauth.provider.exchangeRefreshToken(
+      client,
+      "two-scope-token",
+      ["vault"],
+    )
+    if (!narrowed.refresh_token) throw new Error("no refresh token issued")
+
+    const tokens = await exchangeRefreshToken(
+      oauth,
+      client,
+      narrowed.refresh_token,
+    )
+
+    expect(tokens.scope).toBe("vault")
+  })
+
+  it("issues the stored scope when a refresh sends a blank scope", async () => {
+    const { oauth, client } = await createKeyedStorageTest()
+    const refreshToken = await issuedRefreshToken(oauth, client)
+
+    const tokens = await oauth.provider.exchangeRefreshToken(
+      client,
+      refreshToken,
+      [""],
     )
 
     expect(tokens.scope).toBe("vault")

--- a/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
@@ -359,6 +359,51 @@ describe("OAuth refresh token schema migration", () => {
     expect(schemaVersion(db)).toBe(1)
   })
 
+  it("logs oauth_refresh_tokens_cleared when clearing raw tokens", () => {
+    const oldDb = new Database(dbPath)
+    oldDb.exec(`
+      CREATE TABLE refresh_tokens (
+        token TEXT PRIMARY KEY,
+        client_id TEXT NOT NULL,
+        scopes TEXT NOT NULL,
+        expires_at INTEGER NOT NULL
+      );
+    `)
+    oldDb
+      .prepare(
+        "INSERT INTO refresh_tokens (token, client_id, scopes, expires_at) VALUES (?, ?, ?, ?)",
+      )
+      .run(
+        "legacy-token",
+        "legacy-client",
+        "vault",
+        DateTime.now().plus({ days: 60 }).toUnixInteger(),
+      )
+    oldDb.close()
+
+    const logs: LogCall[] = []
+    const testLogger = recordingLogger(logs)
+    createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      dbPath,
+      logger: testLogger,
+    })
+
+    const event = logs.find(
+      (log) => log.message === "oauth_refresh_tokens_cleared",
+    )
+    expect(event).toEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "oauth_refresh_tokens_cleared",
+        data: expect.objectContaining({
+          reason: "storage_key_upgrade",
+          rows: 1,
+        }),
+      }),
+    )
+  })
+
   it("keeps keyed refresh tokens when the provider is re-opened on a migrated DB", async () => {
     createOAuthProvider({
       authToken: AUTH_TOKEN,
@@ -851,6 +896,23 @@ describe("OAuth refresh token storage keyed by the auth token", () => {
     ).rejects.toThrow("Requested scope exceeds the granted scope")
   })
 
+  it("consumes the refresh token even when scope validation rejects", async () => {
+    const { oauth, db, client } = await createKeyedStorageTest()
+    const refreshToken = await issuedRefreshToken(oauth, client)
+
+    await expect(
+      oauth.provider.exchangeRefreshToken(client, refreshToken, [
+        "vault",
+        "admin",
+      ]),
+    ).rejects.toThrow("Requested scope exceeds the granted scope")
+
+    expect(storedRefreshTokenKeys(db)).toEqual([])
+    await expect(
+      exchangeRefreshToken(oauth, client, refreshToken),
+    ).rejects.toThrow("Refresh token expired or invalid")
+  })
+
   it("issues the stored scope when a refresh requests none", async () => {
     const { oauth, db, client } = await createKeyedStorageTest()
     seedRefreshToken(
@@ -892,5 +954,46 @@ describe("OAuth refresh token storage keyed by the auth token", () => {
 
     expect(storedRevokedTokens(db)).toEqual([])
     expect(storedRefreshTokenKeys(db)).toEqual([])
+  })
+
+  it("logs scope_exceeds_grant reason when a refresh widens scope", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "oauth-keyed-log-test-"))
+    const dbPath = join(dir, "oauth.db")
+    const logs: LogCall[] = []
+    const testLogger = recordingLogger(logs)
+    const oauth = createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      dbPath,
+      logger: testLogger,
+    })
+    const db = new Database(dbPath)
+    onTestFinished(async () => {
+      db.close()
+      await rm(dir, { recursive: true, force: true })
+    })
+    const client = seedClient(db)
+    const refreshToken = await issuedRefreshToken(oauth, client)
+    logs.length = 0
+
+    await expect(
+      oauth.provider.exchangeRefreshToken(client, refreshToken, [
+        "vault",
+        "admin",
+      ]),
+    ).rejects.toThrow("Requested scope exceeds the granted scope")
+
+    const event = logs.find(
+      (log) => log.message === "oauth_token_refresh_failed",
+    )
+    expect(event).toEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "oauth_token_refresh_failed",
+        data: expect.objectContaining({
+          reason: "scope_exceeds_grant",
+          clientId: client.client_id,
+        }),
+      }),
+    )
   })
 })

--- a/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-routes.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  onTestFinished,
+} from "vitest"
+import { createHash, randomBytes } from "node:crypto"
 import { mkdtemp, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
@@ -769,5 +777,229 @@ describe("OAuth protected resource metadata", () => {
       )
       expect(response.status).toBe(200)
     }
+  })
+})
+
+describe("OAuth refresh over HTTP", () => {
+  type RegisteredClient = { client_id: string; client_secret: string }
+  type IssuedTokens = { access_token: string; refresh_token: string }
+
+  const isRegisteredClient = (value: unknown): value is RegisteredClient =>
+    typeof value === "object" &&
+    value !== null &&
+    "client_id" in value &&
+    "client_secret" in value
+
+  const isIssuedTokens = (value: unknown): value is IssuedTokens =>
+    typeof value === "object" &&
+    value !== null &&
+    "access_token" in value &&
+    "refresh_token" in value
+
+  const base64Url = (buffer: Buffer): string =>
+    buffer
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "")
+
+  const createRefreshTest = async (): Promise<{ baseUrl: string }> => {
+    const dir = await mkdtemp(join(tmpdir(), "oauth-refresh-http-"))
+    const oauth = createOAuthProvider({
+      authToken: AUTH_TOKEN,
+      dbPath: join(dir, "oauth.db"),
+      logger,
+    })
+    const router = createOAuthRoutes({
+      authToken: AUTH_TOKEN,
+      serverUrl: new URL("http://localhost:8000"),
+      oauthProvider: oauth,
+      serviceDocumentationUrl: "https://example.com",
+      trustForwardedHeader: true,
+      logger,
+    })
+    const app = express()
+    app.use(router)
+    const server = await new Promise<Server>((resolve) => {
+      const listening = app.listen(0, () => resolve(listening))
+    })
+    onTestFinished(async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await rm(dir, { recursive: true, force: true })
+    })
+    return { baseUrl: `http://localhost:${getListeningPort(server)}` }
+  }
+
+  // Each registration carries its own Forwarded address so two clients in one
+  // test don't share a rate-limit bucket.
+  const registerClient = async (
+    baseUrl: string,
+    forwardedClientIp: string,
+  ): Promise<RegisteredClient> => {
+    const response = await fetch(`${baseUrl}/register`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        forwarded: `for=${forwardedClientIp}`,
+      },
+      body: JSON.stringify({
+        client_name: "refresh-test",
+        redirect_uris: [REDIRECT_URI],
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+      }),
+    })
+    expect(response.status).toBe(201)
+    const registered: unknown = await response.json()
+    if (!isRegisteredClient(registered)) throw new Error("malformed client")
+    return registered
+  }
+
+  /** Consent page → approve → PKCE code exchange, all over HTTP. */
+  const issueTokens = async (
+    baseUrl: string,
+    client: RegisteredClient,
+    forwardedClientIp: string,
+  ): Promise<IssuedTokens> => {
+    const verifier = base64Url(randomBytes(32))
+    const challenge = base64Url(createHash("sha256").update(verifier).digest())
+    const authorizeUrl = new URL(`${baseUrl}/authorize`)
+    authorizeUrl.search = new URLSearchParams({
+      response_type: "code",
+      client_id: client.client_id,
+      redirect_uri: REDIRECT_URI,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      scope: "vault",
+    }).toString()
+    const consentHtml = await (
+      await fetch(authorizeUrl, {
+        headers: { forwarded: `for=${forwardedClientIp}` },
+      })
+    ).text()
+    const requestId = REQUEST_ID_PATTERN.exec(consentHtml)?.[1]
+    if (!requestId) throw new Error("consent page carried no request_id")
+    const decision = await fetch(`${baseUrl}/oauth/decide`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        forwarded: `for=${forwardedClientIp}`,
+      },
+      body: new URLSearchParams({
+        request_id: requestId,
+        token: AUTH_TOKEN,
+        action: "approve",
+      }),
+      redirect: "manual",
+    })
+    const location = decision.headers.get("location")
+    const code = location ? new URL(location).searchParams.get("code") : null
+    if (!code) throw new Error(`consent did not redirect with a code`)
+    const tokenResponse = await fetch(`${baseUrl}/token`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        forwarded: `for=${forwardedClientIp}`,
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        code_verifier: verifier,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+        redirect_uri: REDIRECT_URI,
+      }),
+    })
+    expect(tokenResponse.status).toBe(200)
+    const issued: unknown = await tokenResponse.json()
+    if (!isIssuedTokens(issued)) throw new Error("malformed token response")
+    return issued
+  }
+
+  const refresh = ({
+    baseUrl,
+    client,
+    refreshToken,
+    scope,
+    forwardedClientIp,
+  }: {
+    baseUrl: string
+    client: RegisteredClient
+    refreshToken: string
+    scope?: string
+    forwardedClientIp: string
+  }): Promise<globalThis.Response> =>
+    fetch(`${baseUrl}/token`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        forwarded: `for=${forwardedClientIp}`,
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+        ...(scope === undefined ? {} : { scope }),
+      }),
+    })
+
+  it("rejects a refresh token presented by a different client with invalid_grant", async () => {
+    const { baseUrl } = await createRefreshTest()
+    const owner = await registerClient(baseUrl, "203.0.113.1")
+    const other = await registerClient(baseUrl, "203.0.113.2")
+    const issued = await issueTokens(baseUrl, owner, "203.0.113.1")
+
+    const response = await refresh({
+      baseUrl,
+      client: other,
+      refreshToken: issued.refresh_token,
+      forwardedClientIp: "203.0.113.2",
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: "invalid_grant",
+      error_description: "Refresh token expired or invalid",
+    })
+    const stillValid = await refresh({
+      baseUrl,
+      client: owner,
+      refreshToken: issued.refresh_token,
+      forwardedClientIp: "203.0.113.1",
+    })
+    expect(stillValid.status).toBe(200)
+  })
+
+  it("rejects a refresh that widens the scope with invalid_scope and consumes the token", async () => {
+    const { baseUrl } = await createRefreshTest()
+    const owner = await registerClient(baseUrl, "203.0.113.3")
+    const issued = await issueTokens(baseUrl, owner, "203.0.113.3")
+
+    const response = await refresh({
+      baseUrl,
+      client: owner,
+      refreshToken: issued.refresh_token,
+      scope: "vault admin",
+      forwardedClientIp: "203.0.113.3",
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: "invalid_scope",
+      error_description: "Requested scope exceeds the granted scope",
+    })
+    const consumed = await refresh({
+      baseUrl,
+      client: owner,
+      refreshToken: issued.refresh_token,
+      forwardedClientIp: "203.0.113.3",
+    })
+    expect(consumed.status).toBe(400)
+    expect(await consumed.json()).toEqual({
+      error: "invalid_grant",
+      error_description: "Refresh token expired or invalid",
+    })
   })
 })

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -64,11 +64,11 @@ type OAuthProviderOptions = {
   logger: Logger
 }
 
-// Schema version recorded in SQLite's user_version pragma. Version 1 is
-// the first schema whose refresh_tokens rows are keyed by HMAC; rows
-// written by an older version are raw tokens of the same length, so
-// they can only be retired by version, not by shape.
-const REFRESH_TOKEN_KEYED_SCHEMA_VERSION = 1
+// Every stored refresh-token key starts with this prefix. Raw tokens
+// are bare hex, so the prefix is what tells a keyed row from one written
+// by a version that stored tokens in plaintext — including rows written
+// after a rollback to such a version.
+const REFRESH_TOKEN_KEY_PREFIX = "hmac-sha256:"
 
 const initDb = (dbPath: string, logger: Logger): Database.Database => {
   const db = new Database(dbPath)
@@ -104,41 +104,39 @@ const initDb = (dbPath: string, logger: Logger): Database.Database => {
       "ALTER TABLE refresh_tokens ADD COLUMN expires_at INTEGER NOT NULL DEFAULT 0",
     )
   }
-  // Migration for DBs whose refresh_tokens rows are raw tokens: the keyed
-  // lookup can never match them, so clear them and record the version in
-  // the same transaction (user_version is transactional). Every OAuth
-  // client re-authorizes once through the consent page.
-  const schemaVersion = db.pragma("user_version", { simple: true })
-  const needsKeyedSchemaMigration =
-    typeof schemaVersion === "number" &&
-    schemaVersion < REFRESH_TOKEN_KEYED_SCHEMA_VERSION
-  if (needsKeyedSchemaMigration) {
-    const clearRawRefreshTokens = db.transaction((): number => {
-      const { changes } = db.prepare("DELETE FROM refresh_tokens").run()
-      db.pragma(`user_version = ${REFRESH_TOKEN_KEYED_SCHEMA_VERSION}`)
-      return changes
-    })
-    const rowsCleared = clearRawRefreshTokens()
+  // Rows whose key lacks the prefix hold raw tokens written by a version
+  // that stored them in plaintext; the keyed lookup can never match them,
+  // so clear them on every boot. Each affected client re-authorizes once
+  // through the consent page.
+  const { changes: rawRowsCleared } = db
+    .prepare("DELETE FROM refresh_tokens WHERE token NOT LIKE ?")
+    .run(`${REFRESH_TOKEN_KEY_PREFIX}%`)
+  if (rawRowsCleared > 0) {
     logger.info("oauth_refresh_tokens_cleared", {
-      reason: "storage_key_upgrade",
-      rows: rowsCleared,
+      reason: "plaintext_rows",
+      rows: rawRowsCleared,
     })
   }
   return db
 }
 
 class SqliteClientsStore implements OAuthRegisteredClientsStore {
+  private readonly selectClientStmt: Database.Statement<
+    [string],
+    { data: string }
+  >
+
   constructor(
     private db: Database.Database,
     private logger: Logger,
-  ) {}
+  ) {
+    this.selectClientStmt = db.prepare(
+      "SELECT data FROM clients WHERE client_id = ?",
+    )
+  }
 
   getClient(clientId: string): OAuthClientInformationFull | undefined {
-    const row = this.db
-      .prepare<unknown[], { data: string }>(
-        "SELECT data FROM clients WHERE client_id = ?",
-      )
-      .get(clientId)
+    const row = this.selectClientStmt.get(clientId)
     if (!row) return undefined
     const parsed: OAuthClientInformationFull = JSON.parse(row.data)
     return parsed
@@ -197,10 +195,12 @@ export const createOAuthProvider = ({
    *  auth token. Rows are only reachable under the secret that wrote
    *  them, so rotating MCP_AUTH_TOKEN ends every session, and a copied
    *  DB holds no token a client could present. */
-  const refreshTokenStorageKey = (token: string): string =>
-    createHmac("sha256", authToken)
+  const refreshTokenStorageKey = (token: string): string => {
+    const digest = createHmac("sha256", authToken)
       .update(REFRESH_TOKEN_KEY_LABEL + token)
       .digest("hex")
+    return REFRESH_TOKEN_KEY_PREFIX + digest
+  }
 
   const insertRefreshTokenStmt = db.prepare<[string, string, string, number]>(
     "INSERT INTO refresh_tokens (token, client_id, scopes, expires_at) VALUES (?, ?, ?, ?)",
@@ -238,8 +238,8 @@ export const createOAuthProvider = ({
     )
 
   /** Stores a refresh token under its storage key. Expired rows are
-   *  purged here rather than on read: a row is only ever read when its
-   *  own token is presented, so rows left by dormant clients — or made
+   *  purged here as well as on read: a row is only read when its own
+   *  token is presented, so rows left by dormant clients — or made
    *  unreachable by a rotation — would otherwise stay forever. */
   const saveRefreshToken = ({
     token,
@@ -390,7 +390,11 @@ export const createOAuthProvider = ({
         throw new InvalidGrantError("Refresh token expired or invalid")
       }
 
-      const grantedScopes = scopes ?? stored.scopes
+      // RFC 6749 §6: an omitted or empty scope means the stored scope.
+      // The SDK splits `scope=` into [""], so blank entries count as empty.
+      const requestedScopes = (scopes ?? []).filter((scope) => scope !== "")
+      const grantedScopes =
+        requestedScopes.length > 0 ? requestedScopes : stored.scopes
       const requestedScopeWidens = grantedScopes.some(
         (scope) => !stored.scopes.includes(scope),
       )

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -220,6 +220,9 @@ export const createOAuthProvider = ({
   const insertRevokedTokenStmt = db.prepare<[string, number]>(
     "INSERT OR IGNORE INTO revoked_tokens (token, revoked_at) VALUES (?, ?)",
   )
+  const selectRevokedTokenStmt = db.prepare<[string]>(
+    "SELECT 1 FROM revoked_tokens WHERE token = ?",
+  )
 
   const issueAccessToken = (clientId: string, scopes: string[]): string =>
     signJwt(
@@ -238,11 +241,15 @@ export const createOAuthProvider = ({
    *  purged here rather than on read: a row is only ever read when its
    *  own token is presented, so rows left by dormant clients — or made
    *  unreachable by a rotation — would otherwise stay forever. */
-  const saveRefreshToken = (
-    token: string,
-    clientId: string,
-    scopes: string[],
-  ): void => {
+  const saveRefreshToken = ({
+    token,
+    clientId,
+    scopes,
+  }: {
+    token: string
+    clientId: string
+    scopes: string[]
+  }): void => {
     const now = DateTime.now()
     deleteExpiredRefreshTokensStmt.run(now.toUnixInteger())
     insertRefreshTokenStmt.run(
@@ -275,7 +282,7 @@ export const createOAuthProvider = ({
   }
 
   const isRevoked = (token: string): boolean =>
-    !!db.prepare("SELECT 1 FROM revoked_tokens WHERE token = ?").get(token)
+    !!selectRevokedTokenStmt.get(token)
 
   // Methods below implement OAuthServerProvider from the MCP SDK.
   // They appear unused locally but are called by mcpAuthRouter() and
@@ -345,7 +352,11 @@ export const createOAuthProvider = ({
       const scopes = stored.params.scopes ?? []
       const accessToken = issueAccessToken(stored.clientId, scopes)
       const refreshToken = randomBytes(32).toString("hex")
-      saveRefreshToken(refreshToken, stored.clientId, scopes)
+      saveRefreshToken({
+        token: refreshToken,
+        clientId: stored.clientId,
+        scopes,
+      })
 
       oauthLogger.info("oauth_code_exchanged", {
         clientId: stored.clientId,
@@ -392,7 +403,11 @@ export const createOAuthProvider = ({
       }
       const accessToken = issueAccessToken(clientId, grantedScopes)
       const newRefreshToken = randomBytes(32).toString("hex")
-      saveRefreshToken(newRefreshToken, clientId, grantedScopes)
+      saveRefreshToken({
+        token: newRefreshToken,
+        clientId,
+        scopes: grantedScopes,
+      })
 
       oauthLogger.info("oauth_token_refreshed", {
         clientId,

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -373,7 +373,8 @@ export const createOAuthProvider = ({
 
     /** RFC 6749 §6: the refresh token must have been issued to the
      *  authenticated client, and a requested scope may narrow but never
-     *  widen the scope originally granted. */
+     *  widen the scope originally granted.
+     *  https://www.rfc-editor.org/rfc/rfc6749#section-6 */
     async exchangeRefreshToken(
       client: OAuthClientInformationFull,
       refreshToken: string,
@@ -390,7 +391,8 @@ export const createOAuthProvider = ({
         throw new InvalidGrantError("Refresh token expired or invalid")
       }
 
-      // RFC 6749 §6: an omitted or empty scope means the stored scope.
+      // RFC 6749 §6: an omitted or empty scope means the stored scope
+      // (https://www.rfc-editor.org/rfc/rfc6749#section-6).
       // The SDK splits `scope=` into [""], so blank entries count as empty.
       const requestedScopes = (scopes ?? []).filter((scope) => scope !== "")
       const grantedScopes =
@@ -474,7 +476,8 @@ export const createOAuthProvider = ({
     /** RFC 7009: revoke whatever the client presents. A refresh token is
      *  removed by its storage key; only a currently-valid access JWT is
      *  added to the revocation list, so revoked_tokens never holds a
-     *  refresh token or an arbitrary string in plaintext. */
+     *  refresh token or an arbitrary string in plaintext.
+     *  https://www.rfc-editor.org/rfc/rfc7009 */
     async revokeToken(
       _client: OAuthClientInformationFull,
       request: OAuthTokenRevocationRequest,

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -478,10 +478,12 @@ export const createOAuthProvider = ({
      *  refresh token or an arbitrary string in plaintext.
      *  https://www.rfc-editor.org/rfc/rfc7009 */
     async revokeToken(
-      _client: OAuthClientInformationFull,
+      client: OAuthClientInformationFull,
       request: OAuthTokenRevocationRequest,
     ): Promise<void> {
-      deleteRefreshTokenStmt.run(refreshTokenStorageKey(request.token))
+      const { changes: refreshTokensDeleted } = deleteRefreshTokenStmt.run(
+        refreshTokenStorageKey(request.token),
+      )
       const isValidAccessToken = verifyJwt(request.token, authToken) !== null
       if (isValidAccessToken) {
         insertRevokedTokenStmt.run(
@@ -489,7 +491,16 @@ export const createOAuthProvider = ({
           DateTime.now().toUnixInteger(),
         )
       }
-      oauthLogger.info("oauth_token_revoked")
+      // Logged from what the revoke matched, not the client's hint.
+      const revokedTokenType = (): string => {
+        if (isValidAccessToken) return "access_token"
+        if (refreshTokensDeleted > 0) return "refresh_token"
+        return "unknown"
+      }
+      oauthLogger.info("oauth_token_revoked", {
+        clientId: client.client_id,
+        tokenType: revokedTokenType(),
+      })
     },
   }
 

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -390,9 +390,9 @@ export const createOAuthProvider = ({
         throw new InvalidGrantError("Refresh token expired or invalid")
       }
 
-      // RFC 6749 §6: an omitted or empty scope means the stored scope
-      // (https://www.rfc-editor.org/rfc/rfc6749#section-6).
-      // The SDK splits `scope=` into [""], so blank entries count as empty.
+      // An omitted or empty scope means the stored scope (RFC 6749 §6, linked
+      // above). The SDK splits `scope=` into [""], so blank entries count
+      // as empty.
       const requestedScopes = (scopes ?? []).filter((scope) => scope !== "")
       const grantedScopes =
         requestedScopes.length > 0 ? requestedScopes : stored.scopes

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -29,6 +29,7 @@ import type {
 import {
   InvalidGrantError,
   InvalidScopeError,
+  InvalidTokenError,
 } from "@modelcontextprotocol/sdk/server/auth/errors.js"
 import { safeEqual } from "../../auth.js"
 import { signJwt, verifyJwt } from "../../jwt.js"
@@ -445,8 +446,6 @@ export const createOAuthProvider = ({
 
       if (isRevoked(token)) {
         oauthLogger.warn("oauth_token_rejected", { reason: "revoked" })
-        const { InvalidTokenError } =
-          await import("@modelcontextprotocol/sdk/server/auth/errors.js")
         throw new InvalidTokenError("Token has been revoked")
       }
 
@@ -467,8 +466,6 @@ export const createOAuthProvider = ({
       oauthLogger.warn("oauth_token_rejected", {
         reason: "invalid_or_expired",
       })
-      const { InvalidTokenError } =
-        await import("@modelcontextprotocol/sdk/server/auth/errors.js")
       throw new InvalidTokenError("Token expired or invalid")
     },
 

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -26,7 +26,10 @@ import type {
   OAuthTokens,
   OAuthTokenRevocationRequest,
 } from "@modelcontextprotocol/sdk/shared/auth.js"
-import { InvalidGrantError } from "@modelcontextprotocol/sdk/server/auth/errors.js"
+import {
+  InvalidGrantError,
+  InvalidScopeError,
+} from "@modelcontextprotocol/sdk/server/auth/errors.js"
 import { safeEqual } from "../../auth.js"
 import { signJwt, verifyJwt } from "../../jwt.js"
 import { renderConsentPage } from "./consent-page.js"
@@ -206,9 +209,11 @@ export const createOAuthProvider = ({
     "DELETE FROM refresh_tokens WHERE expires_at < ?",
   )
   const selectRefreshTokenStmt = db.prepare<
-    [string],
-    { client_id: string; scopes: string; expires_at: number }
-  >("SELECT client_id, scopes, expires_at FROM refresh_tokens WHERE token = ?")
+    [string, string],
+    { scopes: string; expires_at: number }
+  >(
+    "SELECT scopes, expires_at FROM refresh_tokens WHERE token = ? AND client_id = ?",
+  )
   const deleteRefreshTokenStmt = db.prepare<[string]>(
     "DELETE FROM refresh_tokens WHERE token = ?",
   )
@@ -254,15 +259,19 @@ export const createOAuthProvider = ({
    *  expires_at is REFRESH_TOKEN_TTL_S from now — every use resets the
    *  countdown, so active clients never expire. A token issued under a
    *  different auth token derives a different key and is never found. */
-  const consumeRefreshToken = (
-    token: string,
-  ): { clientId: string; scopes: string[] } | null => {
+  const consumeRefreshToken = ({
+    token,
+    clientId,
+  }: {
+    token: string
+    clientId: string
+  }): { scopes: string[] } | null => {
     const storageKey = refreshTokenStorageKey(token)
-    const row = selectRefreshTokenStmt.get(storageKey)
+    const row = selectRefreshTokenStmt.get(storageKey, clientId)
     if (!row) return null
     deleteRefreshTokenStmt.run(storageKey)
     if (row.expires_at < DateTime.now().toUnixInteger()) return null
-    return { clientId: row.client_id, scopes: row.scopes.split(" ") }
+    return { scopes: row.scopes.split(" ") }
   }
 
   const isRevoked = (token: string): boolean =>
@@ -351,27 +360,42 @@ export const createOAuthProvider = ({
       }
     },
 
+    /** RFC 6749 §6: the refresh token must have been issued to the
+     *  authenticated client, and a requested scope may narrow but never
+     *  widen the scope originally granted. */
     async exchangeRefreshToken(
-      _client: OAuthClientInformationFull,
+      client: OAuthClientInformationFull,
       refreshToken: string,
       scopes?: string[],
       _resource?: URL,
     ): Promise<OAuthTokens> {
-      const stored = consumeRefreshToken(refreshToken)
+      const clientId = client.client_id
+      const stored = consumeRefreshToken({ token: refreshToken, clientId })
       if (!stored) {
         oauthLogger.warn("oauth_token_refresh_failed", {
           reason: "expired_or_invalid",
+          clientId,
         })
         throw new InvalidGrantError("Refresh token expired or invalid")
       }
 
       const grantedScopes = scopes ?? stored.scopes
-      const accessToken = issueAccessToken(stored.clientId, grantedScopes)
+      const requestedScopeWidens = grantedScopes.some(
+        (scope) => !stored.scopes.includes(scope),
+      )
+      if (requestedScopeWidens) {
+        oauthLogger.warn("oauth_token_refresh_failed", {
+          reason: "scope_exceeds_grant",
+          clientId,
+        })
+        throw new InvalidScopeError("Requested scope exceeds the granted scope")
+      }
+      const accessToken = issueAccessToken(clientId, grantedScopes)
       const newRefreshToken = randomBytes(32).toString("hex")
-      saveRefreshToken(newRefreshToken, stored.clientId, grantedScopes)
+      saveRefreshToken(newRefreshToken, clientId, grantedScopes)
 
       oauthLogger.info("oauth_token_refreshed", {
-        clientId: stored.clientId,
+        clientId,
         scopes: grantedScopes,
       })
       return {

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -5,12 +5,14 @@
  * - Authorization code flow with PKCE
  * - JWT access tokens (HS256, verifiable by Lambda + Express)
  * - Backward-compatible static token verification (MCP_AUTH_TOKEN)
- * - SQLite persistence for refresh tokens + clients (survives restarts)
+ * - SQLite persistence for refresh tokens + clients (survives restarts);
+ *   refresh tokens are stored keyed by an HMAC under MCP_AUTH_TOKEN, so
+ *   rotating the token ends every session and the DB holds no usable token
  * - Consent page gated by the server's auth token
  */
 
 import Database from "better-sqlite3"
-import { randomUUID, randomBytes } from "node:crypto"
+import { createHmac, randomUUID, randomBytes } from "node:crypto"
 import { DateTime } from "luxon"
 import type { Response } from "express"
 import type {
@@ -59,7 +61,13 @@ type OAuthProviderOptions = {
   logger: Logger
 }
 
-const initDb = (dbPath: string): Database.Database => {
+// Schema version recorded in SQLite's user_version pragma. Version 1 is
+// the first schema whose refresh_tokens rows are keyed by HMAC; rows
+// written by an older version are raw tokens of the same length, so
+// they can only be retired by version, not by shape.
+const REFRESH_TOKEN_KEYED_SCHEMA_VERSION = 1
+
+const initDb = (dbPath: string, logger: Logger): Database.Database => {
   const db = new Database(dbPath)
   db.pragma("journal_mode = WAL") // concurrent reads during writes
   db.exec(`
@@ -92,6 +100,26 @@ const initDb = (dbPath: string): Database.Database => {
     db.exec(
       "ALTER TABLE refresh_tokens ADD COLUMN expires_at INTEGER NOT NULL DEFAULT 0",
     )
+  }
+  // Migration for DBs whose refresh_tokens rows are raw tokens: the keyed
+  // lookup can never match them, so clear them and record the version in
+  // the same transaction (user_version is transactional). Every OAuth
+  // client re-authorizes once through the consent page.
+  const schemaVersion = db.pragma("user_version", { simple: true })
+  const needsKeyedSchemaMigration =
+    typeof schemaVersion === "number" &&
+    schemaVersion < REFRESH_TOKEN_KEYED_SCHEMA_VERSION
+  if (needsKeyedSchemaMigration) {
+    const clearRawRefreshTokens = db.transaction((): number => {
+      const { changes } = db.prepare("DELETE FROM refresh_tokens").run()
+      db.pragma(`user_version = ${REFRESH_TOKEN_KEYED_SCHEMA_VERSION}`)
+      return changes
+    })
+    const rowsCleared = clearRawRefreshTokens()
+    logger.info("oauth_refresh_tokens_cleared", {
+      reason: "storage_key_upgrade",
+      rows: rowsCleared,
+    })
   }
   return db
 }
@@ -153,10 +181,40 @@ export const createOAuthProvider = ({
   logger,
 }: OAuthProviderOptions): OAuthProvider => {
   const oauthLogger = logger.child({ component: "oauth" })
-  const db = initDb(dbPath)
+  const db = initDb(dbPath, oauthLogger)
   const store = new SqliteClientsStore(db, oauthLogger)
   const pendingRequests = new Map<string, PendingAuthRequest>()
   const authCodes = new Map<string, StoredAuthCode>()
+
+  // Prefix that separates this HMAC from the JWT signature, which uses
+  // the same key (see jwt.ts).
+  const REFRESH_TOKEN_KEY_LABEL = "refresh-token:"
+
+  /** Storage key for a refresh token: an HMAC of the token under the
+   *  auth token. Rows are only reachable under the secret that wrote
+   *  them, so rotating MCP_AUTH_TOKEN ends every session, and a copied
+   *  DB holds no token a client could present. */
+  const refreshTokenStorageKey = (token: string): string =>
+    createHmac("sha256", authToken)
+      .update(REFRESH_TOKEN_KEY_LABEL + token)
+      .digest("hex")
+
+  const insertRefreshTokenStmt = db.prepare<[string, string, string, number]>(
+    "INSERT INTO refresh_tokens (token, client_id, scopes, expires_at) VALUES (?, ?, ?, ?)",
+  )
+  const deleteExpiredRefreshTokensStmt = db.prepare<[number]>(
+    "DELETE FROM refresh_tokens WHERE expires_at < ?",
+  )
+  const selectRefreshTokenStmt = db.prepare<
+    [string],
+    { client_id: string; scopes: string; expires_at: number }
+  >("SELECT client_id, scopes, expires_at FROM refresh_tokens WHERE token = ?")
+  const deleteRefreshTokenStmt = db.prepare<[string]>(
+    "DELETE FROM refresh_tokens WHERE token = ?",
+  )
+  const insertRevokedTokenStmt = db.prepare<[string, number]>(
+    "INSERT OR IGNORE INTO revoked_tokens (token, revoked_at) VALUES (?, ?)",
+  )
 
   const issueAccessToken = (clientId: string, scopes: string[]): string =>
     signJwt(
@@ -171,18 +229,22 @@ export const createOAuthProvider = ({
       authToken,
     )
 
+  /** Stores a refresh token under its storage key. Expired rows are
+   *  purged here rather than on read: a row is only ever read when its
+   *  own token is presented, so rows left by dormant clients — or made
+   *  unreachable by a rotation — would otherwise stay forever. */
   const saveRefreshToken = (
     token: string,
     clientId: string,
     scopes: string[],
   ): void => {
-    db.prepare(
-      "INSERT INTO refresh_tokens (token, client_id, scopes, expires_at) VALUES (?, ?, ?, ?)",
-    ).run(
-      token,
+    const now = DateTime.now()
+    deleteExpiredRefreshTokensStmt.run(now.toUnixInteger())
+    insertRefreshTokenStmt.run(
+      refreshTokenStorageKey(token),
       clientId,
       scopes.join(" "),
-      DateTime.now().plus({ seconds: REFRESH_TOKEN_TTL_S }).toUnixInteger(),
+      now.plus({ seconds: REFRESH_TOKEN_TTL_S }).toUnixInteger(),
     )
   }
 
@@ -190,21 +252,15 @@ export const createOAuthProvider = ({
    *  (consumed on read to prevent replay) AND time-bounded (rejected
    *  past expires_at). A successful refresh issues a new token whose
    *  expires_at is REFRESH_TOKEN_TTL_S from now — every use resets the
-   *  countdown, so active clients never expire. Expired rows are still
-   *  deleted on read so the table self-cleans. */
+   *  countdown, so active clients never expire. A token issued under a
+   *  different auth token derives a different key and is never found. */
   const consumeRefreshToken = (
     token: string,
   ): { clientId: string; scopes: string[] } | null => {
-    const row = db
-      .prepare<
-        [string],
-        { client_id: string; scopes: string; expires_at: number }
-      >(
-        "SELECT client_id, scopes, expires_at FROM refresh_tokens WHERE token = ?",
-      )
-      .get(token)
+    const storageKey = refreshTokenStorageKey(token)
+    const row = selectRefreshTokenStmt.get(storageKey)
     if (!row) return null
-    db.prepare("DELETE FROM refresh_tokens WHERE token = ?").run(token)
+    deleteRefreshTokenStmt.run(storageKey)
     if (row.expires_at < DateTime.now().toUnixInteger()) return null
     return { clientId: row.client_id, scopes: row.scopes.split(" ") }
   }
@@ -372,16 +428,22 @@ export const createOAuthProvider = ({
       throw new InvalidTokenError("Token expired or invalid")
     },
 
+    /** RFC 7009: revoke whatever the client presents. A refresh token is
+     *  removed by its storage key; only a currently-valid access JWT is
+     *  added to the revocation list, so revoked_tokens never holds a
+     *  refresh token or an arbitrary string in plaintext. */
     async revokeToken(
       _client: OAuthClientInformationFull,
       request: OAuthTokenRevocationRequest,
     ): Promise<void> {
-      db.prepare(
-        "INSERT OR IGNORE INTO revoked_tokens (token, revoked_at) VALUES (?, ?)",
-      ).run(request.token, DateTime.now().toUnixInteger())
-      db.prepare("DELETE FROM refresh_tokens WHERE token = ?").run(
-        request.token,
-      )
+      deleteRefreshTokenStmt.run(refreshTokenStorageKey(request.token))
+      const isValidAccessToken = verifyJwt(request.token, authToken) !== null
+      if (isValidAccessToken) {
+        insertRevokedTokenStmt.run(
+          request.token,
+          DateTime.now().toUnixInteger(),
+        )
+      }
       oauthLogger.info("oauth_token_revoked")
     },
   }

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -69,6 +69,9 @@ type OAuthProviderOptions = {
 // by a version that stored tokens in plaintext — including rows written
 // after a rollback to such a version.
 const REFRESH_TOKEN_KEY_PREFIX = "hmac-sha256:"
+// Prepended to the token before hashing, so this HMAC can never equal the
+// JWT signature, which uses the same key (see jwt.ts).
+const REFRESH_TOKEN_KEY_LABEL = "refresh-token:"
 
 const initDb = (dbPath: string, logger: Logger): Database.Database => {
   const db = new Database(dbPath)
@@ -186,10 +189,6 @@ export const createOAuthProvider = ({
   const store = new SqliteClientsStore(db, oauthLogger)
   const pendingRequests = new Map<string, PendingAuthRequest>()
   const authCodes = new Map<string, StoredAuthCode>()
-
-  // Prefix that separates this HMAC from the JWT signature, which uses
-  // the same key (see jwt.ts).
-  const REFRESH_TOKEN_KEY_LABEL = "refresh-token:"
 
   /** Storage key for a refresh token: an HMAC of the token under the
    *  auth token. Rows are only reachable under the secret that wrote


### PR DESCRIPTION
## Problem

Rotating `MCP_AUTH_TOKEN` invalidated access JWTs (they are signed with it) but not refresh tokens. `refresh_tokens` rows were keyed by the raw random token with no link to the secret, so `exchangeRefreshToken` found the row and minted a new JWT under the new secret — a connected client silently reconnected after a rotation. The same gap meant the database stored refresh tokens in plaintext: a copy of `oauth.db` held live credentials.

## Change

Each `refresh_tokens` row is now keyed by `"hmac-sha256:" + HMAC-SHA256(MCP_AUTH_TOKEN, "refresh-token:" + token)` instead of the raw token. Save, lookup, and revoke derive the same key, so:

- a row written under one auth token is unreachable under another — rotation ends every OAuth session, structurally;
- the database never holds a token a client could present.

Three call sites read or write the column (`saveRefreshToken`, `consumeRefreshToken`, `revokeToken`); nothing else does, and the SDK passes the raw body token straight through to `exchangeRefreshToken` and `revokeToken`. The label prefix separates this HMAC from the JWT signature, which uses the same key.

Also in this change:

- **Plaintext rows are cleared on every boot.** Raw tokens are bare hex; keyed rows carry the `hmac-sha256:` prefix, so `initDb` deletes every row without the prefix and logs `oauth_refresh_tokens_cleared` with the count. Identifying rows by shape rather than a version marker means a rollback to an image that writes raw tokens, followed by a re-upgrade, still clears what the rollback wrote.
- **Expired rows are purged on each mint as well as on read.** A row is only ever read when its own token is presented, so rows left by dormant clients — or made unreachable by a rotation — never got deleted. `saveRefreshToken` now deletes every row past `expires_at` before inserting; a presented expired token is still deleted on read.
- **`revokeToken` no longer stores refresh tokens in plaintext.** It previously inserted whatever the client presented into `revoked_tokens` before deleting the refresh row, so a revoked refresh token (or any string posted to `/revoke`) sat on disk forever. It now deletes by storage key unconditionally and records only a currently-valid access JWT in `revoked_tokens`. Refresh tokens revoked under earlier versions remain in that table as dead strings; their `refresh_tokens` rows were deleted at revoke time.
- **Refresh tokens are bound to their client (RFC 6749 §6).** `exchangeRefreshToken` previously ignored the authenticated client and honoured any `scopes` the caller sent, so a registered client could redeem a refresh token issued to another client, and could request a wider scope than the one granted. The lookup now includes `client_id`; a token presented by a different client is rejected and its row is left in place. A requested scope outside the stored scope is rejected with `invalid_scope`; an omitted or blank scope keeps the stored one (the SDK splits `scope=` into `[""]`); a subset narrows the issued token and the narrowed scope persists on the rotated refresh token. Practical exposure was low — every supported client is a public client, and the server grants a single scope — but the check is a MUST in the spec.
- Touched statements are prepared once at factory scope; the clients and revoked-token SELECTs too.

## Docs

`ARCHITECTURE.md` (token storage, expiry, rotation), `DEPLOY.md` (rotation procedure), `RECOVERY.md` (what carries over from a snapshot), `README.md` (Authentication), `SECURITY.md` (OAuth database), and both one-click guides, which documented the old behaviour as a caveat.

## Tests

`oauth-provider.test.ts` — 45 tests (was 25):

- refresh token issued under one auth token is rejected by a provider opened on the same database under another, and its row is left in place; a sibling token still refreshes under the original
- an issued refresh token is stored only under its HMAC key (whole-table assertion)
- raw rows (no key prefix) are cleared on boot — whether written before the upgrade or after a rollback — and keyed rows beside them are kept; re-opening keeps keyed rows; the clear is logged with its count
- expired rows are purged when a refresh token is issued (live decoy kept)
- revoking a refresh token removes its row and records nothing in `revoked_tokens`; revoking an access token records it and rejects it afterwards; revoking an unknown string records nothing
- a refresh token presented by a different client is rejected and its row is left in place; a refresh requesting a scope outside the grant is rejected; an omitted or blank scope keeps the stored scope; a subset narrows it and the narrowed scope persists on the rotated token
- a widening request still consumes the token; the `scope_exceeds_grant` and `oauth_refresh_tokens_cleared` log events are asserted
- existing seeds and lookups adapted to the storage key, computed in the test file rather than imported from production

`oauth-routes.test.ts` (+2, over HTTP through the SDK router): a refresh token presented by a second registered client → `400 invalid_grant` while the owner can still use it; `scope=vault admin` → `400 invalid_scope` and the token is consumed. `oauth_token_revoked` now logs `clientId` and `tokenType` (derived from what the revoke matched, not the client's hint); three audit tests pin the three values.

`server-integration.test.ts` (+1, real server over HTTP): register → consent page → approve → PKCE code exchange → `/mcp` 200 → refresh 200 under token A; the server is stopped and rebooted with token B on the same data directory; the refresh token rotated under A → `400 invalid_grant`, A's access token on `/mcp` → 401, a fresh consent under B → `/mcp` 200 and its refresh token refreshes. Mutation (HMAC keyed by a constant instead of the auth token) fails this test at the post-rotation refresh.

Mutation check (each applied to the committed file, suite run, file restored):

| Mutation | Killed by |
| --- | --- |
| consume looks up the raw token | accepts a refresh token used within the 60-day window (+6 others) |
| revoke deletes by the raw token | revoking a refresh token removes its row without recording it in revoked_tokens |
| no purge on mint | purges expired rows when a refresh token is issued |
| no plaintext-row sweep on boot | clears raw refresh tokens written by a version that stored them in plaintext; …written after a rollback beside keyed rows it keeps; logs oauth_refresh_tokens_cleared… |
| no delete on read | removes an expired token from the DB on read; invalidates the old token after rotation (single-use) |
| never insert into `revoked_tokens` | revoking an access token records it in revoked_tokens and rejects it afterwards |
| lookup ignores `client_id` | rejects a refresh token presented by a client other than the one it was issued to… |
| no scope-widening check | rejects a refresh that requests a scope outside the granted scope |
| blank scope not treated as empty | issues the stored scope when a refresh sends a blank scope |
| rotated token saves the original scope | keeps a narrowed scope on the rotated refresh token |
| rotated token issued with a 1-day window | rotates to a new token with a fresh 60-day window on use |

`npm test` (3,012), `npm run lint`, `npm run build` green.

## Live validation

**Upgrade path (test deploy of `d54b46e` to the reference deployment):** the container came up from the branch build (`org.opencontainers.image.revision` = `d54b46e`), the boot log shows `oauth_refresh_tokens_cleared` with `rows: 4`, then `server started`; `/healthz` 200; no Sync guard or `Deleting` lines. A client holding a still-valid access JWT kept working without a prompt (the JWT is signed with the unchanged secret); each client re-authorizes through the consent page when its JWT expires and it tries to refresh.

**Rotation path (server built from `d54b46e`, run locally against the fixture vault, driven over HTTP):** under token A — `/register` 201, consent page → approve → code → `/token` 200, `/mcp` 200 with the access token, refresh 200 with a new refresh token issued. Server stopped and restarted with token B on the same data directory — refresh with A's token `400 {"error":"invalid_grant","error_description":"Refresh token expired or invalid"}`; A's access token on `/mcp` 401; a fresh consent under B succeeds (`/mcp` 200) and its refresh token refreshes (200).

BREAKING CHANGE: Upgrading clears every stored refresh token; each OAuth client re-authorizes once through the consent page when its access token expires (within 24 hours). Rotating `MCP_AUTH_TOKEN` now ends every OAuth session immediately.
