### PR TITLE
chore(sst): keep API Gateway and authorizer CloudWatch logs for 1 year

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -180,6 +180,16 @@ Note: `2>&1` is needed because error-level logs go to stderr — piping to jq re
 
 Set `LOG_LEVEL` in `.env` to control the threshold (default: `info`).
 
+### CloudWatch logs
+
+API Gateway and the Lambda authorizer log to CloudWatch, separately from the container. Both log groups keep 1 year (set in `sst.config.ts`; SST's default is 1 month). A year of these logs is a few MB, inside the CloudWatch free tier.
+
+```bash
+# Authorizer invocations (log group name is stage-specific; list to find it)
+aws logs describe-log-groups --query 'logGroups[].[logGroupName,retentionInDays]' --output table
+aws logs tail /aws/lambda/<authorizer-function> --since 24h
+```
+
 ## Command reference
 
 | Command                  | What it does                                                                                                    |

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -182,7 +182,7 @@ Set `LOG_LEVEL` in `.env` to control the threshold (default: `info`).
 
 ### CloudWatch logs
 
-API Gateway and the Lambda authorizer log to CloudWatch, separately from the container. Both log groups keep 1 year (set in `sst.config.ts`; SST's default is 1 month). A year of these logs is a few MB, inside the CloudWatch free tier.
+API Gateway and the Lambda authorizer log to CloudWatch, separately from the container. Both log groups keep 1 year (set in `sst.config.ts`; SST's default is 1 month). A year of these logs is about 100 MB, inside the CloudWatch free tier.
 
 ```bash
 # Authorizer invocations (log group name is stage-specific; list to find it)

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -303,6 +303,10 @@ export default $config({
             cert: customDomainCertArn,
           },
         }),
+      // CloudWatch retention for the gateway access log (the authorizer's
+      // log group below matches). SST defaults to 1 month, which caps how
+      // far back an auth audit can look; a year of these logs is a few MB.
+      accessLog: { retention: "1 year" },
       transform: {
         api: { disableExecuteApiEndpoint },
         stage: {
@@ -338,6 +342,7 @@ export default $config({
           runtime: "nodejs24.x",
           timeout: "5 seconds",
           memory: "128 MB",
+          logging: { retention: "1 year" },
         },
         identitySources: ["$request.header.Authorization"],
       },

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -305,7 +305,7 @@ export default $config({
         }),
       // CloudWatch retention for the gateway access log (the authorizer's
       // log group below matches). SST defaults to 1 month, which caps how
-      // far back an auth audit can look; a year of these logs is a few MB.
+      // far back an auth audit can look; a year of them is about 100 MB.
       accessLog: { retention: "1 year" },
       transform: {
         api: { disableExecuteApiEndpoint },


### PR DESCRIPTION
## What

- `accessLog: { retention: "1 year" }` on the API Gateway and `logging: { retention: "1 year" }` on the Lambda authorizer function in `sst.config.ts`. Both log groups were on SST's 1-month default.
- New **CloudWatch logs** subsection under Monitoring in `DEPLOY.md` stating the retention and how to find the log groups.

## Why

One month of gateway and authorizer logs caps how far back an auth audit can look. The two groups hold about 9 MB per month combined (about 100 MB a year), so a year of them stays well inside the CloudWatch free tier.

## Notes

- Retention updates the existing log groups in place (no replacement). Already-expired logs are not recovered; the full year accumulates from the deploy forward.
- `npm run build:sst`, Prettier, and markdownlint pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
