### PR TITLE
fix(search): one malformed note no longer prevents server startup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,9 @@
 dist/
 .sst/
 node_modules/
+# Fixture vault content is byte-exact test data — reformatting it changes
+# what the integration tests exercise
+src/__tests__/integration/fixtures/vault/
 *.db
 *.sqlite
 CHANGELOG.md

--- a/src/__tests__/integration/fixtures/vault/Multi Column Template.md
+++ b/src/__tests__/integration/fixtures/vault/Multi Column Template.md
@@ -1,0 +1,16 @@
+--- start-multi-column: ExampleRegion1
+```column-settings
+number of columns: 2
+largest column: left
+```
+>[!info] First Column
+
+Fixture for issue 485: the server must boot and index this file even though its first line looks like a gray-matter engine directive.
+
+--- end-column ---
+
+>[!example] Column 2
+
+Text displayed in column 2.
+
+--- end-multi-column

--- a/src/__tests__/integration/server-integration.test.ts
+++ b/src/__tests__/integration/server-integration.test.ts
@@ -163,6 +163,10 @@ describe("default config", () => {
       expect(text).toContain("Projects/alpha.md")
       expect(text).toContain("Projects/beta.md")
       expect(text).toContain("Orphan Note.md")
+      // The Multi Column fixture opens with `--- start-multi-column:` —
+      // its presence in the listing proves the server indexed a note
+      // whose first line gray-matter alone would reject (issue #485)
+      expect(text).toContain("Multi Column Template.md")
     })
 
     it("vault_list_notes — folder filter", async () => {

--- a/src/__tests__/integration/server-integration.test.ts
+++ b/src/__tests__/integration/server-integration.test.ts
@@ -164,7 +164,7 @@ describe("default config", () => {
       expect(text).toContain("Projects/beta.md")
       expect(text).toContain("Orphan Note.md")
       // The Multi Column fixture opens with `--- start-multi-column:` —
-      // its presence in the listing proves the server indexed a note
+      // its presence proves the server booted without crashing on a note
       // whose first line gray-matter alone would reject (issue #485)
       expect(text).toContain("Multi Column Template.md")
     })

--- a/src/vault-mcp/obsidian-markdown/__tests__/frontmatter.test.ts
+++ b/src/vault-mcp/obsidian-markdown/__tests__/frontmatter.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest"
+import { parseNote, stringifyNote, mergeFrontmatter } from "../frontmatter.js"
+
+/** Written as a code point so no invisible literal hides in the source. */
+const BOM = String.fromCharCode(0xfeff)
+
+/**
+ * Multi Column Markdown template from issue #485 — a `--- <text>` first
+ * line that gray-matter alone reads as an unregistered parser-engine
+ * name and throws on. Obsidian treats the file as plain text with no
+ * properties.
+ */
+const MULTI_COLUMN_NOTE = [
+  "--- start-multi-column: ExampleRegion1",
+  "```column-settings",
+  "number of columns: 2",
+  "largest column: left",
+  "```",
+  ">[!info] First Column",
+  "",
+  "Text displayed in column 1.",
+  "",
+  "--- end-column ---",
+  "",
+  ">[!example] Column 2",
+  "",
+  "Text displayed in column 2.",
+  "",
+  "--- end-multi-column",
+  "",
+].join("\n")
+
+// ── parseNote ────────────────────────────────────────────────────
+
+describe("parseNote", () => {
+  it("returns the issue #485 Multi Column template as body with no frontmatter", () => {
+    expect(parseNote(MULTI_COLUMN_NOTE)).toEqual({
+      data: {},
+      content: MULTI_COLUMN_NOTE,
+    })
+  })
+
+  it("treats a `--- text` first line as body, not a parser-engine name", () => {
+    expect(parseNote("--- some text\nbody line\n")).toEqual({
+      data: {},
+      content: "--- some text\nbody line\n",
+    })
+  })
+
+  it("treats a `----` first line as body", () => {
+    expect(parseNote("----\nbody line\n")).toEqual({
+      data: {},
+      content: "----\nbody line\n",
+    })
+  })
+
+  it("treats an opener with no closing dash line as body — Obsidian parses no properties from an unclosed fence", () => {
+    const unclosedFence =
+      "---\ntags:\n  - hello\n# Title\nsome text after, no closing dashes\n"
+    expect(parseNote(unclosedFence)).toEqual({
+      data: {},
+      content: unclosedFence,
+    })
+  })
+
+  it("parses a block closed by `----`, matching Obsidian's metadata cache", () => {
+    // The fourth dash leaks into content — gray-matter and Obsidian's
+    // cache both close on the `---` prefix
+    expect(parseNote("---\ntags:\n  - hello\n----\n")).toEqual({
+      data: { tags: ["hello"] },
+      content: "-\n",
+    })
+  })
+
+  it("parses a block closed by `---,`, matching Obsidian's metadata cache", () => {
+    expect(
+      parseNote("---\ntags:\n  - hello\n---,\n# Title\nsome text\n"),
+    ).toEqual({
+      data: { tags: ["hello"] },
+      content: ",\n# Title\nsome text\n",
+    })
+  })
+
+  it("parses an ordinary frontmatter block", () => {
+    expect(parseNote("---\ntitle: x\n---\nbody\n")).toEqual({
+      data: { title: "x" },
+      content: "body\n",
+    })
+  })
+
+  it("parses an opener with trailing whitespace", () => {
+    expect(parseNote("---  \ntitle: x\n---\nbody\n")).toEqual({
+      data: { title: "x" },
+      content: "body\n",
+    })
+  })
+
+  it("parses CRLF frontmatter", () => {
+    // The \r inside the value is gray-matter's pre-existing CRLF
+    // handling, pinned as-is — the opener gate must not reject the file
+    expect(parseNote("---\r\ntitle: x\r\n---\r\nbody\r\n")).toEqual({
+      data: { title: "x\r" },
+      content: "body\r\n",
+    })
+  })
+
+  it("strips a BOM before an ordinary frontmatter block", () => {
+    expect(parseNote(BOM + "---\ntitle: x\n---\nbody\n")).toEqual({
+      data: { title: "x" },
+      content: "body\n",
+    })
+  })
+
+  it("strips a BOM from a note with no frontmatter", () => {
+    expect(parseNote(BOM + "plain body\n")).toEqual({
+      data: {},
+      content: "plain body\n",
+    })
+  })
+
+  it("treats a whole-file `---` as body", () => {
+    expect(parseNote("---")).toEqual({ data: {}, content: "---" })
+  })
+
+  it("returns empty data for an empty fence pair", () => {
+    expect(parseNote("---\n---\n")).toEqual({ data: {}, content: "" })
+  })
+
+  it("throws on invalid YAML inside a real fenced block", () => {
+    expect(() => parseNote("---\ntitle: [unclosed\n---\nbody\n")).toThrow(
+      "Flow sequence in block collection must be sufficiently indented",
+    )
+  })
+})
+
+// ── stringifyNote ────────────────────────────────────────────────
+
+describe("stringifyNote", () => {
+  it("prepends a frontmatter block above a body that opens with plugin syntax", () => {
+    const pluginBody =
+      "--- start-multi-column: ExampleRegion1\ntext in column\n"
+    expect(stringifyNote(pluginBody, { title: "x" })).toBe(
+      "---\ntitle: x\n---\n--- start-multi-column: ExampleRegion1\ntext in column\n",
+    )
+  })
+
+  it("preserves a body that opens with a horizontal rule", () => {
+    // gray-matter's string form re-parses the body and consumes an
+    // HR-leading body as an unclosed fence, erasing it — the object
+    // form passed by stringifyNote must keep it verbatim
+    expect(stringifyNote("---\nrest of body\n", { title: "x" })).toBe(
+      "---\ntitle: x\n---\n---\nrest of body\n",
+    )
+  })
+
+  it("wraps an ordinary body", () => {
+    expect(stringifyNote("plain body\n", { title: "x" })).toBe(
+      "---\ntitle: x\n---\nplain body\n",
+    )
+  })
+
+  it("writes no frontmatter block for empty properties", () => {
+    expect(stringifyNote("plain body\n", {})).toBe("plain body\n")
+  })
+
+  it("round-trips a plugin-syntax body through parseNote", () => {
+    const pluginBody =
+      "--- start-multi-column: ExampleRegion1\ntext in column\n"
+    expect(parseNote(stringifyNote(pluginBody, { title: "x" }))).toEqual({
+      data: { title: "x" },
+      content: pluginBody,
+    })
+  })
+})
+
+// ── mergeFrontmatter ─────────────────────────────────────────────
+
+describe("mergeFrontmatter", () => {
+  it("adds new keys and overwrites matching ones", () => {
+    expect(
+      mergeFrontmatter({ title: "old", type: "note" }, { title: "new" }),
+    ).toEqual({ title: "new", type: "note" })
+  })
+
+  it("removes keys explicitly set to null in updates", () => {
+    expect(
+      mergeFrontmatter({ title: "old", draft: true }, { draft: null }),
+    ).toEqual({ title: "old" })
+  })
+
+  it("preserves nulls already present in existing frontmatter", () => {
+    expect(mergeFrontmatter({ due: null }, { title: "x" })).toEqual({
+      due: null,
+      title: "x",
+    })
+  })
+})

--- a/src/vault-mcp/obsidian-markdown/frontmatter.ts
+++ b/src/vault-mcp/obsidian-markdown/frontmatter.ts
@@ -36,26 +36,84 @@ const MATTER_OPTIONS = {
 }
 
 /**
+ * Frontmatter and body of a parsed note. This is `parseNote`'s whole
+ * contract — the underlying gray-matter result carries extra fields
+ * (excerpt, language, orig) that no caller may rely on.
+ */
+export type ParsedNote = {
+  data: Record<string, unknown>
+  content: string
+}
+
+/**
+ * Matches a frontmatter opener: `---` alone on the first line (optional
+ * BOM, trailing spaces/tabs, CRLF, or a whole-file `---`). Obsidian
+ * starts a properties block only on this form; gray-matter alone is
+ * wider — it reads `--- <text>` as a named parser-engine and throws on
+ * unregistered names (Multi Column Markdown's
+ * `--- start-multi-column: <name>` syntax, issue #485).
+ */
+const FRONTMATTER_OPENER = /^\uFEFF?---[ \t]*(\r?\n|$)/
+
+/**
+ * Matches a frontmatter closer after the opener line: any later line
+ * starting with `---`. Loose on purpose — Obsidian's metadata cache
+ * accepts closers like `----` or `---,` (its properties panel merely
+ * skips rendering such a block), and gray-matter closes on the same
+ * prefix, so the two parsers agree.
+ */
+const FRONTMATTER_CLOSER = /\n---/
+
+/**
  * Parses a note into frontmatter `data` + `content`, with the
  * string-preserving YAML engine applied.
+ *
+ * A properties block exists only when the first line is a bare `---`
+ * AND a later line starts with `---` — the rule Obsidian's metadata
+ * cache follows. Anything else (a `--- <text>` first line, an opener
+ * with no closer) is body text, returned untouched apart from a
+ * leading BOM being stripped (gray-matter's own normalization, applied
+ * on both paths). Invalid YAML inside a real block still throws —
+ * write paths must reject loudly rather than silently stack a second
+ * properties block above a broken one.
  *
  * Always use this instead of calling gray-matter directly — a bare
  * `matter()` call reverts to the js-yaml engine and reintroduces the
  * UTC-Z datetime bug.
  */
-export const parseNote = (content: string): matter.GrayMatterFile<string> =>
-  matter(content, MATTER_OPTIONS)
+export const parseNote = (content: string): ParsedNote => {
+  const hasFrontmatterFences =
+    FRONTMATTER_OPENER.test(content) && FRONTMATTER_CLOSER.test(content)
+  if (hasFrontmatterFences) {
+    // Rebuilt as a literal so the runtime value carries exactly the
+    // declared fields — gray-matter's result has extra enumerable keys
+    // (excerpt, isEmpty) that would otherwise leak through spreads
+    const parsed = matter(content, MATTER_OPTIONS)
+    return { data: parsed.data, content: parsed.content }
+  }
+  const contentWithoutBom = content.startsWith("\uFEFF")
+    ? content.slice(1)
+    : content
+  return { data: {}, content: contentWithoutBom }
+}
 
 /**
  * Serializes a body + frontmatter object back into a note string, with
  * the string-preserving YAML engine applied.
+ *
+ * The body is wrapped in `{ content: body }` because `matter.stringify`
+ * given a plain string re-parses it as a whole note first: a body
+ * opening with plugin syntax (`--- start-multi-column: …`) would hit
+ * the unregistered-engine throw, and a body opening with a `---`
+ * horizontal rule would be consumed as an unclosed frontmatter fence
+ * and dropped entirely. The object form uses the body verbatim.
  *
  * Always use this instead of calling `matter.stringify` directly — a
  * bare call reverts to the js-yaml engine and reintroduces the UTC-Z
  * datetime bug.
  */
 export const stringifyNote = (body: string, data: object): string =>
-  matter.stringify(body, data, MATTER_OPTIONS)
+  matter.stringify({ content: body }, data, MATTER_OPTIONS)
 
 /**
  * Merges `updates` into `existing` frontmatter. A key explicitly set to

--- a/src/vault-mcp/search/__tests__/memory-index.test.ts
+++ b/src/vault-mcp/search/__tests__/memory-index.test.ts
@@ -526,6 +526,33 @@ title: Agents
     expect(countVectors(inspect)).toBe(3)
   })
 
+  it("keeps a skipped memory note's entries when its parse fails during rebuild", async () => {
+    const { dir, memoryDirPath, index, inspect } = await createRebuiltVault()
+    const firstBuild = await index.rebuildFromVault({ vaultPath: dir }, logger)
+    await firstBuild.embedding
+    const rowsAfterFirstBuild = selectEntryRows(inspect)
+    expect(rowsAfterFirstBuild).toHaveLength(4)
+
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+    onTestFinished(() => warnSpy.mockRestore())
+    await writeFile(
+      join(memoryDirPath, "Opinions.md"),
+      "---\ntitle: [unclosed\n---\n# Opinions\n",
+    )
+    const secondBuild = await index.rebuildFromVault({ vaultPath: dir }, logger)
+    await secondBuild.embedding
+
+    // The skip actually happened: warned, and the note left the index
+    expect(warnSpy).toHaveBeenCalledWith(
+      "skipped malformed note during rebuild",
+      expect.objectContaining({ path: "About Me/Opinions.md" }),
+    )
+    expect(index.fullTextSearch({ query: "Immutable" }, logger)).toHaveLength(0)
+    // A still-on-disk memory note must not be treated as deleted — its
+    // entry rows survive until a rebuild parses it successfully again
+    expect(selectEntryRows(inspect)).toEqual(rowsAfterFirstBuild)
+  })
+
   it("embeds zero entries on a second rebuild with unchanged files", async () => {
     const { dir, index, embedder } = await createRebuiltVault()
     const firstBuild = await index.rebuildFromVault({ vaultPath: dir }, logger)

--- a/src/vault-mcp/search/__tests__/search-index.test.ts
+++ b/src/vault-mcp/search/__tests__/search-index.test.ts
@@ -1828,6 +1828,82 @@ describe("rebuildFromVault", () => {
     expect(results[0]?.path).toBe("About Me/Principles.md")
   })
 
+  it("skips a note whose frontmatter fails to parse, warns, and indexes the rest", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+    onTestFinished(() => warnSpy.mockRestore())
+    await writeFile(
+      join(vaultDir, "broken.md"),
+      "---\ntitle: [unclosed\n---\nbroken body text\n",
+      "utf8",
+    )
+    const { count } = await index.rebuildFromVault(
+      { vaultPath: vaultDir },
+      logger,
+    )
+    expect(count).toBe(2)
+    expect(warnSpy).toHaveBeenCalledWith(
+      "skipped malformed note during rebuild",
+      expect.objectContaining({ path: "broken.md" }),
+    )
+    const healthyPaths = index
+      .fullTextSearch({ query: "burnout" }, logger)
+      .map((result) => result.path)
+    expect(healthyPaths).toEqual(["About Me/Principles.md"])
+    expect(index.fullTextSearch({ query: "broken" }, logger)).toHaveLength(0)
+  })
+
+  it("indexes a note opening with Multi Column plugin syntax as plain content", async () => {
+    await writeFile(
+      join(vaultDir, "multi-column.md"),
+      "--- start-multi-column: ExampleRegion1\ncolumn snippet text\n\n--- end-multi-column\n",
+      "utf8",
+    )
+    const { count } = await index.rebuildFromVault(
+      { vaultPath: vaultDir },
+      logger,
+    )
+    expect(count).toBe(3)
+    // The plugin line stays in the indexed content — it would vanish if
+    // it were parsed as frontmatter
+    const firstLineHits = index
+      .fullTextSearch({ query: "ExampleRegion1" }, logger)
+      .map((result) => result.path)
+    expect(firstLineHits).toEqual(["multi-column.md"])
+    const propertyHits = index.searchByProperty(
+      { key: "start-multi-column", value: "ExampleRegion1" },
+      logger,
+    )
+    expect(propertyHits).toHaveLength(0)
+  })
+
+  it("stores a link into a skipped note as its raw target", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {})
+    onTestFinished(() => warnSpy.mockRestore())
+    await writeFile(
+      join(vaultDir, "broken.md"),
+      "---\ntitle: [unclosed\n---\nbroken body text\n",
+      "utf8",
+    )
+    await writeFile(
+      join(vaultDir, "linker.md"),
+      "# Linker\n\nSee [[broken]].\n",
+      "utf8",
+    )
+    await index.rebuildFromVault({ vaultPath: vaultDir }, logger)
+    // exists: false proves the skip happened — an indexed broken.md
+    // would have resolved the link to "broken.md"
+    expect(index.getOutgoingLinks({ path: "linker.md" }, logger)).toEqual([
+      {
+        path: "broken",
+        title: null,
+        exists: false,
+        kind: "note",
+        bytes: null,
+        daily_note_forward_ref: false,
+      },
+    ])
+  })
+
   it("resolves a frontmatter wikilink whose target is indexed later (forward reference)", async () => {
     // related: points to a note that sorts after the source, so the source is
     // indexed first; the two-pass rebuild must still resolve it. The body has

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -2122,27 +2122,37 @@ export const createSearchIndex = (
 
       db.exec("DELETE FROM links")
       for (const note of noteContents) {
-        // A note skipped in Pass 1 would throw the same parse error here
         if (skippedNotePaths.has(note.relativePath)) continue
-        const parsed = parseNote(note.content)
-        for (const rawTarget of links.extractAll(parsed.content, parsed.data)) {
-          const resolved = links.resolve({
-            target: rawTarget,
-            allPaths: pathList,
-            sourcePath: note.relativePath,
-          })
-          if (resolved !== null) {
-            insertLinkStmt.run(note.relativePath, resolved)
-          } else {
-            const resolvedNonMdPath = resolveNonMarkdownFile(
-              rawTarget,
-              note.relativePath,
-            )
-            insertLinkStmt.run(
-              note.relativePath,
-              resolvedNonMdPath ?? rawTarget,
-            )
+        try {
+          const parsed = parseNote(note.content)
+          for (const rawTarget of links.extractAll(
+            parsed.content,
+            parsed.data,
+          )) {
+            const resolved = links.resolve({
+              target: rawTarget,
+              allPaths: pathList,
+              sourcePath: note.relativePath,
+            })
+            if (resolved !== null) {
+              insertLinkStmt.run(note.relativePath, resolved)
+            } else {
+              const resolvedNonMdPath = resolveNonMarkdownFile(
+                rawTarget,
+                note.relativePath,
+              )
+              insertLinkStmt.run(
+                note.relativePath,
+                resolvedNonMdPath ?? rawTarget,
+              )
+            }
           }
+        } catch (error) {
+          skippedNotePaths.add(note.relativePath)
+          logger.warn("skipped malformed note during rebuild", {
+            path: note.relativePath,
+            error: describeError(error),
+          })
         }
       }
 

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -2027,20 +2027,30 @@ export const createSearchIndex = (
       )
     ).filter((entry) => entry !== null)
 
-    const noteContents = await Promise.all(
-      markdownFiles.map(async (file) => {
-        const [content, fileStat] = await Promise.all([
-          readFile(file.absolutePath, "utf8"),
-          stat(file.absolutePath),
-        ])
-        return {
-          relativePath: file.relativePath,
-          content,
-          modifiedAtMs: fileStat.mtimeMs,
-          sizeBytes: fileStat.size,
-        }
-      }),
-    )
+    const noteContents = (
+      await Promise.all(
+        markdownFiles.map(async (file) => {
+          try {
+            const [content, fileStat] = await Promise.all([
+              readFile(file.absolutePath, "utf8"),
+              stat(file.absolutePath),
+            ])
+            return {
+              relativePath: file.relativePath,
+              content,
+              modifiedAtMs: fileStat.mtimeMs,
+              sizeBytes: fileStat.size,
+            }
+          } catch (error) {
+            logger.warn("skipped unreadable note during rebuild", {
+              path: file.relativePath,
+              error: describeError(error),
+            })
+            return null
+          }
+        }),
+      )
+    ).filter((entry) => entry !== null)
 
     // Notes whose parse or index write throws are skipped with a warning
     // instead of aborting the rebuild — one malformed note must never
@@ -2081,13 +2091,13 @@ export const createSearchIndex = (
       // its rows survive on content-hash identity), so files that vanished
       // from disk leave orphaned entries the per-file upsert never touches.
       if (selectDistinctMemoryFilesStmt) {
-        // Built from the unfiltered disk listing on purpose: a note in
-        // skippedNotePaths still exists on disk, and treating it as deleted
-        // here would permanently remove its memory_entries rows (the table
-        // survives rebuilds on content-hash identity).
+        // Built from the disk listing (markdownFiles) on purpose: a note
+        // that failed to read or parse still exists on disk, and treating
+        // it as deleted here would permanently remove its memory_entries
+        // rows (the table survives rebuilds on content-hash identity).
         const memoryFilesOnDisk = new Set(
-          noteContents
-            .map((note) => memoryFileNameFromPath(note.relativePath))
+          markdownFiles
+            .map((file) => memoryFileNameFromPath(file.relativePath))
             .filter((fileName) => fileName !== null),
         )
         const deletedMemoryFiles = selectDistinctMemoryFilesStmt

--- a/src/vault-mcp/search/search-index.ts
+++ b/src/vault-mcp/search/search-index.ts
@@ -2042,6 +2042,11 @@ export const createSearchIndex = (
       }),
     )
 
+    // Notes whose parse or index write throws are skipped with a warning
+    // instead of aborting the rebuild — one malformed note must never
+    // prevent the server from starting.
+    const skippedNotePaths = new Set<string>()
+
     // better-sqlite3: .transaction() returns a function; call it immediately
     db.transaction(() => {
       // Index non-markdown files so extensionless wikilinks to .canvas, .base,
@@ -2052,15 +2057,23 @@ export const createSearchIndex = (
       // Pass 1: index all notes (content, frontmatter, FTS) — skip link
       // extraction here; Pass 2 handles it with the complete path list.
       for (const note of noteContents) {
-        upsertNote(
-          {
-            filePath: note.relativePath,
-            rawContent: note.content,
-            fileStat: { mtimeMs: note.modifiedAtMs, size: note.sizeBytes },
-            skipLinks: true,
-          },
-          logger,
-        )
+        try {
+          upsertNote(
+            {
+              filePath: note.relativePath,
+              rawContent: note.content,
+              fileStat: { mtimeMs: note.modifiedAtMs, size: note.sizeBytes },
+              skipLinks: true,
+            },
+            logger,
+          )
+        } catch (error) {
+          skippedNotePaths.add(note.relativePath)
+          logger.warn("skipped malformed note during rebuild", {
+            path: note.relativePath,
+            error: describeError(error),
+          })
+        }
       }
 
       // Entry-index reconciliation for memory files deleted while the server
@@ -2068,6 +2081,10 @@ export const createSearchIndex = (
       // its rows survive on content-hash identity), so files that vanished
       // from disk leave orphaned entries the per-file upsert never touches.
       if (selectDistinctMemoryFilesStmt) {
+        // Built from the unfiltered disk listing on purpose: a note in
+        // skippedNotePaths still exists on disk, and treating it as deleted
+        // here would permanently remove its memory_entries rows (the table
+        // survives rebuilds on content-hash identity).
         const memoryFilesOnDisk = new Set(
           noteContents
             .map((note) => memoryFileNameFromPath(note.relativePath))
@@ -2095,6 +2112,8 @@ export const createSearchIndex = (
 
       db.exec("DELETE FROM links")
       for (const note of noteContents) {
+        // A note skipped in Pass 1 would throw the same parse error here
+        if (skippedNotePaths.has(note.relativePath)) continue
         const parsed = parseNote(note.content)
         for (const rawTarget of links.extractAll(parsed.content, parsed.data)) {
           const resolved = links.resolve({
@@ -2147,11 +2166,18 @@ export const createSearchIndex = (
       }
     })()
 
-    const totalBytes = noteContents.reduce(
+    const indexedNotes = noteContents.filter(
+      (note) => !skippedNotePaths.has(note.relativePath),
+    )
+    const totalBytes = indexedNotes.reduce(
       (sum, note) => sum + note.sizeBytes,
       0,
     )
-    logger.info("rebuilt index", { count: noteContents.length, totalBytes })
+    logger.info("rebuilt index", {
+      count: indexedNotes.length,
+      totalBytes,
+      ...(skippedNotePaths.size > 0 ? { skipped: skippedNotePaths.size } : {}),
+    })
 
     // Extract only what Pass 3 needs so the full noteContents array (with
     // every note's body + stats) can be garbage-collected during embedding.
@@ -2344,7 +2370,7 @@ export const createSearchIndex = (
       logger.error("embedding pass failed", { error: describeError(err) })
     })
 
-    return { count: noteContents.length, embedding: embeddingPromise }
+    return { count: indexedNotes.length, embedding: embeddingPromise }
   }
 
   // ── Query context + delegation ───────────────────────────────

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -261,6 +261,17 @@ describe("readNote", () => {
 })
 
 describe("writeNote", () => {
+  it("creates a note whose body opens with Multi Column plugin syntax", async () => {
+    const pluginBody =
+      "--- start-multi-column: ExampleRegion1\ncolumn text\n--- end-multi-column\n"
+    await writeNote(
+      { vaultPath: vault, path: "snippet.md", body: pluginBody },
+      logger,
+    )
+    const written = await readFile(join(vault, "snippet.md"), "utf8")
+    expect(written).toBe(pluginBody)
+  })
+
   it("creates a new file with frontmatter", async () => {
     await writeNote(
       {
@@ -937,6 +948,41 @@ describe("readNoteProperties", () => {
 })
 
 describe("updateProperties", () => {
+  it("prepends a properties block above Multi Column plugin syntax", async () => {
+    const pluginBody =
+      "--- start-multi-column: ExampleRegion1\ncolumn text\n--- end-multi-column\n"
+    await writeFile(join(vault, "snippet.md"), pluginBody, "utf8")
+    await updateProperties(
+      {
+        vaultPath: vault,
+        path: "snippet.md",
+        properties: { title: "Snippet" },
+      },
+      logger,
+    )
+    const written = await readFile(join(vault, "snippet.md"), "utf8")
+    expect(written).toBe("---\ntitle: Snippet\n---\n" + pluginBody)
+  })
+
+  it("preserves a body that opens with a horizontal rule", async () => {
+    // The serializer must not re-parse the body: an HR-leading body read
+    // back through gray-matter's string form is consumed as an unclosed
+    // frontmatter fence and erased
+    await writeFile(
+      join(vault, "rules.md"),
+      "---\ntitle: Original\n---\n---\nbody after rule\n",
+      "utf8",
+    )
+    await updateProperties(
+      { vaultPath: vault, path: "rules.md", properties: { status: "active" } },
+      logger,
+    )
+    const written = await readFile(join(vault, "rules.md"), "utf8")
+    expect(written).toBe(
+      "---\ntitle: Original\nstatus: active\n---\n---\nbody after rule\n",
+    )
+  })
+
   it("merges new keys without changing body", async () => {
     await writeFile(
       join(vault, "test.md"),


### PR DESCRIPTION
## What does this PR do?

Fixes #485: one malformed note could crash-loop the server at startup.

### Problem

A note whose first line is `--- start-multi-column: ExampleRegion1` (a Multi Column Markdown template) made the frontmatter parser throw: gray-matter reads text after an opening `---` as the name of a custom parser engine, finds nothing registered under that name, and throws. The startup indexer had no per-note error handling for markdown notes (canvas, PDF, and text files already had it), so the throw aborted startup, the container restarted, and the same file crashed it again, forever. Each failed attempt also left a committed empty index, because the table wipes run before the transaction that refills them.

Fixing this surfaced a second defect in the same module: `matter.stringify` given a body string re-parses that string as a whole note. Writing a note whose body opens with plugin syntax threw the same engine error, and updating properties on a note whose body opens with a `---` horizontal rule silently erased the body (the re-parse consumed it as an unclosed frontmatter fence).

### Fix

1. **Frontmatter detection follows Obsidian's rule.** `parseNote` treats a file as having frontmatter only when the first line is exactly `---` and some later line starts with `---`. Verified against Obsidian directly: its metadata cache accepts loose closers such as `----` or `---,` (the property registers even though the properties panel skips rendering the block) and treats an opener with no closer as plain text. gray-matter already agrees on the loose closer, so the gate needed only those two conditions; anything failing them is returned as body text, byte for byte. Invalid YAML inside a real fence still throws, so write tools reject loudly instead of stacking a second properties block above a broken one.
2. **The startup rebuild survives any single bad note.** A note whose parse still fails is skipped with a `skipped malformed note during rebuild` warning naming the file, excluded from link extraction, and left out of the indexed count. The server always starts. The file watcher already handled this case; startup was the only unprotected path.
3. **`stringifyNote` passes `{ content: body }`** so gray-matter uses the body verbatim instead of re-parsing it, fixing both the write-path throw and the horizontal-rule data loss.

Also: the integration fixture vault is now listed in `.prettierignore`. Fixture content is byte-exact test data, and Prettier's markdown formatter restructures the Multi Column syntax.

### Tests

- New `frontmatter.test.ts` (22 tests): the reporter's exact template round-trips as body; `--- text`, `----`, unclosed-fence, loose-closer (`----`, `---,`), empty-pair, whole-file `---`, BOM, CRLF, and trailing-whitespace cases; invalid YAML still throws; `stringifyNote` preserves plugin-syntax and horizontal-rule bodies; plugin body round-trips through `parseNote`.
- Rebuild: a malformed note among healthy notes resolves the rebuild (warning asserted with the file's path, count reflects indexed notes only, healthy notes stay searchable, the malformed note is absent); a Multi Column note indexes as plain content; a link into a skipped note stays a raw unresolved target; a skipped memory note keeps its `memory_entries` rows.
- Write paths: `vault_update_properties` prepends a real properties block above plugin syntax; `vault_write_note` can create such a note; a horizontal-rule body survives a property update (this test fails on main by erasing the body).
- Integration: a Multi Column template note joins the fixture vault, so every server boot in the suite permanently regression-covers the crash; the note is asserted in the `vault_list_notes` listing.

Every guard is mutation-verified: dropping the opener condition, the closer condition, the rebuild's per-note catch, the link-pass skip, or the stringify object form makes exactly its named test fail.

## Type of change

- [ ] New MCP tool
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / workflow change
- [ ] Infrastructure (SST, Docker)
- [ ] Other

## Checklist

- [x] `npm test` passes (3,050 tests)
- [x] `npm run lint` passes (0 errors)
- [x] `npm run prettier:check` passes
- [x] `npm run build` succeeds
- [ ] New MCP tools follow the naming and description conventions in AGENTS.md (no new tools)
- [ ] README or ARCHITECTURE.md updated (no documented claim describes frontmatter fence handling or the rebuild's failure behavior; the rule is documented on the parser's regex)

---

_Generated with [Claude Code](https://claude.com/claude-code)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Obsidian frontmatter and plugin syntax, including multi-column layouts and horizontal rules.
  - Notes with malformed frontmatter are safely skipped during indexing instead of interrupting vault rebuilds.
  - Search results and link information remain consistent when notes cannot be indexed.
  - Note content is preserved byte-for-byte when writing or updating properties.
- **Tests**
  - Added coverage for frontmatter parsing, multi-column notes, malformed files, and rebuild behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->