### PR TITLE
chore: bump umm-actually to v0.3.13

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -84,7 +84,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@f8d09b8d4cc8ef1cae72f0e270cb7910348a4627 # v0.3.12
+      - uses: aliasunder/umm-actually@74276fdab1793e985ccef030fabfdcd9ccc72e4d # v0.3.13
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
## Summary

Bump umm-actually to v0.3.13 (`74276fd`).

- Workflow job summary now shows priority docs already in context via another channel, priority docs not included (missing, unreadable, or over budget), and the token budget split (total · diff · priority-doc floor · left for docs) — so a starved run is diagnosable from the check run alone.

## Test plan

- [ ] Self-review runs on this PR and posts its status/summary with the new rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
