### PR TITLE
fix(oauth): use seconds-based TTL in sliding-expiry test assertion

### DIFF
--- a/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
@@ -178,6 +178,10 @@ const storedRevokedClients = (
     .all()
 
 describe("OAuth refresh token sliding expiry", () => {
+  // Matches production's REFRESH_TOKEN_TTL_S — test-owned so the test
+  // catches a production change and avoids calendar-vs-seconds DST drift.
+  const REFRESH_TOKEN_TTL_S = 60 * 24 * 60 * 60
+
   let dir: string
   let dbPath: string
   let oauth: OAuthProvider
@@ -276,7 +280,9 @@ describe("OAuth refresh token sliding expiry", () => {
 
     // The new token's expires_at should be ~60 days from "now" — i.e.
     // a fresh window, not inherited from the old token's expires_at.
-    const expected = DateTime.now().plus({ days: 60 }).toUnixInteger()
+    const expected = DateTime.now()
+      .plus({ seconds: REFRESH_TOKEN_TTL_S })
+      .toUnixInteger()
     expect(row.expires_at).toBeGreaterThanOrEqual(expected - 5)
     expect(row.expires_at).toBeLessThanOrEqual(expected + 5)
   })

--- a/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
+++ b/src/vault-mcp/oauth/__tests__/oauth-provider.test.ts
@@ -220,8 +220,7 @@ describe("OAuth refresh token sliding expiry", () => {
       "fresh-token",
     )
 
-    expect(typeof tokens.refresh_token).toBe("string")
-    expect(tokens.refresh_token!.length).toBeGreaterThan(0)
+    if (!tokens.refresh_token) throw new Error("no refresh token issued")
     expect(tokens.refresh_token).not.toBe("fresh-token")
     expect(tokens.scope).toBe("vault")
   })


### PR DESCRIPTION
## Summary

- Fix the `oauth-provider.test.ts` "rotates to a new token with a fresh 60-day window on use" test that fails locally on ET machines whenever `now + 60 days` crosses a DST boundary (e.g. Sep 2 → Nov 1)
- Root cause: the test's expected value used Luxon's `plus({ days: 60 })` (calendar days, DST-aware) while production uses `plus({ seconds: 5_184_000 })` (fixed seconds) — these diverge by 3,600 s at a clock change, exceeding the ±5 s tolerance
- Define a test-owned `REFRESH_TOKEN_TTL_S` constant and use `plus({ seconds })` so both sides compute the same window regardless of timezone

## Test plan

- [x] `npm test -- --run oauth-provider.test` — 82/82 pass locally (DST window currently active: Sep 9 + 60 = Nov 8, crosses Nov 1 fall-back)
- [x] Mutation: changed `REFRESH_TOKEN_TTL_S` to `59 * 24 * 60 * 60` → test fails (constant is load-bearing)
- [x] Full suite: `npm test` — 3578/3578 pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
