### PR TITLE
chore: replace CLAUDE.md with symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# CLAUDE.md
-
-@AGENTS.md
-
-## Claude-Specific Tips
-
-<!-- Any Claude Code specific tips go here -->
+AGENTS.md


### PR DESCRIPTION
## Summary
- Replace CLAUDE.md with a symlink to AGENTS.md
- Claude Code follows the symlink and reads AGENTS.md directly — no `@AGENTS.md` import indirection
- CLAUDE.md had no unique content (just the import + empty tips section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)