### PR TITLE
ci: wire the phases review-dispatch input to the UMM_PHASES repo variable

### DIFF
--- a/.github/workflows/umm_review.yml
+++ b/.github/workflows/umm_review.yml
@@ -112,6 +112,12 @@ jobs:
           # No count cap — bounded only by the shared token budget below;
           # docs that don't fit are named in the review's context notes
           priority_docs: ${{ vars.UMM_PRIORITY_DOCS || 'README.md' }}
+          # How the review dimensions are dispatched: combined (one model
+          # call carrying every dimension) | parallel (three focused calls
+          # at once — deeper reads, roughly triple the prompt tokens) |
+          # sequential (the same three calls in order, each seeing the
+          # earlier findings). Empty = combined
+          phases: ${{ vars.UMM_PHASES }}
           # One shared token pool for all prompt context, spent in priority
           # order: diff → changed files → import-traced related files →
           # priority docs → mention-matched docs. (Conventions file has its


### PR DESCRIPTION
Adds the `phases` input to `umm_review.yml`, wired to the `UMM_PHASES` repo variable. The input shipped in umm-actually v0.4.0 (`combined` | `parallel` | `sequential` review dispatch) but the consumer template never exposed it, so no repo variable could reach it and reviews always ran the default mode.

An unset variable passes an empty string, which the action treats as `combined` — behavior is unchanged until `UMM_PHASES` is set in this repo's Actions variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
