### PR TITLE
feat(setup): name the platform's settings tab on the setup page

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -905,7 +905,10 @@ flowchart TD
    `/healthz` answers `{ ok: true, mode: "setup" }` within seconds (so a
    platform deploy goes live), `/setup` serves the sign-in page, browser
    GETs to any other path redirect to `/setup`, and API requests answer
-   503 with the setup URL.
+   503 with the setup URL. When `RENDER_EXTERNAL_URL` or
+   `RAILWAY_PUBLIC_DOMAIN` identifies the host, the page names that
+   platform's settings tab wherever it tells the owner to find or fix a
+   variable.
 4. `POST /setup` checks `MCP_AUTH_TOKEN` first, then signs in through
    Obsidian's account API (the same request `ob login` makes, two-factor
    included).

--- a/src/__tests__/docker/remote-image-boot.test.ts
+++ b/src/__tests__/docker/remote-image-boot.test.ts
@@ -1128,7 +1128,13 @@ describe("remote image boot — setup mode (no Sync token anywhere)", () => {
   it("serves the sign-in page and rejects a wrong MCP token without contacting Obsidian", async () => {
     const page = await fetch(`http://127.0.0.1:${port}/setup`)
     expect(page.status).toBe(200)
-    expect(await page.text()).toContain("<h1>Connect Obsidian Sync</h1>")
+    const html = await page.text()
+    expect(html).toContain("<h1>Connect Obsidian Sync</h1>")
+    // RAILWAY_PUBLIC_DOMAIN is a container env var, so the hint proves the
+    // s6 longrun hands the platform variable to the setup server.
+    expect(html).toContain(
+      "value from the service's Variables tab on Railway — it proves this is your server.",
+    )
 
     const rejected = await postSetupForm(port, {
       token: "not-the-token",

--- a/src/vault-mcp/setup/__tests__/setup-page.test.ts
+++ b/src/vault-mcp/setup/__tests__/setup-page.test.ts
@@ -42,6 +42,30 @@ describe("renderSetupPage — sign-in", () => {
       '<div class="error">&lt;script&gt;&quot;x&quot;&lt;/script&gt;</div>',
     )
   })
+
+  it("points the token hint at the Variables tab on Railway", () => {
+    const html = renderSetupPage({ ...SIGN_IN, hostingPlatform: "railway" })
+
+    expect(html).toContain(
+      `<div class="hint">The <code>MCP_AUTH_TOKEN</code> value from the service's Variables tab on Railway — it proves this is your server.</div>`,
+    )
+  })
+
+  it("points the token hint at the Environment tab on Render", () => {
+    const html = renderSetupPage({ ...SIGN_IN, hostingPlatform: "render" })
+
+    expect(html).toContain(
+      `<div class="hint">The <code>MCP_AUTH_TOKEN</code> value from the service's Environment tab on Render — it proves this is your server.</div>`,
+    )
+  })
+
+  it("keeps the generic token hint when the hosting platform is unknown", () => {
+    const html = renderSetupPage(SIGN_IN)
+
+    expect(html).toContain(
+      `<div class="hint">The <code>MCP_AUTH_TOKEN</code> value from your deployment's settings — it proves this is your server.</div>`,
+    )
+  })
 })
 
 describe("renderSetupPage — mfa", () => {
@@ -177,6 +201,44 @@ describe("renderSetupPage — blocked", () => {
       "<p>Obsidian's vault listing did not include what this server needs to check the password for <code>Notes</code>, so syncing it would fail on the next start.</p>",
     )
     expect(html).toContain("Try again in a few minutes.")
+  })
+
+  it("names the Environment tab on Render in the VAULT_PASSWORD remedy", () => {
+    const html = renderSetupPage({
+      kind: "blocked",
+      accountEmail: "user@example.com",
+      problem: { kind: "password-missing", vaultName: "Notes" },
+      hostingPlatform: "render",
+    })
+
+    expect(html).toContain(
+      "Add <code>VAULT_PASSWORD</code> — the vault's encryption password — to the service's Environment tab on Render, redeploy, then sign in here again.",
+    )
+  })
+
+  it("names the Variables tab on Railway in the VAULT_NAME remedy", () => {
+    const html = renderSetupPage({
+      kind: "blocked",
+      accountEmail: "user@example.com",
+      problem: { kind: "vault-not-found", vaultName: "Notes", vaultNames: [] },
+      hostingPlatform: "railway",
+    })
+
+    expect(html).toContain(
+      "Fix <code>VAULT_NAME</code> in the service's Variables tab on Railway, redeploy, then sign in here again.",
+    )
+  })
+
+  it("keeps the generic remedy when the hosting platform is unknown", () => {
+    const html = renderSetupPage({
+      kind: "blocked",
+      accountEmail: "user@example.com",
+      problem: { kind: "vault-name-unset" },
+    })
+
+    expect(html).toContain(
+      "Add <code>VAULT_NAME</code> to your deployment's settings — your vault's name, the same as it is in Obsidian — then redeploy and sign in here again.",
+    )
   })
 
   it("asks for a rename when two vaults share the name", () => {

--- a/src/vault-mcp/setup/__tests__/setup-routes.test.ts
+++ b/src/vault-mcp/setup/__tests__/setup-routes.test.ts
@@ -9,6 +9,7 @@ import { DateTime } from "luxon"
 import { describe, expect, it, onTestFinished, vi } from "vitest"
 import type { Logger } from "../../../logger.js"
 import { createSetupRoutes } from "../setup-routes.js"
+import type { HostingPlatform } from "../setup-page.js"
 import { syncTokenStore } from "../sync-token-store.js"
 import { startFakeObsidianApi } from "./fake-obsidian-api.js"
 import type { FakeApiRequest, FakeApiResponse } from "./fake-obsidian-api.js"
@@ -97,6 +98,7 @@ const startHarness = async ({
   // the destructuring default and silently test the wrong thing.
   vaultNameUnset = false,
   publicUrlUnset = false,
+  hostingPlatform,
 }: {
   api?: ApiScript
   vaultPasswordSet?: boolean
@@ -104,6 +106,7 @@ const startHarness = async ({
   savedLoginRejected?: boolean
   vaultNameUnset?: boolean
   publicUrlUnset?: boolean
+  hostingPlatform?: HostingPlatform
 } = {}): Promise<Harness> => {
   const vaultName = vaultNameUnset ? undefined : "Notes"
   const configuredVaultPassword = vaultPasswordWrong
@@ -142,6 +145,7 @@ const startHarness = async ({
       tokenFilePath,
       obsidianApiBaseUrl: fakeApi.baseUrl,
       savedLoginRejected,
+      hostingPlatform,
       trustForwardedHops: 0,
       onSetupComplete,
       logger: recordingLogger(logs),
@@ -211,6 +215,16 @@ describe("GET /setup", () => {
     expect(html).toContain("Your saved Obsidian login stopped working")
   })
 
+  it("names the platform's settings tab in the token hint when the platform is known", async () => {
+    const harness = await startHarness({ hostingPlatform: "railway" })
+
+    const html = await (await fetch(`${harness.baseUrl}/setup`)).text()
+
+    expect(html).toContain(
+      `<div class="hint">The <code>MCP_AUTH_TOKEN</code> value from the service's Variables tab on Railway — it proves this is your server.</div>`,
+    )
+  })
+
   it("warns about plain HTTP for a non-local host but not for any loopback form", async () => {
     const harness = await startHarness()
     // fetch() drops a caller-set Host header; node:http sends it as given.
@@ -256,12 +270,26 @@ describe("POST /setup — MCP token gate", () => {
     const html = await response.text()
 
     expect(response.status).toBe(401)
-    expect(html).toContain("That MCP token does not match this server.")
+    expect(html).toContain(
+      `<div class="error">That MCP token does not match this server. Check the MCP_AUTH_TOKEN value in your deployment's settings.</div>`,
+    )
     expect(harness.apiRequests).toEqual([])
     expect(existsSync(harness.tokenFilePath)).toBe(false)
     expect(harness.logs.map((call) => [call.level, call.message])).toEqual([
       ["warn", "setup_bad_token"],
     ])
+  })
+
+  it("names the platform's settings tab in the wrong-token error when the platform is known", async () => {
+    const harness = await startHarness({ hostingPlatform: "render" })
+
+    const html = await (
+      await harness.postForm({ ...CREDENTIALS, token: "not-the-token" })
+    ).text()
+
+    expect(html).toContain(
+      `<div class="error">That MCP token does not match this server. Check the MCP_AUTH_TOKEN value in the service's Environment tab on Render.</div>`,
+    )
   })
 
   it("accepts a token copied with wrapped whitespace", async () => {
@@ -777,6 +805,20 @@ describe("POST /setup — vault pre-flight", () => {
       "/user/signin",
     ])
     expect(existsSync(harness.tokenFilePath)).toBe(false)
+  })
+
+  it("names the platform's settings tab in the remedy when the platform is known", async () => {
+    const harness = await startHarness({
+      vaultNameUnset: true,
+      hostingPlatform: "railway",
+      api: { signIn: () => ({ body: SIGNED_IN }) },
+    })
+
+    const html = await (await harness.postForm(CREDENTIALS)).text()
+
+    expect(html).toContain(
+      "Add <code>VAULT_NAME</code> to the service's Variables tab on Railway — your vault's name, the same as it is in Obsidian — then redeploy and sign in here again.",
+    )
   })
 
   it("completes anyway when the vault listing cannot be fetched", async () => {

--- a/src/vault-mcp/setup/__tests__/setup-server.test.ts
+++ b/src/vault-mcp/setup/__tests__/setup-server.test.ts
@@ -335,6 +335,62 @@ describe("setup-server entry point", () => {
     )
   })
 
+  describe("hosting platform detection", () => {
+    const signInPage = async (env: Record<string, string>): Promise<string> => {
+      const server = await spawnSetupServer({
+        HOME: tmpdir(),
+        MCP_AUTH_TOKEN: AUTH_TOKEN,
+        ...env,
+      })
+      await waitForStart(server)
+      return (await fetch(`http://127.0.0.1:${server.port}/setup`)).text()
+    }
+
+    const RENDER_HINT = `<div class="hint">The <code>MCP_AUTH_TOKEN</code> value from the service's Environment tab on Render — it proves this is your server.</div>`
+    const RAILWAY_HINT = `<div class="hint">The <code>MCP_AUTH_TOKEN</code> value from the service's Variables tab on Railway — it proves this is your server.</div>`
+    const GENERIC_HINT = `<div class="hint">The <code>MCP_AUTH_TOKEN</code> value from your deployment's settings — it proves this is your server.</div>`
+
+    it("names Render's Environment tab when RENDER_EXTERNAL_URL is set", async () => {
+      const html = await signInPage({
+        RENDER_EXTERNAL_URL: "https://x.onrender.com",
+      })
+
+      expect(html).toContain(RENDER_HINT)
+    })
+
+    it("names Railway's Variables tab when RAILWAY_PUBLIC_DOMAIN is set", async () => {
+      const html = await signInPage({
+        RAILWAY_PUBLIC_DOMAIN: "x.up.railway.app",
+      })
+
+      expect(html).toContain(RAILWAY_HINT)
+    })
+
+    it("prefers Render when both platform variables are set, like the PUBLIC_URL derivation", async () => {
+      const html = await signInPage({
+        RENDER_EXTERNAL_URL: "https://x.onrender.com",
+        RAILWAY_PUBLIC_DOMAIN: "x.up.railway.app",
+      })
+
+      expect(html).toContain(RENDER_HINT)
+    })
+
+    it("treats a blank RENDER_EXTERNAL_URL as unset", async () => {
+      const html = await signInPage({
+        RENDER_EXTERNAL_URL: "",
+        RAILWAY_PUBLIC_DOMAIN: "x.up.railway.app",
+      })
+
+      expect(html).toContain(RAILWAY_HINT)
+    })
+
+    it("keeps the generic hint when neither platform variable is set", async () => {
+      const html = await signInPage({})
+
+      expect(html).toContain(GENERIC_HINT)
+    })
+  })
+
   it("exits 1 with one searchable log line when MCP_AUTH_TOKEN is missing", async () => {
     const server = await spawnSetupServer({ HOME: tmpdir() })
 

--- a/src/vault-mcp/setup/setup-page.ts
+++ b/src/vault-mcp/setup/setup-page.ts
@@ -31,8 +31,8 @@ export type PreflightProblem =
 export type HostingPlatform = "render" | "railway"
 
 /** Where the reader finds the deployment's settings, as a noun phrase that
- *  slots after "from", "in", or "to". The platform phrases match the deploy
- *  guides word for word so the page and the guide agree. */
+ *  slots after "from", "in", or "to". The platform phrases use each deploy
+ *  guide's exact tab name so the page and the guide agree. */
 export const settingsLocation = (
   hostingPlatform: HostingPlatform | undefined,
 ): string => {

--- a/src/vault-mcp/setup/setup-page.ts
+++ b/src/vault-mcp/setup/setup-page.ts
@@ -25,6 +25,24 @@ export type PreflightProblem =
       encryptionVersion: number | undefined
     }
 
+/** The container hosting platforms whose dashboards the page can name.
+ *  Undefined means unknown, and the copy falls back to "your deployment's
+ *  settings". */
+export type HostingPlatform = "render" | "railway"
+
+/** Where the reader finds the deployment's settings, as a noun phrase that
+ *  slots after "from", "in", or "to". The platform phrases match the deploy
+ *  guides word for word so the page and the guide agree. */
+export const settingsLocation = (
+  hostingPlatform: HostingPlatform | undefined,
+): string => {
+  if (hostingPlatform === "render")
+    return "the service's Environment tab on Render"
+  if (hostingPlatform === "railway")
+    return "the service's Variables tab on Railway"
+  return "your deployment's settings"
+}
+
 export type SetupView =
   | {
       kind: "sign-in"
@@ -33,9 +51,15 @@ export type SetupView =
       savedLoginRejected: boolean
       /** The page arrived over plain HTTP from a non-local address. */
       insecureTransport: boolean
+      hostingPlatform?: HostingPlatform | undefined
     }
   | { kind: "mfa"; requestId: string; error?: string | undefined }
-  | { kind: "blocked"; accountEmail: string; problem: PreflightProblem }
+  | {
+      kind: "blocked"
+      accountEmail: string
+      problem: PreflightProblem
+      hostingPlatform?: HostingPlatform | undefined
+    }
   | {
       kind: "complete"
       accountEmail: string
@@ -90,19 +114,22 @@ ${body}
 const errorBox = (error: string | undefined): string =>
   error ? `<div class="error">${escapeHtml(error)}</div>` : ""
 
-const TOKEN_FIELD = `<div class="field">
+const tokenField = (
+  settingsLocationPhrase: string,
+): string => `<div class="field">
     <label class="label" for="token">MCP token</label>
     <div class="token-input">
       <input type="password" id="token" name="token" placeholder="MCP_AUTH_TOKEN" required autocomplete="off">
       <button type="button" class="reveal" aria-label="Show or hide token" onclick="var t=document.getElementById('token');var s=t.type==='password';t.type=s?'text':'password';this.textContent=s?'Hide':'Show'">Show</button>
     </div>
-    <div class="hint">The <code>MCP_AUTH_TOKEN</code> value from your deployment's settings — it proves this is your server.</div>
+    <div class="hint">The <code>MCP_AUTH_TOKEN</code> value from ${settingsLocationPhrase} — it proves this is your server.</div>
   </div>`
 
 const renderSignIn = ({
   error,
   savedLoginRejected,
   insecureTransport,
+  hostingPlatform,
 }: Extract<SetupView, { kind: "sign-in" }>): string =>
   shell(
     "Connect Obsidian Sync",
@@ -120,7 +147,7 @@ const renderSignIn = ({
   ${errorBox(error)}
   <p>Sign in with your Obsidian account so this server can sync your vault. Your email and password are sent to Obsidian once and not kept; only the Sync token they return is stored.</p>
   <form method="POST" action="/setup">
-  ${TOKEN_FIELD}
+  ${tokenField(settingsLocation(hostingPlatform))}
   <div class="field">
     <label class="label" for="email">Obsidian account email</label>
     <input type="email" id="email" name="email" required autocomplete="username">
@@ -152,11 +179,14 @@ const renderMfa = ({
   </form>`,
   )
 
-const problemCopy = (problem: PreflightProblem): string => {
+const problemCopy = (
+  problem: PreflightProblem,
+  settingsLocationPhrase: string,
+): string => {
   switch (problem.kind) {
     case "vault-name-unset":
       return `<p><code>VAULT_NAME</code> is not set, so the server does not know which vault to sync.</p>
-  <p>Add <code>VAULT_NAME</code> to your deployment's settings — your vault's name, the same as it is in Obsidian — then redeploy and sign in here again.</p>`
+  <p>Add <code>VAULT_NAME</code> to ${settingsLocationPhrase} — your vault's name, the same as it is in Obsidian — then redeploy and sign in here again.</p>`
     case "vault-not-found": {
       const vaultList = problem.vaultNames.length
         ? `<p>Your account's vaults:</p><ul>${problem.vaultNames
@@ -167,17 +197,17 @@ const problemCopy = (problem: PreflightProblem): string => {
         : `<p>Your account has no vaults in Obsidian Sync yet.</p>`
       return `<p>There is no vault named <code>${escapeHtml(problem.vaultName)}</code> in this Obsidian account (names are case-sensitive).</p>
   ${vaultList}
-  <p>Fix <code>VAULT_NAME</code> in your deployment's settings, redeploy, then sign in here again.</p>`
+  <p>Fix <code>VAULT_NAME</code> in ${settingsLocationPhrase}, redeploy, then sign in here again.</p>`
     }
     case "vault-name-ambiguous":
       return `<p>This Obsidian account has more than one vault named <code>${escapeHtml(problem.vaultName)}</code>, so the server cannot tell which one to sync.</p>
   <p>Rename one of them in Obsidian, then sign in here again.</p>`
     case "password-missing":
       return `<p>The vault <code>${escapeHtml(problem.vaultName)}</code> is end-to-end encrypted, and <code>VAULT_PASSWORD</code> is not set.</p>
-  <p>Add <code>VAULT_PASSWORD</code> — the vault's encryption password — to your deployment's settings, redeploy, then sign in here again.</p>`
+  <p>Add <code>VAULT_PASSWORD</code> — the vault's encryption password — to ${settingsLocationPhrase}, redeploy, then sign in here again.</p>`
     case "vault-access-rejected":
       return `<p>Obsidian did not accept <code>VAULT_PASSWORD</code> for the vault <code>${escapeHtml(problem.vaultName)}</code>: ${escapeHtml(problem.apiMessage)}</p>
-  <p>Fix <code>VAULT_PASSWORD</code> — the vault's encryption password — in your deployment's settings, redeploy, then sign in here again.</p>`
+  <p>Fix <code>VAULT_PASSWORD</code> — the vault's encryption password — in ${settingsLocationPhrase}, redeploy, then sign in here again.</p>`
     case "vault-key-underivable":
       return underivableKeyCopy(problem)
   }
@@ -202,12 +232,13 @@ const underivableKeyCopy = ({
 const renderBlocked = ({
   accountEmail,
   problem,
+  hostingPlatform,
 }: Extract<SetupView, { kind: "blocked" }>): string =>
   shell(
     "One more setting",
     `<h1>One more setting</h1>
   <p>Signed in as <strong>${escapeHtml(accountEmail)}</strong>.</p>
-  ${problemCopy(problem)}
+  ${problemCopy(problem, settingsLocation(hostingPlatform))}
   <p class="muted">Nothing was saved this time; the sign-in only takes a moment to repeat.</p>`,
   )
 

--- a/src/vault-mcp/setup/setup-routes.ts
+++ b/src/vault-mcp/setup/setup-routes.ts
@@ -22,8 +22,8 @@ import type {
   VaultKeyStatus,
 } from "./obsidian-api.js"
 import { deriveVaultKeyHash } from "./vault-key.js"
-import { renderSetupPage } from "./setup-page.js"
-import type { PreflightProblem } from "./setup-page.js"
+import { renderSetupPage, settingsLocation } from "./setup-page.js"
+import type { HostingPlatform, PreflightProblem } from "./setup-page.js"
 import { syncTokenStore } from "./sync-token-store.js"
 
 type SetupRoutesOptions = {
@@ -39,6 +39,9 @@ type SetupRoutesOptions = {
   obsidianApiBaseUrl: string
   /** Set when the boot chain rejected a token already on the volume. */
   savedLoginRejected: boolean
+  /** Lets the page name the platform's settings tab; undefined keeps the
+   *  generic wording. */
+  hostingPlatform: HostingPlatform | undefined
   trustForwardedHops: number
   /** Runs once the completion page has been delivered — the wiring exits
    *  the process so the container can restart into a normal boot. */
@@ -69,6 +72,7 @@ export const createSetupRoutes = ({
   tokenFilePath,
   obsidianApiBaseUrl,
   savedLoginRejected,
+  hostingPlatform,
   trustForwardedHops,
   onSetupComplete,
   logger,
@@ -158,6 +162,7 @@ export const createSetupRoutes = ({
           error,
           savedLoginRejected,
           insecureTransport: isInsecureTransport(req),
+          hostingPlatform,
         }),
       )
   }
@@ -283,9 +288,14 @@ export const createSetupRoutes = ({
     const problem = await runVaultPreflight(token, requestLogger)
     if (problem) {
       requestLogger.warn("setup_blocked", { problem: problem.kind })
-      res
-        .type("html")
-        .send(renderSetupPage({ kind: "blocked", accountEmail, problem }))
+      res.type("html").send(
+        renderSetupPage({
+          kind: "blocked",
+          accountEmail,
+          problem,
+          hostingPlatform,
+        }),
+      )
       return
     }
     await syncTokenStore.writeSyncToken({ tokenFilePath, token }, requestLogger)
@@ -326,8 +336,7 @@ export const createSetupRoutes = ({
       requestLogger.warn("setup_bad_token")
       sendSignInPage(req, res, {
         status: 401,
-        error:
-          "That MCP token does not match this server. Check the MCP_AUTH_TOKEN value in your deployment's settings.",
+        error: `That MCP token does not match this server. Check the MCP_AUTH_TOKEN value in ${settingsLocation(hostingPlatform)}.`,
       })
       return
     }

--- a/src/vault-mcp/setup/setup-server.ts
+++ b/src/vault-mcp/setup/setup-server.ts
@@ -12,6 +12,17 @@ import { loadConfig } from "../config.js"
 import { logger } from "../../logger.js"
 import { describeError } from "../../utils/describe-error.js"
 import { createSetupRoutes } from "./setup-routes.js"
+import type { HostingPlatform } from "./setup-page.js"
+
+/** Which container hosting platform the page is served from, read from the
+ *  variable each platform sets on its services. Checked in the same order
+ *  as print-derived-env's PUBLIC_URL derivation, so the page never names a
+ *  different platform than the one the URL came from. */
+const detectHostingPlatform = (): HostingPlatform | undefined => {
+  if (env.get("RENDER_EXTERNAL_URL").asString()?.trim()) return "render"
+  if (env.get("RAILWAY_PUBLIC_DOMAIN").asString()?.trim()) return "railway"
+  return undefined
+}
 
 const startSetupServer = (): void => {
   // Validates the rest of the deployment's settings too, so a typo in an
@@ -39,6 +50,7 @@ const startSetupServer = (): void => {
   const vaultPassword = env.get("VAULT_PASSWORD").asString() || undefined
   const savedLoginRejected =
     env.get("SETUP_REASON").default("").asString() === "login-failed"
+  const hostingPlatform = detectHostingPlatform()
 
   const setupUrl = publicUrl ? new URL("/setup", publicUrl).href : "/setup"
 
@@ -61,6 +73,7 @@ const startSetupServer = (): void => {
       tokenFilePath,
       obsidianApiBaseUrl,
       savedLoginRejected,
+      hostingPlatform,
       trustForwardedHops: config.trustForwardedHops,
       onSetupComplete: () => {
         logger.info("setup server exiting for restart")


### PR DESCRIPTION
## What

The `/setup` page now names the platform's settings tab instead of "your deployment's settings" when it can tell which container hosting platform it runs on:

| Platform | Detected by | Phrase |
| --- | --- | --- |
| Render | `RENDER_EXTERNAL_URL` | the service's Environment tab on Render |
| Railway | `RAILWAY_PUBLIC_DOMAIN` | the service's Variables tab on Railway |
| anything else | neither set | your deployment's settings (unchanged) |

The phrase appears wherever the page tells the owner to find or fix a variable: the `MCP_AUTH_TOKEN` hint under the token field, the wrong-token error, and the four "One more setting" remedies (`VAULT_NAME` unset or not found, `VAULT_PASSWORD` missing or rejected). The wording matches the Railway and Render guides word for word, so the page and the guide a user is following agree.

## How

- `setup-page.ts`: `HostingPlatform` type, `settingsLocation()` helper, an optional `hostingPlatform` on the `sign-in` and `blocked` views; the six sentences compose with the phrase.
- `setup-server.ts`: `detectHostingPlatform()` reads the two platform variables via `env-var`, Render first, the same order as `print-derived-env`'s `PUBLIC_URL` derivation so the page never names a different platform than the one the URL came from. Detection does not depend on whether `PUBLIC_URL` was set by hand.
- `setup-routes.ts`: `hostingPlatform` option, threaded into the sign-in and blocked views and the 401 message.
- `ARCHITECTURE.md`: one sentence in the setup-mode list.

The full server's "Already set up" page is untouched.

## Tests

| Tier | Covers | Result |
| --- | --- | --- |
| `setup-page.test.ts` (+6) | exact hint and remedy sentences per platform; the generic sentences pinned verbatim | pass |
| `setup-routes.test.ts` (+3) | the platform reaches the sign-in view, the 401 error, and the blocked view | pass |
| `setup-server.test.ts` (+5) | real entry point with a controlled env: Render, Railway, both set (Render wins), blank `RENDER_EXTERNAL_URL` treated as unset, neither | pass |
| `remote-image-boot.test.ts` (+1 assertion) | the platform variable reaches the setup server inside the `:remote` image through the s6 longrun | pass (51 tests, image built from this branch) |
| `npm test` | 3,506 pass; the one failure (`oauth-provider.test.ts` sliding-expiry) fails on `main` too and is unrelated: its expected value uses calendar days across a daylight-saving change | pre-existing |

Mutation checks (each reverted after): swapping the detection order failed the both-set test; dropping the blocked-view threading failed its routes test; rewording the generic phrase failed the pinned-generic tests. `npm run lint`, `npm run build`, and `knip` clean.

No live deploy: the copy is deterministic and the boot tier proves the environment inheritance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Setup pages now provide platform-specific guidance for Render and Railway deployments.
  - Instructions identify the relevant Environment or Variables tab when users need to configure or fix settings.
  - Generic guidance remains available when the hosting platform cannot be detected.

- **Tests**
  - Added coverage for platform detection, platform-specific instructions, precedence, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->