### PR TITLE
chore(hooks): install deps at session start and worktree entry

### DIFF
--- a/.claude/hooks/install-deps.sh
+++ b/.claude/hooks/install-deps.sh
@@ -92,6 +92,14 @@ else
     fi
     log "concurrent installer (pid ${owner}) died without finishing in ${checkout}"
   fi
+  # Re-read: another session may have taken over the lock while we waited.
+  # Without this, a completed takeover (claim already removed) is invisible
+  # and this session's mkdir-claim succeeds, leading to two concurrent installs.
+  owner="$(cat "${lock}/pid" 2>/dev/null || true)"
+  if [[ -n "${owner}" ]] && kill -0 "${owner}" 2>/dev/null; then
+    log "another session (pid ${owner}) took over the install in ${checkout} — skipping"
+    exit 0
+  fi
   # The claim token makes the takeover exclusive: rm-then-mkdir alone is not
   # atomic, so without it a second taker's rm could delete the first taker's
   # fresh lock and both would install. The claim records its taker's pid so a

--- a/.claude/hooks/install-deps.sh
+++ b/.claude/hooks/install-deps.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Ensures the current checkout's dependencies are installed. Registered on
+# SessionStart and on PostToolUse for EnterWorktree: fresh cloud clones and
+# fresh git worktrees start without node_modules.
+set -euo pipefail
+
+# A hook's non-interactive shell never sources .bashrc, so nvm must be loaded
+# here; without it, npm can resolve to a system Node (cloud images ship
+# Node 22 at /opt/node22). Sourcing nvm.sh activates the default alias.
+# Cloud setup scripts run with HOME=/root, hence the second candidate.
+for dir in "${HOME}/.nvm" /root/.nvm; do
+  if [[ -s "${dir}/nvm.sh" ]]; then
+    export NVM_DIR="${dir}"
+    # shellcheck disable=SC1091
+    . "${dir}/nvm.sh"
+    break
+  fi
+done
+
+# The payload cwd follows the session into a worktree; CLAUDE_PROJECT_DIR
+# stays at the original project root, so it is only the fallback.
+payload_cwd="$(node -e 'let d="";process.stdin.on("data",(c)=>d+=c).on("end",()=>process.stdout.write(JSON.parse(d).cwd??""))' 2>/dev/null || true)"
+checkout="$(git -C "${payload_cwd:-${CLAUDE_PROJECT_DIR:-.}}" rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+[[ -d "${checkout}/node_modules" ]] && exit 0
+cd "${checkout}"
+# ONNXRUNTIME_NODE_INSTALL=skip: onnxruntime-node's postinstall would download
+# GPU binaries whose extractor (adm-zip) is stubbed out — required on linux/x64.
+ONNXRUNTIME_NODE_INSTALL=skip npm ci

--- a/.claude/hooks/install-deps.sh
+++ b/.claude/hooks/install-deps.sh
@@ -4,6 +4,9 @@
 # fresh git worktrees start without node_modules.
 set -euo pipefail
 
+# stderr only: SessionStart hook stdout is injected into the model's context.
+log() { echo "[install-deps] $*" >&2; }
+
 # A hook's non-interactive shell never sources .bashrc, so nvm must be loaded
 # here; without it, npm can resolve to a system Node (cloud images ship
 # Node 22 at /opt/node22). Sourcing nvm.sh activates the default alias.
@@ -20,10 +23,47 @@ done
 # The payload cwd follows the session into a worktree; CLAUDE_PROJECT_DIR
 # stays at the original project root, so it is only the fallback.
 payload_cwd="$(node -e 'let d="";process.stdin.on("data",(c)=>d+=c).on("end",()=>process.stdout.write(JSON.parse(d).cwd??""))' 2>/dev/null || true)"
-checkout="$(git -C "${payload_cwd:-${CLAUDE_PROJECT_DIR:-.}}" rev-parse --show-toplevel 2>/dev/null)" || exit 0
+checkout="$(git -C "${payload_cwd:-${CLAUDE_PROJECT_DIR:-.}}" rev-parse --show-toplevel 2>/dev/null)" || {
+  log "no git checkout resolved from '${payload_cwd:-<empty>}' — skipping"
+  exit 0
+}
 
-[[ -d "${checkout}/node_modules" ]] && exit 0
+# The marker survives an interrupted npm ci (a hook-timeout kill included), so
+# a partial node_modules is retried instead of trusted. It lives outside
+# node_modules because npm ci deletes that directory before installing.
+marker="${checkout}/.claude/.install-deps-incomplete"
+if [[ -d "${checkout}/node_modules" && ! -f "${marker}" ]]; then
+  log "node_modules present in ${checkout} — nothing to do"
+  exit 0
+fi
+
+# mkdir is the portable atomic lock (flock is Linux-only). A held lock means a
+# concurrent session is installing — skip rather than race npm ci. A lock older
+# than 30 minutes was left by a killed hook: take it over instead of blocking
+# installs forever.
+lock="${checkout}/.claude/.install-deps.lock"
+if ! mkdir "${lock}" 2>/dev/null; then
+  if [[ -n "$(find "${lock}" -maxdepth 0 -mmin +30 2>/dev/null)" ]]; then
+    log "stale install lock (>30 min) in ${checkout} — taking over"
+  else
+    log "another session is installing in ${checkout} — skipping"
+    exit 0
+  fi
+fi
+trap 'rmdir "${lock}" 2>/dev/null || true' EXIT
+
 cd "${checkout}"
+touch "${marker}"
+# Honor the checkout's .nvmrc when that Node is already installed; otherwise
+# stay on the default alias — a hook must never download a Node version.
+command -v nvm >/dev/null 2>&1 && nvm use >/dev/null 2>&1 || true
+log "installing dependencies in ${checkout} (node $(node --version 2>/dev/null || echo unknown))"
 # ONNXRUNTIME_NODE_INSTALL=skip: onnxruntime-node's postinstall would download
 # GPU binaries whose extractor (adm-zip) is stubbed out — required on linux/x64.
-ONNXRUNTIME_NODE_INSTALL=skip npm ci
+if ONNXRUNTIME_NODE_INSTALL=skip npm ci; then
+  rm -f "${marker}"
+  log "install complete"
+else
+  log "npm ci failed — the session continues without dependencies; the marker forces a retry next session"
+fi
+exit 0

--- a/.claude/hooks/install-deps.sh
+++ b/.claude/hooks/install-deps.sh
@@ -32,9 +32,19 @@ checkout="$(git -C "${payload_cwd:-${CLAUDE_PROJECT_DIR:-.}}" rev-parse --show-t
 # a partial node_modules is retried instead of trusted. It lives outside
 # node_modules because npm ci deletes that directory before installing.
 marker="${checkout}/.claude/.install-deps-incomplete"
+# The stamp records which package-lock.json the hook's own last install used,
+# so a stamped checkout reinstalls after a pull changes the lockfile. An
+# unstamped checkout (node_modules installed by the developer, not the hook)
+# is trusted as-is — the hook must never wipe an install it does not own.
+stamp="${checkout}/.claude/.install-deps-lockhash"
+lockfile_hash="$(git -C "${checkout}" hash-object package-lock.json 2>/dev/null || true)"
 if [[ -d "${checkout}/node_modules" && ! -f "${marker}" ]]; then
-  log "node_modules present in ${checkout} — nothing to do"
-  exit 0
+  stamped="$(cat "${stamp}" 2>/dev/null || true)"
+  if [[ -z "${stamped}" || "${stamped}" == "${lockfile_hash}" ]]; then
+    log "node_modules present in ${checkout} — nothing to do"
+    exit 0
+  fi
+  log "package-lock.json changed since the hook's last install in ${checkout} — reinstalling"
 fi
 
 # mkdir is the portable atomic lock (flock is Linux-only). The lock records its
@@ -69,8 +79,17 @@ log "installing dependencies in ${checkout} (node $(node --version 2>/dev/null |
 # ONNXRUNTIME_NODE_INSTALL=skip: onnxruntime-node's postinstall would download
 # GPU binaries whose extractor (adm-zip) is stubbed out — required on linux/x64.
 # npm's stdout goes to stderr too: SessionStart hook stdout enters the model's context.
-if ONNXRUNTIME_NODE_INSTALL=skip npm ci >&2; then
+ONNXRUNTIME_NODE_INSTALL=skip npm ci >&2 &
+install_pid=$!
+# The lock's liveness target becomes the npm process itself: if the hook shell
+# is killed but its npm ci survives, the lock stays respected until the process
+# actually mutating node_modules is gone.
+echo "${install_pid}" > "${lock}/pid"
+if wait "${install_pid}"; then
   rm -f "${marker}"
+  if [[ -n "${lockfile_hash}" ]]; then
+    printf '%s\n' "${lockfile_hash}" > "${stamp}"
+  fi
   log "install complete"
 else
   log "npm ci failed — the session continues without dependencies; the marker forces a retry next session"

--- a/.claude/hooks/install-deps.sh
+++ b/.claude/hooks/install-deps.sh
@@ -42,7 +42,9 @@ fi
 # than race npm ci; a dead owner (hook killed mid-install) is taken over
 # immediately, so the marker's retry is never blocked behind an orphaned lock.
 lock="${checkout}/.claude/.install-deps.lock"
-if ! mkdir "${lock}" 2>/dev/null; then
+if mkdir "${lock}" 2>/dev/null; then
+  echo "$$" > "${lock}/pid"
+else
   owner="$(cat "${lock}/pid" 2>/dev/null || true)"
   if [[ -n "${owner}" ]] && kill -0 "${owner}" 2>/dev/null; then
     log "another session (pid ${owner}) is installing in ${checkout} — skipping"
@@ -54,8 +56,8 @@ if ! mkdir "${lock}" 2>/dev/null; then
     log "lost the takeover race to another session — skipping"
     exit 0
   }
+  echo "$$" > "${lock}/pid"
 fi
-echo "$$" > "${lock}/pid"
 trap 'rm -rf "${lock}"' EXIT
 
 cd "${checkout}"

--- a/.claude/hooks/install-deps.sh
+++ b/.claude/hooks/install-deps.sh
@@ -37,20 +37,26 @@ if [[ -d "${checkout}/node_modules" && ! -f "${marker}" ]]; then
   exit 0
 fi
 
-# mkdir is the portable atomic lock (flock is Linux-only). A held lock means a
-# concurrent session is installing — skip rather than race npm ci. A lock older
-# than 30 minutes was left by a killed hook: take it over instead of blocking
-# installs forever.
+# mkdir is the portable atomic lock (flock is Linux-only). The lock records its
+# owner's pid: a live owner means a concurrent install is running — skip rather
+# than race npm ci; a dead owner (hook killed mid-install) is taken over
+# immediately, so the marker's retry is never blocked behind an orphaned lock.
 lock="${checkout}/.claude/.install-deps.lock"
 if ! mkdir "${lock}" 2>/dev/null; then
-  if [[ -n "$(find "${lock}" -maxdepth 0 -mmin +30 2>/dev/null)" ]]; then
-    log "stale install lock (>30 min) in ${checkout} — taking over"
-  else
-    log "another session is installing in ${checkout} — skipping"
+  owner="$(cat "${lock}/pid" 2>/dev/null || true)"
+  if [[ -n "${owner}" ]] && kill -0 "${owner}" 2>/dev/null; then
+    log "another session (pid ${owner}) is installing in ${checkout} — skipping"
     exit 0
   fi
+  log "install lock owner (pid ${owner:-unknown}) is gone — taking over"
+  rm -rf "${lock}"
+  mkdir "${lock}" 2>/dev/null || {
+    log "lost the takeover race to another session — skipping"
+    exit 0
+  }
 fi
-trap 'rmdir "${lock}" 2>/dev/null || true' EXIT
+echo "$$" > "${lock}/pid"
+trap 'rm -rf "${lock}"' EXIT
 
 cd "${checkout}"
 touch "${marker}"
@@ -60,7 +66,8 @@ command -v nvm >/dev/null 2>&1 && nvm use >/dev/null 2>&1 || true
 log "installing dependencies in ${checkout} (node $(node --version 2>/dev/null || echo unknown))"
 # ONNXRUNTIME_NODE_INSTALL=skip: onnxruntime-node's postinstall would download
 # GPU binaries whose extractor (adm-zip) is stubbed out — required on linux/x64.
-if ONNXRUNTIME_NODE_INSTALL=skip npm ci; then
+# npm's stdout goes to stderr too: SessionStart hook stdout enters the model's context.
+if ONNXRUNTIME_NODE_INSTALL=skip npm ci >&2; then
   rm -f "${marker}"
   log "install complete"
 else

--- a/.claude/hooks/install-deps.sh
+++ b/.claude/hooks/install-deps.sh
@@ -68,7 +68,16 @@ else
   }
   echo "$$" > "${lock}/pid"
 fi
-trap 'rm -rf "${lock}"' EXIT
+cleanup() {
+  # If npm ci is still running (hook killed while npm continues), leave the
+  # lock — its pid targets the live npm process; the takeover logic (above)
+  # handles the eventual cleanup once npm exits.
+  if [[ -n "${install_pid:-}" ]] && kill -0 "${install_pid}" 2>/dev/null; then
+    return
+  fi
+  rm -rf "${lock}"
+}
+trap cleanup EXIT
 
 cd "${checkout}"
 touch "${marker}"

--- a/.claude/hooks/install-deps.sh
+++ b/.claude/hooks/install-deps.sh
@@ -46,6 +46,17 @@ if [[ -d "${checkout}/node_modules" && ! -f "${marker}" ]]; then
   fi
   log "package-lock.json changed since the hook's last install in ${checkout} — reinstalling"
 fi
+# A hook killed by timeout can leave the marker even though its orphaned npm ci
+# finished the install. A tree that passes npm ls is complete — clear the
+# marker instead of rebuilding it; without a stamp it is then trusted the same
+# way a developer's own install is.
+if [[ -d "${checkout}/node_modules" && -f "${marker}" ]]; then
+  if npm --prefix "${checkout}" ls --depth=0 >/dev/null 2>&1; then
+    rm -f "${marker}"
+    log "marker left by an interrupted hook but the dependency tree in ${checkout} is complete — clearing"
+    exit 0
+  fi
+fi
 
 # mkdir is the portable atomic lock (flock is Linux-only). The lock records its
 # owner's pid: a live owner means a concurrent install is running — skip rather
@@ -65,12 +76,18 @@ else
   # fresh lock and both would install. A claim left by a kill mid-takeover is
   # stale within a minute — the takeover itself is a few filesystem operations.
   claim="${lock}.claim"
+  # The second mkdir attempt covers a stale claim this session just cleared
+  # (left by a takeover killed mid-flight) — mkdir stays the atomic arbiter
+  # both times, so two clearers still produce exactly one taker.
   if ! mkdir "${claim}" 2>/dev/null; then
     if [[ -n "$(find "${claim}" -maxdepth 0 -mmin +1 2>/dev/null)" ]]; then
+      log "clearing a stale takeover claim in ${checkout}"
       rm -rf "${claim}"
     fi
-    log "another session is taking over the stale lock in ${checkout} — skipping"
-    exit 0
+    if ! mkdir "${claim}" 2>/dev/null; then
+      log "another session is taking over the stale lock in ${checkout} — skipping"
+      exit 0
+    fi
   fi
   log "install lock owner (pid ${owner:-unknown}) is gone — taking over"
   rm -rf "${lock}"

--- a/.claude/hooks/install-deps.sh
+++ b/.claude/hooks/install-deps.sh
@@ -60,14 +60,29 @@ else
     log "another session (pid ${owner}) is installing in ${checkout} — skipping"
     exit 0
   fi
+  # The claim token makes the takeover exclusive: rm-then-mkdir alone is not
+  # atomic, so without it a second taker's rm could delete the first taker's
+  # fresh lock and both would install. A claim left by a kill mid-takeover is
+  # stale within a minute — the takeover itself is a few filesystem operations.
+  claim="${lock}.claim"
+  if ! mkdir "${claim}" 2>/dev/null; then
+    if [[ -n "$(find "${claim}" -maxdepth 0 -mmin +1 2>/dev/null)" ]]; then
+      rm -rf "${claim}"
+    fi
+    log "another session is taking over the stale lock in ${checkout} — skipping"
+    exit 0
+  fi
   log "install lock owner (pid ${owner:-unknown}) is gone — taking over"
   rm -rf "${lock}"
-  mkdir "${lock}" 2>/dev/null || {
-    log "lost the takeover race to another session — skipping"
+  if ! mkdir "${lock}" 2>/dev/null; then
+    rm -rf "${claim}"
+    log "lost the lock to a newly arrived session — skipping"
     exit 0
-  }
+  fi
   echo "$$" > "${lock}/pid"
+  rm -rf "${claim}"
 fi
+owned_pid="$$"
 cleanup() {
   # If npm ci is still running (hook killed while npm continues), leave the
   # lock — its pid targets the live npm process; the takeover logic (above)
@@ -75,7 +90,12 @@ cleanup() {
   if [[ -n "${install_pid:-}" ]] && kill -0 "${install_pid}" 2>/dev/null; then
     return
   fi
-  rm -rf "${lock}"
+  # Release only a lock this hook still owns: after this hook's npm exited, a
+  # takeover may have replaced the lock, and removing it would unlock a third
+  # session against the second's live install.
+  if [[ "$(cat "${lock}/pid" 2>/dev/null)" == "${owned_pid}" ]]; then
+    rm -rf "${lock}"
+  fi
 }
 trap cleanup EXIT
 
@@ -94,6 +114,7 @@ install_pid=$!
 # is killed but its npm ci survives, the lock stays respected until the process
 # actually mutating node_modules is gone.
 echo "${install_pid}" > "${lock}/pid"
+owned_pid="${install_pid}"
 if wait "${install_pid}"; then
   rm -f "${marker}"
   if [[ -n "${lockfile_hash}" ]]; then

--- a/.claude/hooks/install-deps.sh
+++ b/.claude/hooks/install-deps.sh
@@ -48,19 +48,24 @@ if [[ -d "${checkout}/node_modules" && ! -f "${marker}" ]]; then
 fi
 # A hook killed by timeout can leave the marker even though its orphaned npm ci
 # finished the install. A tree that passes npm ls is complete — clear the
-# marker instead of rebuilding it; without a stamp it is then trusted the same
-# way a developer's own install is.
+# marker and stamp it instead of rebuilding it.
 if [[ -d "${checkout}/node_modules" && -f "${marker}" ]]; then
   if npm --prefix "${checkout}" ls --depth=0 >/dev/null 2>&1; then
     rm -f "${marker}"
+    # Stamped like the normal success path: the orphaned install was still the
+    # hook's own, and leaving it unstamped would disable the lockfile-change
+    # guard for this checkout forever.
+    if [[ -n "${lockfile_hash}" ]]; then
+      printf '%s\n' "${lockfile_hash}" > "${stamp}"
+    fi
     log "marker left by an interrupted hook but the dependency tree in ${checkout} is complete — clearing"
     exit 0
   fi
 fi
 
 # mkdir is the portable atomic lock (flock is Linux-only). The lock records its
-# owner's pid: a live owner means a concurrent install is running — skip rather
-# than race npm ci; a dead owner (hook killed mid-install) is taken over
+# owner's pid: a live owner means a concurrent install is running — wait for it
+# rather than race npm ci; a dead owner (hook killed mid-install) is taken over
 # immediately, so the marker's retry is never blocked behind an orphaned lock.
 lock="${checkout}/.claude/.install-deps.lock"
 if mkdir "${lock}" 2>/dev/null; then
@@ -68,19 +73,45 @@ if mkdir "${lock}" 2>/dev/null; then
 else
   owner="$(cat "${lock}/pid" 2>/dev/null || true)"
   if [[ -n "${owner}" ]] && kill -0 "${owner}" 2>/dev/null; then
-    log "another session (pid ${owner}) is installing in ${checkout} — skipping"
-    exit 0
+    # A live concurrent install: wait for it (bounded well inside the 600s
+    # hook budget) so this session starts with dependencies instead of racing
+    # a tree npm ci is actively rewriting.
+    log "another session (pid ${owner}) is installing in ${checkout} — waiting for it"
+    waited=0
+    while kill -0 "${owner}" 2>/dev/null && ((waited < 480)); do
+      sleep 5
+      waited=$((waited + 5))
+    done
+    if [[ -d "${checkout}/node_modules" && ! -f "${marker}" ]]; then
+      log "concurrent install finished in ${checkout} — nothing to do"
+      exit 0
+    fi
+    if ((waited >= 480)); then
+      log "concurrent install still running after ${waited}s in ${checkout} — skipping"
+      exit 0
+    fi
+    log "concurrent installer (pid ${owner}) died without finishing in ${checkout}"
   fi
   # The claim token makes the takeover exclusive: rm-then-mkdir alone is not
   # atomic, so without it a second taker's rm could delete the first taker's
-  # fresh lock and both would install. A claim left by a kill mid-takeover is
-  # stale within a minute — the takeover itself is a few filesystem operations.
+  # fresh lock and both would install. The claim records its taker's pid so a
+  # killed takeover is reclaimed immediately; the age check covers only a
+  # pidless claim (its taker died between mkdir and the pid write).
   claim="${lock}.claim"
-  # The second mkdir attempt covers a stale claim this session just cleared
-  # (left by a takeover killed mid-flight) — mkdir stays the atomic arbiter
-  # both times, so two clearers still produce exactly one taker.
+  claim_is_stale() {
+    local claim_owner
+    claim_owner="$(cat "${claim}/pid" 2>/dev/null || true)"
+    if [[ -n "${claim_owner}" ]]; then
+      ! kill -0 "${claim_owner}" 2>/dev/null
+    else
+      [[ -n "$(find "${claim}" -maxdepth 0 -mmin +1 2>/dev/null)" ]]
+    fi
+  }
+  # The second mkdir attempt covers a stale claim this session just cleared —
+  # mkdir stays the atomic arbiter both times, so two clearers still produce
+  # exactly one taker.
   if ! mkdir "${claim}" 2>/dev/null; then
-    if [[ -n "$(find "${claim}" -maxdepth 0 -mmin +1 2>/dev/null)" ]]; then
+    if claim_is_stale; then
       log "clearing a stale takeover claim in ${checkout}"
       rm -rf "${claim}"
     fi
@@ -89,6 +120,7 @@ else
       exit 0
     fi
   fi
+  echo "$$" > "${claim}/pid"
   log "install lock owner (pid ${owner:-unknown}) is gone — taking over"
   rm -rf "${lock}"
   if ! mkdir "${lock}" 2>/dev/null; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/install-deps.sh",
+            "command": "\"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/install-deps.sh",
             "timeout": 600
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/install-deps.sh",
+            "command": "\"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/install-deps.sh",
             "timeout": 600
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/install-deps.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/install-deps.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,13 @@ dist/
 *.log
 CLAUDE.local.md
 .serena/
-.claude/
+# .claude/ is local state except the committed session hooks (a trailing-slash
+# dir ignore would block the re-includes — git never descends into ignored dirs)
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/hooks/*
+!.claude/hooks/install-deps.sh
 TASKS.md
 .DS_Store
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,10 @@ server.json                            # MCP server registry manifest
 render.yaml                            # Render Blueprint (repo root — Render reads it only from there); backs the Deploy to Render button
 Dockerfile                             # Two-target build: local (default) + remote
 Brewfile                               # Homebrew dev dependencies (optipng)
+.claude/                               # Committed Claude Code session hooks (rest of .claude/ is gitignored)
+  settings.json                        #   SessionStart + PostToolUse(EnterWorktree) → install-deps.sh
+  hooks/
+    install-deps.sh                    #   nvm + npm ci guard for fresh clones and worktrees
 obsidian-headless/                     # Lockfile-pinned obsidian-headless for Docker remote target
   package.json                         #   pins obsidian-headless version
   package-lock.json                    #   sha512 integrity hashes (supply-chain security)


### PR DESCRIPTION
## Problem

Fresh checkouts start without `node_modules`: cloud (claude.ai/code) sessions clone the repo after the environment's setup script has already run (the setup script builds a cached base image — `npm ci` there is structurally impossible), and fresh git worktrees never inherit the main checkout's `node_modules`. Every agent session pays the discovery cost or works against missing deps.

## Change

- **`.claude/settings.json`** (new, committed): registers `install-deps.sh` on `SessionStart` (`startup|resume`) and on `PostToolUse` for `EnterWorktree`, 600s timeout.
- **`.claude/hooks/install-deps.sh`** (new, committed): resolves the active checkout from the hook payload's `cwd` (which follows the session into a worktree, unlike `$CLAUDE_PROJECT_DIR`, which stays at the project root), exits immediately when `node_modules` exists, otherwise sources nvm (`$HOME/.nvm` or `/root/.nvm` — cloud setup runs with `HOME=/root`) and runs `ONNXRUNTIME_NODE_INSTALL=skip npm ci`.
- **`.gitignore`**: `.claude/` → `.claude/*` with re-includes for exactly these two files; `settings.local.json`, `worktrees/`, and local hook rules stay ignored (verified with `git check-ignore`).

## Verification

- Guard path: payload `cwd` at a populated checkout → exit 0, no work.
- Install path: payload `cwd` at a fresh worktree → real `npm ci`, 367 packages installed; immediate second run exits 0.
- Malformed/absent payload falls back to `$CLAUDE_PROJECT_DIR`; a non-git `cwd` exits 0 silently.

## Caveat

PostToolUse matching on `EnterWorktree` is not documented (the hooks reference lists ordinary tool matchers); if it never fires, the hook still covers session start, and worktree coverage degrades to sessions launched inside a worktree. Worth confirming in a live session — the registration is inert if unmatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic dependency setup when starting or resuming a development session, including after creating a worktree.
  * Dependency installation now detects existing installations and safely handles concurrent setup attempts.

* **Documentation**
  * Documented the new development-session setup hooks and dependency installation behavior.

* **Chores**
  * Updated project ignore rules to retain the committed development-session configuration while excluding other local state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->