### PR TITLE
test: register temp-dir cleanup in the init-setup-user spec

### DIFF
--- a/src/vault-mcp/__tests__/init-setup-user.test.ts
+++ b/src/vault-mcp/__tests__/init-setup-user.test.ts
@@ -4,12 +4,13 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  rmSync,
   writeFileSync,
 } from "node:fs"
 import { tmpdir } from "node:os"
 import { isAbsolute, join, resolve } from "node:path"
 
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, onTestFinished } from "vitest"
 
 /**
  * Behavioral spec for the remote image's ownership step
@@ -67,6 +68,7 @@ type SetupUserRunOptions = {
 
 const runSetupUser = (options: SetupUserRunOptions): SetupUserRun => {
   const tempDir = mkdtempSync(join(tmpdir(), "init-setup-user-"))
+  onTestFinished(() => rmSync(tempDir, { recursive: true, force: true }))
   const stubBinDir = join(tempDir, "bin")
   const homeDir = join(tempDir, "home")
   const vaultPath = join(tempDir, "vault")


### PR DESCRIPTION
## What

Registers `onTestFinished(() => rmSync(tempDir, ...))` next to the `mkdtempSync` in `init-setup-user.test.ts`, so each test's temp dir is removed when the test finishes.

## Why

The setup-vault and first-sync specs got this cleanup on #476; this file has the same `mkdtempSync` factory and was missed in that pass, so every run leaked one directory per test into the OS temp dir.

## Tests

- `npx vitest run src/vault-mcp/__tests__/init-setup-user.test.ts` — 8/8 pass
- Verified post-run that no `init-setup-user-*` directories were created in the temp dir by the fixed suite
- `tsc --noEmit` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
