### PR TITLE
chore: add 30m job timeout to umm-review workflow

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: umm, actually
     if: >-
       (


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes: 30` to the umm-review job as a safety net for stuck LLM requests
- The application-level `AbortController` timeout (default 600s) failed to fire on [run 32779937273](https://github.com/aliasunder/vault-cortex/actions/runs/32779937273), which hung for 38+ min on PR #491
- Without a job timeout, GitHub's 6h default applies — this caps runner waste at 30m

## Test plan
- [ ] Verify the workflow YAML is valid (Actions tab shows no parse errors on push)
- [ ] Confirm normal reviews complete well under 30m (typical: 2-5 min)