### PR TITLE
chore: bump umm-actually to v0.4.1

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -84,7 +84,7 @@ jobs:
       # to the action's defaults. Inputs whose default is empty
       # (fallback_model, max_findings) pass empty when the var is unset —
       # identical to omitting them.
-      - uses: aliasunder/umm-actually@65ccbe7415a9a48226c21da5ab2500530965e6be # v0.4.0
+      - uses: aliasunder/umm-actually@726c687ac01b08ae66cc1604ba4b1b5f67fa8f3f # v0.4.1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           openrouter_api_key: ${{ secrets.OPENROUTER_KEY }}


### PR DESCRIPTION
## Summary

- Bump umm-actually pin to v0.4.1 (`726c687`)
- Key change: diff-level file exclusion enabled by default — generated files (lockfiles, minified sources, source maps) are excluded from the review diff before the token budget check, so large generated artifacts no longer starve or skip the review of hand-written code
- Readability refactor: dropped the `ignore` dependency, explicit naming across the exclusion module
