### PR TITLE
build(deps): bump commander to 15.0.0 and drop its Dependabot major ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,6 @@ updates:
       development:
         dependency-type: development
     ignore:
-      # commander is version-synced with cli/package.json (a test enforces
-      # it). Major bumps are a deliberate cli decision.
-      - dependency-name: commander
-        update-types: ["version-update:semver-major"]
       # typescript is aliased to @typescript/typescript6 (the JS compiler
       # API that typescript-eslint depends on). TS 7 (Go native) has no JS
       # API. This ignore prevents dependabot from replacing the TS 6 compat

--- a/cli/package.json
+++ b/cli/package.json
@@ -49,6 +49,6 @@
   ],
   "dependencies": {
     "@clack/prompts": "1.7.0",
-    "commander": "14.0.3"
+    "commander": "15.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@types/picomatch": "4.0.3",
         "@typescript/native": "npm:typescript@7.0.2",
         "@vitest/coverage-v8": "5.0.0",
-        "commander": "14.0.3",
+        "commander": "15.0.0",
         "eslint": "10.9.1",
         "eslint-config-prettier": "10.1.8",
         "husky": "9.1.7",
@@ -5565,13 +5565,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/content-disposition": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@types/picomatch": "4.0.3",
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitest/coverage-v8": "5.0.0",
-    "commander": "14.0.3",
+    "commander": "15.0.0",
     "eslint": "10.9.1",
     "eslint-config-prettier": "10.1.8",
     "husky": "9.1.7",


### PR DESCRIPTION
## Summary

- Bump `commander` from 14.0.3 to 15.0.0 in the root package and `cli/package.json` together (the version-sync test requires the pair to move as one)
- Drop the `commander` semver-major ignore from `.github/dependabot.yml` — it existed to hold majors back while commander 15's Node floor (>= 22.12.0) was above the CLI's supported range; the CLI's engines floor is now exactly 22.12.0, so majors no longer need holding

## Breaking-changes audit (commander 15)

| Change | Impact here |
| --- | --- |
| ESM-only distribution | None — both the root package and the CLI are `"type": "module"`, importing via bare `import { Command } from "commander"` |
| Node >= 22.12.0 required | Already the CLI's `engines` floor |
| `--no-*` paired-option default behavior | No `--no-*` options defined |
| `commander/esm.mjs` export removed | Not imported anywhere |

The root dependency is a devDependency held only for the version sync — no root source imports commander.

## Test plan

- [x] CLI unit suite (includes the version-sync drift test): 384 passed
- [x] `npm run build` (server + CLI + SST typechecks) clean
- [x] Built binary smoke on commander 15: `node cli/dist/bin.js --version` and `--help` render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
