### PR TITLE
build(deps): override smol-toml to 1.8.0 to clear GHSA-7w5x-hrqm-74c2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7778,19 +7778,6 @@
         "markdownlint-cli2": ">=0.0.4"
       }
     },
-    "node_modules/markdownlint-cli2/node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
     "node_modules/markdownlint/node_modules/string-width": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
   "overrides": {
     "adm-zip": "0.6.0",
     "js-yaml": "4.3.2",
+    "smol-toml": "1.8.0",
     "@huggingface/transformers": {
       "onnxruntime-web": "npm:empty-npm-package@1.0.0",
       "sharp": "npm:empty-npm-package@1.0.0"


### PR DESCRIPTION
## Summary

- Add `smol-toml: 1.8.0` to the `overrides` block in `package.json` and regenerate the lockfile.
- Clears Dependabot alert 41 (GHSA-7w5x-hrqm-74c2, high, denial of service via malformed TOML documents).

## Why an override

`markdownlint-cli2` pins `smol-toml` at exactly `1.7.0`, which is the last affected version. The earliest fixed release is `1.7.1`, and the current `markdownlint-cli2` release (`0.23.2`) still carries the `1.7.0` pin, so Dependabot's security update job ended with `security_update_not_possible`: its only path was a downgrade of `markdownlint-cli2` to `0.21.0`.

The override lifts the nested copy to `1.8.0`, which `knip` already resolves at the top level, so the tree ends up with a single deduplicated copy. Same approach as the earlier `js-yaml` override.

## Impact

Development-only dependency. `markdownlint-cli2` uses `smol-toml` solely to read TOML config files, and this repo's config is `.markdownlint-cli2.jsonc`.

## Verification

- `npm ls smol-toml` shows one copy at `1.8.0` under both `knip` and `markdownlint-cli2`.
- `npm run markdownlint` runs clean on the same 18 files as before (0 issues).
- `knip` clean.

## Follow-up

The override can be dropped once a `markdownlint-cli2` release depends on `smol-toml >= 1.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
