### PR TITLE
chore(deps): bump umm-actually to v0.4.0

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -84,7 +84,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@2581a0acedb2185ff2bf727d744b65d28f2cd77f # v0.3.14
+      - uses: aliasunder/umm-actually@65ccbe7415a9a48226c21da5ab2500530965e6be # v0.4.0
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
## Summary

Bump umm-actually from v0.3.14 to v0.4.0 (`65ccbe7`).

### Changes in v0.4.0

- feat: staged review phases — parallel and sequential modes (\#79)
- feat: content-based cross-run dedup for shifted/reworded findings (\#85)
- fix: content dedup follow-ups — coalesceAnchors, titleSimilarity, logging (\#86)
- fix: filter self-negating findings (\#84)
- chore: bump default context_budget_tokens from 80K to 300K (\#87)
- docs: drop the early-development status section (\#83)
