### PR TITLE
ci(cli-release): serialize with server releases and push branch and tag atomically

### DIFF
--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -27,8 +27,11 @@ on:
           - beta
           - none
 
+# Shares the server release/deploy group: both release flows push to
+# main, and a CLI release racing a server release loses its push. A run
+# dispatched while a server release is in flight queues until it's done.
 concurrency:
-  group: cli-release
+  group: deploy-prod
   cancel-in-progress: false
 
 # Top-level token is read-only; the job declares its writes.
@@ -143,11 +146,19 @@ jobs:
             git add cli/package.json
             git commit -m "release(cli): v$NEXT"
           fi
+          # Branch before tag, as separate pushes: refs in one push succeed
+          # or fail independently, so a rejected branch push alongside
+          # --tags leaves a tag pointing at a commit that never reached
+          # main — which then blocks the next release until it's deleted.
+          if ! git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD; then
+            echo "::error::Push rejected — main gained commits during this run. Dispatch the workflow again (a re-run of this run reuses its stale checkout and cannot succeed)."
+            exit 1
+          fi
           # Tag may already exist when re-running after a failed publish.
           if ! git rev-parse -q --verify "refs/tags/cli-v$NEXT" > /dev/null; then
             git tag "cli-v$NEXT"
           fi
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD --tags
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/cli-v$NEXT"
 
       - name: Publish to npm (Trusted Publishing / OIDC)
         env:

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -146,19 +146,20 @@ jobs:
             git add cli/package.json
             git commit -m "release(cli): v$NEXT"
           fi
-          # Branch before tag, as separate pushes: refs in one push succeed
-          # or fail independently, so a rejected branch push alongside
-          # --tags leaves a tag pointing at a commit that never reached
-          # main — which then blocks the next release until it's deleted.
-          if ! git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD; then
-            echo "::error::Push rejected — main gained commits during this run. Dispatch the workflow again (a re-run of this run reuses its stale checkout and cannot succeed)."
-            exit 1
-          fi
           # Tag may already exist when re-running after a failed publish.
           if ! git rev-parse -q --verify "refs/tags/cli-v$NEXT" > /dev/null; then
             git tag "cli-v$NEXT"
           fi
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/cli-v$NEXT"
+          # --atomic updates both refs or neither: without it, a rejected
+          # branch push can still deliver the tag (a tag pointing at a
+          # commit that never reached main), and a failed tag push can
+          # strand an untagged bump commit on main — each partial state
+          # breaks the next release's version math. All-or-nothing keeps
+          # the failure path a bare re-dispatch with nothing to clean up.
+          if ! git push --atomic "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD "refs/tags/cli-v$NEXT"; then
+            echo "::error::Push rejected — main gained commits during this run, or the push failed partway. Nothing was pushed; dispatch the workflow again (a re-run of this run reuses its stale checkout and cannot succeed)."
+            exit 1
+          fi
 
       - name: Publish to npm (Trusted Publishing / OIDC)
         env:


### PR DESCRIPTION
## Problem

A CLI release failed at the "Commit, tag, and push" step and left the repo in a state that blocked every subsequent release attempt:

1. **The race.** The workflow was dispatched while a server release was finishing. A commit landed on main seconds before the CLI release pushed, so the push of the version-bump commit was rejected as non-fast-forward.
2. **The stranded tag.** The push was a single `git push HEAD --tags`. Git accepts or rejects each ref in a push independently, so while the branch update was rejected, the `cli-v*` tag in the same push went through — pointing at a bump commit that never reached main. That tag then tripped the tagged-but-not-on-npm guard on every later dispatch until it was deleted by hand.

## Changes

- **Share the `deploy-prod` concurrency group** (previously the workflow had its own `cli-release` group). Both release flows push to main; a CLI release dispatched while a server release or deploy is in flight now queues until it finishes instead of racing it.
- **Push the branch and the tag in one `--atomic` push.** Git normally accepts or rejects each ref in a push independently — the failure above. `--atomic` makes the two ref updates a single transaction: if the branch update is rejected (main moved during the run — e.g. a PR merge, which no concurrency group can serialize against) or the push fails partway, neither ref lands. The step fails with an error directing the operator to dispatch a fresh run, and a failed run leaves nothing behind — no stranded tag, and no untagged bump commit on main. An earlier revision of this PR used two ordered pushes (branch, then tag); review caught that a tag push failing after a successful branch push would strand an untagged bump commit, silently skipping that version on the next dispatch.

The bump="none" recovery path (re-publish a tagged version after a failed npm publish) is unchanged: an existing tag is still detected and not recreated, and pushing an identical existing tag is a no-op.

## Testing

- The new step body was exercised verbatim under `bash -e` with a stub `git` across three scenarios: happy path (bump commit, tag created, exactly one atomic push carrying both refs), rejected push (step exits 1 with the error annotation, nothing pushed), and pre-existing tag (not recreated, still included in the atomic push). All pass.
- `npx prettier --check` passes on the workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
