### PR TITLE
fix(deps): bump hono to 4.13.7 and js-yaml override to 4.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6789,9 +6789,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
-      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7035,9 +7035,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "overrides": {
     "adm-zip": "0.6.0",
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "@huggingface/transformers": {
       "onnxruntime-web": "npm:empty-npm-package@1.0.0",
       "sharp": "npm:empty-npm-package@1.0.0"


### PR DESCRIPTION
## What

Two dependency bumps, no source changes:

- **hono** 4.12.34 → 4.13.7 — transitive via `@modelcontextprotocol/sdk` (`^4.11.4`), so a plain lockfile update. Clears GHSA-crvj-82cr-hjcx, GHSA-g6gw-c38x-mqfc, GHSA-gqvv-2mrq-wpjv (all fixed in 4.13.5).
- **js-yaml** override 4.3.1 → 4.3.2 — clears GHSA-2883-xcg3-v3hh. The override exists because `gray-matter` pins `^3.x`; bumping it is the only way the fix reaches the lockfile.

## Why

Four of the five advisories behind the Scorecard Vulnerabilities finding have patched releases. The fifth, adm-zip GHSA-vwc7-r8mq-g2x9, has no patched version (0.6.0 is both latest and last-affected; the upstream fix is still an open PR), so it stays.

## Verification

- `npm ls hono js-yaml adm-zip`: hono 4.13.7 (deduped under `@hono/node-server`), js-yaml 4.3.2 overridden, adm-zip 0.6.0 overridden (unchanged)
- `npm audit`: only the adm-zip chain remains (3 moderate, one advisory)
- `npm run build` green (incl. `build:sst`)
- `npm run lint`: 0 errors
- `npm test`: 3559 passed, 1 failed — the pre-existing OAuth sliding-expiry test that fails locally on DST offsets until November; unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
