### PR TITLE
build(deps): stub adm-zip with empty-npm-package to clear GHSA-vwc7-r8mq-g2x9

### DIFF
--- a/.github/workflows/arch_smoke.yml
+++ b/.github/workflows/arch_smoke.yml
@@ -189,6 +189,9 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+        # Without this, onnxruntime-node's postinstall downloads CUDA binaries on linux/x64
+        env:
+          ONNXRUNTIME_NODE_INSTALL: skip
 
       # Runs the vitest config directly: `npm run test:remote-boot` would
       # rebuild the image, and the buildx step above already built it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
           cache: npm
 
       - run: npm ci
+        # Without this, onnxruntime-node's postinstall downloads CUDA binaries on linux/x64
+        env:
+          ONNXRUNTIME_NODE_INSTALL: skip
 
       - run: npm run prettier:check
 
@@ -93,6 +96,9 @@ jobs:
           cache: npm
 
       - run: npm ci
+        # Without this, onnxruntime-node's postinstall downloads CUDA binaries on linux/x64
+        env:
+          ONNXRUNTIME_NODE_INSTALL: skip
 
       - run: npx tsc -p cli/tsconfig.json
 

--- a/.github/workflows/cli_pty_tests.yml
+++ b/.github/workflows/cli_pty_tests.yml
@@ -22,6 +22,9 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+        # Without this, onnxruntime-node's postinstall downloads CUDA binaries on linux/x64
+        env:
+          ONNXRUNTIME_NODE_INSTALL: skip
       - run: npx tsc -p cli/tsconfig.json
       - run: npx tsc -p cli/tsconfig.test.json
       - name: CLI interactive tests (node-pty)

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -111,6 +111,9 @@ jobs:
           fi
 
       - run: npm ci
+        # Without this, onnxruntime-node's postinstall downloads CUDA binaries on linux/x64
+        env:
+          ONNXRUNTIME_NODE_INSTALL: skip
 
       - run: npx tsc -p cli/tsconfig.json
       - run: npx tsc -p cli/tsconfig.test.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,9 @@ jobs:
           cache: npm
 
       - run: npm ci
+        # Without this, onnxruntime-node's postinstall downloads CUDA binaries on linux/x64
+        env:
+          ONNXRUNTIME_NODE_INSTALL: skip
 
       - name: Configure AWS credentials (OIDC)
         if: ${{ !inputs.skip_instance }}

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -57,6 +57,9 @@ jobs:
           cache: npm
 
       - run: npm ci
+        # Without this, onnxruntime-node's postinstall downloads CUDA binaries on linux/x64
+        env:
+          ONNXRUNTIME_NODE_INSTALL: skip
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,2 @@
 engine-strict=true
 save-exact=true
-; onnxruntime-node's postinstall downloads CUDA binaries on linux/x64 and
-; unzips them with adm-zip, which is stubbed out in package.json overrides.
-; The server runs CPU inference only, so skip the download everywhere.
-onnxruntime-node-install=skip

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,6 @@
 engine-strict=true
 save-exact=true
+; onnxruntime-node's postinstall downloads CUDA binaries on linux/x64 and
+; unzips them with adm-zip, which is stubbed out in package.json overrides.
+; The server runs CPU inference only, so skip the download everywhere.
+onnxruntime-node-install=skip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,13 @@ to get started.
    npx sst install
    ```
 
+   **Linux (x64):** run the install as
+   `ONNXRUNTIME_NODE_INSTALL=skip npm install`. Without the variable,
+   `onnxruntime-node`'s install script downloads GPU binaries the server
+   never uses, and the download fails — its archive extractor (`adm-zip`)
+   is stubbed out to resolve a security advisory. macOS and arm64 Linux
+   skip the download on their own.
+
    **Windows:** this repo uses symlinks (`CLAUDE.md → AGENTS.md`). Run
    `git config core.symlinks true` before cloning, or re-clone after
    setting it — otherwise Git checks out symlinks as plain text files

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -27,6 +27,9 @@ SST manages the AWS infrastructure declared in `sst.config.ts`, with each develo
 npm install
 ```
 
+On Linux (x64), run `ONNXRUNTIME_NODE_INSTALL=skip npm install` instead —
+see the Linux note in [CONTRIBUTING.md](./CONTRIBUTING.md#quick-start).
+
 **2. Generate MCP auth token and set SST secret:**
 
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ FROM node:24-trixie-slim@sha256:6950b66b4c0cb0151ce89fa75074673850763d096b044f42
 WORKDIR /app
 RUN apt-get update -qq && apt-get install -y --no-install-recommends python3 make g++ && rm -rf /var/lib/apt/lists/*
 COPY package.json package-lock.json* ./
-RUN npm ci
+# Without the env var, onnxruntime-node's postinstall downloads CUDA binaries on linux/x64.
+RUN ONNXRUNTIME_NODE_INSTALL=skip npm ci
 COPY tsconfig.json sst-env.d.ts ./
 COPY src/ ./src/
 # Server compile only — cli/ is npm-distributed and never copied into the image.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5253,15 +5253,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/adm-zip": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
-      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -8651,6 +8642,13 @@
         "global-agent": "^3.0.0",
         "onnxruntime-common": "1.24.3"
       }
+    },
+    "node_modules/onnxruntime-node/node_modules/adm-zip": {
+      "name": "empty-npm-package",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/empty-npm-package/-/empty-npm-package-1.0.0.tgz",
+      "integrity": "sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA==",
+      "license": "ISC"
     },
     "node_modules/onnxruntime-web": {
       "name": "empty-npm-package",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "zod": "4.5.4"
   },
   "overrides": {
-    "adm-zip": "0.6.0",
+    "adm-zip": "npm:empty-npm-package@1.0.0",
     "js-yaml": "4.3.2",
     "smol-toml": "1.8.0",
     "@huggingface/transformers": {


### PR DESCRIPTION
## Summary

- Change the `adm-zip` override in `package.json` from `0.6.0` to `npm:empty-npm-package@1.0.0` and regenerate the lockfile. This removes the vulnerable package from the tree and closes Dependabot alert 36 (GHSA-vwc7-r8mq-g2x9, medium, extraction follows destination symlinks).
- Set `ONNXRUNTIME_NODE_INSTALL=skip` on every `npm ci` that runs lifecycle scripts: the seven workflow steps across six workflows, and the Dockerfile's `build` stage. The postinstall then exits before downloading anything.

## Why a stub rather than a version bump

No fixed `adm-zip` release exists. The vulnerable range is `>= 0.5.9, <= 0.6.0`, and `0.6.0` is still the latest published version, so the existing `0.6.0` override was already as high as the tree could go.

## What the first CI run revealed

The alert had been dismissed as "not used" on the understanding that the postinstall never runs. That was wrong for CI. On `linux/x64`, `onnxruntime-node`'s install metadata requires the `cuda12` manifest by default, so every `npm ci` on a GitHub runner has been downloading `microsoft.ml.onnxruntime.gpu.linux` from nuget.org and extracting it with `adm-zip`. The first run of this PR failed on every job with `AdmZip is not a constructor`, which is the stub doing its job at exactly the point the vulnerable code used to execute.

The server runs CPU inference only, so those binaries were never used. The Dockerfile's `deps` stage already passes `--ignore-scripts`, but its `build` stage does not, so every image build on `linux/amd64` had the same download; the second CI run failed there (arch-smoke and trivy-pr) and the Dockerfile now sets the variable too. macOS and `linux/arm64` never had a download to skip.

## Why a workflow env var rather than `.npmrc`

The postinstall also honors an `onnxruntime-node-install=skip` key in `.npmrc`, which would have been one file. npm 11 warns `Unknown project config "onnxruntime-node-install"` on every command for a key it does not own, and states that npm 12 will stop forwarding such keys to lifecycle scripts. The env var is read directly by the postinstall and has no such caveat.

## Verification

- Running the postinstall with `ONNXRUNTIME_NODE_INSTALL=skip` exits 0 without output.
- `npm ls adm-zip` resolves to `adm-zip@npm:empty-npm-package@1.0.0`; the `adm-zip-0.6.0.tgz` entry is gone from the lockfile.
- `npm audit` reports 0 vulnerabilities.
- `node -e "require('onnxruntime-node')"` loads and exposes `InferenceSession`; the runtime entry point never references `adm-zip`.
- Embedder and reranker tests pass (34 tests); `knip` clean; `actionlint` clean on the edited workflows.
- CI on this PR is the real gate for the `linux/x64` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
