### PR TITLE
fix(scripts): keep the instance host out of waitForDocker log lines

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -74,9 +74,9 @@ const run = (cmd: string): void => {
   execSync(cmd, { stdio: "inherit", env })
 }
 
-// The target host is deliberately absent from both messages — like the
-// success line at the end of lightsail:up, keeping the instance address out
-// of logs entirely beats relying on CI masking.
+// The target host is deliberately absent from both messages — matching the
+// success line at the end of lightsail:up. The echoed ssh/scp commands still
+// print the address, so mask() is what keeps it out of public CI logs.
 const waitForDocker = (ip: string, id: string, timeoutSec = 120): void => {
   const deadline = Date.now() + timeoutSec * 1000
   console.log(`⏳ Waiting for Docker on the instance (up to ${timeoutSec}s)...`)

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -74,9 +74,12 @@ const run = (cmd: string): void => {
   execSync(cmd, { stdio: "inherit", env })
 }
 
+// The target host is deliberately absent from both messages — like the
+// success line at the end of lightsail:up, keeping the instance address out
+// of logs entirely beats relying on CI masking.
 const waitForDocker = (ip: string, id: string, timeoutSec = 120): void => {
   const deadline = Date.now() + timeoutSec * 1000
-  console.log(`⏳ Waiting for Docker on ${ip} (up to ${timeoutSec}s)...`)
+  console.log(`⏳ Waiting for Docker on the instance (up to ${timeoutSec}s)...`)
   while (Date.now() < deadline) {
     try {
       execSync(
@@ -91,7 +94,7 @@ const waitForDocker = (ip: string, id: string, timeoutSec = 120): void => {
     }
   }
   console.error(
-    `✕ Docker not available on ${ip} after ${timeoutSec}s. Check cloud-init logs.`,
+    `✕ Docker not available on the instance after ${timeoutSec}s. Check cloud-init logs.`,
   )
   process.exit(1)
 }


### PR DESCRIPTION
## Summary

CodeQL's `js/clear-text-logging` alert (\#285, high) flags `waitForDocker`'s failure message: it interpolates the deploy target host, which can come from the `LIGHTSAIL_SSH_HOST` environment variable, into a `console.error` — clear-text logging of an environment-derived value.

The practical exposure was already limited — `lightsail:up` calls `mask()` on the host before this point, so Actions log output masks the value in CI, and local output goes to the operator's own terminal. But the file's own convention is stronger: the success line at the end of `lightsail:up` deliberately prints no instance address, with a comment saying that not printing it at all beats relying on masking. This applies the same rule to both `waitForDocker` messages — neither the waiting line nor the failure line needs the host; the operator knows which instance they are deploying to.

## Changes

- `scripts/dev.ts`: `waitForDocker`'s waiting and failure messages say "the instance" instead of interpolating the host; a comment above the function records the convention.

## Tests

- No automated coverage — the change is two log-message strings in a maintainer deploy script with no behavioral surface; `npm run lint` and the pre-commit `tsc`/`knip` gates pass. The CodeQL alert should close on the next scan of `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
