### PR TITLE
test(setup): give the disconnect-survival test explicit waitFor budgets

### DIFF
--- a/src/vault-mcp/setup/__tests__/setup-routes.test.ts
+++ b/src/vault-mcp/setup/__tests__/setup-routes.test.ts
@@ -387,8 +387,11 @@ describe("POST /setup — sign-in outcomes", () => {
       .spyOn(syncTokenStore, "writeSyncToken")
       .mockImplementation(async (params, logger) => {
         abortController.abort()
-        await vi.waitFor(async () =>
-          expect(await harness.openConnections()).toBe(0),
+        // Socket teardown and the completion chain take milliseconds locally
+        // but can exceed vi.waitFor's default 1s budget on slow containers.
+        await vi.waitFor(
+          async () => expect(await harness.openConnections()).toBe(0),
+          { timeout: 10_000 },
         )
         return writeSyncToken(params, logger)
       })
@@ -398,8 +401,9 @@ describe("POST /setup — sign-in outcomes", () => {
       harness.postForm(CREDENTIALS, abortController.signal),
     ).rejects.toThrow("This operation was aborted")
 
-    await vi.waitFor(() =>
-      expect(harness.onSetupComplete).toHaveBeenCalledTimes(1),
+    await vi.waitFor(
+      () => expect(harness.onSetupComplete).toHaveBeenCalledTimes(1),
+      { timeout: 10_000 },
     )
     expect(await readFile(harness.tokenFilePath, "utf8")).toBe("sync-tok")
   })


### PR DESCRIPTION
## Summary

- Give the disconnect-survival test in `setup-routes.test.ts` explicit `vi.waitFor` budgets (`timeout: 10_000`) on both of its waits.

## Why

The test ("signals completion even when the browser disconnects while the token is written") stacks real socket work behind `vi.waitFor`'s default 1-second budget: the spy aborts the client's connection, waits for the server to observe zero open connections, then the completion chain (token write, vault listing, completion signal) must finish before the outer wait expires. On a fast machine the whole file runs in ~500ms, but on a slow or loaded machine socket teardown plus the remaining chain can exceed one second — the inner wait then throws inside the spy, the handler dies, and the test fails with `onSetupComplete` never called.

The behavior under test is fine; only the wait budgets were tight. No production change.

The sibling happy-path test's bare `vi.waitFor` is left alone — it starts after the response has fully arrived, so it has no teardown chain to outwait.

## Testing

- `npx vitest run src/vault-mcp/setup/__tests__/setup-routes.test.ts` — 30 passed (30), 487ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
