### PR TITLE
ci: bump umm-actually to v0.3.14

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -84,7 +84,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@74276fdab1793e985ccef030fabfdcd9ccc72e4d # v0.3.13
+      - uses: aliasunder/umm-actually@2581a0acedb2185ff2bf727d744b65d28f2cd77f # v0.3.14
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
Pins the review action to v0.3.14: an authoritative per-attempt request deadline (a request the provider keeps serving no longer holds the job open past `request_timeout_seconds`; the attempt is recorded as `timeout` and the ladder advances) and a filter that drops findings naming a file the model was never given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)