### PR TITLE
fix(oauth): re-enable express-rate-limit validation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -727,8 +727,10 @@ client-IP key derived from the deployment's explicit proxy-trust config:
   Access policy on the tunnel host admits nothing else, so the only
   `Forwarded` header reaching the container is the gateway's.
 
-(express-rate-limit's built-in validators are disabled — they assume
-direct-to-server traffic, not reverse-proxy deployments.) A tripped limiter
+(express-rate-limit's built-in validators run; the proxy-header checks
+live inside the library's default key generator, which the custom
+`extractClientIp` key generator replaces, so they don't fire behind the
+reverse proxy.) A tripped limiter
 emits an `oauth_rate_limited` warn log with the client IP and endpoint path
 before returning the 429.
 

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "entry": ["cli/src/bin.ts"],
   "project": ["src/**/*.ts", "cli/src/**/*.ts", "scripts/**/*.ts"],
-  "ignoreBinaries": ["optipng"]
+  "ignoreBinaries": ["optipng", "knip", "markdownlint-cli2"],
+  "ignoreDependencies": ["markdownlint-cli2"]
 }

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,5 @@
 {
   "entry": ["cli/src/bin.ts"],
   "project": ["src/**/*.ts", "cli/src/**/*.ts", "scripts/**/*.ts"],
-  "ignoreBinaries": ["optipng", "knip", "markdownlint-cli2"],
-  "ignoreDependencies": ["markdownlint-cli2"]
+  "ignoreBinaries": ["optipng"]
 }

--- a/src/vault-mcp/oauth/oauth-routes.ts
+++ b/src/vault-mcp/oauth/oauth-routes.ts
@@ -77,7 +77,6 @@ export const createOAuthRoutes = ({
       })
       res.status(options.statusCode).send(options.message)
     },
-    validate: false as const,
   }
 
   const scopesSupported = [DEFAULT_SCOPE]


### PR DESCRIPTION
## Summary

- Remove `validate: false` from the OAuth flow rate limiter, restoring the library's built-in safety checks

## Why this is safe

The `validate: false` switch was set on launch day (`a9663ce`) because express-rate-limit's proxy validators threw behind API Gateway. Source analysis of express-rate-limit 8.5.2 shows those three validators (`trustProxy`, `xForwardedForHeader`, `forwardedHeader`) all live **inside the library's default `keyGenerator` function** (index.mjs lines 779-783). Since we provide a custom `keyGenerator` (`extractClientIp`), the default is replaced entirely and the proxy validators never execute.

The initialization-time validators all pass cleanly:
- `keyGeneratorIpFallback` — checks `keyGenerator.toString()` for `req.ip`; our arrow function delegates to `extractClientIp` in a separate module, so the string doesn't match
- `ipv6SubnetOrKeyGenerator` — only fires when both `ipv6Subnet` and `keyGenerator` are set; we don't pass `ipv6Subnet`
- All other init-time checks (knownOptions, deprecated options, etc.) pass

**Note for future express-rate-limit major upgrades:** if v9+ moves the proxy validators out of the default `keyGenerator`, the existing integration tests (which exercise rate limiting under all four supported topologies) will surface any issues — the validators are caught and logged, not thrown, so behavioral regressions would show up as test failures, not crashes.

## Test plan

- [x] `npx tsc --noEmit` — type-check passes
- [x] `npm test` — 3,343 tests pass (85 files)
- [x] Grepped test output for `ERR_ERL` / `WRN_ERL` / `express-rate-limit.*validation` — zero matches
- [x] Existing rate-limit integration tests cover all four topologies (default, `TRUST_PROXY_HOPS=1`, `TRUST_FORWARDED_HOPS=1`, `TRUST_FORWARDED_HOPS=2`)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)