### PR TITLE
ci: expose diff_exclude_paths and respect_linguist_generated in umm_review.yml

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -138,5 +138,14 @@ jobs:
           # scan — invisible to import-tracing and doc-mention matching.
           # Changed files and priority_docs are never excluded.
           exclude_paths: ${{ vars.UMM_EXCLUDE_PATHS }}
+          # Comma-separated folder prefixes or globs removed from the review
+          # diff before the token budget check — excluded files are named in
+          # the review but their content is not reviewed. Extends the built-in
+          # generated-file list (lockfiles, *.min.js, *.min.css, *.map); a
+          # leading `none` drops it. Empty = built-in list only
+          diff_exclude_paths: ${{ vars.UMM_DIFF_EXCLUDE_PATHS }}
+          # true | false — also exclude changed files the root .gitattributes
+          # marks linguist-generated=true
+          respect_linguist_generated: ${{ vars.UMM_RESPECT_LINGUIST_GENERATED || 'true' }}
           # true | false — per-run cost report in the workflow step summary
           cost_summary: ${{ vars.UMM_COST_SUMMARY || 'true' }}


### PR DESCRIPTION
## Summary

Wires the two diff-exclusion inputs that shipped in umm-actually v0.4.1 into the review workflow, so they can be set per repo through Actions variables like every other optional input:

- `diff_exclude_paths` ← `vars.UMM_DIFF_EXCLUDE_PATHS` — folder prefixes or globs removed from the review diff before the token-budget check. Empty keeps the action's built-in generated-file list.
- `respect_linguist_generated` ← `vars.UMM_RESPECT_LINGUIST_GENERATED`, defaulting to `true` — the action's boolean parser rejects an empty string, so the fallback mirrors `trace_related_files`.

Without these lines the workflow always ran on the action defaults, and a repo with large generated files that are not marked `linguist-generated` had no way to keep them out of the diff besides editing `.gitattributes`.

## Test plan

- [ ] Workflow parses (Actions lists the run on this PR)
- [ ] Review runs with the variables unset — behaviour identical to before
- [ ] Setting `UMM_DIFF_EXCLUDE_PATHS` to a folder drops that folder's files from the next review's diff and names them in the review output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
