### PR TITLE
fix(oauth): grant the vault scope when a client requests none

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -635,6 +635,10 @@ sequenceDiagram
 **JWT payload:** `{ sub: clientId, scope: "vault", exp: <unix>, iss: "vault-cortex" }`
 Signed with HMAC-SHA256 using `MCP_AUTH_TOKEN` as the key. Both the Lambda
 authorizer and Express can verify independently — no shared state needed.
+`vault` is the server's only scope: a client that requests it gets it, and a
+client that requests no scope is granted it at authorization time, so the
+consent page, the access token, and every refresh carry the same value as the
+static token.
 
 **Token storage:** what each credential is and where it lives.
 

--- a/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
@@ -839,6 +839,129 @@ const startAuthFlow = async (
   return match[1]
 }
 
+describe("OAuth default scope", () => {
+  /** Starts an authorization flow with the given scopes and returns the
+   *  rendered consent HTML plus the request id it carries. */
+  const startAuthFlowWithScopes = async (
+    oauth: OAuthProvider,
+    client: OAuthClientInformationFull,
+    scopes: string[] | undefined,
+  ): Promise<{ consentHtml: string; requestId: string }> => {
+    let consentHtml = ""
+    const res = {
+      type: () => res,
+      send: (html: string) => {
+        consentHtml = html
+        return res
+      },
+    }
+    await oauth.provider.authorize(
+      client,
+      {
+        codeChallenge: "test-challenge",
+        redirectUri: "https://example.com/cb",
+        ...(scopes === undefined ? {} : { scopes }),
+      },
+      res as never,
+    )
+    const requestId = /name="request_id"\s+value="([^"]+)"/.exec(
+      consentHtml,
+    )?.[1]
+    if (!requestId) throw new Error("no request_id in consent HTML")
+    return { consentHtml, requestId }
+  }
+
+  it("grants vault when the request names no scope", async () => {
+    const { logs, testLogger, oauth, client } = await setupAuditTest()
+
+    const { consentHtml, requestId } = await startAuthFlowWithScopes(
+      oauth,
+      client,
+      [],
+    )
+
+    const started = logs.find(
+      (log) => log.message === "oauth_authorize_started",
+    )
+    expect(started?.data.scopes).toEqual(["vault"])
+    expect(consentHtml).toContain("<li>vault</li>")
+    expect(consentHtml).not.toContain("No specific scopes requested")
+
+    const code = oauth.approveRequest(requestId, testLogger)
+    const issued = await oauth.provider.exchangeAuthorizationCode(client, code)
+    expect(issued.scope).toBe("vault")
+    const verified = await oauth.provider.verifyAccessToken(issued.access_token)
+    expect(verified.scopes).toEqual(["vault"])
+
+    if (!issued.refresh_token) throw new Error("no refresh token issued")
+    const refreshed = await exchangeRefreshToken(
+      oauth,
+      client,
+      issued.refresh_token,
+    )
+    expect(refreshed.scope).toBe("vault")
+  })
+
+  it("grants vault when the request's scope is blank", async () => {
+    const { logs, testLogger, oauth, client } = await setupAuditTest()
+
+    // The SDK turns `scope=` into [""].
+    const { consentHtml, requestId } = await startAuthFlowWithScopes(
+      oauth,
+      client,
+      [""],
+    )
+
+    const started = logs.find(
+      (log) => log.message === "oauth_authorize_started",
+    )
+    expect(started?.data.scopes).toEqual(["vault"])
+    expect(consentHtml).toContain("<li>vault</li>")
+    expect(consentHtml).not.toContain("<li></li>")
+
+    const code = oauth.approveRequest(requestId, testLogger)
+    const issued = await oauth.provider.exchangeAuthorizationCode(client, code)
+    expect(issued.scope).toBe("vault")
+  })
+
+  it("keeps the scope a request names", async () => {
+    const { logs, testLogger, oauth, client } = await setupAuditTest()
+
+    const { consentHtml, requestId } = await startAuthFlowWithScopes(
+      oauth,
+      client,
+      ["vault"],
+    )
+
+    const started = logs.find(
+      (log) => log.message === "oauth_authorize_started",
+    )
+    expect(started?.data.scopes).toEqual(["vault"])
+    expect(consentHtml).toContain("<li>vault</li>")
+
+    const code = oauth.approveRequest(requestId, testLogger)
+    const issued = await oauth.provider.exchangeAuthorizationCode(client, code)
+    expect(issued.scope).toBe("vault")
+  })
+
+  it("does not widen a narrower explicit scope to vault", async () => {
+    const { oauth, testLogger, client } = await setupAuditTest()
+
+    const { consentHtml, requestId } = await startAuthFlowWithScopes(
+      oauth,
+      client,
+      ["read"],
+    )
+
+    expect(consentHtml).toContain("<li>read</li>")
+    expect(consentHtml).not.toContain("<li>vault</li>")
+
+    const code = oauth.approveRequest(requestId, testLogger)
+    const issued = await oauth.provider.exchangeAuthorizationCode(client, code)
+    expect(issued.scope).toBe("read")
+  })
+})
+
 describe("OAuth refresh token storage keyed by the auth token", () => {
   const createKeyedStorageTest = async (): Promise<{
     dbPath: string

--- a/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
@@ -960,6 +960,28 @@ describe("OAuth default scope", () => {
     const issued = await oauth.provider.exchangeAuthorizationCode(client, code)
     expect(issued.scope).toBe("read")
   })
+
+  it("grants vault when the scopes key is absent from the request", async () => {
+    const { logs, testLogger, oauth, client } = await setupAuditTest()
+
+    // When the SDK receives no `scope` parameter at all, params.scopes is
+    // undefined — the ?? [] nullish guard in authorize handles this.
+    const { consentHtml, requestId } = await startAuthFlowWithScopes(
+      oauth,
+      client,
+      undefined,
+    )
+
+    const started = logs.find(
+      (log) => log.message === "oauth_authorize_started",
+    )
+    expect(started?.data.scopes).toEqual(["vault"])
+    expect(consentHtml).toContain("<li>vault</li>")
+
+    const code = oauth.approveRequest(requestId, testLogger)
+    const issued = await oauth.provider.exchangeAuthorizationCode(client, code)
+    expect(issued.scope).toBe("vault")
+  })
 })
 
 describe("OAuth refresh token storage keyed by the auth token", () => {

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -48,7 +48,7 @@ const AUTH_CODE_TTL_S = 10 * 60
 // The one scope the server grants; also what the static token carries
 // (see verifyAccessToken) and what the metadata advertises as
 // scopes_supported.
-export const DEFAULT_SCOPE = "vault"
+export const DEFAULT_SCOPE = "vault" as const
 
 type PendingAuthRequest = {
   client: OAuthClientInformationFull

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -48,7 +48,7 @@ const AUTH_CODE_TTL_S = 10 * 60
 // The one scope the server grants; also what the static token carries
 // (see verifyAccessToken) and what the metadata advertises as
 // scopes_supported.
-const DEFAULT_SCOPE = "vault"
+export const DEFAULT_SCOPE = "vault"
 
 type PendingAuthRequest = {
   client: OAuthClientInformationFull

--- a/src/vault-mcp/oauth/oauth-provider.ts
+++ b/src/vault-mcp/oauth/oauth-provider.ts
@@ -45,6 +45,10 @@ const ACCESS_TOKEN_TTL_S = 24 * 60 * 60
 const REFRESH_TOKEN_TTL_S = 60 * 24 * 60 * 60
 // 10 minutes — OAuth spec recommends short auth code lifetimes.
 const AUTH_CODE_TTL_S = 10 * 60
+// The one scope the server grants; also what the static token carries
+// (see verifyAccessToken) and what the metadata advertises as
+// scopes_supported.
+const DEFAULT_SCOPE = "vault"
 
 type PendingAuthRequest = {
   client: OAuthClientInformationFull
@@ -353,28 +357,38 @@ export const createOAuthProvider = ({
       return store
     },
 
+    /** A request that names no scope is granted the server's one scope.
+     *  The default is applied here, before the request is stored, so the
+     *  consent page, the code exchange, and every later refresh read the
+     *  same value. */
     async authorize(
       client: OAuthClientInformationFull,
       params: AuthorizationParams,
       res: Response,
     ): Promise<void> {
       const requestId = randomUUID()
+      // The SDK splits `scope=` into [""], so blank entries count as none.
+      const requestedScopes = (params.scopes ?? []).filter(
+        (scope) => scope !== "",
+      )
+      const scopes =
+        requestedScopes.length > 0 ? requestedScopes : [DEFAULT_SCOPE]
       pendingRequests.set(requestId, {
         client,
-        params,
+        params: { ...params, scopes },
         createdAt: DateTime.now(),
       })
 
       oauthLogger.info("oauth_authorize_started", {
         clientId: client.client_id,
         requestId,
-        scopes: params.scopes ?? [],
+        scopes,
       })
       res.type("html").send(
         renderConsentPage({
           clientName: client.client_name ?? client.client_id,
           clientId: client.client_id,
-          scopes: params.scopes ?? [],
+          scopes,
           requestId,
         }),
       )
@@ -500,7 +514,7 @@ export const createOAuthProvider = ({
         return {
           token,
           clientId: "static",
-          scopes: ["vault"],
+          scopes: [DEFAULT_SCOPE],
           expiresAt: DateTime.now().plus({ years: 10 }).toUnixInteger(),
         }
       }

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -7,7 +7,7 @@ import { metadataHandler } from "@modelcontextprotocol/sdk/server/auth/handlers/
 import type { OAuthProtectedResourceMetadata } from "@modelcontextprotocol/sdk/shared/auth.js"
 import { extractClientIp, safeEqual } from "../../auth.js"
 import { renderConsentPage } from "./consent-page.js"
-import type { OAuthProvider } from "./oauth-provider.js"
+import { DEFAULT_SCOPE, type OAuthProvider } from "./oauth-provider.js"
 import type { Logger } from "../../logger.js"
 
 type OAuthRoutesOptions = {
@@ -76,7 +76,7 @@ export const createOAuthRoutes = ({
     validate: false as const,
   }
 
-  const scopesSupported = ["vault"]
+  const scopesSupported = [DEFAULT_SCOPE]
 
   // RFC 9728 §3.1: a metadata document's `resource` must equal the resource
   // identifier its well-known URL derives from, so this suffixed document


### PR DESCRIPTION
## What

- `authorize` in `oauth-provider.ts` defaults the requested scope to `vault` when the client sends none or a blank `scope=`. The default is applied once, before the request is stored, so the consent page, the code exchange, and every refresh read the same value.
- `DEFAULT_SCOPE` (`"vault" as const`) names the server's one scope; the static token's `AuthInfo` and the metadata's `scopes_supported` in `oauth-routes.ts` both read it.
- ARCHITECTURE.md: one sentence under the JWT payload describing the rule.

## Why

A client that requested no scope got an access token with an empty `scope` claim and a consent page reading "No specific scopes requested", while the static token carries `vault` and the metadata advertises `vault` as the only supported scope. Nothing reads the claim today, so this is cosmetic, but it becomes a real seam once tokens carry more claims and layers start comparing them.

## Behaviour

| Request | Before | After |
| --- | --- | --- |
| no `scope` | consent: "No specific scopes requested"; token `scope: ""` | consent lists `vault`; token `scope: "vault"` |
| `scope=` (blank) | consent: empty list item; token `scope: ""` | same as above |
| `scope=vault` | unchanged | unchanged |
| `scope=read` | `read` | `read` (the default never widens a named scope) |

`scopes_supported` is unchanged; a refresh still may narrow but never widen the grant.

## Tests

- Five provider tests: three grant `vault` (no scope `[]`, blank scope `[""]`, `scopes` key absent) and two keep an explicit scope (`vault`, narrower `read`). Each asserts the `oauth_authorize_started` log, the rendered consent list, and the issued token's `scope`; the no-scope case also asserts the verified `AuthInfo.scopes` and the refreshed token's scope.
- Mutation check: with the default removed, the three "grants vault" tests fail and the two explicit-scope tests still pass.
- Full suite: 3,294 tests green.

No automated per-PR coverage over HTTP for the no-scope case; the route tests exercise `scope=vault` end to end and the provider tests cover the default at the boundary where the SDK hands over `scopes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
