### PR TITLE
fix(cli): strip quoted values from .env before docker run

### DIFF
--- a/cli/src/__tests__/lifecycle.test.ts
+++ b/cli/src/__tests__/lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it, onTestFinished } from "vitest"
@@ -497,6 +497,25 @@ describe("runRestart", () => {
       "Applied the current .env settings.",
     ])
     expect(scripted.outros).toEqual(["Restart complete."])
+  })
+
+  it("strips quoted values from .env before docker run", async () => {
+    const targetDir = makeTempTargetDir("vault-cli-restart-")
+    writeFileSync(
+      join(targetDir, ".env"),
+      'MCP_AUTH_TOKEN=abc123\nVAULT_PATH="/home/user/My Vault"\nPORT="9000"\nPUBLIC_URL=http://localhost:9000\n',
+    )
+    const scripted = createScriptedPrompts()
+
+    await runRestart(
+      { dir: targetDir },
+      { prompts: scripted.prompts, docker: dockerReady, fetchFn: fetchOk },
+    )
+
+    const envAfter = readFileSync(join(targetDir, ".env"), "utf8")
+    expect(envAfter).toContain("VAULT_PATH=/home/user/My Vault\n")
+    expect(envAfter).toContain("PORT=9000\n")
+    expect(envAfter).not.toMatch(/^(VAULT_PATH|PORT)="/m)
   })
 
   it("re-creates a remote container without a vault path", async () => {

--- a/cli/src/__tests__/scaffold.test.ts
+++ b/cli/src/__tests__/scaffold.test.ts
@@ -16,6 +16,7 @@ import {
   readEnvPort,
   readEnvPublicUrl,
   readEnvVaultPath,
+  sanitizeEnvFile,
   writeFiles,
 } from "../scaffold.js"
 
@@ -191,6 +192,28 @@ describe("readEnvVaultPath", () => {
 
     expect(readEnvVaultPath(envPath)).toBe("/Users/me/My Vault")
   })
+
+  it("strips surrounding double quotes from the value", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-"))
+    const envPath = join(targetDir, ".env")
+    writeFileSync(
+      envPath,
+      'MCP_AUTH_TOKEN=abc\nVAULT_PATH="/Users/me/My Vault"\n',
+    )
+
+    expect(readEnvVaultPath(envPath)).toBe("/Users/me/My Vault")
+  })
+
+  it("strips surrounding single quotes from the value", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-"))
+    const envPath = join(targetDir, ".env")
+    writeFileSync(
+      envPath,
+      "MCP_AUTH_TOKEN=abc\nVAULT_PATH='/Users/me/My Vault'\n",
+    )
+
+    expect(readEnvVaultPath(envPath)).toBe("/Users/me/My Vault")
+  })
 })
 
 describe("readEnvPublicUrl", () => {
@@ -261,6 +284,28 @@ describe("readEnvPublicUrl", () => {
     writeFileSync(envPath, "MCP_AUTH_TOKEN=abc\nPUBLIC_URL=   \n")
 
     expect(readEnvPublicUrl(envPath)).toBeUndefined()
+  })
+
+  it("strips surrounding double quotes from the value", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-"))
+    const envPath = join(targetDir, ".env")
+    writeFileSync(
+      envPath,
+      'MCP_AUTH_TOKEN=abc\nPUBLIC_URL="https://vault.example.com"\n',
+    )
+
+    expect(readEnvPublicUrl(envPath)).toBe("https://vault.example.com")
+  })
+
+  it("strips quotes then trailing slashes", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-"))
+    const envPath = join(targetDir, ".env")
+    writeFileSync(
+      envPath,
+      'MCP_AUTH_TOKEN=abc\nPUBLIC_URL="https://vault.example.com/"\n',
+    )
+
+    expect(readEnvPublicUrl(envPath)).toBe("https://vault.example.com")
   })
 })
 
@@ -421,5 +466,93 @@ describe("patchEnvObsidianToken", () => {
     expect(readFileSync(envPath, "utf8")).toBe(
       "# Comment\nMCP_AUTH_TOKEN=abc\nOBSIDIAN_AUTH_TOKEN=new\nVAULT_NAME=Test\n# Footer\n",
     )
+  })
+})
+
+describe("sanitizeEnvFile", () => {
+  it("returns false when the file does not exist", () => {
+    const missingPath = join(tmpdir(), "vault-cli-no-such-env", ".env")
+
+    expect(sanitizeEnvFile(missingPath)).toBe(false)
+  })
+
+  it("returns false when no values are quoted", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-sanitize-"))
+    const envPath = join(targetDir, ".env")
+    const content = "MCP_AUTH_TOKEN=abc\nVAULT_NAME=My Vault\n"
+    writeFileSync(envPath, content)
+
+    expect(sanitizeEnvFile(envPath)).toBe(false)
+    expect(readFileSync(envPath, "utf8")).toBe(content)
+  })
+
+  it("strips double quotes from values and writes the file", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-sanitize-"))
+    const envPath = join(targetDir, ".env")
+    writeFileSync(envPath, 'MCP_AUTH_TOKEN=abc\nVAULT_NAME="My Vault"\n')
+
+    expect(sanitizeEnvFile(envPath)).toBe(true)
+    expect(readFileSync(envPath, "utf8")).toBe(
+      "MCP_AUTH_TOKEN=abc\nVAULT_NAME=My Vault\n",
+    )
+  })
+
+  it("strips single quotes from values", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-sanitize-"))
+    const envPath = join(targetDir, ".env")
+    writeFileSync(envPath, "MCP_AUTH_TOKEN=abc\nVAULT_NAME='My Vault'\n")
+
+    expect(sanitizeEnvFile(envPath)).toBe(true)
+    expect(readFileSync(envPath, "utf8")).toBe(
+      "MCP_AUTH_TOKEN=abc\nVAULT_NAME=My Vault\n",
+    )
+  })
+
+  it("strips quotes from multiple values in one pass", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-sanitize-"))
+    const envPath = join(targetDir, ".env")
+    writeFileSync(
+      envPath,
+      'VAULT_NAME="My Vault"\nSYNC_EXCLUDED_FOLDERS="Folder A,Folder B"\n',
+    )
+
+    expect(sanitizeEnvFile(envPath)).toBe(true)
+    expect(readFileSync(envPath, "utf8")).toBe(
+      "VAULT_NAME=My Vault\nSYNC_EXCLUDED_FOLDERS=Folder A,Folder B\n",
+    )
+  })
+
+  it("preserves comments and unquoted values", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-sanitize-"))
+    const envPath = join(targetDir, ".env")
+    const content =
+      '# Comment\nMCP_AUTH_TOKEN=abc\nVAULT_NAME="My Vault"\nPORT=8000\n# Footer\n'
+    writeFileSync(envPath, content)
+
+    sanitizeEnvFile(envPath)
+
+    expect(readFileSync(envPath, "utf8")).toBe(
+      "# Comment\nMCP_AUTH_TOKEN=abc\nVAULT_NAME=My Vault\nPORT=8000\n# Footer\n",
+    )
+  })
+
+  it("does not strip mismatched quotes", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-sanitize-"))
+    const envPath = join(targetDir, ".env")
+    const content = "VAULT_NAME=\"My Vault'\n"
+    writeFileSync(envPath, content)
+
+    expect(sanitizeEnvFile(envPath)).toBe(false)
+    expect(readFileSync(envPath, "utf8")).toBe(content)
+  })
+
+  it("preserves inner quotes of a different type", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-sanitize-"))
+    const envPath = join(targetDir, ".env")
+    writeFileSync(envPath, "VAULT_NAME=\"My 'Cool' Vault\"\n")
+
+    sanitizeEnvFile(envPath)
+
+    expect(readFileSync(envPath, "utf8")).toBe("VAULT_NAME=My 'Cool' Vault\n")
   })
 })

--- a/cli/src/__tests__/scaffold.test.ts
+++ b/cli/src/__tests__/scaffold.test.ts
@@ -154,6 +154,14 @@ describe("readEnvPort", () => {
 
     expect(readEnvPort(envPath)).toBe(9000)
   })
+
+  it("strips surrounding double quotes from the port value", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "vault-cli-"))
+    const envPath = join(targetDir, ".env")
+    writeFileSync(envPath, 'MCP_AUTH_TOKEN=abc\nPORT="9000"\n')
+
+    expect(readEnvPort(envPath)).toBe(9000)
+  })
 })
 
 describe("readEnvVaultPath", () => {

--- a/cli/src/__tests__/scaffold.test.ts
+++ b/cli/src/__tests__/scaffold.test.ts
@@ -16,7 +16,7 @@ import {
   readEnvPort,
   readEnvPublicUrl,
   readEnvVaultPath,
-  sanitizeEnvFile,
+  stripEnvQuotedValues,
   writeFiles,
 } from "../scaffold.js"
 
@@ -469,11 +469,11 @@ describe("patchEnvObsidianToken", () => {
   })
 })
 
-describe("sanitizeEnvFile", () => {
+describe("stripEnvQuotedValues", () => {
   it("returns false when the file does not exist", () => {
     const missingPath = join(tmpdir(), "vault-cli-no-such-env", ".env")
 
-    expect(sanitizeEnvFile(missingPath)).toBe(false)
+    expect(stripEnvQuotedValues(missingPath)).toBe(false)
   })
 
   it("returns false when no values are quoted", () => {
@@ -482,7 +482,7 @@ describe("sanitizeEnvFile", () => {
     const content = "MCP_AUTH_TOKEN=abc\nVAULT_NAME=My Vault\n"
     writeFileSync(envPath, content)
 
-    expect(sanitizeEnvFile(envPath)).toBe(false)
+    expect(stripEnvQuotedValues(envPath)).toBe(false)
     expect(readFileSync(envPath, "utf8")).toBe(content)
   })
 
@@ -491,7 +491,7 @@ describe("sanitizeEnvFile", () => {
     const envPath = join(targetDir, ".env")
     writeFileSync(envPath, 'MCP_AUTH_TOKEN=abc\nVAULT_NAME="My Vault"\n')
 
-    expect(sanitizeEnvFile(envPath)).toBe(true)
+    expect(stripEnvQuotedValues(envPath)).toBe(true)
     expect(readFileSync(envPath, "utf8")).toBe(
       "MCP_AUTH_TOKEN=abc\nVAULT_NAME=My Vault\n",
     )
@@ -502,7 +502,7 @@ describe("sanitizeEnvFile", () => {
     const envPath = join(targetDir, ".env")
     writeFileSync(envPath, "MCP_AUTH_TOKEN=abc\nVAULT_NAME='My Vault'\n")
 
-    expect(sanitizeEnvFile(envPath)).toBe(true)
+    expect(stripEnvQuotedValues(envPath)).toBe(true)
     expect(readFileSync(envPath, "utf8")).toBe(
       "MCP_AUTH_TOKEN=abc\nVAULT_NAME=My Vault\n",
     )
@@ -516,7 +516,7 @@ describe("sanitizeEnvFile", () => {
       'VAULT_NAME="My Vault"\nSYNC_EXCLUDED_FOLDERS="Folder A,Folder B"\n',
     )
 
-    expect(sanitizeEnvFile(envPath)).toBe(true)
+    expect(stripEnvQuotedValues(envPath)).toBe(true)
     expect(readFileSync(envPath, "utf8")).toBe(
       "VAULT_NAME=My Vault\nSYNC_EXCLUDED_FOLDERS=Folder A,Folder B\n",
     )
@@ -529,7 +529,7 @@ describe("sanitizeEnvFile", () => {
       '# Comment\nMCP_AUTH_TOKEN=abc\nVAULT_NAME="My Vault"\nPORT=8000\n# Footer\n'
     writeFileSync(envPath, content)
 
-    sanitizeEnvFile(envPath)
+    stripEnvQuotedValues(envPath)
 
     expect(readFileSync(envPath, "utf8")).toBe(
       "# Comment\nMCP_AUTH_TOKEN=abc\nVAULT_NAME=My Vault\nPORT=8000\n# Footer\n",
@@ -542,7 +542,7 @@ describe("sanitizeEnvFile", () => {
     const content = "VAULT_NAME=\"My Vault'\n"
     writeFileSync(envPath, content)
 
-    expect(sanitizeEnvFile(envPath)).toBe(false)
+    expect(stripEnvQuotedValues(envPath)).toBe(false)
     expect(readFileSync(envPath, "utf8")).toBe(content)
   })
 
@@ -551,7 +551,7 @@ describe("sanitizeEnvFile", () => {
     const envPath = join(targetDir, ".env")
     writeFileSync(envPath, "VAULT_NAME=\"My 'Cool' Vault\"\n")
 
-    sanitizeEnvFile(envPath)
+    stripEnvQuotedValues(envPath)
 
     expect(readFileSync(envPath, "utf8")).toBe("VAULT_NAME=My 'Cool' Vault\n")
   })

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -27,6 +27,7 @@ import {
   buildFilesToWrite,
   readEnvPort,
   readEnvPublicUrl,
+  sanitizeEnvFile,
   writeFiles,
   type FileWriteResult,
   type Mode,
@@ -264,9 +265,11 @@ const offerDockerRun = async (
   }
   const startNow = await prompts.confirm("Start the server now?", true)
   if (!startNow) return "not-started"
+  const envFilePath = join(targetDir, ".env")
+  sanitizeEnvFile(envFilePath)
   const containerStarted = docker.dockerRun({
     mode,
-    envFilePath: join(targetDir, ".env"),
+    envFilePath,
     port,
     vaultPath,
   })

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -27,7 +27,7 @@ import {
   buildFilesToWrite,
   readEnvPort,
   readEnvPublicUrl,
-  sanitizeEnvFile,
+  stripEnvQuotedValues,
   writeFiles,
   type FileWriteResult,
   type Mode,
@@ -266,7 +266,7 @@ const offerDockerRun = async (
   const startNow = await prompts.confirm("Start the server now?", true)
   if (!startNow) return "not-started"
   const envFilePath = join(targetDir, ".env")
-  sanitizeEnvFile(envFilePath)
+  stripEnvQuotedValues(envFilePath)
   const containerStarted = docker.dockerRun({
     mode,
     envFilePath,

--- a/cli/src/lifecycle.ts
+++ b/cli/src/lifecycle.ts
@@ -18,7 +18,7 @@ import {
   readEnvPort,
   readEnvPublicUrl,
   readEnvVaultPath,
-  sanitizeEnvFile,
+  stripEnvQuotedValues,
   type Mode,
 } from "./scaffold.js"
 import { expandTilde } from "./vault.js"
@@ -215,7 +215,7 @@ export const recreateContainer = async (
     return 1
   }
 
-  sanitizeEnvFile(deployment.envFilePath)
+  stripEnvQuotedValues(deployment.envFilePath)
   prompts.log("Starting container...")
   const containerStarted = docker.dockerRun({
     mode: deployment.mode,

--- a/cli/src/lifecycle.ts
+++ b/cli/src/lifecycle.ts
@@ -18,6 +18,7 @@ import {
   readEnvPort,
   readEnvPublicUrl,
   readEnvVaultPath,
+  sanitizeEnvFile,
   type Mode,
 } from "./scaffold.js"
 import { expandTilde } from "./vault.js"
@@ -214,6 +215,7 @@ export const recreateContainer = async (
     return 1
   }
 
+  sanitizeEnvFile(deployment.envFilePath)
   prompts.log("Starting container...")
   const containerStarted = docker.dockerRun({
     mode: deployment.mode,

--- a/cli/src/scaffold.ts
+++ b/cli/src/scaffold.ts
@@ -40,6 +40,19 @@ const ENV_PUBLIC_URL_VALUE_LINE = /^PUBLIC_URL=(.+)\s*$/m
 /** Matches an active (uncommented) OBSIDIAN_AUTH_TOKEN line. */
 const OBSIDIAN_AUTH_TOKEN_LINE = /^OBSIDIAN_AUTH_TOKEN=/m
 
+/** Matches an env line whose value is wrapped in matching quotes. */
+const QUOTED_ENV_VALUE = /^([A-Za-z_][A-Za-z0-9_]*=)(["'])(.*)\2(\s*)$/gm
+
+/**
+ * Strips matching surrounding quotes from a value — `"foo"` → `foo`,
+ * `'bar'` → `bar`, `unquoted` → `unquoted`. Only strips when the
+ * opening and closing quote characters match.
+ */
+const stripSurroundingQuotes = (value: string): string => {
+  const quoteMatch = /^(["'])(.*)\1$/.exec(value)
+  return quoteMatch ? quoteMatch[2] : value
+}
+
 export const buildFilesToWrite = (envContent: string): FileToWrite[] => [
   // .env holds the bearer token (and possibly a vault password) — owner-only.
   { name: ".env", content: envContent, mode: 0o600 },
@@ -64,7 +77,8 @@ export const readEnvPort = (envFilePath: string): number => {
 export const readEnvVaultPath = (envFilePath: string): string | undefined => {
   if (!existsSync(envFilePath)) return undefined
   const match = ENV_VAULT_PATH_LINE.exec(readFileSync(envFilePath, "utf8"))
-  return match?.[1].trim()
+  const rawValue = match?.[1].trim()
+  return rawValue ? stripSurroundingQuotes(rawValue) : undefined
 }
 
 /**
@@ -93,11 +107,12 @@ export const readEnvPublicUrl = (envFilePath: string): string | undefined => {
   )
   // A whitespace-only line matches the regex and trims to "" — normalize to
   // undefined so the non-empty contract holds ("" is never a legitimate URL).
-  const publicUrlValue = match?.[1].trim()
+  const rawValue = match?.[1].trim()
+  const unquotedValue = rawValue ? stripSurroundingQuotes(rawValue) : undefined
   // Strip trailing slashes (mirroring askPublicUrl's prompt-side
   // normalization): consumers append paths to this base, and a hand-edited
   // `https://host/` would otherwise print broken `//mcp` connect URLs.
-  const normalizedPublicUrl = publicUrlValue?.replace(/\/+$/, "")
+  const normalizedPublicUrl = unquotedValue?.replace(/\/+$/, "")
   return normalizedPublicUrl || undefined
 }
 
@@ -133,6 +148,24 @@ export const patchEnvObsidianToken = (
     () => `OBSIDIAN_AUTH_TOKEN=${token}`,
   )
   writeFileSync(envFilePath, patched)
+  return true
+}
+
+/**
+ * Strips surrounding quotes from env values in the file. `docker run
+ * --env-file` passes quotes literally (`VAULT_NAME="My Vault"` becomes
+ * the value `"My Vault"` with embedded quotes), while Compose strips
+ * them. Removing quotes makes the file work correctly for both paths.
+ * Returns true when the file was modified.
+ */
+export const sanitizeEnvFile = (envFilePath: string): boolean => {
+  if (!existsSync(envFilePath)) return false
+  const content = readFileSync(envFilePath, "utf8")
+  // Reset lastIndex — the /g flag makes the regex stateful.
+  QUOTED_ENV_VALUE.lastIndex = 0
+  const sanitized = content.replace(QUOTED_ENV_VALUE, "$1$3$4")
+  if (sanitized === content) return false
+  writeFileSync(envFilePath, sanitized)
   return true
 }
 

--- a/cli/src/scaffold.ts
+++ b/cli/src/scaffold.ts
@@ -25,8 +25,8 @@ export type FileWriteResult = {
 /** Default host port — matches the container's internal port. */
 export const DEFAULT_PORT = 8000
 
-/** Matches an active (uncommented) PORT line in a .env file. */
-const ENV_PORT_LINE = /^PORT=(\d+)\s*$/m
+/** Matches an active (uncommented) PORT line, with optional surrounding quotes. */
+const ENV_PORT_LINE = /^PORT=["']?(\d+)["']?\s*$/m
 
 /** Matches an active (uncommented) VAULT_PATH line in a .env file. */
 const ENV_VAULT_PATH_LINE = /^VAULT_PATH=(.+)\s*$/m

--- a/cli/src/scaffold.ts
+++ b/cli/src/scaffold.ts
@@ -158,7 +158,7 @@ export const patchEnvObsidianToken = (
  * them. Removing quotes makes the file work correctly for both paths.
  * Returns true when the file was modified.
  */
-export const sanitizeEnvFile = (envFilePath: string): boolean => {
+export const stripEnvQuotedValues = (envFilePath: string): boolean => {
   if (!existsSync(envFilePath)) return false
   const content = readFileSync(envFilePath, "utf8")
   // Reset lastIndex — the /g flag makes the regex stateful.

--- a/deploy/local/.env.example
+++ b/deploy/local/.env.example
@@ -1,5 +1,10 @@
 # vault-cortex — local quickstart
 # Copy to .env and fill in values, then: docker compose up
+#
+# Write values without quotes — docker run --env-file passes them literally,
+# so VAULT_PATH="/path/to/My Vault" sets the value "/path/to/My Vault"
+# (with quotes). The CLI strips quotes automatically; plain docker run
+# does not.
 
 # Required ──────────────────────────────────────────────────
 

--- a/deploy/remote/.env.example
+++ b/deploy/remote/.env.example
@@ -1,5 +1,9 @@
 # vault-cortex — remote quickstart (Obsidian Sync)
 # Copy to .env and fill in values, then: docker compose up -d
+#
+# Write values without quotes — docker run --env-file passes them literally,
+# so VAULT_NAME="My Vault" sets the value "My Vault" (with quotes).
+# The CLI strips quotes automatically; plain docker run does not.
 
 # Required ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `docker run --env-file` passes quotes literally, so a hand-edited `VAULT_NAME="My Vault"` becomes the value `"My Vault"` (with quotes), causing `Vault ""My Vault"" not found`. Compose strips quotes; `docker run` does not.
- Add `sanitizeEnvFile` that strips matching surrounding quotes from env values in the file before every `docker run` call (init and lifecycle/restart/upgrade paths)
- Fix `readEnvVaultPath` and `readEnvPublicUrl` to strip quotes from captured values (the CLI's own reads, independent of Docker)
- Add a "write values without quotes" note to both `deploy/.env.example` files for users running plain `docker run` without the CLI

## Test plan

- [ ] New `sanitizeEnvFile` tests: strips double/single quotes, handles multiple values, preserves comments and unquoted values, skips mismatched quotes, preserves inner quotes of a different type (7 tests)
- [ ] New `readEnvVaultPath` quote tests: double and single quotes stripped (2 tests)
- [ ] New `readEnvPublicUrl` quote tests: quotes stripped, quotes-then-trailing-slashes stripped (2 tests)
- [ ] All 9 new tests mutation-verified (4 reader tests + 5 sanitize tests killed their respective mutations)
- [ ] Full suite passes (3,078 tests), lint clean, build clean
- [ ] Template drift tests pass (env var consistency across deploy surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)