### PR TITLE
fix(test): use node:http request.destroy() for browser-disconnect test

### DIFF
--- a/src/vault-mcp/setup/__tests__/setup-routes.test.ts
+++ b/src/vault-mcp/setup/__tests__/setup-routes.test.ts
@@ -380,13 +380,15 @@ describe("POST /setup — sign-in outcomes", () => {
       },
     })
     const writeSyncToken = syncTokenStore.writeSyncToken
-    const abortController = new AbortController()
+    // node:http request whose socket we can destroy — Node 24's fetch
+    // abort does not reliably close the server-side TCP socket.
+    let clientRequest: ReturnType<typeof httpRequest> | undefined
     // Hold the token write until the browser's connection is gone, so the
     // completion page can only ever be sent to a closed connection.
     const writeSpy = vi
       .spyOn(syncTokenStore, "writeSyncToken")
       .mockImplementation(async (params, logger) => {
-        abortController.abort()
+        clientRequest?.destroy()
         // Socket teardown and the completion chain take milliseconds locally
         // but can exceed vi.waitFor's default 1s budget on slow containers.
         await vi.waitFor(
@@ -397,9 +399,24 @@ describe("POST /setup — sign-in outcomes", () => {
       })
     onTestFinished(() => writeSpy.mockRestore())
 
+    const body = new URLSearchParams(CREDENTIALS).toString()
     await expect(
-      harness.postForm(CREDENTIALS, abortController.signal),
-    ).rejects.toThrow("This operation was aborted")
+      new Promise<void>((resolve, reject) => {
+        clientRequest = httpRequest(
+          `${harness.baseUrl}/setup`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+              "content-length": Buffer.byteLength(body).toString(),
+            },
+          },
+          () => resolve(),
+        )
+        clientRequest.on("error", reject)
+        clientRequest.end(body)
+      }),
+    ).rejects.toThrow("socket hang up")
 
     await vi.waitFor(
       () => expect(harness.onSetupComplete).toHaveBeenCalledTimes(1),


### PR DESCRIPTION
## What does this PR do?

Replaces the `fetch` + `AbortController.abort()` approach in the browser-disconnect setup-routes test with `node:http`'s `request.destroy()`, which closes the server-side TCP socket deterministically.

Node 24.21+'s built-in fetch (undici) does not reliably close the server-side TCP socket on abort, so `server.getConnections()` may not reach 0 within the polling window — causing the mock to hang and the test to fail. `request.destroy()` tears down the socket immediately regardless of Node version.

Keeps the explicit `{ timeout: 10_000 }` budgets from #553 as hardening for slow containers.

## Type of change

- [x] Bug fix

## Checklist

- [x] `npm test` passes — 3603/3603 on Node 24.21 (container)
- [x] `npm run lint` passes
- [x] `npm run prettier:check` passes
- [ ] `npm run build` succeeds
- [ ] New MCP tools follow the naming and description conventions in AGENTS.md
- [ ] README or ARCHITECTURE.md updated (if user-facing behavior changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoCGVGAxyWyeGinZFJ4PyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AoCGVGAxyWyeGinZFJ4PyU)_