### PR TITLE
repro(deploy): drop authorizer identity source to reproduce the 403 on tokenless /mcp

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -339,7 +339,8 @@ export default $config({
           timeout: "5 seconds",
           memory: "128 MB",
         },
-        identitySources: ["$request.header.Authorization"],
+        // REPRO BRANCH — never merge. identitySources removed so tokenless
+        // /mcp requests reach the Lambda and its deny becomes a 403.
       },
     })
 

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -339,8 +339,11 @@ export default $config({
           timeout: "5 seconds",
           memory: "128 MB",
         },
-        // REPRO BRANCH — never merge. identitySources removed so tokenless
-        // /mcp requests reach the Lambda and its deny becomes a 403.
+        // REPRO BRANCH — never merge. An empty identity source (the May 8
+        // wiring) sends tokenless /mcp requests to the Lambda, whose deny
+        // becomes a 403. Omitting the key does not do this: SST defaults it
+        // to the Authorization header.
+        identitySources: [],
       },
     })
 


### PR DESCRIPTION
Test-deploy only. Never merge.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>