### PR TITLE
fix(vault): log write-path cleanup failures instead of swallowing them

### DIFF
--- a/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
@@ -1211,16 +1211,14 @@ describe("moveNote — guards", () => {
 
     const newFullPath = join(vault, "foo.md")
     vi.mocked(atomicWriteFile).mockImplementation(
-      async (filePath, content, writeLogger) => {
-        if (filePath === newFullPath) throw new Error("ENOSPC: no space left")
+      async (writeParams, writeLogger) => {
+        if (writeParams.filePath === newFullPath) {
+          throw new Error("ENOSPC: no space left")
+        }
         const actualVaultFilesystem = await vi.importActual<
           typeof import("../vault-filesystem.js")
         >("../vault-filesystem.js")
-        return actualVaultFilesystem.atomicWriteFile(
-          filePath,
-          content,
-          writeLogger,
-        )
+        return actualVaultFilesystem.atomicWriteFile(writeParams, writeLogger)
       },
     )
     onTestFinished(() => vi.mocked(atomicWriteFile).mockRestore())
@@ -1244,16 +1242,14 @@ describe("moveNote — guards", () => {
 
     const hubFullPath = join(vault, "Hub.md")
     vi.mocked(atomicWriteFile).mockImplementation(
-      async (filePath, content, writeLogger) => {
-        if (filePath === hubFullPath) throw new Error("ENOSPC: no space left")
+      async (writeParams, writeLogger) => {
+        if (writeParams.filePath === hubFullPath) {
+          throw new Error("ENOSPC: no space left")
+        }
         const actualVaultFilesystem = await vi.importActual<
           typeof import("../vault-filesystem.js")
         >("../vault-filesystem.js")
-        return actualVaultFilesystem.atomicWriteFile(
-          filePath,
-          content,
-          writeLogger,
-        )
+        return actualVaultFilesystem.atomicWriteFile(writeParams, writeLogger)
       },
     )
     onTestFinished(() => vi.mocked(atomicWriteFile).mockRestore())

--- a/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/note-mover.test.ts
@@ -1210,13 +1210,19 @@ describe("moveNote — guards", () => {
     forceCaseOnlyRenameDetection(vault)
 
     const newFullPath = join(vault, "foo.md")
-    vi.mocked(atomicWriteFile).mockImplementation(async (filePath, content) => {
-      if (filePath === newFullPath) throw new Error("ENOSPC: no space left")
-      const actualVaultFilesystem = await vi.importActual<
-        typeof import("../vault-filesystem.js")
-      >("../vault-filesystem.js")
-      return actualVaultFilesystem.atomicWriteFile(filePath, content)
-    })
+    vi.mocked(atomicWriteFile).mockImplementation(
+      async (filePath, content, writeLogger) => {
+        if (filePath === newFullPath) throw new Error("ENOSPC: no space left")
+        const actualVaultFilesystem = await vi.importActual<
+          typeof import("../vault-filesystem.js")
+        >("../vault-filesystem.js")
+        return actualVaultFilesystem.atomicWriteFile(
+          filePath,
+          content,
+          writeLogger,
+        )
+      },
+    )
     onTestFinished(() => vi.mocked(atomicWriteFile).mockRestore())
 
     await expect(
@@ -1237,13 +1243,19 @@ describe("moveNote — guards", () => {
     forceCaseOnlyRenameDetection(vault)
 
     const hubFullPath = join(vault, "Hub.md")
-    vi.mocked(atomicWriteFile).mockImplementation(async (filePath, content) => {
-      if (filePath === hubFullPath) throw new Error("ENOSPC: no space left")
-      const actualVaultFilesystem = await vi.importActual<
-        typeof import("../vault-filesystem.js")
-      >("../vault-filesystem.js")
-      return actualVaultFilesystem.atomicWriteFile(filePath, content)
-    })
+    vi.mocked(atomicWriteFile).mockImplementation(
+      async (filePath, content, writeLogger) => {
+        if (filePath === hubFullPath) throw new Error("ENOSPC: no space left")
+        const actualVaultFilesystem = await vi.importActual<
+          typeof import("../vault-filesystem.js")
+        >("../vault-filesystem.js")
+        return actualVaultFilesystem.atomicWriteFile(
+          filePath,
+          content,
+          writeLogger,
+        )
+      },
+    )
     onTestFinished(() => vi.mocked(atomicWriteFile).mockRestore())
 
     await expect(

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -65,12 +65,18 @@ afterEach(async () => {
 describe("atomicWriteFile", () => {
   it("writes the exact content to the target path", async () => {
     const target = join(vault, "atomic.md")
-    await atomicWriteFile(target, "exact content\n", logger)
+    await atomicWriteFile(
+      { filePath: target, content: "exact content\n" },
+      logger,
+    )
     expect(await readFile(target, "utf8")).toBe("exact content\n")
   })
 
   it("leaves no .tmp staging file behind on success", async () => {
-    await atomicWriteFile(join(vault, "clean.md"), "body\n", logger)
+    await atomicWriteFile(
+      { filePath: join(vault, "clean.md"), content: "body\n" },
+      logger,
+    )
     const entries = await readdir(vault)
     expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
   })
@@ -81,9 +87,9 @@ describe("atomicWriteFile", () => {
     // the catch-and-cleanup branch, not the initial writeFile.
     const target = join(vault, "occupied")
     await mkdir(target)
-    await expect(atomicWriteFile(target, "body\n", logger)).rejects.toThrow(
-      /EISDIR/,
-    )
+    await expect(
+      atomicWriteFile({ filePath: target, content: "body\n" }, logger),
+    ).rejects.toThrow(/EISDIR/)
     const entries = await readdir(vault)
     expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
   })
@@ -98,9 +104,9 @@ describe("atomicWriteFile", () => {
       throw new Error("EPERM: injected cleanup failure")
     })
 
-    await expect(atomicWriteFile(target, "body\n", logger)).rejects.toThrow(
-      /EISDIR/,
-    )
+    await expect(
+      atomicWriteFile({ filePath: target, content: "body\n" }, logger),
+    ).rejects.toThrow(/EISDIR/)
 
     // The temp path carries a random UUID, so only its shape is assertable
     expect(warnSpy).toHaveBeenCalledTimes(1)
@@ -114,32 +120,41 @@ describe("atomicWriteFile", () => {
 describe("atomicWriteFileExclusive", () => {
   it("writes the exact content to a new target path", async () => {
     const target = join(vault, "created.md")
-    await atomicWriteFileExclusive(target, "fresh content\n", logger)
+    await atomicWriteFileExclusive(
+      { filePath: target, content: "fresh content\n" },
+      logger,
+    )
     expect(await readFile(target, "utf8")).toBe("fresh content\n")
   })
 
   it("throws EEXIST and leaves existing content untouched when the target exists", async () => {
     const target = join(vault, "taken.md")
-    await atomicWriteFile(target, "original\n", logger)
+    await atomicWriteFile({ filePath: target, content: "original\n" }, logger)
 
     await expect(
-      atomicWriteFileExclusive(target, "overwrite\n", logger),
+      atomicWriteFileExclusive(
+        { filePath: target, content: "overwrite\n" },
+        logger,
+      ),
     ).rejects.toMatchObject({ code: "EEXIST" })
     // The no-clobber guard must not have modified the existing file.
     expect(await readFile(target, "utf8")).toBe("original\n")
   })
 
   it("leaves no .tmp staging file behind on success", async () => {
-    await atomicWriteFileExclusive(join(vault, "clean.md"), "body\n", logger)
+    await atomicWriteFileExclusive(
+      { filePath: join(vault, "clean.md"), content: "body\n" },
+      logger,
+    )
     const entries = await readdir(vault)
     expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
   })
 
   it("leaves no .tmp staging file behind when the target already exists", async () => {
     const target = join(vault, "exists.md")
-    await atomicWriteFile(target, "original\n", logger)
+    await atomicWriteFile({ filePath: target, content: "original\n" }, logger)
     await expect(
-      atomicWriteFileExclusive(target, "body\n", logger),
+      atomicWriteFileExclusive({ filePath: target, content: "body\n" }, logger),
     ).rejects.toMatchObject({ code: "EEXIST" })
     const entries = await readdir(vault)
     expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
@@ -150,20 +165,30 @@ describe("atomicWriteFileExclusive", () => {
   describe("hardLinksSupported: false (rename strategy)", () => {
     it("writes the exact content to a new target path via rename", async () => {
       const target = join(vault, "created.md")
-      await atomicWriteFileExclusive(target, "fresh content\n", logger, {
-        hardLinksSupported: false,
-      })
+      await atomicWriteFileExclusive(
+        {
+          filePath: target,
+          content: "fresh content\n",
+          hardLinksSupported: false,
+        },
+        logger,
+      )
       expect(await readFile(target, "utf8")).toBe("fresh content\n")
     })
 
     it("throws EEXIST and leaves existing content untouched when the target exists", async () => {
       const target = join(vault, "taken.md")
-      await atomicWriteFile(target, "original\n", logger)
+      await atomicWriteFile({ filePath: target, content: "original\n" }, logger)
 
       await expect(
-        atomicWriteFileExclusive(target, "overwrite\n", logger, {
-          hardLinksSupported: false,
-        }),
+        atomicWriteFileExclusive(
+          {
+            filePath: target,
+            content: "overwrite\n",
+            hardLinksSupported: false,
+          },
+          logger,
+        ),
       ).rejects.toMatchObject({ code: "EEXIST" })
       // The no-clobber guard must not have modified the existing file.
       expect(await readFile(target, "utf8")).toBe("original\n")
@@ -171,12 +196,12 @@ describe("atomicWriteFileExclusive", () => {
 
     it("leaves no .tmp staging file behind on success", async () => {
       await atomicWriteFileExclusive(
-        join(vault, "clean.md"),
-        "body\n",
-        logger,
         {
+          filePath: join(vault, "clean.md"),
+          content: "body\n",
           hardLinksSupported: false,
         },
+        logger,
       )
       const entries = await readdir(vault)
       expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
@@ -196,9 +221,10 @@ describe("atomicWriteFileExclusive", () => {
       })
 
       await expect(
-        atomicWriteFileExclusive(target, "body\n", logger, {
-          hardLinksSupported: false,
-        }),
+        atomicWriteFileExclusive(
+          { filePath: target, content: "body\n", hardLinksSupported: false },
+          logger,
+        ),
       ).rejects.toThrow("EIO: injected swap failure")
 
       expect(warnSpy).toHaveBeenCalledTimes(1)

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -1357,6 +1357,47 @@ describe("deleteNote — trash behavior", () => {
     })
   })
 
+  it("logs the placeholder cleanup failure when both the rename and the cleanup fail", async () => {
+    await writeFile(join(vault, "cleanupfail.md"), "keep me", "utf8")
+    const warnSpy = vi.spyOn(logger, "warn")
+    onTestFinished(() => warnSpy.mockRestore())
+    vi.mocked(rename).mockImplementationOnce(async () => {
+      throw new Error("EIO: injected rename failure")
+    })
+    // The next rm call is the placeholder cleanup inside moveNoteToTrash
+    vi.mocked(rm).mockImplementationOnce(async () => {
+      throw new Error("EPERM: injected cleanup failure")
+    })
+
+    await expect(
+      deleteNote(
+        {
+          vaultPath: vault,
+          path: "cleanupfail.md",
+          protectedPaths: [],
+          pruneEmptyFolders: false,
+          trashOption: "local",
+        },
+        logger,
+      ),
+    ).rejects.toThrow('cannot move to trash "cleanupfail.md"')
+
+    // The failed cleanup is visible in the logs, and the placeholder it could
+    // not remove genuinely survives — proof the injected rm was the cleanup
+    expect(warnSpy).toHaveBeenCalledWith("failed to remove claim placeholder", {
+      path: ".trash/cleanupfail.md",
+      error: "[Error]: EPERM: injected cleanup failure",
+    })
+    expect(warnSpy).toHaveBeenCalledWith("failed to move to trash", {
+      path: "cleanupfail.md",
+      error: "[Error]: EIO: injected rename failure",
+    })
+    expect((await stat(join(vault, ".trash", "cleanupfail.md"))).size).toBe(0)
+    expect(await readFile(join(vault, "cleanupfail.md"), "utf8")).toBe(
+      "keep me",
+    )
+  })
+
   it("surfaces a vault-relative error and preserves the source when the claim fails for a non-EEXIST reason", async () => {
     await writeFile(join(vault, "claimfail.md"), "keep me", "utf8")
     const warnSpy = vi.spyOn(logger, "warn")

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -160,6 +160,36 @@ describe("atomicWriteFileExclusive", () => {
     expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
   })
 
+  it("logs the temp-file cleanup failure when the claim fails and the cleanup fails", async () => {
+    const target = join(vault, "taken.md")
+    await atomicWriteFile({ filePath: target, content: "original\n" }, logger)
+    const warnSpy = vi.spyOn(logger, "warn")
+    onTestFinished(() => warnSpy.mockRestore())
+    // The next rm call is the finally block's temp-file cleanup, reached
+    // after link throws EEXIST on the occupied target
+    vi.mocked(rm).mockImplementationOnce(async () => {
+      throw new Error("EPERM: injected cleanup failure")
+    })
+
+    await expect(
+      atomicWriteFileExclusive(
+        { filePath: target, content: "overwrite\n" },
+        logger,
+      ),
+    ).rejects.toMatchObject({ code: "EEXIST" })
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith("failed to remove temp file", {
+      path: expect.stringMatching(/taken\.md\..+\.tmp$/),
+      error: "[Error]: EPERM: injected cleanup failure",
+    })
+    // The intercepted cleanup genuinely left the staging file on disk, and
+    // the occupied target survives untouched
+    const entries = await readdir(vault)
+    expect(entries.filter((name) => name.endsWith(".tmp"))).toHaveLength(1)
+    expect(await readFile(target, "utf8")).toBe("original\n")
+  })
+
   // Covers the rename fallback path taken on filesystems without hard-link
   // support (e.g. a Windows-drive Docker bind mount).
   describe("hardLinksSupported: false (rename strategy)", () => {

--- a/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
+++ b/src/vault-mcp/vault-operations/__tests__/vault-filesystem.test.ts
@@ -65,12 +65,12 @@ afterEach(async () => {
 describe("atomicWriteFile", () => {
   it("writes the exact content to the target path", async () => {
     const target = join(vault, "atomic.md")
-    await atomicWriteFile(target, "exact content\n")
+    await atomicWriteFile(target, "exact content\n", logger)
     expect(await readFile(target, "utf8")).toBe("exact content\n")
   })
 
   it("leaves no .tmp staging file behind on success", async () => {
-    await atomicWriteFile(join(vault, "clean.md"), "body\n")
+    await atomicWriteFile(join(vault, "clean.md"), "body\n", logger)
     const entries = await readdir(vault)
     expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
   })
@@ -81,41 +81,65 @@ describe("atomicWriteFile", () => {
     // the catch-and-cleanup branch, not the initial writeFile.
     const target = join(vault, "occupied")
     await mkdir(target)
-    await expect(atomicWriteFile(target, "body\n")).rejects.toThrow(/EISDIR/)
+    await expect(atomicWriteFile(target, "body\n", logger)).rejects.toThrow(
+      /EISDIR/,
+    )
     const entries = await readdir(vault)
     expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
+  })
+
+  it("logs the temp-file cleanup failure when both the rename and the cleanup fail", async () => {
+    const target = join(vault, "occupied")
+    await mkdir(target)
+    const warnSpy = vi.spyOn(logger, "warn")
+    onTestFinished(() => warnSpy.mockRestore())
+    // The next rm call is the temp-file cleanup after the EISDIR rename
+    vi.mocked(rm).mockImplementationOnce(async () => {
+      throw new Error("EPERM: injected cleanup failure")
+    })
+
+    await expect(atomicWriteFile(target, "body\n", logger)).rejects.toThrow(
+      /EISDIR/,
+    )
+
+    // The temp path carries a random UUID, so only its shape is assertable
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith("failed to remove temp file", {
+      path: expect.stringMatching(/occupied\..+\.tmp$/),
+      error: "[Error]: EPERM: injected cleanup failure",
+    })
   })
 })
 
 describe("atomicWriteFileExclusive", () => {
   it("writes the exact content to a new target path", async () => {
     const target = join(vault, "created.md")
-    await atomicWriteFileExclusive(target, "fresh content\n")
+    await atomicWriteFileExclusive(target, "fresh content\n", logger)
     expect(await readFile(target, "utf8")).toBe("fresh content\n")
   })
 
   it("throws EEXIST and leaves existing content untouched when the target exists", async () => {
     const target = join(vault, "taken.md")
-    await atomicWriteFile(target, "original\n")
+    await atomicWriteFile(target, "original\n", logger)
 
     await expect(
-      atomicWriteFileExclusive(target, "overwrite\n"),
+      atomicWriteFileExclusive(target, "overwrite\n", logger),
     ).rejects.toMatchObject({ code: "EEXIST" })
     // The no-clobber guard must not have modified the existing file.
     expect(await readFile(target, "utf8")).toBe("original\n")
   })
 
   it("leaves no .tmp staging file behind on success", async () => {
-    await atomicWriteFileExclusive(join(vault, "clean.md"), "body\n")
+    await atomicWriteFileExclusive(join(vault, "clean.md"), "body\n", logger)
     const entries = await readdir(vault)
     expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
   })
 
   it("leaves no .tmp staging file behind when the target already exists", async () => {
     const target = join(vault, "exists.md")
-    await atomicWriteFile(target, "original\n")
+    await atomicWriteFile(target, "original\n", logger)
     await expect(
-      atomicWriteFileExclusive(target, "body\n"),
+      atomicWriteFileExclusive(target, "body\n", logger),
     ).rejects.toMatchObject({ code: "EEXIST" })
     const entries = await readdir(vault)
     expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
@@ -126,7 +150,7 @@ describe("atomicWriteFileExclusive", () => {
   describe("hardLinksSupported: false (rename strategy)", () => {
     it("writes the exact content to a new target path via rename", async () => {
       const target = join(vault, "created.md")
-      await atomicWriteFileExclusive(target, "fresh content\n", {
+      await atomicWriteFileExclusive(target, "fresh content\n", logger, {
         hardLinksSupported: false,
       })
       expect(await readFile(target, "utf8")).toBe("fresh content\n")
@@ -134,10 +158,10 @@ describe("atomicWriteFileExclusive", () => {
 
     it("throws EEXIST and leaves existing content untouched when the target exists", async () => {
       const target = join(vault, "taken.md")
-      await atomicWriteFile(target, "original\n")
+      await atomicWriteFile(target, "original\n", logger)
 
       await expect(
-        atomicWriteFileExclusive(target, "overwrite\n", {
+        atomicWriteFileExclusive(target, "overwrite\n", logger, {
           hardLinksSupported: false,
         }),
       ).rejects.toMatchObject({ code: "EEXIST" })
@@ -146,11 +170,45 @@ describe("atomicWriteFileExclusive", () => {
     })
 
     it("leaves no .tmp staging file behind on success", async () => {
-      await atomicWriteFileExclusive(join(vault, "clean.md"), "body\n", {
-        hardLinksSupported: false,
-      })
+      await atomicWriteFileExclusive(
+        join(vault, "clean.md"),
+        "body\n",
+        logger,
+        {
+          hardLinksSupported: false,
+        },
+      )
       const entries = await readdir(vault)
       expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([])
+    })
+
+    it("logs the placeholder cleanup failure when both the swap and the cleanup fail", async () => {
+      const target = join(vault, "reserved.md")
+      const warnSpy = vi.spyOn(logger, "warn")
+      onTestFinished(() => warnSpy.mockRestore())
+      vi.mocked(rename).mockImplementationOnce(async () => {
+        throw new Error("EIO: injected swap failure")
+      })
+      // The next rm call is the reservation-placeholder cleanup; the finally
+      // block's temp-file rm runs unmocked afterward and succeeds
+      vi.mocked(rm).mockImplementationOnce(async () => {
+        throw new Error("EPERM: injected cleanup failure")
+      })
+
+      await expect(
+        atomicWriteFileExclusive(target, "body\n", logger, {
+          hardLinksSupported: false,
+        }),
+      ).rejects.toThrow("EIO: injected swap failure")
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(
+        "failed to remove reservation placeholder",
+        {
+          path: target,
+          error: "[Error]: EPERM: injected cleanup failure",
+        },
+      )
     })
   })
 })

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -660,7 +660,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
             section: newSection,
             bullet,
           })
-          await atomicWriteFile(filePath, content, logger)
+          await atomicWriteFile({ filePath, content }, logger)
           logger.info("created memory file", {
             file: params.file,
             section: newSection,
@@ -699,8 +699,10 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
           const afterBytes = Buffer.byteLength(serialized, "utf8")
           guardAgainstShrink(beforeBytes, afterBytes, "creating memory section")
           await atomicWriteFile(
-            memoryFilePath(params.vaultPath, params.file),
-            serialized,
+            {
+              filePath: memoryFilePath(params.vaultPath, params.file),
+              content: serialized,
+            },
             logger,
           )
           logger.info("created memory section", {
@@ -774,8 +776,10 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         const afterBytes = Buffer.byteLength(serialized, "utf8")
         guardAgainstShrink(beforeBytes, afterBytes, "updating memory entry")
         await atomicWriteFile(
-          memoryFilePath(params.vaultPath, params.file),
-          serialized,
+          {
+            filePath: memoryFilePath(params.vaultPath, params.file),
+            content: serialized,
+          },
           logger,
         )
         logger.info("updated memory", {
@@ -934,8 +938,10 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         const afterBytes = Buffer.byteLength(serialized, "utf8")
         guardAgainstShrink(beforeBytes, afterBytes, "deleting memory entry")
         await atomicWriteFile(
-          memoryFilePath(params.vaultPath, params.file),
-          serialized,
+          {
+            filePath: memoryFilePath(params.vaultPath, params.file),
+            content: serialized,
+          },
           logger,
         )
         logger.info("deleted memory entry", {
@@ -972,8 +978,10 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
     await Promise.all(
       templates.map((template) =>
         atomicWriteFile(
-          join(dirPath, `${template.fileName}.md`),
-          template.content,
+          {
+            filePath: join(dirPath, `${template.fileName}.md`),
+            content: template.content,
+          },
           logger,
         ),
       ),

--- a/src/vault-mcp/vault-operations/memory-store.ts
+++ b/src/vault-mcp/vault-operations/memory-store.ts
@@ -660,7 +660,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
             section: newSection,
             bullet,
           })
-          await atomicWriteFile(filePath, content)
+          await atomicWriteFile(filePath, content, logger)
           logger.info("created memory file", {
             file: params.file,
             section: newSection,
@@ -701,6 +701,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
           await atomicWriteFile(
             memoryFilePath(params.vaultPath, params.file),
             serialized,
+            logger,
           )
           logger.info("created memory section", {
             file: params.file,
@@ -775,6 +776,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         await atomicWriteFile(
           memoryFilePath(params.vaultPath, params.file),
           serialized,
+          logger,
         )
         logger.info("updated memory", {
           file: params.file,
@@ -934,6 +936,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         await atomicWriteFile(
           memoryFilePath(params.vaultPath, params.file),
           serialized,
+          logger,
         )
         logger.info("deleted memory entry", {
           file: params.file,
@@ -971,6 +974,7 @@ export const createMemoryStore = (options: { memoryDir: string }) => {
         atomicWriteFile(
           join(dirPath, `${template.fileName}.md`),
           template.content,
+          logger,
         ),
       ),
     )

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -906,7 +906,7 @@ const moveNote = async (
           }
           if (movedLinksRewritten > 0) {
             try {
-              await atomicWriteFile(newFullPath, movedContent)
+              await atomicWriteFile(newFullPath, movedContent, logger)
             } catch (error) {
               logger.error(
                 "note move failed while rewriting the renamed note's links",
@@ -920,7 +920,7 @@ const moveNote = async (
           }
         } else {
           try {
-            await atomicWriteFileExclusive(newFullPath, movedContent, {
+            await atomicWriteFileExclusive(newFullPath, movedContent, logger, {
               hardLinksSupported: !params.windowsBindMount,
             })
           } catch (error) {
@@ -947,7 +947,7 @@ const moveNote = async (
           concurrency: REWRITE_CONCURRENCY,
           mapper: async (planned) => {
             try {
-              await atomicWriteFile(planned.fullPath, planned.content)
+              await atomicWriteFile(planned.fullPath, planned.content, logger)
               sourcesWritten += 1
             } catch (error) {
               logger.error("note move failed while writing a backlink source", {

--- a/src/vault-mcp/vault-operations/note-mover.ts
+++ b/src/vault-mcp/vault-operations/note-mover.ts
@@ -906,7 +906,10 @@ const moveNote = async (
           }
           if (movedLinksRewritten > 0) {
             try {
-              await atomicWriteFile(newFullPath, movedContent, logger)
+              await atomicWriteFile(
+                { filePath: newFullPath, content: movedContent },
+                logger,
+              )
             } catch (error) {
               logger.error(
                 "note move failed while rewriting the renamed note's links",
@@ -920,9 +923,14 @@ const moveNote = async (
           }
         } else {
           try {
-            await atomicWriteFileExclusive(newFullPath, movedContent, logger, {
-              hardLinksSupported: !params.windowsBindMount,
-            })
+            await atomicWriteFileExclusive(
+              {
+                filePath: newFullPath,
+                content: movedContent,
+                hardLinksSupported: !params.windowsBindMount,
+              },
+              logger,
+            )
           } catch (error) {
             if (isErrnoException(error, "EEXIST")) {
               throw new Error(`destination exists: "${newPath}"`, {
@@ -947,7 +955,10 @@ const moveNote = async (
           concurrency: REWRITE_CONCURRENCY,
           mapper: async (planned) => {
             try {
-              await atomicWriteFile(planned.fullPath, planned.content, logger)
+              await atomicWriteFile(
+                { filePath: planned.fullPath, content: planned.content },
+                logger,
+              )
               sourcesWritten += 1
             } catch (error) {
               logger.error("note move failed while writing a backlink source", {

--- a/src/vault-mcp/vault-operations/task-mutations.ts
+++ b/src/vault-mcp/vault-operations/task-mutations.ts
@@ -830,7 +830,7 @@ const createTask = async (
 
     // Write atomically
     const serialized = stringifyNote(resultLines.join("\n"), parsed.data)
-    await atomicWriteFile(fullPath, serialized, logger)
+    await atomicWriteFile({ filePath: fullPath, content: serialized }, logger)
 
     const finalLine = bodyStartLine + insertAt + 1
 
@@ -1182,7 +1182,7 @@ const updateTask = async (
 
     // Write atomically
     const serialized = stringifyNote(resultLines.join("\n"), parsed.data)
-    await atomicWriteFile(fullPath, serialized, logger)
+    await atomicWriteFile({ filePath: fullPath, content: serialized }, logger)
 
     const finalLine = bodyStartLine + finalTaskIndex + 1
     const finalTaskLine = resultLines[finalTaskIndex] ?? mutatedLine

--- a/src/vault-mcp/vault-operations/task-mutations.ts
+++ b/src/vault-mcp/vault-operations/task-mutations.ts
@@ -830,7 +830,7 @@ const createTask = async (
 
     // Write atomically
     const serialized = stringifyNote(resultLines.join("\n"), parsed.data)
-    await atomicWriteFile(fullPath, serialized)
+    await atomicWriteFile(fullPath, serialized, logger)
 
     const finalLine = bodyStartLine + insertAt + 1
 
@@ -1182,7 +1182,7 @@ const updateTask = async (
 
     // Write atomically
     const serialized = stringifyNote(resultLines.join("\n"), parsed.data)
-    await atomicWriteFile(fullPath, serialized)
+    await atomicWriteFile(fullPath, serialized, logger)
 
     const finalLine = bodyStartLine + finalTaskIndex + 1
     const finalTaskLine = resultLines[finalTaskIndex] ?? mutatedLine

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -506,11 +506,14 @@ const claimTrashTarget = async (targetPath: string): Promise<boolean> => {
  *  claim and takes the next suffix instead. The claim itself is the
  *  existence check — no stat-based precheck decides whether a name is
  *  safe. Returns the vault-relative trash path. */
-const moveNoteToTrash = async (params: {
-  vaultPath: string
-  relativePath: string
-  fullPath: string
-}): Promise<string> => {
+const moveNoteToTrash = async (
+  params: {
+    vaultPath: string
+    relativePath: string
+    fullPath: string
+  },
+  logger: Logger,
+): Promise<string> => {
   const { dir, name, ext } = parse(params.relativePath)
   const candidateRelativePaths = [
     `.trash/${params.relativePath}`,
@@ -529,9 +532,16 @@ const moveNoteToTrash = async (params: {
       await rename(params.fullPath, candidateFullPath)
     } catch (renameError) {
       // The claim took but the move failed — drop our placeholder so it
-      // doesn't strand a 0-byte file occupying a suffix. Swallow cleanup
-      // errors so the rename failure propagates.
-      await rm(candidateFullPath, { force: true }).catch(() => {})
+      // doesn't strand a 0-byte file occupying a suffix. A failed cleanup is
+      // logged, not thrown, so the rename failure propagates as the cause.
+      await rm(candidateFullPath, { force: true }).catch(
+        (cleanupError: unknown) => {
+          logger.warn("failed to remove claim placeholder", {
+            path: candidateRelativePath,
+            error: describeError(cleanupError),
+          })
+        },
+      )
       throw renameError
     }
     return candidateRelativePath
@@ -591,11 +601,14 @@ const deleteNote = async (
       // Only "local" has a destination here. "system" trash doesn't exist
       // inside a container and "none" means delete, so both unlink for good.
       if (params.trashOption === "local") {
-        trashLocation = await moveNoteToTrash({
-          vaultPath: params.vaultPath,
-          relativePath: path,
-          fullPath,
-        })
+        trashLocation = await moveNoteToTrash(
+          {
+            vaultPath: params.vaultPath,
+            relativePath: path,
+            fullPath,
+          },
+          logger,
+        )
       } else {
         await unlink(fullPath)
       }

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -169,18 +169,22 @@ export const pruneEmptyParents = async (
 export const atomicWriteFile = async (
   filePath: string,
   content: string,
+  logger: Logger,
 ): Promise<void> => {
   const tmpPath = `${filePath}.${randomUUID()}.tmp`
   try {
     await writeFile(tmpPath, content, "utf8")
     await rename(tmpPath, filePath)
   } catch (err) {
-    // Best-effort cleanup so a failed write never strands a temp file. Swallow
-    // any cleanup error so the original write/rename failure is still thrown.
+    // Best-effort cleanup so a failed write never strands a temp file. A
+    // failed cleanup is logged, not thrown, so the write failure propagates.
     try {
       await rm(tmpPath, { force: true })
-    } catch {
-      // ignore — preserving the root-cause error below matters more
+    } catch (cleanupError) {
+      logger.warn("failed to remove temp file", {
+        path: tmpPath,
+        error: describeError(cleanupError),
+      })
     }
     throw err
   }
@@ -208,6 +212,7 @@ export const atomicWriteFile = async (
 export const atomicWriteFileExclusive = async (
   filePath: string,
   content: string,
+  logger: Logger,
   options?: { hardLinksSupported?: boolean },
 ): Promise<void> => {
   const tmpPath = `${filePath}.${randomUUID()}.tmp`
@@ -229,14 +234,26 @@ export const atomicWriteFileExclusive = async (
       await rename(tmpPath, filePath)
     } catch (renameError) {
       // The reservation took but the swap failed — drop the placeholder so a
-      // failed write never strands a 0-byte note at the destination.
-      await rm(filePath, { force: true }).catch(() => {})
+      // failed write never strands a 0-byte note at the destination. A failed
+      // cleanup is logged, not thrown, so the swap failure propagates.
+      await rm(filePath, { force: true }).catch((cleanupError: unknown) => {
+        logger.warn("failed to remove reservation placeholder", {
+          path: filePath,
+          error: describeError(cleanupError),
+        })
+      })
       throw renameError
     }
   } finally {
     // Always drop the temp file — renamed away on success, redundant otherwise.
-    // Swallow cleanup errors so the original failure (e.g. EEXIST) propagates.
-    await rm(tmpPath, { force: true }).catch(() => {})
+    // A failed cleanup is logged, not thrown, so the original failure (e.g.
+    // EEXIST) propagates.
+    await rm(tmpPath, { force: true }).catch((cleanupError: unknown) => {
+      logger.warn("failed to remove temp file", {
+        path: tmpPath,
+        error: describeError(cleanupError),
+      })
+    })
   }
 }
 
@@ -430,7 +447,7 @@ const writeNote = async (
       throw new Error(`note already exists: "${params.path}"`)
     }
     const serialized = serializeNote(existing, params.body, params.properties)
-    await atomicWriteFile(fullPath, serialized)
+    await atomicWriteFile(fullPath, serialized, logger)
     logger.info("wrote note", {
       path: params.path,
       beforeBytes: existing ? Buffer.byteLength(existing, "utf8") : 0,
@@ -458,7 +475,7 @@ const updateProperties = async (
     const parsed = parseNote(existing)
     const mergedProperties = mergeFrontmatter(parsed.data, params.properties)
     const serialized = stringifyNote(parsed.content, mergedProperties)
-    await atomicWriteFile(fullPath, serialized)
+    await atomicWriteFile(fullPath, serialized, logger)
     logger.info("updated properties", {
       path: params.path,
       beforeBytes: Buffer.byteLength(existing, "utf8"),

--- a/src/vault-mcp/vault-operations/vault-filesystem.ts
+++ b/src/vault-mcp/vault-operations/vault-filesystem.ts
@@ -167,14 +167,13 @@ export const pruneEmptyParents = async (
  * must not already exist.
  */
 export const atomicWriteFile = async (
-  filePath: string,
-  content: string,
+  params: { filePath: string; content: string },
   logger: Logger,
 ): Promise<void> => {
-  const tmpPath = `${filePath}.${randomUUID()}.tmp`
+  const tmpPath = `${params.filePath}.${randomUUID()}.tmp`
   try {
-    await writeFile(tmpPath, content, "utf8")
-    await rename(tmpPath, filePath)
+    await writeFile(tmpPath, params.content, "utf8")
+    await rename(tmpPath, params.filePath)
   } catch (err) {
     // Best-effort cleanup so a failed write never strands a temp file. A
     // failed cleanup is logged, not thrown, so the write failure propagates.
@@ -210,38 +209,42 @@ export const atomicWriteFile = async (
  * than `link`, so it works where hard links don't.
  */
 export const atomicWriteFileExclusive = async (
-  filePath: string,
-  content: string,
+  params: {
+    filePath: string
+    content: string
+    hardLinksSupported?: boolean
+  },
   logger: Logger,
-  options?: { hardLinksSupported?: boolean },
 ): Promise<void> => {
-  const tmpPath = `${filePath}.${randomUUID()}.tmp`
-  const hardLinksSupported = options?.hardLinksSupported ?? true
+  const tmpPath = `${params.filePath}.${randomUUID()}.tmp`
+  const hardLinksSupported = params.hardLinksSupported ?? true
   try {
-    await writeFile(tmpPath, content, "utf8")
+    await writeFile(tmpPath, params.content, "utf8")
     if (hardLinksSupported) {
       // Atomic no-clobber create — link throws EEXIST if filePath exists.
-      await link(tmpPath, filePath)
+      await link(tmpPath, params.filePath)
       return
     }
     // No hard links on this filesystem. Reserve the target atomically
     // (O_EXCL) — it throws EEXIST if the target exists, with no separate
     // check, so there's no TOCTOU window in which a concurrent writer's file
     // could be clobbered.
-    await writeFile(filePath, "", { flag: "wx" })
+    await writeFile(params.filePath, "", { flag: "wx" })
     try {
       // Swap the fully-staged content over the empty placeholder.
-      await rename(tmpPath, filePath)
+      await rename(tmpPath, params.filePath)
     } catch (renameError) {
       // The reservation took but the swap failed — drop the placeholder so a
       // failed write never strands a 0-byte note at the destination. A failed
       // cleanup is logged, not thrown, so the swap failure propagates.
-      await rm(filePath, { force: true }).catch((cleanupError: unknown) => {
-        logger.warn("failed to remove reservation placeholder", {
-          path: filePath,
-          error: describeError(cleanupError),
-        })
-      })
+      await rm(params.filePath, { force: true }).catch(
+        (cleanupError: unknown) => {
+          logger.warn("failed to remove reservation placeholder", {
+            path: params.filePath,
+            error: describeError(cleanupError),
+          })
+        },
+      )
       throw renameError
     }
   } finally {
@@ -447,7 +450,7 @@ const writeNote = async (
       throw new Error(`note already exists: "${params.path}"`)
     }
     const serialized = serializeNote(existing, params.body, params.properties)
-    await atomicWriteFile(fullPath, serialized, logger)
+    await atomicWriteFile({ filePath: fullPath, content: serialized }, logger)
     logger.info("wrote note", {
       path: params.path,
       beforeBytes: existing ? Buffer.byteLength(existing, "utf8") : 0,
@@ -475,7 +478,7 @@ const updateProperties = async (
     const parsed = parseNote(existing)
     const mergedProperties = mergeFrontmatter(parsed.data, params.properties)
     const serialized = stringifyNote(parsed.content, mergedProperties)
-    await atomicWriteFile(fullPath, serialized, logger)
+    await atomicWriteFile({ filePath: fullPath, content: serialized }, logger)
     logger.info("updated properties", {
       path: params.path,
       beforeBytes: Buffer.byteLength(existing, "utf8"),

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -174,7 +174,7 @@ const writePatchedNote = async (
   logger: Logger,
 ): Promise<number> => {
   const serialized = stringifyNote(lines.join("\n"), data)
-  await atomicWriteFile(fullPath, serialized, logger)
+  await atomicWriteFile({ filePath: fullPath, content: serialized }, logger)
   return Buffer.byteLength(serialized, "utf8")
 }
 

--- a/src/vault-mcp/vault-operations/vault-patcher.ts
+++ b/src/vault-mcp/vault-operations/vault-patcher.ts
@@ -171,9 +171,10 @@ const writePatchedNote = async (
   fullPath: string,
   data: Record<string, unknown>,
   lines: readonly string[],
+  logger: Logger,
 ): Promise<number> => {
   const serialized = stringifyNote(lines.join("\n"), data)
-  await atomicWriteFile(fullPath, serialized)
+  await atomicWriteFile(fullPath, serialized, logger)
   return Buffer.byteLength(serialized, "utf8")
 }
 
@@ -309,7 +310,12 @@ const patchNote = async (
         operation === "append"
           ? [...lines, ...contentLines]
           : [...contentLines, ...lines]
-      const afterBytes = await writePatchedNote(fullPath, data, updatedLines)
+      const afterBytes = await writePatchedNote(
+        fullPath,
+        data,
+        updatedLines,
+        logger,
+      )
       logger.info("patched note", {
         path,
         operation,
@@ -369,7 +375,12 @@ const patchNote = async (
       operation,
     )
 
-    const afterBytes = await writePatchedNote(fullPath, data, updatedLines)
+    const afterBytes = await writePatchedNote(
+      fullPath,
+      data,
+      updatedLines,
+      logger,
+    )
     logger.info("patched note", {
       path,
       operation,
@@ -435,7 +446,12 @@ const replaceInNote = async (
       newText.length === 0 ? collapseBlankRuns(updatedBody) : updatedBody
 
     const updatedLines = normalizedBody.split("\n")
-    const afterBytes = await writePatchedNote(fullPath, data, updatedLines)
+    const afterBytes = await writePatchedNote(
+      fullPath,
+      data,
+      updatedLines,
+      logger,
+    )
     logger.info("replaced in note", { path, count, beforeBytes, afterBytes })
     return {
       message: `Replaced ${count} occurrence${count > 1 ? "s" : ""} in ${path}`,
@@ -493,6 +509,7 @@ const deleteSpan = async (
       fullPath,
       data,
       normalizedBody.split("\n"),
+      logger,
     )
 
     logger.info("deleted span", {
@@ -562,6 +579,7 @@ const replaceSpan = async (
       fullPath,
       data,
       normalizedBody.split("\n"),
+      logger,
     )
 
     logger.info("replaced span", {
@@ -622,7 +640,12 @@ const insertAtAnchor = async (
     const insertIndex = position === "before" ? anchorLine : anchorLine + 1
     const updatedLines = lines.toSpliced(insertIndex, 0, ...contentLines)
 
-    const afterBytes = await writePatchedNote(fullPath, data, updatedLines)
+    const afterBytes = await writePatchedNote(
+      fullPath,
+      data,
+      updatedLines,
+      logger,
+    )
 
     logger.info("inserted at anchor", {
       path,


### PR DESCRIPTION
## Problem

The vault's write-path cleanup handlers swallow their own failures. `moveNoteToTrash`'s rename-failure cleanup, `atomicWriteFile`'s temp-file removal, and `atomicWriteFileExclusive`'s placeholder and temp-file removals all use `.catch(() => {})` or an empty catch, so a 0-byte placeholder or stray `.tmp` file that survives cleanup sits in the vault (or occupies a `.trash/` suffix slot) with no trace in the logs. The conventions ban silent catches — every catch logs or re-throws.

## Fix

The logger threads into all three functions (the standard data-layer `(params, logger)` shape), and every cleanup failure logs a warn with the path and error before the original failure propagates as the thrown cause:

- `moveNoteToTrash` — `failed to remove claim placeholder` with the vault-relative trash candidate path.
- `atomicWriteFile` — `failed to remove temp file` with the staging path.
- `atomicWriteFileExclusive` — `failed to remove reservation placeholder` for the `wx` fallback's target, and `failed to remove temp file` for the staged copy.

All fourteen call sites (note-mover, memory-store, task-mutations, vault-patcher, vault-filesystem) pass their in-scope logger.

Follow-up to #557 — the `moveNoteToTrash` fix was written for its final review round and missed the merge by seconds; the helper coverage answers the follow-up review round on this PR.

## Tests

Three new double-failure cases (all passing; full suite 3651):

- `moveNoteToTrash`: injected rename EIO + cleanup EPERM asserts both warns, the surviving 0-byte placeholder (proof the injected `rm` was the cleanup call), and the intact source note.
- `atomicWriteFile`: EISDIR rename failure + injected cleanup EPERM asserts the temp-file warn (path asserted by shape — it carries a random UUID).
- `atomicWriteFileExclusive` (`wx` fallback): injected swap EIO + cleanup EPERM asserts the reservation-placeholder warn with the exact target path.

Mutation-checked — silencing any of the catches fails exactly its guarding test while the rest of the file stays green.

`npm test` (3651), `npm run build`, and lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
