### PR TITLE
ci(gitleaks): scan main plus the pull request's commits, not every branch

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -36,14 +36,12 @@ jobs:
           grep " ${ASSET}$" "gitleaks_${GITLEAKS_VERSION}_checksums.txt" | sha256sum -c -
           tar -xzf "${ASSET}" -C /usr/local/bin gitleaks
 
-      # A PR scans only its own commits. `--all` would cover every branch on
-      # the remote, so an unmerged PR's findings (or its allowlist, which
-      # gitleaks reads from the checkout) would decide another PR's result.
-      - name: Scan pull request commits
+      # HEAD is the PR's merge commit, so its ancestry is main plus this PR
+      # and nothing from other branches. `--all` would let an unmerged PR's
+      # findings (or its allowlist, read from the checkout) decide this one.
+      - name: Scan main plus pull request commits
         if: github.event_name == 'pull_request'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: gitleaks detect --source . --log-opts="${BASE_SHA}..HEAD" --redact --verbose
+        run: gitleaks detect --source . --log-opts="HEAD" --redact --verbose
 
       - name: Scan full git history
         if: github.event_name == 'push'

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -36,5 +36,15 @@ jobs:
           grep " ${ASSET}$" "gitleaks_${GITLEAKS_VERSION}_checksums.txt" | sha256sum -c -
           tar -xzf "${ASSET}" -C /usr/local/bin gitleaks
 
+      # A PR scans only its own commits. `--all` would cover every branch on
+      # the remote, so an unmerged PR's findings (or its allowlist, which
+      # gitleaks reads from the checkout) would decide another PR's result.
+      - name: Scan pull request commits
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: gitleaks detect --source . --log-opts="${BASE_SHA}..HEAD" --redact --verbose
+
       - name: Scan full git history
+        if: github.event_name == 'push'
         run: gitleaks detect --source . --log-opts="--all" --redact --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,8 +150,8 @@ truth. Key points:
      and boots it on a native runner for each architecture, then boots the
      remote image with a stubbed Sync client to run its init chain
      end-to-end (`npm run test:remote-boot`)
-   - `gitleaks` — secret detection over the PR's own commits (the push to
-     `main` rescans the full history)
+   - `gitleaks` — secret detection over `main` plus the PR's commits, so a
+     finding on `main` fails every open PR until it is cleaned up
    - `trivy-pr` — vulnerability scan of the Docker image built from your
      branch; a fixable CRITICAL/HIGH CVE fails it
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,8 @@ truth. Key points:
      and boots it on a native runner for each architecture, then boots the
      remote image with a stubbed Sync client to run its init chain
      end-to-end (`npm run test:remote-boot`)
-   - `gitleaks` — secret detection
+   - `gitleaks` — secret detection over the PR's own commits (the push to
+     `main` rescans the full history)
    - `trivy-pr` — vulnerability scan of the Docker image built from your
      branch; a fixable CRITICAL/HIGH CVE fails it
 


### PR DESCRIPTION
## What

- On `pull_request`, gitleaks scans `HEAD`: the merge commit's ancestry, which is `main` plus this PR's commits and nothing from other branches. A finding on `main` fails every open PR until it is cleaned up.
- On `push` to `main`, the full-history `--all` scan is unchanged.
- `CONTRIBUTING.md` required-checks list states the scope.

## Why

`--all` on a `fetch-depth: 0` checkout scans every branch on the remote, so a finding on one unmerged PR's branch fails every other PR's scan. It also means the allowlist gitleaks reads from the PR's own checkout has to cover other branches' fixtures. Seen on #504, which failed on test vectors that live only on #500's branch (#500 itself passes because its branch also allowlists them).

## Verified

- This PR's own gitleaks run exercises the new step: "Scan main plus pull request commits", 902 commits scanned, no leaks found. Before this change the same job scanned 932 commits (every branch).
- Local gitleaks over a synthetic merge commit of `main` + #504's branch: no findings from #500's branch; `--all` reproduces them. (Local gitleaks 8.30.1 flags one string literal on `main` that CI's pinned 8.21.2 does not; that entry would need an allowlist line if the pinned version is ever bumped.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)