### PR TITLE
chore(lint): enforce no-nested-ternary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -675,6 +675,10 @@ undefined) return`) or schema validation to narrow types instead.
   incident dates, deployment names, task-board IDs, remediation
   narration, and investigation chronology never enter any public
   artifact — committed files, PR descriptions, or comments.
+- No nested ternaries — a chained `a ? b : c ? d : e` forces the
+  reader to simulate branches. Decompose into named const steps or
+  use an early-return guard with a trailing ternary. Lint-enforced
+  via `no-nested-ternary`.
 - Early returns over nested `if/else` — reduces indentation depth
   and cognitive load. Prefer `if (done) return` over wrapping 15
   lines in `if (!done) { ... }`. In loops, prefer `if (cond) { …;

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -568,10 +568,9 @@ export const runInit = async (
 
   // Mode resolution: explicit --mode wins; --yes implies local; otherwise
   // ask, defaulting to local — it's the simpler activation path.
-  const explicitMode =
-    flags.mode !== undefined && isMode(flags.mode) ? flags.mode : undefined
-  const mode: Mode =
-    explicitMode ?? (flags.yes ? "local" : await askMode(prompts))
+  const hasValidModeFlag = flags.mode !== undefined && isMode(flags.mode)
+  const flagMode = hasValidModeFlag ? flags.mode : undefined
+  const mode: Mode = flagMode ?? (flags.yes ? "local" : await askMode(prompts))
 
   const exitCode =
     mode === "local"

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -568,12 +568,10 @@ export const runInit = async (
 
   // Mode resolution: explicit --mode wins; --yes implies local; otherwise
   // ask, defaulting to local — it's the simpler activation path.
+  const explicitMode =
+    flags.mode !== undefined && isMode(flags.mode) ? flags.mode : undefined
   const mode: Mode =
-    flags.mode !== undefined && isMode(flags.mode)
-      ? flags.mode
-      : flags.yes
-        ? "local"
-        : await askMode(prompts)
+    explicitMode ?? (flags.yes ? "local" : await askMode(prompts))
 
   const exitCode =
     mode === "local"

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -568,8 +568,7 @@ export const runInit = async (
 
   // Mode resolution: explicit --mode wins; --yes implies local; otherwise
   // ask, defaulting to local — it's the simpler activation path.
-  const hasValidModeFlag = flags.mode !== undefined && isMode(flags.mode)
-  const flagMode = hasValidModeFlag ? flags.mode : undefined
+  const flagMode = flags.mode && isMode(flags.mode) ? flags.mode : undefined
   const mode: Mode = flagMode ?? (flags.yes ? "local" : await askMode(prompts))
 
   const exitCode =

--- a/cli/src/messages.ts
+++ b/cli/src/messages.ts
@@ -200,12 +200,12 @@ export const buildLocalConnectMessage = (params: {
 
   const baseUrl = `http://localhost:${port}`
 
+  const nonRunningLine =
+    startStatus === "starting"
+      ? startingInBackgroundLine()
+      : startServerLine(targetDir)
   const startLine =
-    startStatus === "running"
-      ? "The server is running."
-      : startStatus === "starting"
-        ? startingInBackgroundLine()
-        : startServerLine(targetDir)
+    startStatus === "running" ? "The server is running." : nonRunningLine
 
   const tokenLine = tokenBlock({ targetDir, token, tokenWritten })
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -58,6 +58,8 @@ export default defineConfig(
       "@typescript-eslint/consistent-type-definitions": ["error", "type"],
       // AGENTS.md → Code style: early returns over nested if/else.
       "no-else-return": "error",
+      // AGENTS.md → Code style: no nested ternaries.
+      "no-nested-ternary": "error",
       // AGENTS.md → Code style: explicit names over abbreviations — no
       // single-char identifiers. Exceptions: `i` (loop index), `a`/`b`
       // (sort comparators), `k` (the RRF constant's literature name),

--- a/src/vault-mcp/mcp-core/prompts/daily-review-prompt.ts
+++ b/src/vault-mcp/mcp-core/prompts/daily-review-prompt.ts
@@ -315,11 +315,10 @@ export const registerDailyReviewPrompt = ({
           dailyNoteTasks.tasks.length > 0
         // Write directives name only served tools; without them, the step
         // falls back to conversational output.
-        const memoryStep = config.memoryEnabled
-          ? isToolEnabled("vault_update_memory")
-            ? `**Surface durable facts** — any preference, decision, or fact worth remembering long-term — and propose saving it to ${config.memoryDir}/ memory via vault_update_memory (append-with-dates, newest-first). Confirm before writing.`
-            : "**Surface durable facts** — any preference, decision, or fact worth remembering long-term — and tell me so I can record them."
-          : ""
+        const memoryStepText = isToolEnabled("vault_update_memory")
+          ? `**Surface durable facts** — any preference, decision, or fact worth remembering long-term — and propose saving it to ${config.memoryDir}/ memory via vault_update_memory (append-with-dates, newest-first). Confirm before writing.`
+          : "**Surface durable facts** — any preference, decision, or fact worth remembering long-term — and tell me so I can record them."
+        const memoryStep = config.memoryEnabled ? memoryStepText : ""
         // vault_update_task is the atomic path for status, priority, and lane
         // moves, but it takes no date fields — rescheduling is still a note
         // edit. Each sentence stands alone so any subset reads correctly.
@@ -338,13 +337,14 @@ export const registerDailyReviewPrompt = ({
         ]
           .filter(Boolean)
           .join(" ")
-        const taskReviewStep = hasTaskData
-          ? taskUpdateDirective.length > 0
+        const taskReviewWithData =
+          taskUpdateDirective.length > 0
             ? `**Review tasks** — check the task summaries above. Are any blocked or need rescheduling? ${taskUpdateDirective}`
             : "**Review tasks** — check the task summaries above. Are any blocked or need rescheduling? Flag what needs updating so I can change it in Obsidian."
-          : dailyNote.exists
-            ? "**Scan for tasks** — no structured tasks surfaced for this date. Look for informal action items or commitments in the daily note."
-            : ""
+        const noDataFallback = dailyNote.exists
+          ? "**Scan for tasks** — no structured tasks surfaced for this date. Look for informal action items or commitments in the daily note."
+          : ""
+        const taskReviewStep = hasTaskData ? taskReviewWithData : noDataFallback
         const noteContextSteps = dailyNote.exists
           ? [
               "**Follow the links** — read linked notes (see outgoing links above) for full context on what was referenced today.",
@@ -364,14 +364,15 @@ export const registerDailyReviewPrompt = ({
           .map((step, index) => `${index + 1}. ${step}`)
           .join("\n")
 
+        const noNoteMessage = isToolEnabled("vault_write_note")
+          ? `No daily note found at \`${dailyNote.path}\`. If you'd like one, create it at that path with vault_write_note.`
+          : `No daily note found at \`${dailyNote.path}\`.`
         const dailyReview = [
           "# Daily review",
           "",
           dailyNote.exists
             ? `Daily note: \`${dailyNote.path}\``
-            : isToolEnabled("vault_write_note")
-              ? `No daily note found at \`${dailyNote.path}\`. If you'd like one, create it at that path with vault_write_note.`
-              : `No daily note found at \`${dailyNote.path}\`.`,
+            : noNoteMessage,
           "",
           "## Daily note",
           "",

--- a/src/vault-mcp/mcp-core/prompts/vault-orientation-prompt.ts
+++ b/src/vault-mcp/mcp-core/prompts/vault-orientation-prompt.ts
@@ -239,11 +239,11 @@ export const registerVaultOrientationPrompt = ({
               ].join("\n")
             : "No orphans found — every note has at least one incoming link."
 
-        const memorySection = config.memoryEnabled
-          ? memoryFiles.length > 0
+        const memorySectionContent =
+          memoryFiles.length > 0
             ? formatMemoryOutline(memoryFiles)
             : `No memory files yet — the ${config.memoryDir}/ layer is empty.${whenToolEnabledText("vault_update_memory", " Use vault_update_memory to start it.")}`
-          : ""
+        const memorySection = config.memoryEnabled ? memorySectionContent : ""
 
         // The "go deeper" menu is a list of calls to make, so every line is
         // keyed on its own tool being served — a suggestion the client cannot

--- a/src/vault-mcp/mcp-core/tools/memory-tools.ts
+++ b/src/vault-mcp/mcp-core/tools/memory-tools.ts
@@ -99,7 +99,8 @@ Returns: Raw markdown text.`,
         reqLogger,
         () => memoryStore.getMemory({ vaultPath, file, section }, reqLogger),
         (text) => {
-          const mode = !file ? "all" : !section ? "file" : "section"
+          const scopeWithFile = !section ? "file" : "section"
+          const mode = !file ? "all" : scopeWithFile
           reqLogger.info("tool_result", { mode })
           return text
         },

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -101,7 +101,7 @@ export const findTrailingCommentBlockStart = (
   // An unclosed comment runs to EOF and is trailing by definition. A closed
   // block is trailing only when nothing but blank lines follow it.
   const hasTrailingClosedBlock =
-    lastClosedBlock !== null &&
+    lastClosedBlock &&
     lines
       .slice(lastClosedBlock.endLine + 1)
       .every((trailingLine) => trailingLine.trim() === "")

--- a/src/vault-mcp/obsidian-markdown/headings.ts
+++ b/src/vault-mcp/obsidian-markdown/headings.ts
@@ -100,14 +100,15 @@ export const findTrailingCommentBlockStart = (
 
   // An unclosed comment runs to EOF and is trailing by definition. A closed
   // block is trailing only when nothing but blank lines follow it.
+  const hasTrailingClosedBlock =
+    lastClosedBlock !== null &&
+    lines
+      .slice(lastClosedBlock.endLine + 1)
+      .every((trailingLine) => trailingLine.trim() === "")
+  const closedTrailingBlock = hasTrailingClosedBlock ? lastClosedBlock : null
   const trailingBlock = commentOpen
     ? { startLine: commentOpenLine }
-    : lastClosedBlock &&
-        lines
-          .slice(lastClosedBlock.endLine + 1)
-          .every((trailingLine) => trailingLine.trim() === "")
-      ? lastClosedBlock
-      : null
+    : closedTrailingBlock
 
   if (!trailingBlock) return lines.length
 

--- a/src/vault-mcp/search/reranker.ts
+++ b/src/vault-mcp/search/reranker.ts
@@ -180,7 +180,8 @@ export const blendScores = (params: {
       throw new Error(`score array length mismatch at index ${index}`)
     }
 
-    const rrfWeight = rank <= 3 ? 0.75 : rank <= 10 ? 0.5 : 0.4
+    const midOrLowWeight = rank <= 10 ? 0.5 : 0.4
+    const rrfWeight = rank <= 3 ? 0.75 : midOrLowWeight
     const rerankWeight = 1 - rrfWeight
 
     return Number(

--- a/src/vault-mcp/search/rrf.ts
+++ b/src/vault-mcp/search/rrf.ts
@@ -29,8 +29,8 @@ export const computeRrfScores = (params: {
     for (const [index, item] of rankedItems.entries()) {
       const rank = index + 1
       const rrfScore = 1 / (dampingConstant + rank)
-      const tailBonus = rank <= 3 ? 0.02 : 0
-      const bonus = rank === 1 ? 0.05 : tailBonus
+      const nearTopBonus = rank <= 3 ? 0.02 : 0
+      const bonus = rank === 1 ? 0.05 : nearTopBonus
       const previousScore = scoresByIdentifier.get(item.identifier) ?? 0
       scoresByIdentifier.set(item.identifier, previousScore + rrfScore + bonus)
     }

--- a/src/vault-mcp/search/rrf.ts
+++ b/src/vault-mcp/search/rrf.ts
@@ -29,7 +29,8 @@ export const computeRrfScores = (params: {
     for (const [index, item] of rankedItems.entries()) {
       const rank = index + 1
       const rrfScore = 1 / (dampingConstant + rank)
-      const bonus = rank === 1 ? 0.05 : rank <= 3 ? 0.02 : 0
+      const tailBonus = rank <= 3 ? 0.02 : 0
+      const bonus = rank === 1 ? 0.05 : tailBonus
       const previousScore = scoresByIdentifier.get(item.identifier) ?? 0
       scoresByIdentifier.set(item.identifier, previousScore + rrfScore + bonus)
     }

--- a/src/vault-mcp/search/search-helpers.ts
+++ b/src/vault-mcp/search/search-helpers.ts
@@ -20,8 +20,10 @@ export const isString = (value: unknown): value is string =>
 /** Coerces a YAML frontmatter field to a string array.
  *  gray-matter may parse multi-value YAML fields as a single string
  *  or an array depending on syntax (flow vs block). */
-export const coerceToArray = (value: unknown): string[] =>
-  Array.isArray(value) ? value : value ? [String(value)] : []
+export const coerceToArray = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value
+  return value ? [String(value)] : []
+}
 
 // ── JSON column parsers (private) ──────────────────────────────
 

--- a/src/vault-mcp/search/search-queries.ts
+++ b/src/vault-mcp/search/search-queries.ts
@@ -828,8 +828,10 @@ const DATE_CASCADE: Record<string, readonly string[]> = {
 
 const toSqlDirection = (
   direction: "asc" | "desc" | undefined,
-): "ASC" | "DESC" | undefined =>
-  direction === undefined ? undefined : direction === "desc" ? "DESC" : "ASC"
+): "ASC" | "DESC" | undefined => {
+  if (direction === undefined) return undefined
+  return direction === "desc" ? "DESC" : "ASC"
+}
 
 /** Builds a cascaded ORDER BY for a date sort key: primary date column, then
  *  each fallback date column (all with NULL-last), then note mtime descending

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -749,14 +749,16 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         // "top" inserts before the first existing bullet (newest-first ordering).
         // "bottom" inserts after the last existing bullet.
         // Empty sections (no bullets) fall back to bodyEndLine — appends at section end.
+        const topInsertIndex =
+          firstBulletOffset >= 0
+            ? match.bodyStartLine + firstBulletOffset
+            : match.bodyEndLine
+        const bottomInsertIndex =
+          lastBulletOffset >= 0
+            ? match.bodyStartLine + lastBulletOffset + 1
+            : match.bodyEndLine
         const insertIndex =
-          position === "top"
-            ? firstBulletOffset >= 0
-              ? match.bodyStartLine + firstBulletOffset
-              : match.bodyEndLine
-            : lastBulletOffset >= 0
-              ? match.bodyStartLine + lastBulletOffset + 1
-              : match.bodyEndLine
+          position === "top" ? topInsertIndex : bottomInsertIndex
 
         // Splice the new bullet into the content lines
         const updatedLines = [


### PR DESCRIPTION
## Summary

- Refactor all 13 nested ternary sites across 10 source files using two const-friendly patterns (zero `let` introduced)
- Add `no-nested-ternary` as an ESLint error beside the existing readability rules
- Document the convention in AGENTS.md code-style section

## Refactoring patterns

Every site uses one of two patterns:

**Named const decomposition** (11 sites): extract the inner ternary to a named `const`, then use a flat ternary referencing it. For 3-level nesting, chain two named consts.

**Early return + trailing ternary** (2 sites): convert expression-bodied arrows to block body with an early-return guard, then a simple ternary return.

## Files changed

| File | Sites | Pattern |
|------|-------|---------|
| `cli/src/init.ts` | 1 | const decomposition (`explicitMode ?? fallback`) |
| `cli/src/messages.ts` | 1 | const decomposition (`nonRunningLine`) |
| `daily-review-prompt.ts` | 3 | const decomposition (`memoryStepText`, `taskReviewWithData`/`noDataFallback`, `noNoteMessage`) |
| `vault-orientation-prompt.ts` | 1 | const decomposition (`memorySectionContent`) |
| `memory-tools.ts` | 1 | const decomposition (`scopeWithFile`) |
| `headings.ts` | 1 | const decomposition (`hasTrailingClosedBlock`/`closedTrailingBlock` — preserves `&&` short-circuit) |
| `reranker.ts` | 1 | const decomposition (`midOrLowWeight`) |
| `rrf.ts` | 1 | const decomposition (`tailBonus`) |
| `search-helpers.ts` | 1 | early return (`coerceToArray`) |
| `search-queries.ts` | 1 | early return (`toSqlDirection`) |
| `memory-store.ts` | 1 | const decomposition (`topInsertIndex`/`bottomInsertIndex`) |

## Test plan

- [x] `npm test` — 3,359 tests pass, no test files modified
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] Planted-violation test: nested ternary in a temp file caught by the rule, then removed
- [x] Verified 0 `no-nested-ternary` violations across the entire codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal conditional logic without changing application behavior.
  - Preserved existing CLI mode selection, messaging, memory handling, search ranking, and vault operations.

- **Code Quality**
  - Added a style rule prohibiting nested ternary expressions.
  - Documented the rule and configured linting to enforce it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->