### PR TITLE
chore(deps): bump umm-actually to v0.3.12

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -84,7 +84,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@04223833a3d8b82a10482440c2aee4118fc5f9e8 # v0.3.11
+      - uses: aliasunder/umm-actually@f8d09b8d4cc8ef1cae72f0e270cb7910348a4627 # v0.3.12
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
## Summary

- Bump `umm-actually` action pin from v0.3.11 to v0.3.12

## Changes in v0.3.12

- Context notes now show which priority docs were satisfied by another channel ("Priority docs already in context: ...") for full disposition visibility
- 10% budget floor reserves tokens for priority docs so related files can't starve them on large PRs
- Floor skips when all priority docs are already in context as changed files (no wasted budget)
- README `priority_docs` description corrected — was "always included", now documents the budget floor and shared-budget constraint