### PR TITLE
fix: skip onnxruntime-node NuGet download via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,6 @@
 engine-strict=true
 save-exact=true
+# onnxruntime-node's install script reads npm_config_onnxruntime_node_install (install-utils.js:236).
+# npm >= 11.2 warns "Unknown project config" but still exposes it; keeps third-party builds (Glama)
+# from hitting the AdmZip crash on the empty-npm-package stub.
 onnxruntime-node-install=skip

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 save-exact=true
+onnxruntime-node-install=skip


### PR DESCRIPTION
## Summary

- Skip onnxruntime-node's NuGet GPU binary download via `.npmrc` so builds that don't set `ONNXRUNTIME_NODE_INSTALL=skip` (e.g. Glama) stop crashing on the adm-zip stub

## Context

The adm-zip override (`npm:empty-npm-package@1.0.0`) neuters the vulnerable dependency, but onnxruntime-node's install script still tries `new AdmZip(buffer)` on the empty stub, crashing with "AdmZip is not a constructor." Our Dockerfile sets `ONNXRUNTIME_NODE_INSTALL=skip` to prevent this, but third-party build environments (Glama) run their own `npm ci` without that env var.

The install script already checks `npm_config_onnxruntime_node_install` as a fallback ([install-utils.js:236](https://github.com/nicklhw/onnxruntime/blob/main/js/node/script/install-utils.js)), and npm exposes `.npmrc` values as `npm_config_*` env vars during lifecycle scripts — so the one-line `.npmrc` addition makes the skip portable to any `npm ci` invocation.

## Test plan

- [x] `npm run env | grep onnxruntime` confirms `npm_config_onnxruntime_node_install=skip`
- [x] Existing tests unaffected (CPU prebuilt binaries ship in the npm package; the install script only downloads GPU-specific NuGet binaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
