### PR TITLE
ci(gitleaks): scan only the ref under test, bump to 8.30.1

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -18,7 +18,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     env:
-      GITLEAKS_VERSION: 8.21.2
+      GITLEAKS_VERSION: 8.30.1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -36,13 +36,9 @@ jobs:
           grep " ${ASSET}$" "gitleaks_${GITLEAKS_VERSION}_checksums.txt" | sha256sum -c -
           tar -xzf "${ASSET}" -C /usr/local/bin gitleaks
 
-      # HEAD is the PR's merge commit, so its ancestry is main plus this PR
-      # and nothing from other branches. `--all` would let an unmerged PR's
-      # findings (or its allowlist, read from the checkout) decide this one.
-      - name: Scan main plus pull request commits
-        if: github.event_name == 'pull_request'
+      # HEAD is the ref under test — a pull request's merge commit (the base
+      # branch plus this PR) or the pushed branch itself. Never --all: an
+      # unmerged branch's findings (or its allowlist, read from the checkout)
+      # must not decide this ref's check.
+      - name: Scan the ref's full history
         run: gitleaks detect --source . --log-opts="HEAD" --redact --verbose
-
-      - name: Scan full git history
-        if: github.event_name == 'push'
-        run: gitleaks detect --source . --log-opts="--all" --redact --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,7 +1,11 @@
 [extend]
 useDefault = true
 
-[allowlist]
+[[allowlists]]
 description = "Documented placeholder used in local-dev quickstarts (README, CONTRIBUTING, docker-compose.local.yml). Not a real credential."
 regexTarget = "match"
 regexes = ['''local-dev-token''']
+
+[[allowlists]]
+description = "Test fixture label in oauth-provider.test.ts flagged by generic-api-key on the accessToken keyword. Not a real credential."
+commits = ["fa6e3a53245494dbfbfd78d215fb4406ec98f4da"]


### PR DESCRIPTION
## Summary

- The push job scanned `--log-opts="--all"` over a full checkout, so findings on unmerged branches could fail main's check. The fix scans `--log-opts="HEAD"` unconditionally — HEAD is the ref under test in both events (PR merge commit or pushed branch), so the two conditional steps collapse into one
- Bump gitleaks from 8.21.2 to 8.30.1. The new version's `generic-api-key` rule flags a test fixture label (`revoked-23h-ago`) in a historical commit — allowlist that commit
- Migrate `.gitleaks.toml` from the deprecated `[allowlist]` singular syntax to the `[[allowlists]]` array-of-tables form

## Test plan

- [x] Verified locally: `gitleaks detect --log-opts="HEAD"` exits 0 over main's full history with 8.30.1
- [x] CI gitleaks check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)