### PR TITLE
chore: replace CLAUDE.md with symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# CLAUDE.md
-
-@AGENTS.md
-
-## Claude-Specific Tips
-
-<!-- Any Claude Code specific tips go here -->
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,11 @@ to get started.
    npx sst install
    ```
 
+   **Windows:** this repo uses symlinks (`CLAUDE.md → AGENTS.md`). Run
+   `git config core.symlinks true` before cloning, or re-clone after
+   setting it — otherwise Git checks out symlinks as plain text files
+   containing the target path.
+
    `npx sst install` fetches the SST platform types that `npm run build`
    typechecks `sst.config.ts` against.
 


### PR DESCRIPTION
## Summary
- Replace CLAUDE.md (which was just `@AGENTS.md` + an empty tips section) with a symlink to AGENTS.md
- Claude Code auto-reads CLAUDE.md and follows the symlink — same content, no indirection

## Test plan
- [ ] Verify `ls -la CLAUDE.md` shows `CLAUDE.md -> AGENTS.md`
- [ ] Verify Claude Code reads AGENTS.md content when auto-loading CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)